### PR TITLE
Improve validation of missing fallback text in payloads

### DIFF
--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -231,16 +231,30 @@ def _to_0_or_1_if_bool(v: Any) -> Union[Any, str]:
 
 
 def _warn_if_text_is_missing(endpoint: str, kwargs: Dict[str, Any]) -> None:
-    text = kwargs.get("text")
-    if text is None or len(text.strip()) == 0:
-        message = (
-            f"The `text` argument is missing in the request payload for a {endpoint} call - "
-            "It's a best practice to always provide a text argument when posting a message. "
-            "The `text` is used in places where `blocks` cannot be rendered such as: "
-            "system push notifications, assistive technology such as screen readers, etc."
-        )
-        # for unit tests etc.
-        skip_deprecation = os.environ.get("SKIP_SLACK_SDK_WARNING")
-        if skip_deprecation:
+    attachments = kwargs.get("attachments")
+    if attachments:
+        if all(
+            [
+                attachment.get("fallback")
+                and len(attachment.get("fallback").strip()) != 0
+                for attachment in attachments
+            ]
+        ):
             return
-        warnings.warn(message, UserWarning)
+        missing = "fallback"
+    else:
+        text = kwargs.get("text")
+        if text and len(text.strip()) != 0:
+            return
+        missing = "text"
+    message = (
+        f"The `{missing}` argument is missing in the request payload for a {endpoint} call - "
+        f"It's a best practice to always provide a `{missing}` argument when posting a message. "
+        f"The `{missing}` argument is used in places where content cannot be rendered such as: "
+        "system push notifications, assistive technology such as screen readers, etc."
+    )
+    # for unit tests etc.
+    skip_deprecation = os.environ.get("SKIP_SLACK_SDK_WARNING")
+    if skip_deprecation:
+        return
+    warnings.warn(message, UserWarning)


### PR DESCRIPTION
Check for an "attachments" argument and validate each "fallback" parameter instead of just checking for a top-level "text" argument.

Closes #965. 

## Summary

(Describe the goal of this PR. Mention any related issue numbers)

### Category (place an `x` in each of the `[ ]`)

- [X] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [X] I've run `python setup.py validate` after making the changes.
