### PR TITLE
Update channel char limit to 80

### DIFF
--- a/docs-src-v2/conversations.rst
+++ b/docs-src-v2/conversations.rst
@@ -34,7 +34,7 @@ See `conversations.open <https://api.slack.com/methods/conversations.open>`_ add
 
 Creating channels
 -------------------------------------
-Creates a new channel, either public or private. The ``name`` parameter is required, may contain numbers, letters, hyphens, and underscores, and must contain fewer than 21 characters. To make the channel private, set the option ``is_private`` parameter to ``True``.
+Creates a new channel, either public or private. The ``name`` parameter is required, may contain numbers, letters, hyphens, and underscores, and must contain fewer than 80 characters. To make the channel private, set the option ``is_private`` parameter to ``True``.
 
 .. code-block:: python
 

--- a/docs-src/web/index.rst
+++ b/docs-src/web/index.rst
@@ -256,7 +256,7 @@ See `conversations.open <https://api.slack.com/methods/conversations.open>`_ add
 
 **Creating channels**
 
-Creates a new channel, either public or private. The ``name`` parameter is required, may contain numbers, letters, hyphens, and underscores, and must contain fewer than 21 characters. To make the channel private, set the option ``is_private`` parameter to ``True``.
+Creates a new channel, either public or private. The ``name`` parameter is required, may contain numbers, letters, hyphens, and underscores, and must contain fewer than 80 characters. To make the channel private, set the option ``is_private`` parameter to ``True``.
 
 .. code-block:: python
 

--- a/docs-v2/.buildinfo
+++ b/docs-v2/.buildinfo
@@ -1,4 +1,4 @@
 # Sphinx build info version 1
 # This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: 2cfca20515a7ec4c5dfdf57393105f87
+config: 150642f94e6c412769c11dc3c042d007
 tags: 645f666f9bcd5a90fca523b33c5a78b7

--- a/docs-v2/conversations.html
+++ b/docs-v2/conversations.html
@@ -266,7 +266,7 @@
 <hr class="docutils" />
 <div class="section" id="creating-channels">
 <h2>Creating channels<a class="headerlink" href="#creating-channels" title="Permalink to this headline">¶</a></h2>
-<p>Creates a new channel, either public or private. The <code class="docutils literal notranslate"><span class="pre">name</span></code> parameter is required, may contain numbers, letters, hyphens, and underscores, and must contain fewer than 21 characters. To make the channel private, set the option <code class="docutils literal notranslate"><span class="pre">is_private</span></code> parameter to <code class="docutils literal notranslate"><span class="pre">True</span></code>.</p>
+<p>Creates a new channel, either public or private. The <code class="docutils literal notranslate"><span class="pre">name</span></code> parameter is required, may contain numbers, letters, hyphens, and underscores, and must contain fewer than 80 characters. To make the channel private, set the option <code class="docutils literal notranslate"><span class="pre">is_private</span></code> parameter to <code class="docutils literal notranslate"><span class="pre">True</span></code>.</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">os</span>
 <span class="kn">from</span> <span class="nn">slack</span> <span class="kn">import</span> <span class="n">WebClient</span>
 <span class="kn">from</span> <span class="nn">time</span> <span class="kn">import</span> <span class="n">time</span>

--- a/docs/.buildinfo
+++ b/docs/.buildinfo
@@ -1,4 +1,4 @@
 # Sphinx build info version 1
 # This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: f47751de68c8ee3f7e02d24a875601e0
+config: 75d354d794d56ac320c399546be0b339
 tags: 645f666f9bcd5a90fca523b33c5a78b7

--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -382,7 +382,7 @@ deletion of threaded replies works the same as regular messages.</p>
 </div>
 <p>See <a class="reference external" href="https://api.slack.com/methods/conversations.open">conversations.open</a> additional info.</p>
 <p><strong>Creating channels</strong></p>
-<p>Creates a new channel, either public or private. The <code class="docutils literal notranslate"><span class="pre">name</span></code> parameter is required, may contain numbers, letters, hyphens, and underscores, and must contain fewer than 21 characters. To make the channel private, set the option <code class="docutils literal notranslate"><span class="pre">is_private</span></code> parameter to <code class="docutils literal notranslate"><span class="pre">True</span></code>.</p>
+<p>Creates a new channel, either public or private. The <code class="docutils literal notranslate"><span class="pre">name</span></code> parameter is required, may contain numbers, letters, hyphens, and underscores, and must contain fewer than 80 characters. To make the channel private, set the option <code class="docutils literal notranslate"><span class="pre">is_private</span></code> parameter to <code class="docutils literal notranslate"><span class="pre">True</span></code>.</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">os</span>
 <span class="kn">from</span> <span class="nn">slack_sdk</span> <span class="kn">import</span> <span class="n">WebClient</span>
 <span class="kn">from</span> <span class="nn">time</span> <span class="kn">import</span> <span class="n">time</span>


### PR DESCRIPTION
## Summary

This pull request updates the channel character limit from 21 to 80 chars. This was reported by our Slack support team, who recently found that our docs were still using the previous character limit.

I've updated this for both v2 and the latest documentation.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] `/docs-src` (Documents, have you run `./docs.sh`?)
- [x] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
