### PR TITLE
Fix #868 by changing List type hints to Sequence

### DIFF
--- a/integration_tests/samples/issues/issue_868.py
+++ b/integration_tests/samples/issues/issue_868.py
@@ -1,0 +1,36 @@
+# ------------------
+# Only for running this script here
+import logging
+import sys
+from os.path import dirname
+
+sys.path.insert(1, f"{dirname(__file__)}/../..")
+logging.basicConfig(level=logging.DEBUG)
+# ------------------
+
+
+def legacy():
+    from slack.web.classes.blocks import SectionBlock
+    from slack.web.classes.objects import TextObject
+
+    fields = []
+    fields.append(TextObject(text='...', type='mrkdwn'))
+    block = SectionBlock(text='', fields=fields)
+    assert block is not None
+
+
+from slack_sdk.models.blocks import SectionBlock, TextObject
+
+fields = []
+fields.append(TextObject(text='...', type='mrkdwn'))
+block = SectionBlock(text='', fields=fields)
+assert block is not None
+
+#
+# pip install mypy
+# mypy integration_tests/samples/issues/issue_868.py | grep integration_tests
+#
+
+# integration_tests/samples/issues/issue_868.py:26: error: Argument "fields" to "SectionBlock" has incompatible type "List[TextObject]"; expected "Optional[List[Union[str, Dict[Any, Any], TextObject]]]"
+# integration_tests/samples/issues/issue_868.py:26: note: "List" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
+# integration_tests/samples/issues/issue_868.py:26: note: Consider using "Sequence" instead, which is covariant

--- a/slack_sdk/models/__init__.py
+++ b/slack_sdk/models/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union, Dict, Any
+from typing import Union, Dict, Any, Sequence, List
 
 from .basic_objects import BaseObject  # noqa
 from .basic_objects import EnumValidator  # noqa
@@ -9,7 +9,7 @@ from .basic_objects import JsonValidator  # noqa
 
 # NOTE: used only for legacy components - don't use this for Block Kit
 def extract_json(
-    item_or_items: Union[JsonObject, List[JsonObject]], *format_args
+    item_or_items: Union[JsonObject, Sequence[JsonObject]], *format_args
 ) -> Union[Dict[Any, Any], List[Dict[Any, Any]]]:
     """
     Given a sequence (or single item), attempt to call the to_dict() method on each

--- a/slack_sdk/models/attachments/__init__.py
+++ b/slack_sdk/models/attachments/__init__.py
@@ -1,6 +1,6 @@
 import re
 from abc import ABCMeta, abstractmethod
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Sequence
 
 from slack_sdk.models import extract_json
 from slack_sdk.models.basic_objects import (
@@ -296,9 +296,9 @@ class Attachment(JsonObject):
         *,
         text: str,
         fallback: Optional[str] = None,
-        fields: Optional[List[AttachmentField]] = None,
+        fields: Optional[Sequence[AttachmentField]] = None,
         color: Optional[str] = None,
-        markdown_in: Optional[List[str]] = None,
+        markdown_in: Optional[Sequence[str]] = None,
         title: Optional[str] = None,
         title_link: Optional[str] = None,
         pretext: Optional[str] = None,
@@ -436,7 +436,7 @@ class BlockAttachment(Attachment):
     attributes = {"color"}
     blocks: List[Block]
 
-    def __init__(self, *, blocks: List[Block], color: Optional[str] = None):
+    def __init__(self, *, blocks: Sequence[Block], color: Optional[str] = None):
         """
         A bridge between legacy attachments and blockkit formatting - pass a list of
         Block objects directly to this attachment.
