### PR TITLE
the timestamp for Slack-post never changes, it is effectivly an ID

### DIFF
--- a/tutorial/PythOnBoardingBot/app.py
+++ b/tutorial/PythOnBoardingBot/app.py
@@ -88,9 +88,6 @@ def update_emoji(payload):
     # Post the updated message in Slack
     updated_message = slack_web_client.chat_update(**message)
 
-    # Update the timestamp saved on the onboarding tutorial object
-    onboarding_tutorial.timestamp = updated_message["ts"]
-
 
 # =============== Pin Added Events ================ #
 # When a users pins a message the type of the event will be 'pin_added'.
@@ -116,9 +113,6 @@ def update_pin(payload):
 
     # Post the updated message in Slack
     updated_message = slack_web_client.chat_update(**message)
-
-    # Update the timestamp saved on the onboarding tutorial object
-    onboarding_tutorial.timestamp = updated_message["ts"]
 
 
 # ============== Message Events ============= #


### PR DESCRIPTION
## Summary

This is a minor change. 

There is one line in the emoji callback and one line in the pin callback that are currently "do-nothing" operations (I believe). 

This  PR is to remove those "do-nothing" operations for the sake of clarity.

One underlying assumption of mine is that Slack uses (channel id, time stamp) as a unique ID for a Slack Message, and that these IDs (timestamps) don't change.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
