### PR TITLE
Add timepicker block element support

### DIFF
--- a/slack_sdk/models/blocks/__init__.py
+++ b/slack_sdk/models/blocks/__init__.py
@@ -23,6 +23,7 @@ from .block_elements import ConversationFilter  # noqa
 from .block_elements import ConversationMultiSelectElement  # noqa
 from .block_elements import ConversationSelectElement  # noqa
 from .block_elements import DatePickerElement  # noqa
+from .block_elements import TimePickerElement  # noqa
 from .block_elements import ExternalDataMultiSelectElement  # noqa
 from .block_elements import ExternalDataSelectElement  # noqa
 from .block_elements import ImageElement  # noqa

--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -378,6 +378,48 @@ class DatePickerElement(InputInteractiveElement):
 
 
 # -------------------------------------------------
+# TimePicker
+# -------------------------------------------------
+
+
+class TimePickerElement(InputInteractiveElement):
+    type = "timepicker"
+
+    @property
+    def attributes(self) -> Set[str]:
+        return super().attributes.union({"initial_time"})
+
+    def __init__(
+        self,
+        *,
+        action_id: Optional[str] = None,
+        placeholder: Optional[Union[str, dict, TextObject]] = None,
+        initial_time: Optional[str] = None,
+        confirm: Optional[Union[dict, ConfirmObject]] = None,
+        **others: dict,
+    ):
+        """
+        An element which allows selection of a time of day.
+        https://api.slack.com/reference/block-kit/block-elements#timepicker
+        """
+        super().__init__(
+            type=self.type,
+            action_id=action_id,
+            placeholder=TextObject.parse(placeholder, PlainTextObject.type),
+            confirm=ConfirmObject.parse(confirm),
+        )
+        show_unknown_key_warning(self, others)
+
+        self.initial_time = initial_time
+
+    @JsonValidator("initial_time attribute must be in format 'HH:mm'")
+    def _validate_initial_time_valid(self):
+        return self.initial_time is None or re.match(
+            r"([0-1][0-9]|2[0-3]):([0-5][0-9])", self.initial_time
+        )
+
+
+# -------------------------------------------------
 # Image
 # -------------------------------------------------
 

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -4,6 +4,7 @@ from slack_sdk.errors import SlackObjectFormationError
 from slack_sdk.models.blocks import (
     ButtonElement,
     DatePickerElement,
+    TimePickerElement,
     ExternalDataSelectElement,
     ImageElement,
     LinkButtonElement,
@@ -214,6 +215,51 @@ class DatePickerElementTests(unittest.TestCase):
         with self.assertRaises(SlackObjectFormationError):
             elem = DatePickerElement(action_id="1", placeholder="12345" * 100)
             elem.to_dict()
+
+
+# -------------------------------------------------
+# TimePicker
+# -------------------------------------------------
+
+
+class TimePickerElementTests(unittest.TestCase):
+    def test_document(self):
+        input = {
+            "type": "timepicker",
+            "action_id": "timepicker123",
+            "initial_time": "11:40",
+            "placeholder": {"type": "plain_text", "text": "Select a time",},
+        }
+        self.assertDictEqual(input, TimePickerElement(**input).to_dict())
+
+    def test_json(self):
+        for hour in range(0, 23):
+            for minute in range(0, 59):
+                time = f"{hour:02}:{minute:02}"
+                self.assertDictEqual(
+                    {
+                        "action_id": "timepicker123",
+                        "initial_time": time,
+                        "placeholder": {
+                            "emoji": True,
+                            "type": "plain_text",
+                            "text": "Select a time",
+                        },
+                        "type": "timepicker",
+                    },
+                    TimePickerElement(
+                        action_id="timepicker123",
+                        placeholder="Select a time",
+                        initial_time=time,
+                    ).to_dict(),
+                )
+
+        with self.assertRaises(SlackObjectFormationError):
+            TimePickerElement(
+                action_id="timepicker123",
+                placeholder="Select a time",
+                initial_time="25:00",
+            ).to_dict()
 
 
 # -------------------------------------------------


### PR DESCRIPTION
## Summary

This pull request adds `timepicker` block element support. As the element is still in beta, the specification can be changed until its GA release.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