@@ -474,13 +474,13 @@ class InteractiveAttachment(Attachment):
     def __init__(
         self,
         *,
-        actions: List[Action],
+        actions: Sequence[Action],
         callback_id: str,
         text: str,
         fallback: Optional[str] = None,
-        fields: Optional[List[AttachmentField]] = None,
+        fields: Optional[Sequence[AttachmentField]] = None,
         color: Optional[str] = None,
-        markdown_in: Optional[List[str]] = None,
+        markdown_in: Optional[Sequence[str]] = None,
         title: Optional[str] = None,
         title_link: Optional[str] = None,
         pretext: Optional[str] = None,

--- a/slack_sdk/models/blocks/basic_components.py
+++ b/slack_sdk/models/blocks/basic_components.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import warnings
-from typing import List, Optional, Set, Union
+from typing import List, Optional, Set, Union, Sequence
 
 from slack_sdk.models import show_unknown_key_warning
 from slack_sdk.models.basic_objects import (
@@ -225,7 +225,7 @@ class Option(JsonObject):
 
     @classmethod
     def parse_all(
-        cls, options: Optional[List[Union[dict, "Option"]]]
+        cls, options: Optional[Sequence[Union[dict, "Option"]]]
     ) -> Optional[List["Option"]]:
         if options is None:
             return None
@@ -287,7 +287,7 @@ class OptionGroup(JsonObject):
         self,
         *,
         label: Optional[Union[str, dict, TextObject]] = None,
-        options: List[Union[dict, Option]],
+        options: Sequence[Union[dict, Option]],
         **others: dict,
     ):
         """
@@ -325,7 +325,7 @@ class OptionGroup(JsonObject):
 
     @classmethod
     def parse_all(
-        cls, option_groups: Optional[List[Union[dict, "OptionGroup"]]]
+        cls, option_groups: Optional[Sequence[Union[dict, "OptionGroup"]]]
     ) -> Optional[List["OptionGroup"]]:
         if option_groups is None:
             return None

--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -3,7 +3,7 @@ import logging
 import re
 import warnings
 from abc import ABCMeta
-from typing import List, Optional, Set, Union
+from typing import List, Optional, Set, Union, Sequence
 
 from slack_sdk.models import show_unknown_key_warning
 from slack_sdk.models.basic_objects import (
@@ -124,7 +124,7 @@ class BlockElement(JsonObject, metaclass=ABCMeta):
 
     @classmethod
     def parse_all(
-        cls, block_elements: List[Union[dict, "BlockElement"]]
+        cls, block_elements: Sequence[Union[dict, "BlockElement"]]
     ) -> List["BlockElement"]:
         return [cls.parse(e) for e in block_elements or []]
 
@@ -314,8 +314,8 @@ class CheckboxesElement(InputInteractiveElement):
         *,
         action_id: Optional[str] = None,
         placeholder: Optional[str] = None,
-        options: Optional[List[Union[dict, Option]]] = None,
-        initial_options: Optional[List[Union[dict, Option]]] = None,
+        options: Optional[Sequence[Union[dict, Option]]] = None,
+        initial_options: Optional[Sequence[Union[dict, Option]]] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         **others: dict,
     ):
@@ -439,8 +439,8 @@ class StaticSelectElement(InputInteractiveElement):
         *,
         placeholder: Optional[Union[str, dict, TextObject]] = None,
         action_id: Optional[str] = None,
-        options: Optional[List[Union[dict, Option]]] = None,
-        option_groups: Optional[List[Union[dict, OptionGroup]]] = None,
+        options: Optional[Sequence[Union[dict, Option]]] = None,
+        option_groups: Optional[Sequence[Union[dict, OptionGroup]]] = None,
         initial_option: Optional[Union[dict, Option]] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         **others: dict,
@@ -498,9 +498,9 @@ class StaticMultiSelectElement(InputInteractiveElement):
         *,
         placeholder: Optional[Union[str, dict, TextObject]] = None,
         action_id: Optional[str] = None,
-        options: Optional[List[Option]] = None,
-        option_groups: Optional[List[OptionGroup]] = None,
-        initial_options: Optional[List[Option]] = None,
+        options: Optional[Sequence[Option]] = None,
+        option_groups: Optional[Sequence[OptionGroup]] = None,
+        initial_options: Optional[Sequence[Option]] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         max_selected_items: Optional[int] = None,
         **others: dict,
@@ -559,8 +559,8 @@ class SelectElement(InputInteractiveElement):
         *,
         action_id: Optional[str] = None,
         placeholder: Optional[str] = None,
-        options: Optional[List[Option]] = None,
-        option_groups: Optional[List[OptionGroup]] = None,
+        options: Optional[Sequence[Option]] = None,
+        option_groups: Optional[Sequence[OptionGroup]] = None,
         initial_option: Optional[Option] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         **others: dict,
@@ -656,7 +656,7 @@ class ExternalDataMultiSelectElement(InputInteractiveElement):
         placeholder: Optional[Union[str, dict, TextObject]] = None,
         action_id: Optional[str] = None,
         min_query_length: Optional[int] = None,
-        initial_options: Optional[List[Union[dict, Option]]] = None,
+        initial_options: Optional[Sequence[Union[dict, Option]]] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         max_selected_items: Optional[int] = None,
         **others: dict,
@@ -728,7 +728,7 @@ class UserMultiSelectElement(InputInteractiveElement):
         *,
         action_id: Optional[str] = None,
         placeholder: Optional[Union[str, dict, TextObject]] = None,
-        initial_users: Optional[List[str]] = None,
+        initial_users: Optional[Sequence[str]] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         max_selected_items: Optional[int] = None,
         **others: dict,
@@ -762,7 +762,7 @@ class ConversationFilter(JsonObject):
     def __init__(
         self,
         *,
-        include: Optional[List[str]] = None,
+        include: Optional[Sequence[str]] = None,
         exclude_bot_users: Optional[bool] = None,
     ):
         self.include = include
@@ -848,7 +848,7 @@ class ConversationMultiSelectElement(InputInteractiveElement):
         *,
         placeholder: Optional[Union[str, dict, TextObject]] = None,
         action_id: Optional[str] = None,
-        initial_conversations: Optional[List[str]] = None,
+        initial_conversations: Optional[Sequence[str]] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         max_selected_items: Optional[int] = None,
         default_to_current_conversation: Optional[bool] = None,
@@ -925,7 +925,7 @@ class ChannelMultiSelectElement(InputInteractiveElement):
         *,
         placeholder: Optional[Union[str, dict, TextObject]] = None,
         action_id: Optional[str] = None,
-        initial_channels: Optional[List[str]] = None,
+        initial_channels: Optional[Sequence[str]] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         max_selected_items: Optional[int] = None,
         **others: dict,
@@ -1017,7 +1017,7 @@ class RadioButtonsElement(InputInteractiveElement):
         *,
         action_id: Optional[str] = None,
         placeholder: Optional[Union[str, dict, TextObject]] = None,
-        options: Optional[List[Union[dict, Option]]] = None,
+        options: Optional[Sequence[Union[dict, Option]]] = None,
         initial_option: Optional[Union[dict, Option]] = None,
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         **others: dict,
@@ -1055,7 +1055,7 @@ class OverflowMenuElement(InteractiveElement):
         self,
         *,
         action_id: Optional[str] = None,
-        options: List[Union[Option]],
+        options: Sequence[Union[Option]],
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         **others: dict,
     ):

--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import warnings
-from typing import Dict, List, Optional, Set, Union, Any
+from typing import Dict, Sequence, Optional, Set, Union, Any, List
 
 from slack_sdk.models import show_unknown_key_warning
 from slack_sdk.models.basic_objects import (
@@ -93,7 +93,9 @@ class Block(JsonObject):
                 return None
 
     @classmethod
-    def parse_all(cls, blocks: Optional[List[Union[dict, "Block"]]]) -> List["Block"]:
+    def parse_all(
+        cls, blocks: Optional[Sequence[Union[dict, "Block"]]]
+    ) -> List["Block"]:
         return [cls.parse(b) for b in blocks or []]
 
 
@@ -116,7 +118,7 @@ class SectionBlock(Block):
         *,
         block_id: Optional[str] = None,
         text: Union[str, dict, TextObject] = None,
-        fields: List[Union[str, dict, TextObject]] = None,
+        fields: Sequence[Union[str, dict, TextObject]] = None,
         accessory: Optional[Union[dict, BlockElement]] = None,
         **others: dict,
     ):
@@ -231,7 +233,7 @@ class ActionsBlock(Block):
     def __init__(
         self,
         *,
-        elements: List[Union[dict, InteractiveElement]],
+        elements: Sequence[Union[dict, InteractiveElement]],
         block_id: Optional[str] = None,
         **others: dict,
     ):
@@ -259,7 +261,7 @@ class ContextBlock(Block):
     def __init__(
         self,
         *,
-        elements: List[Union[dict, ImageBlock, TextObject]],
+        elements: Sequence[Union[dict, ImageBlock, TextObject]],
         block_id: Optional[str] = None,
         **others: dict,
     ):

--- a/slack_sdk/models/dialoags/__init__.py
+++ b/slack_sdk/models/dialoags/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from json import dumps
-from typing import List, Optional, Union, Set
+from typing import List, Optional, Union, Set, Sequence
 
 from slack_sdk.models import extract_json
 from slack_sdk.models.attachments import AbstractActionSelector
@@ -221,7 +221,7 @@ class DialogStaticSelector(AbstractDialogSelector):
         *,
         name: str,
         label: str,
-        options: Union[List[Option], List[OptionGroup]],
+        options: Union[Sequence[Option], Sequence[OptionGroup]],
         optional: bool = False,
         value: Union[Option, str] = None,
         placeholder: str = None,
@@ -627,7 +627,7 @@ class DialogBuilder(JsonObject):
         *,
         name: str,
         label: str,
-        options: Union[List[Option], List[OptionGroup]],
+        options: Union[Sequence[Option], Sequence[OptionGroup]],
         optional: bool = False,
         value: Optional[str] = None,
         placeholder: Optional[str] = None,
@@ -883,7 +883,7 @@ class ActionStaticSelector(AbstractActionSelector):
         *,
         name: str,
         text: str,
-        options: List[Union[Option, OptionGroup]],
+        options: Sequence[Union[Option, OptionGroup]],
         selected_option: Optional[Option] = None,
     ):
         """

--- a/slack_sdk/models/messages/message.py
+++ b/slack_sdk/models/messages/message.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Optional, Sequence
 
 from slack_sdk.models import extract_json
 from slack_sdk.models.attachments import Attachment
@@ -21,8 +21,8 @@ class Message(JsonObject):
         self,
         *,
         text: str,
-        attachments: Optional[List[Attachment]] = None,
-        blocks: Optional[List[Block]] = None,
+        attachments: Optional[Sequence[Attachment]] = None,
+        blocks: Optional[Sequence[Block]] = None,
         markdown: bool = True,
     ):
         """

--- a/slack_sdk/models/views/__init__.py
+++ b/slack_sdk/models/views/__init__.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from typing import List, Optional, Union, Dict
+from typing import Optional, Union, Dict, Sequence
 
 from slack_sdk.models.basic_objects import JsonObject, JsonValidator
 from slack_sdk.models.blocks import Block, TextObject, PlainTextObject, Option
@@ -50,7 +50,7 @@ class View(JsonObject):
         title: Union[str, dict, PlainTextObject] = None,
         submit: Optional[Union[str, dict, PlainTextObject]] = None,
         close: Optional[Union[str, dict, PlainTextObject]] = None,
-        blocks: Optional[List[Union[dict, Block]]] = None,
+        blocks: Optional[Sequence[Union[dict, Block]]] = None,
         private_metadata: Optional[str] = None,
         state: Optional[Union[dict, "ViewState"]] = None,
         hash: Optional[str] = None,  # skipcq: PYL-W0622
@@ -214,10 +214,10 @@ class ViewStateValue(JsonObject):
         selected_channel: Optional[str] = None,
         selected_user: Optional[str] = None,
         selected_option: Optional[str] = None,
-        selected_conversations: Optional[List[str]] = None,
-        selected_channels: Optional[List[str]] = None,
-        selected_users: Optional[List[str]] = None,
-        selected_options: Optional[List[Union[dict, Option]]] = None,
+        selected_conversations: Optional[Sequence[str]] = None,
+        selected_channels: Optional[Sequence[str]] = None,
+        selected_users: Optional[Sequence[str]] = None,
+        selected_options: Optional[Sequence[Union[dict, Option]]] = None,
     ):
         self.type = type
         self.value = value

--- a/slack_sdk/oauth/authorize_url_generator/__init__.py
+++ b/slack_sdk/oauth/authorize_url_generator/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, Sequence
 
 
 class AuthorizeUrlGenerator:
@@ -7,8 +7,8 @@ class AuthorizeUrlGenerator:
         *,
         client_id: str,
         redirect_uri: Optional[str] = None,
-        scopes: Optional[List[str]] = None,
-        user_scopes: Optional[List[str]] = None,
+        scopes: Optional[Sequence[str]] = None,
+        user_scopes: Optional[Sequence[str]] = None,
         authorization_url: str = "https://slack.com/oauth/v2/authorize",
     ):
         self.client_id = client_id

--- a/slack_sdk/oauth/installation_store/models/bot.py
+++ b/slack_sdk/oauth/installation_store/models/bot.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Union, List, Dict, Any
+from typing import Optional, Union, Dict, Any, Sequence
 
 
 class Bot:
@@ -9,7 +9,7 @@ class Bot:
     bot_token: str
     bot_id: str
     bot_user_id: str
-    bot_scopes: List[str]
+    bot_scopes: Sequence[str]
     installed_at: float
 
     def __init__(
@@ -23,7 +23,7 @@ class Bot:
         bot_token: str,
         bot_id: str,
         bot_user_id: str,
-        bot_scopes: Union[str, List[str]] = "",
+        bot_scopes: Union[str, Sequence[str]] = "",
         # timestamps
         installed_at: float,
     ):

--- a/slack_sdk/oauth/installation_store/models/installation.py
+++ b/slack_sdk/oauth/installation_store/models/installation.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from time import time
-from typing import Optional, List, Union, Dict, Any
+from typing import Optional, Union, Dict, Any, Sequence
 
 from slack_sdk.oauth.installation_store.models.bot import Bot
 
@@ -12,10 +12,10 @@ class Installation:
     bot_token: str
     bot_id: str
     bot_user_id: str
-    bot_scopes: List[str]
+    bot_scopes: Sequence[str]
     user_id: Optional[str]
     user_token: Optional[str]
-    user_scopes: Optional[List[str]]
+    user_scopes: Optional[Sequence[str]]
     incoming_webhook_url: Optional[str]
     incoming_webhook_channel_id: Optional[str]
     incoming_webhook_configuration_url: Optional[str]
@@ -32,11 +32,11 @@ class Installation:
         bot_token: str,
         bot_id: str,
         bot_user_id: str,
-        bot_scopes: Union[str, List[str]] = "",
+        bot_scopes: Union[str, Sequence[str]] = "",
         # installer
         user_id: Optional[str] = None,
         user_token: Optional[str] = None,
-        user_scopes: Union[str, List[str]] = "",
+        user_scopes: Union[str, Sequence[str]] = "",
         # incoming webhook
         incoming_webhook_url: Optional[str] = None,
         incoming_webhook_channel_id: Optional[str] = None,

--- a/slack_sdk/oauth/state_utils/__init__.py
+++ b/slack_sdk/oauth/state_utils/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, List, Union
+from typing import Optional, Dict, Sequence, Union
 
 
 class OAuthStateUtils:
@@ -36,7 +36,9 @@ class OAuthStateUtils:
         )
 
     def is_valid_browser(
-        self, state: Optional[str], request_headers: Dict[str, Union[str, List[str]]]
+        self,
+        state: Optional[str],
+        request_headers: Dict[str, Union[str, Sequence[str]]],
     ) -> bool:
         if (
             state is None

--- a/slack_sdk/rtm/__init__.py
+++ b/slack_sdk/rtm/__init__.py
@@ -10,7 +10,7 @@ import signal
 from asyncio import Future
 from ssl import SSLContext
 from threading import current_thread, main_thread
-from typing import List, Any, Union
+from typing import Any, Union, Sequence
 from typing import Optional, Callable, DefaultDict
 
 import aiohttp
@@ -575,7 +575,7 @@ class RTMClient(object):  # skipcq: PYL-R0205
             self._logger.debug("Waiting %s seconds before reconnecting.", wait_time)
             await asyncio.sleep(float(wait_time))
 
-    def _close_websocket(self) -> List[Future]:
+    def _close_websocket(self) -> Sequence[Future]:
         """Closes the websocket connection."""
         futures = []
         close_method = getattr(self._websocket, "close", None)

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -10,7 +10,7 @@
 """A Python module for interacting with Slack's Web API."""
 import os
 from io import IOBase
