### PR TITLE
Update WebClient to accept not only list but also tuple

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -10,7 +10,7 @@
 """A Python module for interacting with Slack's Web API."""
 import os
 from io import IOBase
-from typing import Union, Sequence, Optional, Dict
+from typing import Union, Sequence, Optional, Dict, Tuple
 
 import slack_sdk.errors as e
 from slack_sdk.models.views import View
@@ -185,7 +185,7 @@ class AsyncWebClient(AsyncBaseClient):
             user_ids (str or list): The users to invite.
         """
         kwargs.update({"channel_id": channel_id})
-        if isinstance(user_ids, list):
+        if isinstance(user_ids, (list, Tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
@@ -523,7 +523,7 @@ class AsyncWebClient(AsyncBaseClient):
                 At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
         """
         kwargs.update({"team_id": team_id})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -600,7 +600,7 @@ class AsyncWebClient(AsyncBaseClient):
             channel_ids (str or list): Comma separated string of channel IDs. e.g. 'C123,C234' or ['C123', 'C234']
         """
         kwargs.update({"team_id": team_id, "usergroup_id": usergroup_id})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -618,7 +618,7 @@ class AsyncWebClient(AsyncBaseClient):
                 e.g. 'T12345678,T98765432' or ['T12345678', 'T98765432']
         """
         kwargs.update({"usergroup_id": usergroup_id})
-        if isinstance(team_ids, list):
+        if isinstance(team_ids, (list, Tuple)):
             kwargs.update({"team_ids": ",".join(team_ids)})
         else:
             kwargs.update({"team_ids": team_ids})
@@ -645,7 +645,7 @@ class AsyncWebClient(AsyncBaseClient):
             channel_ids (str or list): Comma separated string of channel IDs. e.g. 'C123,C234' or ['C123', 'C234']
         """
         kwargs.update({"usergroup_id": usergroup_id})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -680,7 +680,7 @@ class AsyncWebClient(AsyncBaseClient):
                 At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
         """
         kwargs.update({"team_id": team_id, "email": email})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -1233,7 +1233,7 @@ class AsyncWebClient(AsyncBaseClient):
             users (str or list): An list of user id's to invite. e.g. ['U2345678901', 'U3456789012']
         """
         kwargs.update({"channel": channel})
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -1425,7 +1425,7 @@ class AsyncWebClient(AsyncBaseClient):
         Args:
             users (str or list): User IDs to fetch information e.g. 'U123,U234' or ["U123", "U234"]
         """
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -1524,7 +1524,7 @@ class AsyncWebClient(AsyncBaseClient):
             channels (str or list): Comma-separated list of channel IDs where the file will be shared.
                 e.g. ['C1234567890', 'C2345678901']
         """
-        if isinstance(channels, list):
+        if isinstance(channels, (list, Tuple)):
             kwargs.update({"channels": ",".join(channels)})
         else:
             kwargs.update({"channels": channels})
@@ -1803,7 +1803,7 @@ class AsyncWebClient(AsyncBaseClient):
             users (str or list): A list of user ids, up to 400 per request.
                 e.g. ['W1234567890', 'U2345678901', 'U3456789012']
         """
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -1853,7 +1853,7 @@ class AsyncWebClient(AsyncBaseClient):
                 is preserved whenever a MPIM group is returned.
                 e.g. ['W1234567890', 'U2345678901', 'U3456789012']
         """
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -2203,7 +2203,7 @@ class AsyncWebClient(AsyncBaseClient):
                 users for the User Group. e.g. ['U060R4BJ4', 'U060RNRCZ']
         """
         kwargs.update({"usergroup": usergroup})
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1,7 +1,7 @@
 """A Python module for interacting with Slack's Web API."""
 import os
 from io import IOBase
-from typing import Union, Sequence, Optional, Dict
+from typing import Union, Sequence, Optional, Dict, Tuple
 
 import slack_sdk.errors as e
 from slack_sdk.models.views import View
@@ -168,7 +168,7 @@ class WebClient(BaseClient):
             user_ids (str or list): The users to invite.
         """
         kwargs.update({"channel_id": channel_id})
-        if isinstance(user_ids, list):
+        if isinstance(user_ids, (list, Tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
@@ -488,7 +488,7 @@ class WebClient(BaseClient):
                 At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
         """
         kwargs.update({"team_id": team_id})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -563,7 +563,7 @@ class WebClient(BaseClient):
             channel_ids (str or list): Comma separated string of channel IDs. e.g. 'C123,C234' or ['C123', 'C234']
         """
         kwargs.update({"team_id": team_id, "usergroup_id": usergroup_id})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -581,7 +581,7 @@ class WebClient(BaseClient):
                 e.g. 'T12345678,T98765432' or ['T12345678', 'T98765432']
         """
         kwargs.update({"usergroup_id": usergroup_id})
-        if isinstance(team_ids, list):
+        if isinstance(team_ids, (list, Tuple)):
             kwargs.update({"team_ids": ",".join(team_ids)})
         else:
             kwargs.update({"team_ids": team_ids})
