### PR TITLE
Add HTTPS_PROXY/HTTP_PROXY env variable support #948

### DIFF
--- a/integration_tests/samples/socket_mode/builtin_proxy_env_variable_example.py
+++ b/integration_tests/samples/socket_mode/builtin_proxy_env_variable_example.py
@@ -1,0 +1,52 @@
+# ------------------
+# Only for running this script here
+import sys
+from os.path import dirname
+
+sys.path.insert(1, f"{dirname(__file__)}/../../..")
+# ------------------
+
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    # format="%(asctime)s.%(msecs)03d %(levelname)s %(pathname)s (%(lineno)s): %(message)s",
+    # datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+import os
+from threading import Event
+from slack_sdk.web import WebClient
+from slack_sdk.socket_mode.response import SocketModeResponse
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.socket_mode import SocketModeClient
+
+# pip3 install proxy.py
+# proxy --port 9000 --log-level d
+os.environ["HTTPS_PROXY"] = "http://localhost:9000"
+
+client = SocketModeClient(
+    app_token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_APP_TOKEN"),
+    web_client=WebClient(
+        token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_BOT_TOKEN"),
+    ),
+    proxy_headers={"Proxy-Authorization": "Basic dXNlcjpwYXNz"},
+    trace_enabled=True,
+    all_message_trace_enabled=True,
+)
+
+if __name__ == "__main__":
+
+    def process(client: SocketModeClient, req: SocketModeRequest):
+        if req.type == "events_api":
+            response = SocketModeResponse(envelope_id=req.envelope_id)
+            client.send_socket_mode_response(response)
+            client.web_client.reactions_add(
+                name="eyes",
+                channel=req.payload["event"]["channel"],
+                timestamp=req.payload["event"]["ts"],
+            )
+
+    client.socket_mode_request_listeners.append(process)
+    client.connect()
+    Event().wait()

--- a/slack_sdk/audit_logs/v1/async_client.py
+++ b/slack_sdk/audit_logs/v1/async_client.py
@@ -14,6 +14,7 @@ from .internal_utils import (
     get_user_agent,
 )
 from .response import AuditLogsResponse
+from ...proxy_env_variable_loader import load_http_proxy_from_env
 
 
 class AsyncAuditLogsClient:
@@ -74,6 +75,11 @@ class AsyncAuditLogsClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
+
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self.logger)
+            if env_variable is not None:
+                self.proxy = env_variable
 
     async def schemas(
         self,

--- a/slack_sdk/audit_logs/v1/client.py
+++ b/slack_sdk/audit_logs/v1/client.py
@@ -15,6 +15,7 @@ from .internal_utils import (
     get_user_agent,
 )
 from .response import AuditLogsResponse
+from ...proxy_env_variable_loader import load_http_proxy_from_env
 
 
 class AuditLogsClient:
@@ -63,6 +64,11 @@ class AuditLogsClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
+
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self.logger)
+            if env_variable is not None:
+                self.proxy = env_variable
 
     def schemas(
         self,

--- a/slack_sdk/proxy_env_variable_loader.py
+++ b/slack_sdk/proxy_env_variable_loader.py
@@ -1,0 +1,19 @@
+import logging
+import os
+from typing import Optional
+
+_default_logger = logging.getLogger(__name__)
+
+
+def load_http_proxy_from_env(logger: logging.Logger = _default_logger) -> Optional[str]:
+    proxy_url = (
+        os.environ.get("HTTPS_PROXY")
+        or os.environ.get("https_proxy")
+        or os.environ.get("HTTP_PROXY")
+        or os.environ.get("http_proxy")
+    )
+    if proxy_url is not None:
+        logger.debug(
+            f"HTTP proxy URL has been loaded from an env variable: {proxy_url}"
+        )
+    return proxy_url

--- a/slack_sdk/rtm/v2/__init__.py
+++ b/slack_sdk/rtm/v2/__init__.py
@@ -9,6 +9,7 @@ from threading import Lock, Event
 from typing import Optional, Callable, List, Union
 
 from slack_sdk.errors import SlackApiError, SlackClientError
+from slack_sdk.proxy_env_variable_loader import load_http_proxy_from_env
 from slack_sdk.socket_mode.builtin.connection import Connection, ConnectionState
 from slack_sdk.socket_mode.interval_runner import IntervalRunner
 from slack_sdk.web import WebClient
@@ -75,6 +76,10 @@ class RTMClient:
         self.headers = headers
         self.ping_interval = ping_interval
         self.logger = logger or logging.getLogger(__name__)
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self.logger)
+            if env_variable is not None:
+                self.proxy = env_variable
 
         self.web_client = web_client or WebClient(
             token=self.token,

--- a/slack_sdk/scim/v1/async_client.py
+++ b/slack_sdk/scim/v1/async_client.py
@@ -33,6 +33,7 @@ from .response import (
 )
 from .user import User
 from .group import Group
+from ...proxy_env_variable_loader import load_http_proxy_from_env
 
 
 class AsyncSCIMClient:
@@ -92,6 +93,11 @@ class AsyncSCIMClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
+
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self.logger)
+            if env_variable is not None:
+                self.proxy = env_variable
 
     # -------------------------
     # Users

