### PR TITLE
Fix #948 built-in SocketModeClient does not support proxy

### DIFF
--- a/integration_tests/samples/rtm_v2/rtm_v2_proxy_app.py
+++ b/integration_tests/samples/rtm_v2/rtm_v2_proxy_app.py
@@ -1,0 +1,46 @@
+# ------------------
+# Only for running this script here
+import sys
+from os.path import dirname
+
+sys.path.insert(1, f"{dirname(__file__)}/../../..")
+# ------------------
+
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s.%(msecs)03d %(levelname)s %(filename)s (%(lineno)s): %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+import os
+from slack_sdk.rtm.v2 import RTMClient
+from integration_tests.env_variable_names import SLACK_SDK_TEST_CLASSIC_APP_BOT_TOKEN
+
+# pip3 install proxy.py
+# proxy --port 9000 --log-level d
+proxy_url = "http://localhost:9000"
+
+if __name__ == "__main__":
+    rtm = RTMClient(
+        token=os.environ.get(SLACK_SDK_TEST_CLASSIC_APP_BOT_TOKEN),
+        trace_enabled=True,
+        all_message_trace_enabled=True,
+        proxy=proxy_url,
+    )
+
+    @rtm.on("message")
+    def handle(client: RTMClient, event: dict):
+        client.web_client.reactions_add(
+            channel=event["channel"],
+            timestamp=event["ts"],
+            name="eyes",
+        )
+
+    @rtm.on("*")
+    def handle(client: RTMClient, event: dict):
+        logger.info(event)
+
+    rtm.start()

--- a/integration_tests/samples/socket_mode/builtin_proxy_example.py
+++ b/integration_tests/samples/socket_mode/builtin_proxy_example.py
@@ -21,8 +21,8 @@ from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode import SocketModeClient
 
