### PR TITLE
Enable to use snake_cased keys for dict arg in SCIMClient/AsyncSCIMClient

### DIFF
--- a/integration_tests/scim/test_scim_client_write.py
+++ b/integration_tests/scim/test_scim_client_write.py
@@ -50,6 +50,31 @@ class TestSCIMClient(unittest.TestCase):
         )
         self.assertEqual(patch_result.status_code, 200)
 
+        # Patch using dict
+        # snake_cased keys will be automatically converted to camelCase
+        patch_result_2 = self.client.patch_user(id=creation.user.id, partial_user={
+            "user_name": f"user_{now}_3",
+            "name": {
+                "given_name": "Kaz",
+                "family_name": "Sera",
+            }
+        })
+        self.assertEqual(patch_result_2.status_code, 200)
+        self.assertEqual(patch_result_2.user.user_name, f"user_{now}_3")
+        self.assertEqual(patch_result_2.user.name.given_name, "Kaz")
+
+        # using camelCase also works
+        patch_result_3 = self.client.patch_user(id=creation.user.id, partial_user={
+            "userName": f"user_{now}_4",
+            "name": {
+                "givenName": "Kazuhiro",
+                "familyName": "Sera",
+            }
+        })
+        self.assertEqual(patch_result_3.status_code, 200)
+        self.assertEqual(patch_result_3.user.user_name, f"user_{now}_4")
+        self.assertEqual(patch_result_3.user.name.given_name, "Kazuhiro")
+
         updated_user = creation.user
         updated_user.name = UserName(given_name="Foo", family_name="Bar")
         update_result = self.client.update_user(user=updated_user)

--- a/slack_sdk/scim/v1/internal_utils.py
+++ b/slack_sdk/scim/v1/internal_utils.py
@@ -43,6 +43,8 @@ def _to_dict_without_not_given(obj: Any) -> dict:
             dict_value[dict_key] = [
                 elem.to_dict() if hasattr(elem, "to_dict") else elem for elem in value
             ]
+        elif isinstance(value, dict):
+            dict_value[dict_key] = _to_dict_without_not_given(value)
         else:
             dict_value[dict_key] = (
                 value.to_dict() if hasattr(value, "to_dict") else value


### PR DESCRIPTION
## Summary

This pull request enables `SCIMClient` and `AsyncSCIMClient` to work with a dict argument using snake_cased keys. 

To make the argument compatible with the server-side, we need to convert the keys to camelCase strings. The implementation in v3.3.0 does not convert nested dict values.

Although we recommend using `User` class for API calls [this way](https://slack.dev/python-slack-sdk/scim/index.html#scimclient), using a dict value can be handier for partial updates (=PATH API calls).

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [x] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