-from typing import Union, List, Optional, Dict
+from typing import Union, Sequence, Optional, Dict
 
 import slack_sdk.errors as e
 from slack_sdk.models.views import View
@@ -149,7 +149,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("admin.conversations.delete", json=kwargs)
 
     async def admin_conversations_invite(
-        self, *, channel_id: str, user_ids: Union[str, List[str]], **kwargs
+        self, *, channel_id: str, user_ids: Union[str, Sequence[str]], **kwargs
     ) -> AsyncSlackResponse:
         """Invite a user to a public or private channel.
 
@@ -486,7 +486,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("admin.teams.settings.info", json=kwargs)
 
     async def admin_teams_settings_setDefaultChannels(
-        self, *, team_id: str, channel_ids: Union[str, List[str]], **kwargs
+        self, *, team_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
     ) -> AsyncSlackResponse:
         """Set the default channels of a workspace.
 
@@ -562,7 +562,7 @@ class AsyncWebClient(AsyncBaseClient):
         *,
         team_id: str,
         usergroup_id: str,
-        channel_ids: Union[str, List[str]],
+        channel_ids: Union[str, Sequence[str]],
         **kwargs
     ) -> AsyncSlackResponse:
         """Add one or more default channels to an IDP group.
@@ -580,7 +580,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("admin.usergroups.addChannels", json=kwargs)
 
     async def admin_usergroups_addTeams(
-        self, *, usergroup_id: str, team_ids: Union[str, List[str]], **kwargs
+        self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
     ) -> AsyncSlackResponse:
         """Associate one or more default workspaces with an organization-wide IDP group.
 