--- a/slack_sdk/scim/v1/client.py
+++ b/slack_sdk/scim/v1/client.py
@@ -33,6 +33,7 @@ from .response import (
 )
 from .user import User
 from .group import Group
+from ...proxy_env_variable_loader import load_http_proxy_from_env
 
 
 class SCIMClient:
@@ -80,6 +81,11 @@ class SCIMClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
+
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self.logger)
+            if env_variable is not None:
+                self.proxy = env_variable
 
     # -------------------------
     # Users

--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -8,6 +8,7 @@ from typing import Union, Optional, List, Callable, Awaitable
 import aiohttp
 from aiohttp import ClientWebSocketResponse, WSMessage, WSMsgType, ClientConnectionError
 
+from slack_sdk.proxy_env_variable_loader import load_http_proxy_from_env
 from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
 from slack_sdk.socket_mode.async_listeners import (
     AsyncWebSocketMessageListener,
@@ -72,6 +73,11 @@ class SocketModeClient(AsyncBaseSocketModeClient):
         self.web_client = web_client or AsyncWebClient()
         self.closed = False
         self.proxy = proxy
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self.logger)
+            if env_variable is not None:
+                self.proxy = env_variable
+
         self.default_auto_reconnect_enabled = auto_reconnect_enabled
         self.auto_reconnect_enabled = self.default_auto_reconnect_enabled
         self.ping_interval = ping_interval

--- a/slack_sdk/socket_mode/builtin/client.py
+++ b/slack_sdk/socket_mode/builtin/client.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from concurrent.futures.thread import ThreadPoolExecutor
 from logging import Logger
 from queue import Queue
@@ -15,6 +16,7 @@ from slack_sdk.web import WebClient
 from .connection import Connection, ConnectionState
 from ..interval_runner import IntervalRunner
 from ...errors import SlackClientConfigurationError
+from ...proxy_env_variable_loader import load_http_proxy_from_env
 
 
 class SocketModeClient(BaseSocketModeClient):
@@ -113,6 +115,10 @@ class SocketModeClient(BaseSocketModeClient):
         self.message_workers = ThreadPoolExecutor(max_workers=concurrency)
 
         self.proxy = proxy
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self.logger)
+            if env_variable is not None:
+                self.proxy = env_variable
         self.proxy_headers = proxy_headers
 
         self.on_message_listeners = on_message_listeners or []

--- a/slack_sdk/socket_mode/builtin/client.py
+++ b/slack_sdk/socket_mode/builtin/client.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from concurrent.futures.thread import ThreadPoolExecutor
 from logging import Logger
 from queue import Queue

--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -17,6 +17,7 @@ from .internal_utils import (
     _get_url,
     get_user_agent,
 )
+from ..proxy_env_variable_loader import load_http_proxy_from_env
 
 
 class AsyncBaseClient:
@@ -54,6 +55,11 @@ class AsyncBaseClient:
         if team_id is not None:
             self.default_params["team_id"] = team_id
         self._logger = logger if logger is not None else logging.getLogger(__name__)
