### PR TITLE
Fix #918 Enable to have additional fields in Bot/Installation instances

### DIFF
--- a/slack_sdk/oauth/installation_store/models/bot.py
+++ b/slack_sdk/oauth/installation_store/models/bot.py
@@ -15,6 +15,8 @@ class Bot:
     is_enterprise_install: bool
     installed_at: float
 
+    custom_values: Dict[str, Any]
+
     def __init__(
         self,
         *,
@@ -32,6 +34,8 @@ class Bot:
         is_enterprise_install: Optional[bool] = False,
         # timestamps
         installed_at: float,
+        # custom values
+        custom_values: Optional[Dict[str, Any]] = None
     ):
         self.app_id = app_id
         self.enterprise_id = enterprise_id
@@ -48,9 +52,16 @@ class Bot:
             self.bot_scopes = bot_scopes
         self.is_enterprise_install = is_enterprise_install or False
         self.installed_at = installed_at
+        self.custom_values = custom_values if custom_values is not None else {}
+
+    def set_custom_value(self, name: str, value: Any):
+        self.custom_values[name] = value
+
+    def get_custom_value(self, name: str) -> Optional[Any]:
+        return self.custom_values.get(name)
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        standard_values = {
             "app_id": self.app_id,
             "enterprise_id": self.enterprise_id,
             "enterprise_name": self.enterprise_name,
@@ -63,3 +74,6 @@ class Bot:
             "is_enterprise_install": self.is_enterprise_install,
             "installed_at": datetime.utcfromtimestamp(self.installed_at),
         }
+        # prioritize standard_values over custom_values
+        # when the same keys exist in both
+        return {**self.custom_values, **standard_values}

--- a/slack_sdk/oauth/installation_store/models/installation.py
+++ b/slack_sdk/oauth/installation_store/models/installation.py
@@ -27,6 +27,8 @@ class Installation:
     token_type: Optional[str]
     installed_at: float
 
+    custom_values: Dict[str, Any]
+
     def __init__(
         self,
         *,
@@ -56,6 +58,8 @@ class Installation:
         token_type: Optional[str] = None,
         # timestamps
         installed_at: Optional[float] = None,
+        # custom values
+        custom_values: Optional[Dict[str, Any]] = None
     ):
         self.app_id = app_id
         self.enterprise_id = enterprise_id
@@ -87,6 +91,7 @@ class Installation:
         self.token_type = token_type
 
         self.installed_at = time() if installed_at is None else installed_at
+        self.custom_values = custom_values if custom_values is not None else {}
 
     def to_bot(self) -> Bot:
         return Bot(
@@ -101,10 +106,17 @@ class Installation:
             bot_scopes=self.bot_scopes,
             is_enterprise_install=self.is_enterprise_install,
             installed_at=self.installed_at,
+            custom_values=self.custom_values,
         )
 
+    def set_custom_value(self, name: str, value: Any):
+        self.custom_values[name] = value
+
+    def get_custom_value(self, name: str) -> Optional[Any]:
+        return self.custom_values.get(name)
+
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        standard_values = {
             "app_id": self.app_id,
             "enterprise_id": self.enterprise_id,
             "enterprise_name": self.enterprise_name,
@@ -126,3 +138,6 @@ class Installation:
             "token_type": self.token_type,
             "installed_at": datetime.utcfromtimestamp(self.installed_at),
         }
+        # prioritize standard_values over custom_values
+        # when the same keys exist in both
+        return {**self.custom_values, **standard_values}

--- a/tests/slack_sdk/oauth/installation_store/test_models.py
+++ b/tests/slack_sdk/oauth/installation_store/test_models.py
@@ -1,0 +1,82 @@
+import time
+import unittest
+
+from slack_sdk.oauth.installation_store import Installation, FileInstallationStore, Bot
+
+
+class TestModels(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_bot(self):
+        bot = Bot(
+            bot_token="xoxb-",
+            bot_id="B111",
+            bot_user_id="U111",
+            installed_at=time.time(),
+        )
+        self.assertIsNotNone(bot)
+        self.assertIsNotNone(bot.to_dict())
+
+    def test_bot_custom_fields(self):
+        bot = Bot(
+            bot_token="xoxb-",
+            bot_id="B111",
+            bot_user_id="U111",
+            installed_at=time.time(),
+        )
+        bot.set_custom_value("service_user_id", "XYZ123")
+        # the same names in custom_values are ignored
+        bot.set_custom_value("app_id", "A222")
+        self.assertEqual(bot.get_custom_value("service_user_id"), "XYZ123")
+        self.assertEqual(bot.to_dict().get("service_user_id"), "XYZ123")
+
+    def test_installation(self):
+        installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_id="B111",
+            bot_token="xoxb-111",
+            bot_scopes=["chat:write"],
+            bot_user_id="U222",
+        )
+        self.assertIsNotNone(installation)
+        self.assertEqual(installation.app_id, "A111")
+
+        self.assertIsNotNone(installation.to_bot())
+        self.assertIsNotNone(installation.to_bot().app_id, "A111")
+
+        self.assertIsNotNone(installation.to_dict())
+        self.assertEqual(installation.to_dict().get("app_id"), "A111")
+
+    def test_installation_custom_fields(self):
+        installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_id="B111",
+            bot_token="xoxb-111",
+            bot_scopes=["chat:write"],
+            bot_user_id="U222",
+        )
+        self.assertIsNotNone(installation)
+
+        installation.set_custom_value("service_user_id", "XYZ123")
+        # the same names in custom_values are ignored
+        installation.set_custom_value("app_id", "A222")
+        self.assertEqual(installation.get_custom_value("service_user_id"), "XYZ123")
+        self.assertEqual(installation.to_dict().get("service_user_id"), "XYZ123")
+        self.assertEqual(installation.to_dict().get("app_id"), "A111")
+
+        bot = installation.to_bot()
+        self.assertEqual(bot.app_id, "A111")
+        self.assertEqual(bot.get_custom_value("service_user_id"), "XYZ123")
+
+        self.assertEqual(bot.to_dict().get("app_id"), "A111")
+        self.assertEqual(bot.to_dict().get("service_user_id"), "XYZ123")


### PR DESCRIPTION
## Summary

This pull request fixes #918 by adding the following methods to `Installation` and `Bot` classes.

* set_custom_value(name, value)
* get_custom_value(name)

Developers can save additional values as part of installation data by utilizing the `custom_values`.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