@@ -609,7 +609,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("admin.usergroups.listChannels", json=kwargs)
 
     async def admin_usergroups_removeChannels(
-        self, *, usergroup_id: str, channel_ids: Union[str, List[str]], **kwargs
+        self, *, usergroup_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
     ) -> AsyncSlackResponse:
         """Add one or more default channels to an IDP group.
 
@@ -637,7 +637,12 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("admin.users.assign", json=kwargs)
 
     async def admin_users_invite(
-        self, *, team_id: str, email: str, channel_ids: Union[str, List[str]], **kwargs
+        self,
+        *,
+        team_id: str,
+        email: str,
+        channel_ids: Union[str, Sequence[str]],
+        **kwargs
     ) -> AsyncSlackResponse:
         """Invite a user to a workspace.
 
@@ -808,7 +813,7 @@ class AsyncWebClient(AsyncBaseClient):
         self,
         *,
         id: str,  # skipcq: PYL-W0622
-        users: Union[str, List[Dict[str, str]]],
+        users: Union[str, Sequence[Dict[str, str]]],
         **kwargs
     ) -> AsyncSlackResponse:
         """Registers new participants added to a Call.
@@ -827,7 +832,7 @@ class AsyncWebClient(AsyncBaseClient):
         self,
         *,
         id: str,  # skipcq: PYL-W0622
-        users: Union[str, List[Dict[str, str]]],
+        users: Union[str, Sequence[Dict[str, str]]],
         **kwargs
     ) -> AsyncSlackResponse:
         """Registers participants removed from a Call.
