### PR TITLE
Fix #889 by correcting the team_join event handler

### DIFF
--- a/tutorial/03-responding-to-slack-events.md
+++ b/tutorial/03-responding-to-slack-events.md
@@ -117,7 +117,7 @@ def onboarding_message(payload):
     user_id = event.get("user", {}).get("id")
 
     # Open a DM with the new user.
-    response = slack_web_client.im_open(user_id)
+    response = slack_web_client.conversations_open(users=user_id)
     channel = response["channel"]["id"]
 
     # Post the onboarding message.

--- a/tutorial/PythOnBoardingBot/app.py
+++ b/tutorial/PythOnBoardingBot/app.py
@@ -52,7 +52,7 @@ def onboarding_message(payload):
     user_id = event.get("user", {}).get("id")
 
     # Open a DM with the new user.
-    response = slack_web_client.im_open(user=user_id)
+    response = slack_web_client.conversations_open(users=user_id)
     channel = response["channel"]["id"]
 
     # Post the onboarding message.

--- a/tutorial/PythOnBoardingBot/async_app.py
+++ b/tutorial/PythOnBoardingBot/async_app.py
@@ -52,7 +52,7 @@ async def onboarding_message(**payload):
     user_id = payload["data"]["user"]["id"]
 
     # Open a DM with the new user.
-    response = web_client.im_open(user_id)
+    response = web_client.conversations_open(users=user_id)
     channel = response["channel"]["id"]
 
     # Post the onboarding message.


### PR DESCRIPTION
## Summary

This pull request fixes a bug in the PythOnBoardingBot tutorial app reported at #889 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [x] PythOnBoardingBot

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
