### PR TITLE
Fix #900 by correcting the WebClient behavior for Org-Wide Apps

### DIFF
--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -141,7 +141,9 @@ def _build_req_args(
         _set_default_params(data, default_params)
     if files is not None and isinstance(files, dict):
         files = {k: v for k, v in files.items() if v is not None}
-        _set_default_params(files, default_params)
+        # NOTE: We do not need to all #_set_default_params here
+        # because other parameters in binary data requests can exist
+        # only in either data or params, not in files.
     if params is not None and isinstance(params, dict):
         params = {k: v for k, v in params.items() if v is not None}
         _set_default_params(params, default_params)

--- a/tests/slack_sdk/web/test_web_client_issue_900.py
+++ b/tests/slack_sdk/web/test_web_client_issue_900.py
@@ -1,0 +1,22 @@
+import unittest
+from os.path import dirname
+
+from slack_sdk.web import WebClient
+from tests.slack_sdk.web.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+
+
+class TestWebClient_Issue_900(unittest.TestCase):
+    def setUp(self):
+        setup_mock_web_api_server(self)
+
+    def tearDown(self):
+        cleanup_mock_web_api_server(self)
+
+    def test_if_it_works_with_default_params(self):
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
+        client.files_upload(file=f"{dirname(__file__)}/test_web_client_issue_900.py")


### PR DESCRIPTION
## Summary

This pull request fixes #900 

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