@@ -1192,7 +1197,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("conversations.info", http_verb="GET", params=kwargs)
 
     async def conversations_invite(
-        self, *, channel: str, users: Union[str, List[str]], **kwargs
+        self, *, channel: str, users: Union[str, Sequence[str]], **kwargs
     ) -> AsyncSlackResponse:
         """Invites users to a channel.
 
@@ -1386,7 +1391,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("dnd.setSnooze", http_verb="GET", params=kwargs)
 
     async def dnd_teamInfo(
-        self, users: Union[str, List[str]], **kwargs
+        self, users: Union[str, Sequence[str]], **kwargs
     ) -> AsyncSlackResponse:
         """Retrieves the Do Not Disturb status for users on a team.
 
@@ -1484,7 +1489,7 @@ class AsyncWebClient(AsyncBaseClient):
         )
 
     async def files_remote_share(
-        self, *, channels: Union[str, List[str]], **kwargs
+        self, *, channels: Union[str, Sequence[str]], **kwargs
     ) -> AsyncSlackResponse:
         """Share a remote file into a channel.
 
@@ -1763,7 +1768,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("im.replies", http_verb="GET", params=kwargs)
 
     async def migration_exchange(
-        self, *, users: Union[str, List[str]], **kwargs
+        self, *, users: Union[str, Sequence[str]], **kwargs
     ) -> AsyncSlackResponse:
         """For Enterprise Grid workspaces, map local user IDs to global user IDs
 
@@ -1812,7 +1817,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("mpim.mark", json=kwargs)
 
     async def mpim_open(
-        self, *, users: Union[str, List[str]], **kwargs
+        self, *, users: Union[str, Sequence[str]], **kwargs
     ) -> AsyncSlackResponse:
         """This method opens a multiparty direct message.
 
@@ -2160,7 +2165,7 @@ class AsyncWebClient(AsyncBaseClient):
         )
 
     async def usergroups_users_update(
-        self, *, usergroup: str, users: Union[str, List[str]], **kwargs
+        self, *, usergroup: str, users: Union[str, Sequence[str]], **kwargs
     ) -> AsyncSlackResponse:
         """Update the list of users for a User Group
 

--- a/slack_sdk/web/async_internal_utils.py
+++ b/slack_sdk/web/async_internal_utils.py
@@ -3,7 +3,7 @@ import json
 import logging
 from asyncio import AbstractEventLoop
 from logging import Logger
-from typing import Optional, BinaryIO, List, Dict
+from typing import Optional, BinaryIO, Dict, Sequence
 
 import aiohttp
 from aiohttp import ClientSession
@@ -21,7 +21,7 @@ def _get_event_loop() -> AbstractEventLoop:
         return loop
 
 
-def _files_to_data(req_args: dict) -> List[BinaryIO]:
+def _files_to_data(req_args: dict) -> Sequence[BinaryIO]:
     open_files = []
     files = req_args.pop("files", None)
     if files is not None:

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1,7 +1,7 @@
 """A Python module for interacting with Slack's Web API."""
 import os
 from io import IOBase
