### PR TITLE
Add aiohttp version validation (ref #912)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -295,7 +295,9 @@ setup(
         "optional": [
             # async modules depend on aiohttp
             "aiodns>1.0",
-            "aiohttp>=3,<4",
+            # We recommend using 3.7.1+ for RTMClient
+            # https://github.com/slackapi/python-slack-sdk/issues/912
+            "aiohttp>=3.7.3,<4",
             # used only under slack_sdk/*_store
             "boto3<=2",
             # InstallationStore/OAuthStateStore

--- a/slack_sdk/aiohttp_version_checker.py
+++ b/slack_sdk/aiohttp_version_checker.py
@@ -1,0 +1,23 @@
+import logging
+from typing import Callable
+
+
+def _print_warning_log(message: str) -> None:
+    logging.getLogger(__name__).warning(message)
+
+
+def validate_aiohttp_version(
+    aiohttp_version: str, print_warning: Callable[[str], None] = _print_warning_log,
+):
+    if aiohttp_version is not None:
+        elements = aiohttp_version.split(".")
+        if len(elements) >= 3:
+            # patch version can be a non-numeric value
+            major, minor, patch = int(elements[0]), int(elements[1]), elements[2]
+            if major <= 2 or (
+                major == 3 and (minor == 6 or (minor == 7 and patch == "0"))
+            ):
+                print_warning(
+                    "We highly recommend upgrading aiohttp to 3.7.3 or higher versions."
+                    "An older version of the library may not work with the Slack server-side in the future."
+                )

--- a/slack_sdk/rtm/__init__.py
+++ b/slack_sdk/rtm/__init__.py
@@ -16,7 +16,11 @@ from typing import Optional, Callable, DefaultDict
 import aiohttp
 
 import slack_sdk.errors as client_err
+from slack_sdk.aiohttp_version_checker import validate_aiohttp_version
 from slack_sdk.web.legacy_client import LegacyWebClient as WebClient
+
+
+validate_aiohttp_version(aiohttp.__version__)
 
 
 class RTMClient(object):  # skipcq: PYL-R0205

--- a/tests/test_aiohttp_version_checker.py
+++ b/tests/test_aiohttp_version_checker.py
@@ -1,0 +1,42 @@
+import logging
+import unittest
+
+from slack_sdk.aiohttp_version_checker import validate_aiohttp_version
+
+
+class TestAiohttpVersionChecker(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger(__name__)
+
+    def tearDown(self):
+        pass
+
+    def test_not_recommended_versions(self):
+        state = {"counter": 0}
+
+        def print(message: str):
+            state["counter"] = state["counter"] + 1
+
+        validate_aiohttp_version("2.1.3", print)
+        self.assertEqual(state["counter"], 1)
+        validate_aiohttp_version("3.6.3", print)
+        self.assertEqual(state["counter"], 2)
+        validate_aiohttp_version("3.7.0", print)
+        self.assertEqual(state["counter"], 3)
+
+    def test_recommended_versions(self):
+        state = {"counter": 0}
+
+        def print(message: str):
+            state["counter"] = state["counter"] + 1
+
+        validate_aiohttp_version("3.7.1", print)
+        self.assertEqual(state["counter"], 0)
+        validate_aiohttp_version("3.7.3", print)
+        self.assertEqual(state["counter"], 0)
+        validate_aiohttp_version("3.8.0", print)
+        self.assertEqual(state["counter"], 0)
+        validate_aiohttp_version("4.0.0", print)
+        self.assertEqual(state["counter"], 0)
+        validate_aiohttp_version("4.0.0rc1", print)
+        self.assertEqual(state["counter"], 0)


### PR DESCRIPTION
## Summary

This pull request adds aiohttp library validator to prevent the situation like #912 happening to many developers. After merging this PR, I will apply the same validation to Socket Mode client based on aiohttp in #883 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
