### PR TITLE
Fix #921 Enable to use custom logger in WebClient, WebhookClient (async/sync)

### DIFF
--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -36,6 +36,7 @@ class AsyncBaseClient:
         user_agent_suffix: Optional[str] = None,
         # for Org-Wide App installation
         team_id: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url
@@ -52,7 +53,7 @@ class AsyncBaseClient:
         self.default_params = {}
         if team_id is not None:
             self.default_params["team_id"] = team_id
-        self._logger = logging.getLogger(__name__)
+        self._logger = logger if logger is not None else logging.getLogger(__name__)
 
     async def api_call(  # skipcq: PYL-R1710
         self,

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -46,6 +46,7 @@ class BaseClient:
         user_agent_suffix: Optional[str] = None,
         # for Org-Wide App installation
         team_id: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url
@@ -59,7 +60,7 @@ class BaseClient:
         self.default_params = {}
         if team_id is not None:
             self.default_params["team_id"] = team_id
-        self._logger = logging.getLogger(__name__)
+        self._logger = logger if logger is not None else logging.getLogger(__name__)
 
     def api_call(  # skipcq: PYL-R1710
         self,

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -54,6 +54,7 @@ class LegacyBaseClient:
         user_agent_suffix: Optional[str] = None,
         # for Org-Wide App installation
         team_id: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url
@@ -70,7 +71,7 @@ class LegacyBaseClient:
         self.default_params = {}
         if team_id is not None:
             self.default_params["team_id"] = team_id
-        self._logger = logging.getLogger(__name__)
+        self._logger = logger if logger is not None else logging.getLogger(__name__)
         self._event_loop = loop
 
     def api_call(  # skipcq: PYL-R1710

--- a/slack_sdk/webhook/async_client.py
+++ b/slack_sdk/webhook/async_client.py
@@ -19,7 +19,15 @@ from .webhook_response import WebhookResponse
 
 
 class AsyncWebhookClient:
-    logger = logging.getLogger(__name__)
+    url: str
+    timeout: int
+    ssl: Optional[SSLContext]
+    proxy: Optional[str]
+    session: Optional[ClientSession]
+    trust_env_in_session: bool
+    auth: Optional[BasicAuth]
+    default_headers: Dict[str, str]
+    logger: logging.Logger
 
     def __init__(
         self,
@@ -33,6 +41,7 @@ class AsyncWebhookClient:
         default_headers: Optional[Dict[str, str]] = None,
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
     ):
         """API client for Incoming Webhooks and response_url
         :param url: a complete URL to send data (e.g., https://hooks.slack.com/XXX)
@@ -45,6 +54,7 @@ class AsyncWebhookClient:
         :param default_headers: request headers to add to all requests
         :param user_agent_prefix: prefix for User-Agent header value
         :param user_agent_suffix: suffix for User-Agent header value
+        :param logger: custom logger
         """
         self.url = url
         self.timeout = timeout
@@ -57,6 +67,7 @@ class AsyncWebhookClient:
         self.default_headers["User-Agent"] = get_user_agent(
             user_agent_prefix, user_agent_suffix
         )
+        self.logger = logger if logger is not None else logging.getLogger(__name__)
 
     async def send(
         self,

--- a/slack_sdk/webhook/client.py
+++ b/slack_sdk/webhook/client.py
@@ -20,7 +20,12 @@ from .webhook_response import WebhookResponse
 
 
 class WebhookClient:
-    logger = logging.getLogger(__name__)
+    url: str
+    timeout: int
+    ssl: Optional[SSLContext]
+    proxy: Optional[str]
+    default_headers: Dict[str, str]
+    logger: logging.Logger
 
     def __init__(
         self,
@@ -31,6 +36,7 @@ class WebhookClient:
         default_headers: Optional[Dict[str, str]] = None,
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
     ):
         """API client for Incoming Webhooks and response_url
         :param url: a complete URL to send data (e.g., https://hooks.slack.com/XXX)
@@ -40,6 +46,7 @@ class WebhookClient:
         :param default_headers: request headers to add to all requests
         :param user_agent_prefix: prefix for User-Agent header value
         :param user_agent_suffix: suffix for User-Agent header value
+        :param logger: custom logger
         """
         self.url = url
         self.timeout = timeout
@@ -49,6 +56,7 @@ class WebhookClient:
         self.default_headers["User-Agent"] = get_user_agent(
             user_agent_prefix, user_agent_suffix
         )
+        self.logger = logger if logger is not None else logging.getLogger(__name__)
 
     def send(
         self,

--- a/tests/slack_sdk/web/test_web_client_issue_921_custom_logger.py
+++ b/tests/slack_sdk/web/test_web_client_issue_921_custom_logger.py
@@ -1,0 +1,35 @@
+import unittest
+from logging import Logger
+
+from slack_sdk.web import WebClient
+from tests.slack_sdk.web.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+
+
+class TestWebClient_Issue_921_CustomLogger(unittest.TestCase):
+    def setUp(self):
+        setup_mock_web_api_server(self)
+
+    def tearDown(self):
+        cleanup_mock_web_api_server(self)
+
+    def test_if_it_uses_custom_logger(self):
+        logger = CustomLogger("test-logger")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", logger=logger,
+        )
+        client.chat_postMessage(channel="C111", text="hello")
+        self.assertTrue(logger.called)
+
+
+class CustomLogger(Logger):
+    called: bool
+
+    def __init__(self, name, level="DEBUG"):
+        Logger.__init__(self, name, level)
+        self.called = False
+
+    def debug(self, msg, *args, **kwargs):
+        self.called = True

--- a/tests/slack_sdk/webhook/test_webhook.py
+++ b/tests/slack_sdk/webhook/test_webhook.py
@@ -1,6 +1,7 @@
 import socket
 import unittest
 import urllib
+from logging import Logger
 
 from slack_sdk.models.attachments import Attachment, AttachmentField
 from slack_sdk.models.blocks import SectionBlock, ImageBlock
@@ -201,3 +202,20 @@ class TestWebhook(unittest.TestCase):
             ],
         )
         self.assertEqual("ok", resp.body)
+
+    def test_if_it_uses_custom_logger_issue_921(self):
+        logger = CustomLogger("test-logger")
+        client = WebhookClient(url="http://localhost:8888", logger=logger)
+        client.send_dict({"text": "hi!"})
+        self.assertTrue(logger.called)
+
+
+class CustomLogger(Logger):
+    called: bool
+
+    def __init__(self, name, level="DEBUG"):
+        Logger.__init__(self, name, level)
+        self.called = False
+
+    def debug(self, msg, *args, **kwargs):
+        self.called = True

--- a/tests/slack_sdk_async/web/test_web_client_issue_921_custom_logger.py
+++ b/tests/slack_sdk_async/web/test_web_client_issue_921_custom_logger.py
@@ -1,0 +1,37 @@
+import unittest
+from logging import Logger
+
+from slack_sdk.web.async_client import AsyncWebClient
+from tests.helpers import async_test
+from tests.slack_sdk.web.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+
+
+class TestWebClient_Issue_921_CustomLogger(unittest.TestCase):
+    def setUp(self):
+        setup_mock_web_api_server(self)
+
+    def tearDown(self):
+        cleanup_mock_web_api_server(self)
+
+    @async_test
+    async def test_if_it_uses_custom_logger(self):
+        logger = CustomLogger("test-logger")
+        client = AsyncWebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", logger=logger,
+        )
+        await client.chat_postMessage(channel="C111", text="hello")
+        self.assertTrue(logger.called)
+
+
+class CustomLogger(Logger):
+    called: bool
+
+    def __init__(self, name, level="DEBUG"):
+        Logger.__init__(self, name, level)
+        self.called = False
+
+    def debug(self, msg, *args, **kwargs):
+        self.called = True

--- a/tests/slack_sdk_async/webhook/test_async_webhook.py
+++ b/tests/slack_sdk_async/webhook/test_async_webhook.py
@@ -1,4 +1,6 @@
 import unittest
+from logging import Logger
+
 from slack_sdk.models.attachments import Attachment, AttachmentField
 from slack_sdk.models.blocks import SectionBlock, ImageBlock
 from slack_sdk.webhook.async_client import AsyncWebhookClient, WebhookResponse
@@ -201,3 +203,20 @@ class TestAsyncWebhook(unittest.TestCase):
             ],
         )
         self.assertEqual("ok", resp.body)