-from typing import Union, List, Optional, Dict
+from typing import Union, Sequence, Optional, Dict
 
 import slack_sdk.errors as e
 from slack_sdk.models.views import View
@@ -134,7 +134,7 @@ class WebClient(BaseClient):
         return self.api_call("admin.conversations.delete", json=kwargs)
 
     def admin_conversations_invite(
-        self, *, channel_id: str, user_ids: Union[str, List[str]], **kwargs
+        self, *, channel_id: str, user_ids: Union[str, Sequence[str]], **kwargs
     ) -> SlackResponse:
         """Invite a user to a public or private channel.
 
@@ -453,7 +453,7 @@ class WebClient(BaseClient):
         return self.api_call("admin.teams.settings.info", json=kwargs)
 
     def admin_teams_settings_setDefaultChannels(
-        self, *, team_id: str, channel_ids: Union[str, List[str]], **kwargs
+        self, *, team_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
     ) -> SlackResponse:
         """Set the default channels of a workspace.
 
@@ -527,7 +527,7 @@ class WebClient(BaseClient):
         *,
         team_id: str,
         usergroup_id: str,
-        channel_ids: Union[str, List[str]],
+        channel_ids: Union[str, Sequence[str]],
         **kwargs
     ) -> SlackResponse:
         """Add one or more default channels to an IDP group.
@@ -545,7 +545,7 @@ class WebClient(BaseClient):
         return self.api_call("admin.usergroups.addChannels", json=kwargs)
 
     def admin_usergroups_addTeams(
-        self, *, usergroup_id: str, team_ids: Union[str, List[str]], **kwargs
+        self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
     ) -> SlackResponse:
         """Associate one or more default workspaces with an organization-wide IDP group.
 
@@ -574,7 +574,7 @@ class WebClient(BaseClient):
         return self.api_call("admin.usergroups.listChannels", json=kwargs)
 
     def admin_usergroups_removeChannels(
-        self, *, usergroup_id: str, channel_ids: Union[str, List[str]], **kwargs
+        self, *, usergroup_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
     ) -> SlackResponse:
         """Add one or more default channels to an IDP group.
 
@@ -602,7 +602,12 @@ class WebClient(BaseClient):
         return self.api_call("admin.users.assign", json=kwargs)
 
     def admin_users_invite(
-        self, *, team_id: str, email: str, channel_ids: Union[str, List[str]], **kwargs
+        self,
+        *,
+        team_id: str,
+        email: str,
+        channel_ids: Union[str, Sequence[str]],
+        **kwargs
     ) -> SlackResponse:
         """Invite a user to a workspace.
 
@@ -769,7 +774,7 @@ class WebClient(BaseClient):
         self,
         *,
         id: str,  # skipcq: PYL-W0622
-        users: Union[str, List[Dict[str, str]]],
+        users: Union[str, Sequence[Dict[str, str]]],
         **kwargs
     ) -> SlackResponse:
         """Registers new participants added to a Call.
@@ -786,7 +791,7 @@ class WebClient(BaseClient):
         self,
         *,
         id: str,  # skipcq: PYL-W0622
-        users: Union[str, List[Dict[str, str]]],
+        users: Union[str, Sequence[Dict[str, str]]],
         **kwargs
     ) -> SlackResponse:
         """Registers participants removed from a Call.
@@ -1123,7 +1128,7 @@ class WebClient(BaseClient):
         return self.api_call("conversations.info", http_verb="GET", params=kwargs)
 
     def conversations_invite(
-        self, *, channel: str, users: Union[str, List[str]], **kwargs
+        self, *, channel: str, users: Union[str, Sequence[str]], **kwargs
     ) -> SlackResponse:
         """Invites users to a channel.
 
@@ -1300,7 +1305,7 @@ class WebClient(BaseClient):
         kwargs.update({"num_minutes": num_minutes})
         return self.api_call("dnd.setSnooze", http_verb="GET", params=kwargs)
 
-    def dnd_teamInfo(self, users: Union[str, List[str]], **kwargs) -> SlackResponse:
+    def dnd_teamInfo(self, users: Union[str, Sequence[str]], **kwargs) -> SlackResponse:
         """Retrieves the Do Not Disturb status for users on a team.
 
         Args:
@@ -1393,7 +1398,7 @@ class WebClient(BaseClient):
         return self.api_call("files.remote.remove", http_verb="GET", params=kwargs)
 
     def files_remote_share(
-        self, *, channels: Union[str, List[str]], **kwargs
+        self, *, channels: Union[str, Sequence[str]], **kwargs
     ) -> SlackResponse:
         """Share a remote file into a channel.
 
@@ -1658,7 +1663,7 @@ class WebClient(BaseClient):
         return self.api_call("im.replies", http_verb="GET", params=kwargs)
 
     def migration_exchange(
-        self, *, users: Union[str, List[str]], **kwargs
+        self, *, users: Union[str, Sequence[str]], **kwargs
     ) -> SlackResponse:
         """For Enterprise Grid workspaces, map local user IDs to global user IDs
 
@@ -1706,7 +1711,7 @@ class WebClient(BaseClient):
         kwargs.update({"channel": channel, "ts": ts})
         return self.api_call("mpim.mark", json=kwargs)
 
