### PR TITLE
docs: Fix simple typo, niether -> neither

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1559,7 +1559,7 @@ class AsyncWebClient(AsyncBaseClient):
             content (str): Supply content when you'd like to create an
                 editable text file containing the specified text. e.g. 'launch plan'
         Raises:
-            SlackRequestError: If niether or both the `file` and `content` args are specified.
+            SlackRequestError: If neither or both the `file` and `content` args are specified.
         """
         if file is None and content is None:
             raise e.SlackRequestError("The file or content argument must be specified.")

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1466,7 +1466,7 @@ class WebClient(BaseClient):
             content (str): Supply content when you'd like to create an
                 editable text file containing the specified text. e.g. 'launch plan'
         Raises:
-            SlackRequestError: If niether or both the `file` and `content` args are specified.
+            SlackRequestError: If neither or both the `file` and `content` args are specified.
         """
         if file is None and content is None:
             raise e.SlackRequestError("The file or content argument must be specified.")

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1559,7 +1559,7 @@ class LegacyWebClient(LegacyBaseClient):
             content (str): Supply content when you'd like to create an
                 editable text file containing the specified text. e.g. 'launch plan'
         Raises:
-            SlackRequestError: If niether or both the `file` and `content` args are specified.
+            SlackRequestError: If neither or both the `file` and `content` args are specified.
         """
         if file is None and content is None:
             raise e.SlackRequestError("The file or content argument must be specified.")


### PR DESCRIPTION
## Summary

Fix simple typo, niether -> neither

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
