### PR TITLE
Add fallback argument in BlockAttachment

### DIFF
--- a/slack_sdk/models/attachments/__init__.py
+++ b/slack_sdk/models/attachments/__init__.py
@@ -433,24 +433,33 @@ class Attachment(JsonObject):
 
 
 class BlockAttachment(Attachment):
-    attributes = {"color"}
     blocks: List[Block]
 
-    def __init__(self, *, blocks: Sequence[Block], color: Optional[str] = None):
+    @property
+    def attributes(self):
+        return super().attributes.union({"blocks", "color"})
+
+    def __init__(
+        self,
+        *,
+        blocks: Sequence[Block],
+        color: Optional[str] = None,
+        fallback: Optional[str] = None,
+    ):
         """
-        A bridge between legacy attachments and blockkit formatting - pass a list of
+        A bridge between legacy attachments and Block Kit formatting - pass a list of
         Block objects directly to this attachment.
 
         https://api.slack.com/reference/messaging/attachments#fields
 
         Args:
             blocks: a sequence of Block objects
-
             color: Changes the color of the border on the left side of this
                 attachment from the default gray. Can either be one of "good" (green),
                 "warning" (yellow), "danger" (red), or any hex color code (eg. #439FE0)
+            fallback: fallback text
         """
-        super().__init__(text="", color=color)
+        super().__init__(text="", fallback=fallback, color=color)
         self.blocks = list(blocks)
 
     @JsonValidator("fields attribute cannot be populated on BlockAttachment")

--- a/tests/web/classes/test_attachments.py
+++ b/tests/web/classes/test_attachments.py
@@ -218,6 +218,6 @@ class BlockAttachmentTests(unittest.TestCase):
         ]
 
         self.assertDictEqual(
-            BlockAttachment(blocks=blocks).to_dict(),
-            {"blocks": [b.to_dict() for b in blocks]},
+            BlockAttachment(fallback="foo", blocks=blocks).to_dict(),
+            {"fallback": "foo", "blocks": [b.to_dict() for b in blocks]},
         )


### PR DESCRIPTION
## Summary

The attachments document encourages having `fallback` field in each attachment: https://api.slack.com/reference/messaging/attachments#legacy_fields

This pull request resolves the missing `fallback` argument in `BlockAttachment` constructor.

Thanks @eddyg for the feedback: https://community.slack.com/archives/CHL4CLRCZ/p1616013860007200
(if you're interested in joining the Slack workspace, you can join the community from https://j.mp/community-slack-com)

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
