### PR TITLE
Fix #903 by parsing in ActionsBlock

### DIFF
--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -243,7 +243,7 @@ class ActionsBlock(Block):
         super().__init__(type=self.type, block_id=block_id)
         show_unknown_key_warning(self, others)
 
-        self.elements = elements
+        self.elements = BlockElement.parse_all(elements)
 
     @JsonValidator(f"elements attribute cannot exceed {elements_max_length} elements")
     def _validate_elements_length(self):

--- a/tests/slack_sdk/web/classes/test_blocks.py
+++ b/tests/slack_sdk/web/classes/test_blocks.py
@@ -13,11 +13,14 @@ from slack_sdk.models.blocks import (
     Block,
     CallBlock,
     ButtonElement,
+    StaticSelectElement,
+    OverflowMenuElement,
     ImageElement,
     LinkButtonElement,
     PlainTextObject,
     MarkdownTextObject,
     HeaderBlock,
+    Option,
 )
 from . import STRING_3001_CHARS
 
@@ -403,6 +406,26 @@ class ActionsBlockTests(unittest.TestCase):
         )
         with self.assertRaises(SlackObjectFormationError):
             ActionsBlock(elements=self.elements * 3).to_dict()
+
+    def test_element_parsing(self):
+        elements = [
+            ButtonElement(text="Click me", action_id="reg_button", value="1"),
+            StaticSelectElement(options=[Option(value='SelectOption')]),
+            ImageElement(image_url='url', alt_text='alt-text'),
+            OverflowMenuElement(options=[Option(value='MenuOption1'), Option(value='MenuOption2')]),
+        ]
+        input = {
+            "type": "actions",
+            "block_id": "actionblock789",
+            "elements": [
+               e.to_dict() for e in elements
+            ],
+        }
+        parsed_elements = ActionsBlock(**input).elements
+        self.assertEqual(len(elements), len(parsed_elements))
+        for original, parsed in zip(elements, parsed_elements):
+            self.assertEqual(type(original), type(parsed))
+            self.assertDictEqual(original.to_dict(), parsed.to_dict())
 
 
 # ----------------------------------------------


### PR DESCRIPTION
## Summary

Fix [issue 903](https://github.com/slackapi/python-slack-sdk/issues/903)

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
