### PR TITLE
Add the browser version link in redirect_uri web page

### DIFF
--- a/integration_tests/samples/oauth/oauth_v2_legacy.py
+++ b/integration_tests/samples/oauth/oauth_v2_legacy.py
@@ -8,6 +8,7 @@ from flask import Flask, request, make_response
 app = Flask(__name__)
 app.debug = True
 
+import logging
 import os
 from uuid import uuid4
 from slack_sdk import WebClient

--- a/slack_sdk/oauth/redirect_uri_page_renderer/__init__.py
+++ b/slack_sdk/oauth/redirect_uri_page_renderer/__init__.py
@@ -34,6 +34,8 @@ class RedirectUriPageRenderer:
                 url = "slack://open"
             else:
                 url = f"slack://app?team={team_id}&id={app_id}"
+        browser_url = f"https://app.slack.com/client/{team_id}"
+
         return f"""
 <html>
 <head>
@@ -48,10 +50,10 @@ body {{
 </head>
 <body>
 <h2>Thank you!</h2>
-<p>Redirecting to the Slack App... click <a href="{url}">here</a></p>
+<p>Redirecting to the Slack App... click <a href="{url}">here</a>. If you use the browser version of Slack, click <a href="{browser_url}" target="_blank">this link</a> instead.</p>
 </body>
 </html>
-"""
+"""  # noqa: E501
 
     def render_failure_page(self, reason: str) -> str:
         return f"""


### PR DESCRIPTION
## Summary

This pull request improves the default HTML page for successful Slack app installation. I got a feedback from a customer, saying the person uses only the browser version of Slack and the `slack://` deep link navigation does not work for me at all. As this is a common use case, I see rooms for improvement on this feature.

<img width="700" src="https://user-images.githubusercontent.com/19658/108955484-9968c000-76b1-11eb-8c3c-0e570d1359a0.png">

We may want to apply the same (or similar) change to `@slack/oauth` npm package and the Java SDK's default behavior.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
