### PR TITLE
Add default team_id to WebClient constructor args

### DIFF
--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -34,6 +34,8 @@ class AsyncBaseClient:
         headers: Optional[dict] = None,
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
+        # for Org-Wide App installation
+        team_id: Optional[str] = None,
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url
@@ -47,6 +49,9 @@ class AsyncBaseClient:
         self.headers["User-Agent"] = get_user_agent(
             user_agent_prefix, user_agent_suffix
         )
+        self.default_params = {}
+        if team_id is not None:
+            self.default_params["team_id"] = team_id
         self._logger = logging.getLogger(__name__)
 
     async def api_call(  # skipcq: PYL-R1710
@@ -111,6 +116,7 @@ class AsyncBaseClient:
             http_verb=http_verb,
             files=files,
             data=data,
+            default_params=self.default_params,
             params=params,
             json=json,  # skipcq: PYL-W0621
             headers=headers,

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -44,6 +44,8 @@ class BaseClient:
         headers: Optional[dict] = None,
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
+        # for Org-Wide App installation
+        team_id: Optional[str] = None,
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url
@@ -54,6 +56,9 @@ class BaseClient:
         self.headers["User-Agent"] = get_user_agent(
             user_agent_prefix, user_agent_suffix
         )
+        self.default_params = {}
+        if team_id is not None:
+            self.default_params["team_id"] = team_id
         self._logger = logging.getLogger(__name__)
 
     def api_call(  # skipcq: PYL-R1710
@@ -109,6 +114,7 @@ class BaseClient:
             http_verb=http_verb,
             files=files,
             data=data,
+            default_params=self.default_params,
             params=params,
             json=json,  # skipcq: PYL-W0621
             headers=headers,

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -110,12 +110,19 @@ def _get_headers(
     return final_headers
 
 
+def _set_default_params(target: dict, default_params: dict) -> None:
+    for name, value in default_params.items():
+        if not name in target:
+            target[name] = value
+
+
 def _build_req_args(
     *,
     token: Optional[str],
     http_verb: str,
     files: dict,
-    data: Union[dict],
+    data: dict,
+    default_params: dict,
     params: dict,
     json: dict,  # skipcq: PYL-W0621
     headers: dict,
@@ -131,10 +138,15 @@ def _build_req_args(
 
     if data is not None and isinstance(data, dict):
         data = {k: v for k, v in data.items() if v is not None}
+        _set_default_params(data, default_params)
     if files is not None and isinstance(files, dict):
         files = {k: v for k, v in files.items() if v is not None}
+        _set_default_params(files, default_params)
     if params is not None and isinstance(params, dict):
         params = {k: v for k, v in params.items() if v is not None}
+        _set_default_params(params, default_params)
+    if json is not None and isinstance(json, dict):
+        _set_default_params(json, default_params)
 
     token: Optional[str] = token
     if params is not None and "token" in params:

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -52,6 +52,8 @@ class LegacyBaseClient:
         headers: Optional[dict] = None,
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
+        # for Org-Wide App installation
+        team_id: Optional[str] = None,
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url
@@ -65,6 +67,9 @@ class LegacyBaseClient:
         self.headers["User-Agent"] = get_user_agent(
             user_agent_prefix, user_agent_suffix
         )
+        self.default_params = {}
+        if team_id is not None:
+            self.default_params["team_id"] = team_id
         self._logger = logging.getLogger(__name__)
         self._event_loop = loop
 
@@ -123,6 +128,7 @@ class LegacyBaseClient:
             http_verb=http_verb,
             files=files,
             data=data,
+            default_params=self.default_params,
             params=params,
             json=json,  # skipcq: PYL-W0621
             headers=headers,

--- a/tests/slack_sdk/web/test_web_client.py
+++ b/tests/slack_sdk/web/test_web_client.py
@@ -170,3 +170,8 @@ class TestWebClient(unittest.TestCase):
         )
         resp = client.api_test()
         self.assertTrue(resp["ok"])
+
+    def test_default_team_id(self):
+        client = WebClient(base_url="http://localhost:8888", team_id="T_DEFAULT")
+        resp = client.users_list(token="xoxb-users_list_pagination")
+        self.assertIsNone(resp["error"])

--- a/tests/slack_sdk_async/web/test_async_web_client.py
+++ b/tests/slack_sdk_async/web/test_async_web_client.py
@@ -147,3 +147,9 @@ class TestAsyncWebClient(unittest.TestCase):
         )
         resp = await client.api_test()
         self.assertTrue(resp["ok"])
+
+    @async_test
+    async def test_default_team_id(self):
+        client = AsyncWebClient(base_url="http://localhost:8888", team_id="T_DEFAULT")
+        resp = await client.users_list(token="xoxb-users_list_pagination")
+        self.assertIsNone(resp["error"])

--- a/tests/web/test_web_client.py
+++ b/tests/web/test_web_client.py
@@ -311,3 +311,8 @@ class TestWebClient(unittest.TestCase):
         #                 # use the local filename if filename is missing
         # >               kwargs["filename"] = file.split(os.path.sep)[-1]
         # E               AttributeError: '_io.BytesIO' object has no attribute 'split'
+
+    def test_default_team_id(self):
+        client = WebClient(base_url="http://localhost:8888", team_id="T_DEFAULT")
+        resp = client.users_list(token="xoxb-users_list_pagination")
+        self.assertIsNone(resp["error"])


### PR DESCRIPTION
## Summary

This pull request updates the Web API clients to hold the default `team_id` in each instance, aiming better support for Org-Wide App installation.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python setup.py validate` after making the changes.