+
+    async def test_if_it_uses_custom_logger_issue_921(self):
+        logger = CustomLogger("test-logger")
+        client = AsyncWebhookClient(url="http://localhost:8888", logger=logger)
+        await client.send_dict({"text": "hi!"})
+        self.assertTrue(logger.called)
+
+
+class CustomLogger(Logger):
+    called: bool
+
+    def __init__(self, name, level="DEBUG"):
+        Logger.__init__(self, name, level)
+        self.called = False
+
+    def debug(self, msg, *args, **kwargs):
+        self.called = True

--- a/tests/web/test_web_client_issue_921_custom_logger.py
+++ b/tests/web/test_web_client_issue_921_custom_logger.py
@@ -1,0 +1,35 @@
+import unittest
+from logging import Logger
+
+from slack.web import WebClient
+from tests.slack_sdk.web.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+
+
+class TestWebClient_Issue_921_CustomLogger(unittest.TestCase):
+    def setUp(self):
+        setup_mock_web_api_server(self)
+
+    def tearDown(self):
+        cleanup_mock_web_api_server(self)
+
+    def test_if_it_uses_custom_logger(self):
+        logger = CustomLogger("test-logger")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", logger=logger,
+        )
+        client.chat_postMessage(channel="C111", text="hello")
+        self.assertTrue(logger.called)
+
+
+class CustomLogger(Logger):
+    called: bool
+
+    def __init__(self, name, level="DEBUG"):
+        Logger.__init__(self, name, level)
+        self.called = False
+
+    def debug(self, msg, *args, **kwargs):
+        self.called = True


### PR DESCRIPTION
## Summary

This pull request fixes #921 by adding custom logger arguments to web clients and webhook clients. Refer to #921  for details.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