-    def mpim_open(self, *, users: Union[str, List[str]], **kwargs) -> SlackResponse:
+    def mpim_open(self, *, users: Union[str, Sequence[str]], **kwargs) -> SlackResponse:
         """This method opens a multiparty direct message.
 
         Args:
@@ -2035,7 +2040,7 @@ class WebClient(BaseClient):
         return self.api_call("usergroups.users.list", http_verb="GET", params=kwargs)
 
     def usergroups_users_update(
-        self, *, usergroup: str, users: Union[str, List[str]], **kwargs
+        self, *, usergroup: str, users: Union[str, Sequence[str]], **kwargs
     ) -> SlackResponse:
         """Update the list of users for a User Group
 

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -2,8 +2,7 @@ import json
 import platform
 import sys
 from ssl import SSLContext
-from typing import Dict, Optional, Any
-from typing import Union, List
+from typing import Dict, Union, Optional, Any, Sequence
 from urllib.parse import urljoin
 
 from slack_sdk import version
@@ -180,7 +179,9 @@ def _parse_web_class_objects(kwargs) -> None:
         kwargs.update({"attachments": dict_attachments})
 
 
-def _update_call_participants(kwargs, users: Union[str, List[Dict[str, str]]]) -> None:
+def _update_call_participants(
+    kwargs, users: Union[str, Sequence[Dict[str, str]]]
+) -> None:
     if users is None:
         return
 
@@ -189,7 +190,7 @@ def _update_call_participants(kwargs, users: Union[str, List[Dict[str, str]]]) -
     elif isinstance(users, str):
         kwargs.update({"users": users})
     else:
-        raise SlackRequestError("users must be either str or List[Dict[str, str]]")
+        raise SlackRequestError("users must be either str or Sequence[Dict[str, str]]")
 
 
 def _next_cursor_is_present(data) -> bool:

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -12,7 +12,7 @@ from asyncio import Future
 """A Python module for interacting with Slack's Web API."""
 import os
 from io import IOBase
-from typing import Union, List, Optional, Dict
+from typing import Union, Sequence, Optional, Dict
 
 import slack_sdk.errors as e
 from slack_sdk.models.views import View
@@ -147,7 +147,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("admin.conversations.delete", json=kwargs)
 
     def admin_conversations_invite(
-        self, *, channel_id: str, user_ids: Union[str, List[str]], **kwargs
+        self, *, channel_id: str, user_ids: Union[str, Sequence[str]], **kwargs
     ) -> Union[Future, SlackResponse]:
         """Invite a user to a public or private channel.
 
@@ -478,7 +478,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("admin.teams.settings.info", json=kwargs)
 
     def admin_teams_settings_setDefaultChannels(
-        self, *, team_id: str, channel_ids: Union[str, List[str]], **kwargs
+        self, *, team_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
     ) -> Union[Future, SlackResponse]:
         """Set the default channels of a workspace.
 
@@ -552,7 +552,7 @@ class LegacyWebClient(LegacyBaseClient):
         *,
         team_id: str,
         usergroup_id: str,
-        channel_ids: Union[str, List[str]],
+        channel_ids: Union[str, Sequence[str]],
         **kwargs
     ) -> Union[Future, SlackResponse]:
         """Add one or more default channels to an IDP group.
@@ -570,7 +570,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("admin.usergroups.addChannels", json=kwargs)
 
     def admin_usergroups_addTeams(
-        self, *, usergroup_id: str, team_ids: Union[str, List[str]], **kwargs
+        self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
     ) -> Union[Future, SlackResponse]:
         """Associate one or more default workspaces with an organization-wide IDP group.
 
@@ -599,7 +599,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("admin.usergroups.listChannels", json=kwargs)
 
     def admin_usergroups_removeChannels(
-        self, *, usergroup_id: str, channel_ids: Union[str, List[str]], **kwargs
+        self, *, usergroup_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
     ) -> Union[Future, SlackResponse]:
         """Add one or more default channels to an IDP group.
 
@@ -627,7 +627,12 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("admin.users.assign", json=kwargs)
 
     def admin_users_invite(
-        self, *, team_id: str, email: str, channel_ids: Union[str, List[str]], **kwargs
+        self,
+        *,
+        team_id: str,
+        email: str,
+        channel_ids: Union[str, Sequence[str]],
+        **kwargs
     ) -> Union[Future, SlackResponse]:
         """Invite a user to a workspace.
 
@@ -800,7 +805,7 @@ class LegacyWebClient(LegacyBaseClient):
         self,
         *,
         id: str,  # skipcq: PYL-W0622
-        users: Union[str, List[Dict[str, str]]],
+        users: Union[str, Sequence[Dict[str, str]]],
         **kwargs
     ) -> Union[Future, SlackResponse]:
         """Registers new participants added to a Call.
@@ -817,7 +822,7 @@ class LegacyWebClient(LegacyBaseClient):
         self,
         *,
         id: str,  # skipcq: PYL-W0622
-        users: Union[str, List[Dict[str, str]]],
+        users: Union[str, Sequence[Dict[str, str]]],
         **kwargs
     ) -> Union[Future, SlackResponse]:
         """Registers participants removed from a Call.
@@ -1192,7 +1197,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("conversations.info", http_verb="GET", params=kwargs)
 
     def conversations_invite(
-        self, *, channel: str, users: Union[str, List[str]], **kwargs
+        self, *, channel: str, users: Union[str, Sequence[str]], **kwargs
     ) -> Union[Future, SlackResponse]:
         """Invites users to a channel.
 
@@ -1386,7 +1391,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("dnd.setSnooze", http_verb="GET", params=kwargs)
 
     def dnd_teamInfo(
-        self, users: Union[str, List[str]], **kwargs
+        self, users: Union[str, Sequence[str]], **kwargs
     ) -> Union[Future, SlackResponse]:
         """Retrieves the Do Not Disturb status for users on a team.
 
