### PR TITLE
Fix #901 by correcting type hints for files_upload method args

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1549,7 +1549,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("files.sharedPublicURL", json=kwargs)
 
     async def files_upload(
-        self, *, file: Union[str, IOBase] = None, content: str = None, **kwargs
+        self, *, file: Union[str, bytes, IOBase] = None, content: str = None, **kwargs
     ) -> AsyncSlackResponse:
         """Uploads or creates a file.
 

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1456,7 +1456,7 @@ class WebClient(BaseClient):
         return self.api_call("files.sharedPublicURL", json=kwargs)
 
     def files_upload(
-        self, *, file: Union[str, IOBase] = None, content: str = None, **kwargs
+        self, *, file: Union[str, bytes, IOBase] = None, content: str = None, **kwargs
     ) -> SlackResponse:
         """Uploads or creates a file.
 

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1549,7 +1549,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("files.sharedPublicURL", json=kwargs)
 
     def files_upload(
-        self, *, file: Union[str, IOBase] = None, content: str = None, **kwargs
+        self, *, file: Union[str, bytes, IOBase] = None, content: str = None, **kwargs
     ) -> Union[Future, SlackResponse]:
         """Uploads or creates a file.
 


### PR DESCRIPTION
## Summary

This pull request fixes #901 by correcting the `file` arg's type hint.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