@@ -608,7 +608,7 @@ class WebClient(BaseClient):
             channel_ids (str or list): Comma separated string of channel IDs. e.g. 'C123,C234' or ['C123', 'C234']
         """
         kwargs.update({"usergroup_id": usergroup_id})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -643,7 +643,7 @@ class WebClient(BaseClient):
                 At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
         """
         kwargs.update({"team_id": team_id, "email": email})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -1162,7 +1162,7 @@ class WebClient(BaseClient):
             users (str or list): An list of user id's to invite. e.g. ['U2345678901', 'U3456789012']
         """
         kwargs.update({"channel": channel})
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -1336,7 +1336,7 @@ class WebClient(BaseClient):
         Args:
             users (str or list): User IDs to fetch information e.g. 'U123,U234' or ["U123", "U234"]
         """
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -1431,7 +1431,7 @@ class WebClient(BaseClient):
             channels (str or list): Comma-separated list of channel IDs where the file will be shared.
                 e.g. ['C1234567890', 'C2345678901']
         """
-        if isinstance(channels, list):
+        if isinstance(channels, (list, Tuple)):
             kwargs.update({"channels": ",".join(channels)})
         else:
             kwargs.update({"channels": channels})
@@ -1696,7 +1696,7 @@ class WebClient(BaseClient):
             users (str or list): A list of user ids, up to 400 per request.
                 e.g. ['W1234567890', 'U2345678901', 'U3456789012']
         """
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -1744,7 +1744,7 @@ class WebClient(BaseClient):
                 is preserved whenever a MPIM group is returned.
                 e.g. ['W1234567890', 'U2345678901', 'U3456789012']
         """
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -2076,7 +2076,7 @@ class WebClient(BaseClient):
                 users for the User Group. e.g. ['U060R4BJ4', 'U060RNRCZ']
         """
         kwargs.update({"usergroup": usergroup})
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -12,7 +12,7 @@ from asyncio import Future
 """A Python module for interacting with Slack's Web API."""
 import os
 from io import IOBase
-from typing import Union, Sequence, Optional, Dict
+from typing import Union, Sequence, Optional, Dict, Tuple
 
 import slack_sdk.errors as e
 from slack_sdk.models.views import View
@@ -183,7 +183,7 @@ class LegacyWebClient(LegacyBaseClient):
             user_ids (str or list): The users to invite.
         """
         kwargs.update({"channel_id": channel_id})
-        if isinstance(user_ids, list):
+        if isinstance(user_ids, (list, Tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
@@ -515,7 +515,7 @@ class LegacyWebClient(LegacyBaseClient):
                 At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
         """
         kwargs.update({"team_id": team_id})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -590,7 +590,7 @@ class LegacyWebClient(LegacyBaseClient):
             channel_ids (str or list): Comma separated string of channel IDs. e.g. 'C123,C234' or ['C123', 'C234']
         """
         kwargs.update({"team_id": team_id, "usergroup_id": usergroup_id})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -608,7 +608,7 @@ class LegacyWebClient(LegacyBaseClient):
                 e.g. 'T12345678,T98765432' or ['T12345678', 'T98765432']
         """
         kwargs.update({"usergroup_id": usergroup_id})
-        if isinstance(team_ids, list):
+        if isinstance(team_ids, (list, Tuple)):
             kwargs.update({"team_ids": ",".join(team_ids)})
         else:
             kwargs.update({"team_ids": team_ids})
@@ -635,7 +635,7 @@ class LegacyWebClient(LegacyBaseClient):
             channel_ids (str or list): Comma separated string of channel IDs. e.g. 'C123,C234' or ['C123', 'C234']
         """
         kwargs.update({"usergroup_id": usergroup_id})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -670,7 +670,7 @@ class LegacyWebClient(LegacyBaseClient):
                 At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
         """
         kwargs.update({"team_id": team_id, "email": email})
-        if isinstance(channel_ids, list):
+        if isinstance(channel_ids, (list, Tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
@@ -1233,7 +1233,7 @@ class LegacyWebClient(LegacyBaseClient):
             users (str or list): An list of user id's to invite. e.g. ['U2345678901', 'U3456789012']
         """
         kwargs.update({"channel": channel})
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -1425,7 +1425,7 @@ class LegacyWebClient(LegacyBaseClient):
         Args:
             users (str or list): User IDs to fetch information e.g. 'U123,U234' or ["U123", "U234"]
         """
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -1520,7 +1520,7 @@ class LegacyWebClient(LegacyBaseClient):
             channels (str or list): Comma-separated list of channel IDs where the file will be shared.
                 e.g. ['C1234567890', 'C2345678901']
         """
-        if isinstance(channels, list):
+        if isinstance(channels, (list, Tuple)):
             kwargs.update({"channels": ",".join(channels)})
         else:
             kwargs.update({"channels": channels})
@@ -1807,7 +1807,7 @@ class LegacyWebClient(LegacyBaseClient):
             users (str or list): A list of user ids, up to 400 per request.
                 e.g. ['W1234567890', 'U2345678901', 'U3456789012']
         """
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -1859,7 +1859,7 @@ class LegacyWebClient(LegacyBaseClient):
                 is preserved whenever a MPIM group is returned.
                 e.g. ['W1234567890', 'U2345678901', 'U3456789012']
         """
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
@@ -2209,7 +2209,7 @@ class LegacyWebClient(LegacyBaseClient):
                 users for the User Group. e.g. ['U060R4BJ4', 'U060RNRCZ']
         """
         kwargs.update({"usergroup": usergroup})
-        if isinstance(users, list):
+        if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})

--- a/tests/slack_sdk_async/web/test_web_client_coverage.py
+++ b/tests/slack_sdk_async/web/test_web_client_coverage.py
@@ -102,6 +102,8 @@ class TestWebClientCoverage(unittest.TestCase):
                     self.api_methods_to_call.remove(
                         method(team_id="T123", channel_ids=["C123", "C234"])["method"]
                     )
+                    # checking tuple compatibility as sample
+                    method(team_id="T123", channel_ids=("C123", "C234"))
                     method(team_id="T123", channel_ids="C123,C234")
                     await async_method(team_id="T123", channel_ids="C123,C234")
                 elif method_name == "admin_teams_settings_setDescription":


### PR DESCRIPTION
## Summary

This pull request updates the internals of `WebClient` to accept tuple values for ids arguments.

for context: https://github.com/slackapi/python-slack-sdk/pull/894#discussion_r541450730

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