@@ -1480,7 +1485,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("files.remote.remove", http_verb="GET", params=kwargs)
 
     def files_remote_share(
-        self, *, channels: Union[str, List[str]], **kwargs
+        self, *, channels: Union[str, Sequence[str]], **kwargs
     ) -> Union[Future, SlackResponse]:
         """Share a remote file into a channel.
 
@@ -1767,7 +1772,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("im.replies", http_verb="GET", params=kwargs)
 
     def migration_exchange(
-        self, *, users: Union[str, List[str]], **kwargs
+        self, *, users: Union[str, Sequence[str]], **kwargs
     ) -> Union[Future, SlackResponse]:
         """For Enterprise Grid workspaces, map local user IDs to global user IDs
 
@@ -1818,7 +1823,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("mpim.mark", json=kwargs)
 
     def mpim_open(
-        self, *, users: Union[str, List[str]], **kwargs
+        self, *, users: Union[str, Sequence[str]], **kwargs
     ) -> Union[Future, SlackResponse]:
         """This method opens a multiparty direct message.
 
@@ -2166,7 +2171,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("usergroups.users.list", http_verb="GET", params=kwargs)
 
     def usergroups_users_update(
-        self, *, usergroup: str, users: Union[str, List[str]], **kwargs
+        self, *, usergroup: str, users: Union[str, Sequence[str]], **kwargs
     ) -> Union[Future, SlackResponse]:
         """Update the list of users for a User Group
 

--- a/slack_sdk/webhook/async_client.py
+++ b/slack_sdk/webhook/async_client.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from ssl import SSLContext
-from typing import Dict, Union, List, Optional, Any
+from typing import Dict, Union, Optional, Any, Sequence
 
 import aiohttp
 from aiohttp import BasicAuth, ClientSession
@@ -62,8 +62,8 @@ class AsyncWebhookClient:
         self,
         *,
         text: Optional[str] = None,
-        attachments: Optional[List[Union[Dict[str, Any], Attachment]]] = None,
-        blocks: Optional[List[Union[Dict[str, Any], Block]]] = None,
+        attachments: Optional[Sequence[Union[Dict[str, Any], Attachment]]] = None,
+        blocks: Optional[Sequence[Union[Dict[str, Any], Block]]] = None,
         response_type: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> WebhookResponse:

--- a/slack_sdk/webhook/client.py
+++ b/slack_sdk/webhook/client.py
@@ -3,7 +3,7 @@ import logging
 import urllib
 from http.client import HTTPResponse
 from ssl import SSLContext
-from typing import Dict, Union, List, Optional
+from typing import Dict, Union, Sequence, Optional
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen, OpenerDirector, ProxyHandler, HTTPSHandler
 
@@ -54,8 +54,8 @@ class WebhookClient:
         self,
         *,
         text: Optional[str] = None,
-        attachments: Optional[List[Union[Dict[str, any], Attachment]]] = None,
-        blocks: Optional[List[Union[Dict[str, any], Block]]] = None,
+        attachments: Optional[Sequence[Union[Dict[str, any], Attachment]]] = None,
+        blocks: Optional[Sequence[Union[Dict[str, any], Block]]] = None,
         response_type: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> WebhookResponse:

--- a/tests/slack_sdk_async/web/test_web_client_coverage.py
+++ b/tests/slack_sdk_async/web/test_web_client_coverage.py
@@ -251,16 +251,22 @@ class TestWebClientCoverage(unittest.TestCase):
                     )
                     await async_method(team_id="T123", user_id="W123")
                 elif method_name == "admin_users_session_invalidate":
-                    self.api_methods_to_call.remove(method(session_id="XXX", team_id="T111")["method"])
+                    self.api_methods_to_call.remove(
+                        method(session_id="XXX", team_id="T111")["method"]
+                    )
                     await async_method(session_id="XXX", team_id="T111")
                 elif method_name == "admin_users_session_reset":
                     self.api_methods_to_call.remove(method(user_id="W123")["method"])
                     await async_method(user_id="W123")
                 elif method_name == "apps_event_authorizations_list":
-                    self.api_methods_to_call.remove(method(event_context="xxx")["method"])
+                    self.api_methods_to_call.remove(
+                        method(event_context="xxx")["method"]
+                    )
                     await async_method(event_context="xxx")
                 elif method_name == "apps_uninstall":
-                    self.api_methods_to_call.remove(method(client_id="111.222", client_secret="xxx")["method"])
+                    self.api_methods_to_call.remove(
+                        method(client_id="111.222", client_secret="xxx")["method"]
+                    )
                     await async_method(client_id="111.222", client_secret="xxx")
                 elif method_name == "calls_add":
                     self.api_methods_to_call.remove(


### PR DESCRIPTION
## Summary

As reported at #868, some argument type hints are `List` and mypy points out that can be a potential issue. As this warning is reasonable enough, we are going to prefer `Sequence` type hint over `List` in arguments.

http://mypy.readthedocs.io/en/latest/common_issues.html#variance

This pull request fixes #868 for the classes under `slack_sdk` package.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.models** (UI component builders)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.rtm.RTMClient** (RTM client)
- [x] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
