### PR TITLE
Add more comments to #972 changes and apply code formatter

### DIFF
--- a/tests/slack_sdk/web/test_web_client_issue_971.py
+++ b/tests/slack_sdk/web/test_web_client_issue_971.py
@@ -16,74 +16,112 @@ class TestWebClient_Issue_971(unittest.TestCase):
         cleanup_mock_web_api_server(self)
 
     def test_text_arg_only(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         resp = client.chat_postMessage(channel="C111", text="test")
         self.assertTrue(resp["ok"])
 
     def test_blocks_with_text_arg(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         resp = client.chat_postMessage(channel="C111", text="test", blocks=[])
         self.assertTrue(resp["ok"])
 
     def test_blocks_without_text_arg(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         with self.assertWarns(UserWarning):
             resp = client.chat_postMessage(channel="C111", blocks=[])
         self.assertTrue(resp["ok"])
 
     def test_attachments_with_fallback(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
-        resp = client.chat_postMessage(channel="C111", attachments=[{'fallback': 'test'}])
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
+        resp = client.chat_postMessage(
+            channel="C111", attachments=[{"fallback": "test"}]
+        )
         self.assertTrue(resp["ok"])
 
     def test_attachments_with_empty_fallback(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         with self.assertWarns(UserWarning):
-            resp = client.chat_postMessage(channel="C111", attachments=[{'fallback': ''}])
+            resp = client.chat_postMessage(
+                channel="C111", attachments=[{"fallback": ""}]
+            )
         self.assertTrue(resp["ok"])
 
     def test_attachments_without_fallback(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         with self.assertWarns(UserWarning):
             resp = client.chat_postMessage(channel="C111", attachments=[{}])
         self.assertTrue(resp["ok"])
 
     def test_attachments_without_fallback_with_text_arg(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         # this warns because each attachment should have its own fallback, even with "text"
         with self.assertWarns(UserWarning):
-            resp = client.chat_postMessage(channel="C111", text="test", attachments=[{}])
+            resp = client.chat_postMessage(
+                channel="C111", text="test", attachments=[{}]
+            )
         self.assertTrue(resp["ok"])
 
     def test_multiple_attachments_one_without_fallback(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         with self.assertWarns(UserWarning):
-            resp = client.chat_postMessage(channel="C111", attachments=[{'fallback': 'test'}, {}])
+            resp = client.chat_postMessage(
+                channel="C111", attachments=[{"fallback": "test"}, {}]
+            )
         self.assertTrue(resp["ok"])
 
     def test_blocks_as_deserialzed_json_without_text_arg(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         # this generates a warning because "text" is missing
         with self.assertWarns(UserWarning):
             resp = client.chat_postMessage(channel="C111", attachments=json.dumps([]))
         self.assertTrue(resp["ok"])
 
     def test_blocks_as_deserialized_json_with_text_arg(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         # this DOESN'T warn because the "text" arg is present
-        resp = client.chat_postMessage(channel="C111", text="test", blocks=json.dumps([]))
+        resp = client.chat_postMessage(
+            channel="C111", text="test", blocks=json.dumps([])
+        )
         self.assertTrue(resp["ok"])
 
     def test_attachments_as_deserialzed_json_without_text_arg(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         # this still generates a warning because "text" is missing. The attachment has already
         # been deserialized, which isn't explicitly prohibited in the docs (but isn't recommended)
         with self.assertWarns(UserWarning):
-            resp = client.chat_postMessage(channel="C111", attachments=json.dumps([{"fallback": "test"}]))
+            resp = client.chat_postMessage(
+                channel="C111", attachments=json.dumps([{"fallback": "test"}])
+            )
         self.assertTrue(resp["ok"])
 
     def test_attachments_as_deserialized_json_with_text_arg(self):
-        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111")
+        client = WebClient(
+            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
+        )
         # this DOESN'T warn because the text arg is present (attachment already deserialized)
-        resp = client.chat_postMessage(channel="C111", text="test", attachments=json.dumps([]))
+        resp = client.chat_postMessage(
+            channel="C111", text="test", attachments=json.dumps([])
+        )
         self.assertTrue(resp["ok"])


### PR DESCRIPTION
## Summary

This pull request applies some minor changes to #972

* Add some comments for its context
* Apply black code formatter to the added tests

cc @eddyg 

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
