### PR TITLE
Addition to #871: AsyncOAuthStateStore and built-in implementations

### DIFF
--- a/scripts/run_validation.sh
+++ b/scripts/run_validation.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# ./scripts/run_validation.sh
+
+script_dir=`dirname $0`
+cd ${script_dir}/..
+black slack_sdk/ slack/ tests/ && \
+  python setup.py codegen && \
+  python setup.py validate

--- a/setup.py
+++ b/setup.py
@@ -187,10 +187,10 @@ class ValidateCommand(BaseCommand):
             "Running black ...", [sys.executable, "-m", "black", f"{here}/slack_sdk"]
         )
         self._run(
-            "Running flake8 ...", [sys.executable, "-m", "flake8", f"{here}/slack"]
+            "Running flake8 for legacy packages ...", [sys.executable, "-m", "flake8", f"{here}/slack"]
         )
         self._run(
-            "Running flake8 ...", [sys.executable, "-m", "flake8", f"{here}/slack_sdk"]
+            "Running flake8 for slack_sdk package ...", [sys.executable, "-m", "flake8", f"{here}/slack_sdk"]
         )
 
         target = self.test_target.replace("tests/", "", 1)

--- a/slack_sdk/oauth/state_store/amazon_s3/__init__.py
+++ b/slack_sdk/oauth/state_store/amazon_s3/__init__.py
@@ -29,13 +29,13 @@ class AmazonS3OAuthStateStore(OAuthStateStore, AsyncOAuthStateStore):
             self._logger = logging.getLogger(__name__)
         return self._logger
 
-    async def async_issue(self) -> str:
-        return self.issue()
+    async def async_issue(self, *args, **kwargs) -> str:
+        return self.issue(*args, **kwargs)
 
     async def async_consume(self, state: str) -> bool:
         return self.consume(state)
 
-    def issue(self) -> str:
+    def issue(self, *args, **kwargs) -> str:
         state = str(uuid4())
         response = self.s3_client.put_object(
             Bucket=self.bucket_name, Body=str(time.time()), Key=state,

--- a/slack_sdk/oauth/state_store/async_state_store.py
+++ b/slack_sdk/oauth/state_store/async_state_store.py
@@ -6,7 +6,7 @@ class AsyncOAuthStateStore:
     def logger(self) -> Logger:
         raise NotImplementedError()
 
-    async def async_issue(self) -> str:
+    async def async_issue(self, *args, **kwargs) -> str:
         raise NotImplementedError()
 
     async def async_consume(self, state: str) -> bool:

--- a/slack_sdk/oauth/state_store/file/__init__.py
+++ b/slack_sdk/oauth/state_store/file/__init__.py
@@ -33,13 +33,13 @@ class FileOAuthStateStore(OAuthStateStore, AsyncOAuthStateStore):
             self._logger = logging.getLogger(__name__)
         return self._logger
 
-    async def async_issue(self) -> str:
-        return self.issue()
+    async def async_issue(self, *args, **kwargs) -> str:
+        return self.issue(*args, **kwargs)
 
     async def async_consume(self, state: str) -> bool:
         return self.consume(state)
 
-    def issue(self) -> str:
+    def issue(self, *args, **kwargs) -> str:
         state = str(uuid4())
         self._mkdir(self.base_dir)
         filepath = f"{self.base_dir}/{state}"

--- a/slack_sdk/oauth/state_store/sqlalchemy/__init__.py
+++ b/slack_sdk/oauth/state_store/sqlalchemy/__init__.py
@@ -48,7 +48,7 @@ class SQLAlchemyOAuthStateStore(OAuthStateStore):
             self._logger = logging.getLogger(__name__)
         return self._logger
 
-    def issue(self) -> str:
+    def issue(self, *args, **kwargs) -> str:
         state: str = str(uuid4())
         now = datetime.utcfromtimestamp(time.time() + self.expiration_seconds)
         with self.engine.begin() as conn:

--- a/slack_sdk/oauth/state_store/sqlite3/__init__.py
+++ b/slack_sdk/oauth/state_store/sqlite3/__init__.py
@@ -59,13 +59,13 @@ class SQLite3OAuthStateStore(OAuthStateStore, AsyncOAuthStateStore):
             self.logger.debug(f"Tables have been created (database: {self.database})")
             conn.commit()
 
-    async def async_issue(self) -> str:
-        return self.issue()
+    async def async_issue(self, *args, **kwargs) -> str:
+        return self.issue(*args, **kwargs)
 
     async def async_consume(self, state: str) -> bool:
         return self.consume(state)
 
-    def issue(self) -> str:
+    def issue(self, *args, **kwargs) -> str:
         state: str = str(uuid4())
         with self.connect() as conn:
             parameters = [

--- a/tests/slack_sdk/oauth/state_store/test_file.py
+++ b/tests/slack_sdk/oauth/state_store/test_file.py
@@ -21,3 +21,7 @@ class TestFile(unittest.TestCase):
         self.assertTrue(result)
         result = store.consume(state)
         self.assertFalse(result)
+
+    def test_kwargs(self):
+        store = FileOAuthStateStore(expiration_seconds=10)
+        store.issue(foo=123, bar="baz")


### PR DESCRIPTION
## Summary

This pull request appends additional changes to #871 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