+
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self._logger)
+            if env_variable is not None:
+                self.proxy = env_variable
 
     async def api_call(  # skipcq: PYL-R1710
         self,

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -29,6 +29,7 @@ from .internal_utils import (
     _build_req_args,
 )
 from .slack_response import SlackResponse
+from ..proxy_env_variable_loader import load_http_proxy_from_env
 
 
 class BaseClient:
@@ -61,6 +62,11 @@ class BaseClient:
         if team_id is not None:
             self.default_params["team_id"] = team_id
         self._logger = logger if logger is not None else logging.getLogger(__name__)
+
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self._logger)
+            if env_variable is not None:
+                self.proxy = env_variable
 
     def api_call(  # skipcq: PYL-R1710
         self,

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -33,6 +33,7 @@ from .internal_utils import (
     _build_req_args,
 )
 from .legacy_slack_response import LegacySlackResponse as SlackResponse
+from ..proxy_env_variable_loader import load_http_proxy_from_env
 
 
 class LegacyBaseClient:
@@ -72,6 +73,11 @@ class LegacyBaseClient:
         if team_id is not None:
             self.default_params["team_id"] = team_id
         self._logger = logger if logger is not None else logging.getLogger(__name__)
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self._logger)
+            if env_variable is not None:
+                self.proxy = env_variable
+
         self._event_loop = loop
 
     def api_call(  # skipcq: PYL-R1710

--- a/slack_sdk/webhook/async_client.py
+++ b/slack_sdk/webhook/async_client.py
@@ -16,6 +16,7 @@ from .internal_utils import (
     get_user_agent,
 )
 from .webhook_response import WebhookResponse
+from ..proxy_env_variable_loader import load_http_proxy_from_env
 
 
 class AsyncWebhookClient:
@@ -68,6 +69,11 @@ class AsyncWebhookClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
+
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self.logger)
+            if env_variable is not None:
+                self.proxy = env_variable
 
     async def send(
         self,

--- a/slack_sdk/webhook/client.py
+++ b/slack_sdk/webhook/client.py
@@ -17,6 +17,7 @@ from .internal_utils import (
     get_user_agent,
 )
 from .webhook_response import WebhookResponse
+from ..proxy_env_variable_loader import load_http_proxy_from_env
 
 
 class WebhookClient:
@@ -57,6 +58,11 @@ class WebhookClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
+
+        if self.proxy is None or len(self.proxy.strip()) == 0:
+            env_variable = load_http_proxy_from_env(self.logger)
+            if env_variable is not None:
+                self.proxy = env_variable
 
     def send(
         self,

--- a/tests/test_proxy_env_variable_loader.py
+++ b/tests/test_proxy_env_variable_loader.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+
+from slack_sdk.proxy_env_variable_loader import load_http_proxy_from_env
+from tests.helpers import remove_os_env_temporarily, restore_os_env
+
+
+class TestProxyEnvVariableLoader(unittest.TestCase):
+    def setUp(self):
+        self.old_env = remove_os_env_temporarily()
+
+    def tearDown(self):
+        restore_os_env(self.old_env)
+
+    def test_load_lower_case(self):
+        os.environ["https_proxy"] = "http://localhost:9999"
+        url = load_http_proxy_from_env()
+        self.assertEqual(url, "http://localhost:9999")
+
+    def test_load_upper_case(self):
+        os.environ["HTTPS_PROXY"] = "http://localhost:9999"
+        url = load_http_proxy_from_env()
+        self.assertEqual(url, "http://localhost:9999")

--- a/tests/test_proxy_env_variable_loader.py
+++ b/tests/test_proxy_env_variable_loader.py
@@ -10,6 +10,7 @@ class TestProxyEnvVariableLoader(unittest.TestCase):
         self.old_env = remove_os_env_temporarily()
 
     def tearDown(self):
+        os.environ.clear()
         restore_os_env(self.old_env)
 
     def test_load_lower_case(self):


### PR DESCRIPTION
## Summary

This pull request adds support for common `HTTPS_PROXY` / `HTTP_PROXY` env variables - related to #948 

This is mostly backward compatible as given `proxy` argument would be prioritized over env variables. However, if an app is running in the host which has the env variables and the application does not have `proxy` argument in constructors, its behavior could be changed. Thus, I think we should enable this in the next minor version (v3.4), not a patch version. Also, we can mention this in the release note.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [x] **slack_sdk.audit_logs** (Audit Logs API client)
- [x] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