-# export SLACK_API_TOKEN=xoxb-***
-# python3 integration_tests/samples/readme/proxy.py
+# pip3 install proxy.py
+# proxy --port 9000 --log-level d
 proxy_url = "http://localhost:9000"
 
 client = SocketModeClient(

--- a/integration_tests/samples/socket_mode/builtin_proxy_example.py
+++ b/integration_tests/samples/socket_mode/builtin_proxy_example.py
@@ -1,0 +1,54 @@
+# ------------------
+# Only for running this script here
+import sys
+from os.path import dirname
+
+sys.path.insert(1, f"{dirname(__file__)}/../../..")
+# ------------------
+
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    # format="%(asctime)s.%(msecs)03d %(levelname)s %(pathname)s (%(lineno)s): %(message)s",
+    # datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+import os
+from threading import Event
+from slack_sdk.web import WebClient
+from slack_sdk.socket_mode.response import SocketModeResponse
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.socket_mode import SocketModeClient
+
+# export SLACK_API_TOKEN=xoxb-***
+# python3 integration_tests/samples/readme/proxy.py
+proxy_url = "http://localhost:9000"
+
+client = SocketModeClient(
+    app_token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_APP_TOKEN"),
+    web_client=WebClient(
+        token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_BOT_TOKEN"),
+        proxy=proxy_url,
+    ),
+    proxy=proxy_url,
+    proxy_headers={"Proxy-Authorization": "Basic dXNlcjpwYXNz"},
+    trace_enabled=True,
+    all_message_trace_enabled=True,
+)
+
+if __name__ == "__main__":
+
+    def process(client: SocketModeClient, req: SocketModeRequest):
+        if req.type == "events_api":
+            response = SocketModeResponse(envelope_id=req.envelope_id)
+            client.send_socket_mode_response(response)
+            client.web_client.reactions_add(
+                name="eyes",
+                channel=req.payload["event"]["channel"],
+                timestamp=req.payload["event"]["ts"],
+            )
+
+    client.socket_mode_request_listeners.append(process)
+    client.connect()
+    Event().wait()

--- a/integration_tests/samples/socket_mode/websocket_client_proxy_example.py
+++ b/integration_tests/samples/socket_mode/websocket_client_proxy_example.py
@@ -21,8 +21,8 @@ client = SocketModeClient(
     app_token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_APP_TOKEN"),
     web_client=WebClient(token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_BOT_TOKEN")),
     trace_enabled=True,
-    # export SLACK_API_TOKEN=xoxb-***
-    # python3 integration_tests/samples/readme/proxy.py
+    # pip3 install proxy.py
+    # proxy --port 9000 --log-level d
     http_proxy_host="localhost",
     http_proxy_port=9000,
     http_proxy_auth=("user", "pass"),

--- a/integration_tests/samples/socket_mode/websocket_client_proxy_example.py
+++ b/integration_tests/samples/socket_mode/websocket_client_proxy_example.py
@@ -19,7 +19,12 @@ from slack_sdk.socket_mode.websocket_client import SocketModeClient
 
 client = SocketModeClient(
     app_token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_APP_TOKEN"),
-    web_client=WebClient(token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_BOT_TOKEN")),
+    web_client=WebClient(
+        token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_BOT_TOKEN"),
+        # pip3 install proxy.py
+        # proxy --port 9000 --log-level d
+        proxy="http://localhost:9000",
+    ),
     trace_enabled=True,
     # pip3 install proxy.py
     # proxy --port 9000 --log-level d

--- a/integration_tests/samples/socket_mode/websocket_client_proxy_example.py
+++ b/integration_tests/samples/socket_mode/websocket_client_proxy_example.py
@@ -1,0 +1,45 @@
+# ------------------
+# Only for running this script here
+import sys
+from os.path import dirname
+
+sys.path.insert(1, f"{dirname(__file__)}/../../..")
+# ------------------
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+import os
+from threading import Event
+from slack_sdk.web import WebClient
+from slack_sdk.socket_mode.response import SocketModeResponse
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.socket_mode.websocket_client import SocketModeClient
+
+client = SocketModeClient(
+    app_token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_APP_TOKEN"),
+    web_client=WebClient(token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_BOT_TOKEN")),
+    trace_enabled=True,
+    # export SLACK_API_TOKEN=xoxb-***
+    # python3 integration_tests/samples/readme/proxy.py
+    http_proxy_host="localhost",
+    http_proxy_port=9000,
+    http_proxy_auth=("user", "pass"),
+)
+
+if __name__ == "__main__":
+
+    def process(client: SocketModeClient, req: SocketModeRequest):
+        if req.type == "events_api":
+            response = SocketModeResponse(envelope_id=req.envelope_id)
+            client.send_socket_mode_response(response)
+            client.web_client.reactions_add(
+                name="eyes",
+                channel=req.payload["event"]["channel"],
+                timestamp=req.payload["event"]["ts"],
+            )
+
+    client.socket_mode_request_listeners.append(process)
+    client.connect()
+    Event().wait()

--- a/slack_sdk/socket_mode/builtin/client.py
+++ b/slack_sdk/socket_mode/builtin/client.py
@@ -3,7 +3,7 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from logging import Logger
 from queue import Queue
 from threading import Lock
-from typing import Union, Optional, List, Callable
+from typing import Union, Optional, List, Callable, Dict
 
 from slack_sdk.socket_mode.client import BaseSocketModeClient
 from slack_sdk.socket_mode.listeners import (
@@ -70,6 +70,7 @@ class SocketModeClient(BaseSocketModeClient):
         receive_buffer_size: int = 1024,
         concurrency: int = 10,
         proxy: Optional[str] = None,
+        proxy_headers: Optional[Dict[str, str]] = None,
         on_message_listeners: Optional[List[Callable[[str], None]]] = None,
         on_error_listeners: Optional[List[Callable[[Exception], None]]] = None,
         on_close_listeners: Optional[List[Callable[[int, Optional[str]], None]]] = None,
@@ -112,6 +113,7 @@ class SocketModeClient(BaseSocketModeClient):
         self.message_workers = ThreadPoolExecutor(max_workers=concurrency)
 
         self.proxy = proxy
+        self.proxy_headers = proxy_headers
 
         self.on_message_listeners = on_message_listeners or []
         self.on_error_listeners = on_error_listeners or []
@@ -140,6 +142,7 @@ class SocketModeClient(BaseSocketModeClient):
             ping_pong_trace_enabled=self.ping_pong_trace_enabled,
             receive_buffer_size=self.receive_buffer_size,
             proxy=self.proxy,
+            proxy_headers=self.proxy_headers,
             on_message_listener=self._on_message,
             on_error_listener=self._on_error,
             on_close_listener=self._on_close,

--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -9,21 +9,91 @@ import struct
 from base64 import encodebytes
 from hmac import compare_digest
 from logging import Logger
-from typing import Tuple, Optional, Union, List, Callable
+from typing import Tuple, Optional, Union, List, Callable, Dict
+from urllib.parse import urlparse
 
 from .frame_header import FrameHeader
 
 
-def _open_new_socket(
-    server_hostname: str, server_port: int, logger: Logger
+def _parse_connect_response(sock) -> (Optional[int], str):
+    status = None
+    lines = []
+    while True:
+        line = []
+        while True:
+            c = sock.recv(1)
+            line.append(c)
+            if c == b"\n":
+                break
+        line = b"".join(line).decode("utf-8").strip()
+        if line is None or len(line) == 0:
+            break
+        lines.append(line)
+        if not status:
+            status_line = line.split(" ", 2)
+            status = int(status_line[1])
+    return status, "\n".join(lines)
+
+
+def _establish_new_socket_connection(
+    session_id: str,
+    server_hostname: str,
+    server_port: int,
+    logger: Logger,
+    receive_timeout: float,
+    proxy: Optional[str],
+    proxy_headers: Optional[Dict[str, str]],
+    trace_enabled: bool,
 ) -> Union[ssl.SSLSocket, Socket]:
+    if proxy is not None:
+        parsed_proxy = urlparse(proxy)
+        proxy_host, proxy_port = parsed_proxy.hostname, parsed_proxy.port or 80
+        proxy_addr = socket.getaddrinfo(
+            proxy_host,
+            proxy_port,
+            0,
+            socket.SOCK_STREAM,
+            socket.SOL_TCP,
+        )[0]
+        sock = socket.socket(proxy_addr[0], proxy_addr[1], proxy_addr[2])
+        sock.settimeout(receive_timeout)
+        sock.connect(proxy_addr[4])  # proxy address
+        message = [f"CONNECT {server_hostname}:{server_port} HTTP/1.0"]
+        if proxy_headers is not None:
+            for k, v in proxy_headers.items():
+                message.append(f"{k}: {v}")
+        message.append("")
+        message.append("")
+        req: str = "\r\n".join([line.lstrip() for line in message])
+        if trace_enabled:
+            logger.debug(f"Proxy connect request (session id: {session_id}):\n{req}")
+        sock.send(req.encode("utf-8"))
+        status, text = _parse_connect_response(sock)
+        if status != 200:
+            raise Exception(f"Failed to connect to the proxy (proxy: {proxy})")
+        if trace_enabled:
+            log_message = f"Proxy connect response (session id: {session_id}):\n{text}"
+            logger.debug(log_message)
+
+        sock = ssl.SSLContext(ssl.PROTOCOL_SSLv23).wrap_socket(
+            sock,
+            do_handshake_on_connect=True,
+            suppress_ragged_eofs=True,
+            server_hostname=server_hostname,
+        )
+        return sock
+
     if server_port != 443:
+        addr = socket.getaddrinfo(
+            server_hostname, server_port, 0, socket.SOCK_STREAM, socket.SOL_TCP
+        )[0]
         # only for library testing
         logger.info(
             f"Using non-ssl socket to connect ({server_hostname}:{server_port})"
         )
-        sock = Socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock = Socket(addr[0], addr[1], addr[2])
         sock.settimeout(3)
+        sock.connect((server_hostname, server_port))
         return sock
 
     sock = Socket(type=ssl.SOCK_STREAM)
@@ -33,7 +103,8 @@ def _open_new_socket(
         suppress_ragged_eofs=True,
         server_hostname=server_hostname,
     )
-    sock.settimeout(5)
+    sock.settimeout(receive_timeout)
+    sock.connect((server_hostname, server_port))
     return sock
 
 
@@ -67,7 +138,7 @@ def _parse_handshake_response(sock: ssl.SSLSocket) -> (int, dict, str):
             elements = line.split(":")
             if len(elements) == 2:
                 headers[elements[0].strip().lower()] = elements[1].strip()
-        if line is None or len(line) == 0:
+        if line is None or len(line.strip()) == 0:
             break
         lines.append(line)
     text = "\n".join(lines)

--- a/tests/slack_sdk/socket_mode/mock_web_api_server.py
+++ b/tests/slack_sdk/socket_mode/mock_web_api_server.py
@@ -120,6 +120,10 @@ class MockHandler(SimpleHTTPRequestHandler):
     def do_POST(self):
         self._handle()
 
+    def do_CONNECT(self):
+        self.wfile.write("HTTP/1.1 200 Connection established\r\n\r\n".encode("utf-8"))
+        self.wfile.close()
+
 
 class MockServerProcessTarget:
     def __init__(self, handler: Type[SimpleHTTPRequestHandler] = MockHandler):

--- a/tests/slack_sdk/socket_mode/test_builtin.py
+++ b/tests/slack_sdk/socket_mode/test_builtin.py
@@ -2,19 +2,15 @@ import logging
 import time
 import unittest
 from threading import Thread
-from typing import Optional, List, Tuple
 
 from slack_sdk import WebClient
 from slack_sdk.socket_mode import SocketModeClient
 from slack_sdk.socket_mode.builtin.connection import Connection, ConnectionState
 from slack_sdk.socket_mode.builtin.frame_header import FrameHeader
 from slack_sdk.socket_mode.builtin.internals import (
-    _open_new_socket,
     _generate_sec_websocket_key,
     _to_readable_opcode,
     _build_data_frame_for_sending,
-    _parse_text_payload,
-    _fetch_messages,
 )
 from slack_sdk.web.legacy_client import LegacyWebClient
 from .mock_web_api_server import (
@@ -115,10 +111,6 @@ class TestBuiltin(unittest.TestCase):
 
     # ----------------------------------
     # internals
-
-    def test_open_new_socket(self):
-        soc = _open_new_socket("0.0.0.0", 3456, self.logger)
-        soc.close()
 
     def test_generate_sec_websocket_key(self):
         key = _generate_sec_websocket_key()


### PR DESCRIPTION
## Summary

This pull request fixes #948 by correcting the built-in SocketModeClient's proxy support. It also fixes #952 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
