### PR TITLE
Use self.current_session instead of inexistent self.connection

### DIFF
--- a/slack_sdk/rtm/v2/__init__.py
+++ b/slack_sdk/rtm/v2/__init__.py
@@ -229,7 +229,7 @@ class RTMClient:
 
     def disconnect(self):
         """Disconnects the current session."""
-        self.connection.disconnect()
+        self.current_session.disconnect()
 
     def close(self) -> None:
         """
@@ -238,7 +238,7 @@ class RTMClient:
         """
         self.closed = True
         self.disconnect()
-        self.connection.close()
+        self.current_session.close()
 
     def start(self) -> None:
         """Establishes an RTM connection and blocks the current thread."""


### PR DESCRIPTION
## Summary
When using RTM Client v2 and calling the `close` method an exception is raised.
```
Traceback (most recent call last):
  File "/opt/errbot/bin/errbot", line 8, in <module>
    sys.exit(main())
  File "/opt/errbot/lib/python3.8/site-packages/errbot/cli.py", line 399, in main
    bootstrap(backend, root_logger, config, restore)
  File "/opt/errbot/lib/python3.8/site-packages/errbot/bootstrap.py", line 259, in bootstrap
    bot.serve_forever()
  File "/opt/errbot/lib/python3.8/site-packages/errbot/backends/base.py", line 882, in serve_forever
    self.shutdown()
  File "/opt/errbot/backends/err-backend-slackv3/slackv3.py", line 1230, in shutdown
    self.slack_rtm.close()
  File "/opt/errbot/lib/python3.8/site-packages/slack_sdk/rtm/v2/__init__.py", line 240, in close
    self.disconnect()
  File "/opt/errbot/lib/python3.8/site-packages/slack_sdk/rtm/v2/__init__.py", line 232, in disconnect
    self.connection.disconnect()
AttributeError: 'RTMClient' object has no attribute 'connection'
```

This patch replaces `self.connection` with `self.current_session`

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
