### PR TITLE
Enable easier proxy auth configuration in built-in SocketModeClient

### DIFF
--- a/integration_tests/samples/socket_mode/builtin_proxy_auth_example.py
+++ b/integration_tests/samples/socket_mode/builtin_proxy_auth_example.py
@@ -21,9 +21,9 @@ from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode import SocketModeClient
 
-# pip3 install proxy.py
-# proxy --port 9000 --log-level d
-proxy_url = "http://localhost:9000"
+# https://github.com/seratch/my-proxy-server
+# go build && ./my-proxy-sever -a
+proxy_url = "http://user:pass@localhost:9000"
 
 client = SocketModeClient(
     app_token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_APP_TOKEN"),
@@ -32,6 +32,8 @@ client = SocketModeClient(
         proxy=proxy_url,
     ),
     proxy=proxy_url,
+    # proxy="http://localhost:9000",
+    # proxy_headers={"Proxy-Authorization": "Basic dXNlcjpwYXNz"},
     trace_enabled=True,
     all_message_trace_enabled=True,
 )


### PR DESCRIPTION
## Summary

This pull request adds support for `{username}:{password}@` format in HTTP proxy URLs, in addition to #951 changes. This update improves the built-in `SocketModeClient`'s compatibility with `WebClient` etc for proxy auth configuration.

ref: #948 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
