### PR TITLE
Fix #926 Handle closing aiohttp.ClientSession in socket mode

### DIFF
--- a/integration_tests/samples/issues/issue_926.py
+++ b/integration_tests/samples/issues/issue_926.py
@@ -1,0 +1,30 @@
+# ------------------
+# Only for running this script here
+import sys
+from os.path import dirname
+
+sys.path.insert(1, f"{dirname(__file__)}/../../..")
+# ------------------
+
+import asyncio
+import logging
+import os
+
+from slack_sdk.socket_mode.aiohttp import SocketModeClient
+
+logging.basicConfig(level=logging.DEBUG)
+
+async def main():
+    client = SocketModeClient(app_token=os.environ["SLACK_APP_TOKEN"])
+    await client.connect()
+    await asyncio.sleep(3)
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+# The issue:
+# ERROR:asyncio:Unclosed client session
+# client_session: <aiohttp.client.ClientSession object at 0x10e1085e0>
+# INFO:slack_sdk.socket_mode.aiohttp:The session has been abandoned


### PR DESCRIPTION
## Summary

This pull request fixes #926 by improving the internals of aiohttp-based SocketModeClient.

@cxlai let me know if you have any comments / feedback on this implementation. I will merge this PR tomorrow and release a new patch version.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.rtm.RTMClient** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
