### PR TITLE
Add public_channel type support for admin.analytics.getFile API

### DIFF
--- a/integration_tests/web/test_admin_analytics.py
+++ b/integration_tests/web/test_admin_analytics.py
@@ -27,13 +27,6 @@ class TestWebClient(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_legacy(self):
-        client = self.legacy_client
-
-        response = client.admin_analytics_getFile(date="2020-10-20", type="member")
-        self.assertTrue(isinstance(response.data, bytes))
-        self.assertIsNotNone(response.data)
-
     def test_sync(self):
         client = self.sync_client
 
@@ -49,6 +42,24 @@ class TestWebClient(unittest.TestCase):
         except SlackApiError as e:
             self.assertFalse(e.response["ok"])
             self.assertEqual("file_not_yet_available", e.response["error"])
+
+    def test_sync_public_channel(self):
+        client = self.sync_client
+
+        response = client.admin_analytics_getFile(
+            date="2020-10-20", type="public_channel"
+        )
+        self.assertTrue(isinstance(response.data, bytes))
+        self.assertIsNotNone(response.data)
+
+    def test_sync_public_channel_medata_only(self):
+        client = self.sync_client
+
+        response = client.admin_analytics_getFile(
+            type="public_channel", metadata_only=True
+        )
+        self.assertTrue(isinstance(response.data, bytes))
+        self.assertIsNotNone(response.data)
 
     @async_test
     async def test_async(self):
@@ -69,3 +80,49 @@ class TestWebClient(unittest.TestCase):
         except SlackApiError as e:
             self.assertFalse(e.response["ok"])
             self.assertEqual("file_not_yet_available", e.response["error"])
+
+    @async_test
+    async def test_async_public_channel(self):
+        client = self.async_client
+
+        response = await client.admin_analytics_getFile(
+            date="2020-10-20", type="public_channel"
+        )
+        self.assertTrue(isinstance(response.data, bytes))
+        self.assertIsNotNone(response.data)
+
+    @async_test
+    async def test_async_public_channel_metadata_only(self):
+        client = self.async_client
+
+        response = await client.admin_analytics_getFile(
+            type="public_channel",
+            metadata_only=True,
+        )
+        self.assertTrue(isinstance(response.data, bytes))
+        self.assertIsNotNone(response.data)
+
+    def test_legacy(self):
+        client = self.legacy_client
+
+        response = client.admin_analytics_getFile(date="2020-10-20", type="member")
+        self.assertTrue(isinstance(response.data, bytes))
+        self.assertIsNotNone(response.data)
+
+    def test_legacy_public_channel(self):
+        client = self.legacy_client
+
+        response = client.admin_analytics_getFile(
+            date="2020-10-20", type="public_channel"
+        )
+        self.assertTrue(isinstance(response.data, bytes))
+        self.assertIsNotNone(response.data)
+
+    def test_legacy_public_channel_metadata_only(self):
+        client = self.legacy_client
+
+        response = client.admin_analytics_getFile(
+            type="public_channel", metadata_only=True
+        )
+        self.assertTrue(isinstance(response.data, bytes))
+        self.assertIsNotNone(response.data)

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -76,7 +76,12 @@ class AsyncWebClient(AsyncBaseClient):
     """
 
     async def admin_analytics_getFile(
-        self, *, date: str, type: str, **kwargs
+        self,
+        *,
+        type: str,
+        date: Optional[str] = None,
+        metadata_only: Optional[bool] = None,
+        **kwargs
     ) -> AsyncSlackResponse:
         """Retrieve analytics data for a given date, presented as a compressed JSON file
 
@@ -86,7 +91,11 @@ class AsyncWebClient(AsyncBaseClient):
             type (str): The type of analytics to retrieve.
                 The options are currently limited to member.
         """
-        kwargs.update({"date": date, "type": type})
+        kwargs.update({"type": type})
+        if date is not None:
+            kwargs.update({"date": date})
+        if metadata_only is not None:
+            kwargs.update({"metadata_only": metadata_only})
         return await self.api_call("admin.analytics.getFile", params=kwargs)
 
     async def admin_apps_approve(

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -67,7 +67,12 @@ class WebClient(BaseClient):
     """
 
     def admin_analytics_getFile(
-        self, *, date: str, type: str, **kwargs
+        self,
+        *,
+        type: str,
+        date: Optional[str] = None,
+        metadata_only: Optional[bool] = None,
+        **kwargs
     ) -> SlackResponse:
         """Retrieve analytics data for a given date, presented as a compressed JSON file
 
@@ -77,7 +82,11 @@ class WebClient(BaseClient):
             type (str): The type of analytics to retrieve.
                 The options are currently limited to member.
         """
-        kwargs.update({"date": date, "type": type})
+        kwargs.update({"type": type})
+        if date is not None:
+            kwargs.update({"date": date})
+        if metadata_only is not None:
+            kwargs.update({"metadata_only": metadata_only})
         return self.api_call("admin.analytics.getFile", params=kwargs)
 
     def admin_apps_approve(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -78,7 +78,12 @@ class LegacyWebClient(LegacyBaseClient):
     """
 
     def admin_analytics_getFile(
-        self, *, date: str, type: str, **kwargs
+        self,
+        *,
+        type: str,
+        date: Optional[str] = None,
+        metadata_only: Optional[bool] = None,
+        **kwargs
     ) -> Union[Future, SlackResponse]:
         """Retrieve analytics data for a given date, presented as a compressed JSON file
 
@@ -88,7 +93,11 @@ class LegacyWebClient(LegacyBaseClient):
             type (str): The type of analytics to retrieve.
                 The options are currently limited to member.
         """
-        kwargs.update({"date": date, "type": type})
+        kwargs.update({"type": type})
+        if date is not None:
+            kwargs.update({"date": date})
+        if metadata_only is not None:
+            kwargs.update({"metadata_only": metadata_only})
         return self.api_call("admin.analytics.getFile", params=kwargs)
 
     def admin_apps_approve(


### PR DESCRIPTION
## Summary

This pull request updates the Web API clients to support newly added `public_channel` type and metadata_only arguments in the admin.analytics.getFile API.

see also: https://api.slack.com/methods/admin.analytics.getFile

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
