### PR TITLE
Add /api-docs in the website

### DIFF
--- a/docs-src/audit-logs/index.rst
+++ b/docs-src/audit-logs/index.rst
@@ -8,6 +8,8 @@ The Audit Logs API can be used by security information and event management (SIE
 
 Follow the instructions in `the API document <https://api.slack.com/admins/audit-logs>`_ to get a valid token for using Audit Logs API. The Slack app using the Audit Logs API needs to be installed in the Enterprise Grid Organization, not an individual workspace within the organization.
 
+The Python document for this module is available at https://slack.dev/python-slack-sdk/api-docs/
+
 AuditLogsClient
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs-src/faq.rst
+++ b/docs-src/faq.rst
@@ -2,6 +2,11 @@
 FAQ
 ==============================================
 
+Python Module Documents
+*********************************
+
+The Python module documents are available at https://slack.dev/python-slack-sdk/api-docs/
+
 Installation Issues
 *********************************
 

--- a/docs-src/index.rst
+++ b/docs-src/index.rst
@@ -44,6 +44,8 @@ The Slack platform offers several APIs to build apps. Each Slack API delivers pa
 | UI Builders                    | Construct UI components using easy-to-use builders.                                           | ``slack_sdk.models``               |
 +--------------------------------+-----------------------------------------------------------------------------------------------+------------------------------------+
 
+The Python module documents are available at https://slack.dev/python-slack-sdk/api-docs/
+
 Installation
 ************
 

--- a/docs-src/oauth/index.rst
+++ b/docs-src/oauth/index.rst
@@ -6,6 +6,8 @@ This section explains the details about how to handle Slack's OAuth flow.
 
 If you're looking for a much easier way to do the same, check `Bolt for Python <https://github.com/slackapi/bolt-python>`_, which is a full-stack Slack App framework. With Bolt, you don't need to implement most of the following code on your own.
 
+The Python document for this module is available at https://slack.dev/python-slack-sdk/api-docs/
+
 App Installation Flow
 *************************************************
 

--- a/docs-src/scim/index.rst
+++ b/docs-src/scim/index.rst
@@ -8,6 +8,8 @@ SCIM API Client
 
 Refer to `the API document <https://api.slack.com/scim>`_ for more details.
 
+The Python document for this module is available at https://slack.dev/python-slack-sdk/api-docs/
+
 SCIMClient
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs-src/socket-mode/index.rst
+++ b/docs-src/socket-mode/index.rst
@@ -4,6 +4,8 @@ Socket Mode Client
 
 Socket Mode is a method of connecting your app to Slack’s APIs using WebSockets instead of HTTP. You can use  ``slack_sdk.socket_mode.SocketModeClient`` for managing `Socket Mode <https://api.slack.com/apis/connections/socket>`_ connections and performing interactions with Slack.
 
+The Python document for this module is available at https://slack.dev/python-slack-sdk/api-docs/
+
 SocketModeClient
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs-src/web/index.rst
+++ b/docs-src/web/index.rst
@@ -8,6 +8,7 @@ Access Slack's API methods requires an OAuth token -- see the `Tokens & Authenti
 
 `Each of these API methods <https://api.slack.com/methods>`_ is fully documented on our developer site at https://api.slack.com/
 
+The Python document for this module is available at https://slack.dev/python-slack-sdk/api-docs/
 
 Messaging
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs-src/webhook/index.rst
+++ b/docs-src/webhook/index.rst
@@ -4,6 +4,8 @@ Webhook Client
 
 You can use ``slack_sdk.webhook.WebhookClient`` for `Incoming Webhooks <https://api.slack.com/messaging/webhooks>`_ and message responses using `response_url in payloads <https://api.slack.com/interactivity/handling#message_responses>`_.
 
+The Python document for this module is available at https://slack.dev/python-slack-sdk/api-docs/
+
 Incoming Webhooks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/scripts/generate_api_docs.sh
+++ b/scripts/generate_api_docs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Generate API documents from the latest source code
+
+script_dir=`dirname $0`
+cd ${script_dir}/..
+
+pip install pdoc3
+rm -rf docs/api-docs
+pdoc slack_sdk --html -o docs/api-docs
+open docs/api-docs/slack_sdk/index.html
+

--- a/slack_sdk/__init__.py
+++ b/slack_sdk/__init__.py
@@ -1,3 +1,42 @@
+"""
+* The SDK website: https://slack.dev/python-slack-sdk/
+* PyPI package: https://pypi.org/project/slack-sdk/
+
+Here is the list of key modules in this SDK:
+
+#### Web API Client
+
+* Web API client: `slack_sdk.web.client`
+* asyncio-based Web API client: `slack_sdk.web.async_client`
+
+#### Webhook / response_url Client
+
+* Webhook client: `slack_sdk.webhook.client`
+* asyncio-based Webhook client: `slack_sdk.webhook.async_client`
+
+#### Socket Mode Client
+
+* The built-in Socket Mode client: `slack_sdk.socket_mode.builtin.client`
+* [aiohttp](https://pypi.org/project/aiohttp/) based client: `slack_sdk.socket_mode.aiohttp`
+* [websocket_client](https://pypi.org/project/websocket-client/) based client: `slack_sdk.socket_mode.websocket_client`
+* [websockets](https://pypi.org/project/websockets/) based client: `slack_sdk.socket_mode.websockets`
+
+#### OAuth
+
+* `slack_sdk.oauth.installation_store.installation_store`
+* `slack_sdk.oauth.state_store`
+
+#### Audit Logs API Client
+
+* `slack_sdk.audit_logs.v1.client`
+* `slack_sdk.audit_logs.v1.async_client`
+
+#### SCIM API Client
+
+* `slack_sdk.scim.v1.client`
+* `slack_sdk.scim.v1.async_client`
+
+"""
 import logging
 from logging import NullHandler
 

--- a/slack_sdk/aiohttp_version_checker.py
+++ b/slack_sdk/aiohttp_version_checker.py
@@ -1,3 +1,4 @@
+"""Internal module for checking aiohttp compatibility of async modules"""
 import logging
 from typing import Callable
 

--- a/slack_sdk/audit_logs/__init__.py
+++ b/slack_sdk/audit_logs/__init__.py
@@ -1,2 +1,6 @@
+"""Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.
+
+Refer to https://slack.dev/python-slack-sdk/audit-logs/ for details.
+"""
 from .v1.client import AuditLogsClient  # noqa
 from .v1.response import AuditLogsResponse  # noqa

--- a/slack_sdk/audit_logs/v1/__init__.py
+++ b/slack_sdk/audit_logs/v1/__init__.py
@@ -1,0 +1,4 @@
+"""Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.
+
+Refer to https://slack.dev/python-slack-sdk/audit-logs/ for details.
+"""

--- a/slack_sdk/audit_logs/v1/async_client.py
+++ b/slack_sdk/audit_logs/v1/async_client.py
@@ -1,3 +1,7 @@
+"""Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.
+
+Refer to https://slack.dev/python-slack-sdk/audit-logs/ for details.
+"""
 import json
 import logging
 from ssl import SSLContext

--- a/slack_sdk/audit_logs/v1/client.py
+++ b/slack_sdk/audit_logs/v1/client.py
@@ -1,3 +1,7 @@
+"""Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.
+
+Refer to https://slack.dev/python-slack-sdk/audit-logs/ for details.
+"""
 import json
 import logging
 import urllib

--- a/slack_sdk/errors/__init__.py
+++ b/slack_sdk/errors/__init__.py
@@ -1,3 +1,6 @@
+"""Errors that can be raised by this SDK"""
+
+
 class SlackClientError(Exception):
     """Base class for Client errors"""
 

--- a/slack_sdk/models/__init__.py
+++ b/slack_sdk/models/__init__.py
@@ -1,3 +1,5 @@
+"""Classes for constructing Slack-specific data strtucture"""
+
 import logging
 from typing import Union, Dict, Any, Sequence, List
 

--- a/slack_sdk/oauth/__init__.py
+++ b/slack_sdk/oauth/__init__.py
@@ -1,3 +1,7 @@
+"""Modules for implementing the Slack OAuth flow
+
+https://slack.dev/python-slack-sdk/oauth/
+"""
 from .authorize_url_generator import AuthorizeUrlGenerator  # noqa
 from .installation_store import InstallationStore  # noqa
 from .redirect_uri_page_renderer import RedirectUriPageRenderer  # noqa

--- a/slack_sdk/oauth/installation_store/installation_store.py
+++ b/slack_sdk/oauth/installation_store/installation_store.py
@@ -1,3 +1,7 @@
+"""Slack installation data store
+
+Refer to https://slack.dev/python-slack-sdk/oauth/ for details.
+"""
 from logging import Logger
 from typing import Optional
 

--- a/slack_sdk/oauth/state_store/__init__.py
+++ b/slack_sdk/oauth/state_store/__init__.py
@@ -1,3 +1,7 @@
+"""OAuth state parameter data store
+
+Refer to https://slack.dev/python-slack-sdk/oauth/ for details.
+"""
 # from .amazon_s3_state_store import AmazonS3OAuthStateStore
 from .file import FileOAuthStateStore  # noqa
 from .state_store import OAuthStateStore  # noqa

--- a/slack_sdk/proxy_env_variable_loader.py
+++ b/slack_sdk/proxy_env_variable_loader.py
@@ -1,3 +1,4 @@
+"""Internal module for loading proxy-related env variables"""
 import logging
 import os
 from typing import Optional

--- a/slack_sdk/scim/__init__.py
+++ b/slack_sdk/scim/__init__.py
@@ -1,3 +1,9 @@
+"""SCIM API is a set of APIs for provisioning and managing user accounts and groups.
+SCIM is used by Single Sign-On (SSO) services and identity providers to manage people across a variety of tools,
+including Slack.
+
+Refer to https://slack.dev/python-slack-sdk/scim/ for details.
+"""
 from .v1.client import SCIMClient  # noqa
 from .v1.response import SCIMResponse  # noqa
 from .v1.response import SearchUsersResponse, ReadUserResponse  # noqa

--- a/slack_sdk/scim/v1/__init__.py
+++ b/slack_sdk/scim/v1/__init__.py
@@ -1,0 +1,6 @@
+"""SCIM API is a set of APIs for provisioning and managing user accounts and groups.
+SCIM is used by Single Sign-On (SSO) services and identity providers to manage people across a variety of tools,
+including Slack.
+
+Refer to https://slack.dev/python-slack-sdk/scim/ for details.
+"""

--- a/slack_sdk/scim/v1/client.py
+++ b/slack_sdk/scim/v1/client.py
@@ -1,3 +1,9 @@
+"""SCIM API is a set of APIs for provisioning and managing user accounts and groups.
+SCIM is used by Single Sign-On (SSO) services and identity providers to manage people across a variety of tools,
+including Slack.
+
+Refer to https://slack.dev/python-slack-sdk/scim/ for details.
+"""
 import json
 import logging
 import urllib

--- a/slack_sdk/signature/__init__.py
+++ b/slack_sdk/signature/__init__.py
@@ -1,3 +1,4 @@
+"""Slack request signature verifier"""
 import hashlib
 import hmac
 from time import time

--- a/slack_sdk/socket_mode/__init__.py
+++ b/slack_sdk/socket_mode/__init__.py
@@ -1,1 +1,7 @@
+"""Socket Mode is a method of connecting your app to Slack’s APIs using WebSockets instead of HTTP.
+You can use slack_sdk.socket_mode.SocketModeClient for managing Socket Mode connections
+and performing interactions with Slack.
+
+https://api.slack.com/apis/connections/socket
+"""
 from .builtin import SocketModeClient  # noqa

--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -1,3 +1,10 @@
+"""aiohttp bassd Socket Mode client
+
+* https://api.slack.com/apis/connections/socket
+* https://slack.dev/python-slack-sdk/socket-mode/
+* https://pypi.org/project/aiohttp/
+
+"""
 import asyncio
 import logging
 from asyncio import Future
@@ -68,6 +75,19 @@ class SocketModeClient(AsyncBaseSocketModeClient):
         on_error_listeners: Optional[List[Callable[[WSMessage], None]]] = None,
         on_close_listeners: Optional[List[Callable[[WSMessage], None]]] = None,
     ):
+        """Socket Mode client
+
+        Args:
+            app_token: App-level token
+            logger: Custom logger
+            web_client: Web API client
+            auto_reconnect_enabled: True if automatic reconnection is enabled (default: True)
+            ping_interval: interval for ping-pong with Slack servers (seconds)
+            proxy: the HTTP proxy URL
+            on_message_listeners: listener functions for on_message
+            on_error_listeners: listener functions for on_error
+            on_close_listeners: listener functions for on_close
+        """
         self.app_token = app_token
         self.logger = logger or logging.getLogger(__name__)
         self.web_client = web_client or AsyncWebClient()

--- a/slack_sdk/socket_mode/builtin/client.py
+++ b/slack_sdk/socket_mode/builtin/client.py
@@ -1,3 +1,9 @@
+"""The built-in Socket Mode client
+
+* https://api.slack.com/apis/connections/socket
+* https://slack.dev/python-slack-sdk/socket-mode/
+
+"""
 import logging
 from concurrent.futures.thread import ThreadPoolExecutor
 from logging import Logger
@@ -76,6 +82,25 @@ class SocketModeClient(BaseSocketModeClient):
         on_error_listeners: Optional[List[Callable[[Exception], None]]] = None,
         on_close_listeners: Optional[List[Callable[[int, Optional[str]], None]]] = None,
     ):
+        """Socket Mode client
+
+        Args:
+            app_token: App-level token
+            logger: Custom logger
+            web_client: Web API client
+            auto_reconnect_enabled: True if automatic reconnection is enabled (default: True)
+            trace_enabled: True if more detailed debug-logging is enabled (default: False)
+            all_message_trace_enabled: True if all message dump in debug logs is enabled (default: False)
+            ping_pong_trace_enabled: True if trace logging for all ping-pong communications is enabled (default: False)
+            ping_interval: interval for ping-pong with Slack servers (seconds)
+            receive_buffer_size: the chunk size of a single socket recv operation (default: 1024)
+            concurrency: the size of thread pool (default: 10)
+            proxy: the HTTP proxy URL
+            proxy_headers: additional HTTP header for proxy connection
+            on_message_listeners: listener functions for on_message
+            on_error_listeners: listener functions for on_error
+            on_close_listeners: listener functions for on_close
+        """
         self.app_token = app_token
         self.logger = logger or logging.getLogger(__name__)
         self.web_client = web_client or WebClient()

--- a/slack_sdk/socket_mode/websocket_client/__init__.py
+++ b/slack_sdk/socket_mode/websocket_client/__init__.py
@@ -1,3 +1,10 @@
+"""websocket-client bassd Socket Mode client
+
+* https://api.slack.com/apis/connections/socket
+* https://slack.dev/python-slack-sdk/socket-mode/
+* https://pypi.org/project/websocket-client/
+
+"""
 import logging
 from concurrent.futures.thread import ThreadPoolExecutor
 from logging import Logger
@@ -78,6 +85,24 @@ class SocketModeClient(BaseSocketModeClient):
         ] = None,
         on_close_listeners: Optional[List[Callable[[WebSocketApp], None]]] = None,
     ):
+        """
+
+        Args:
+            app_token: App-level token
+            logger: Custom logger
+            web_client: Web API client
+            auto_reconnect_enabled: True if automatic reconnection is enabled (default: True)
+            ping_interval: interval for ping-pong with Slack servers (seconds)
+            concurrency: the size of thread pool (default: 10)
+            http_proxy_host: the HTTP proxy host
+            http_proxy_port: the HTTP proxy port
+            http_proxy_auth: the HTTP proxy username & password
+            proxy_type: the HTTP proxy type
+            on_open_listeners: listener functions for on_open
+            on_message_listeners: listener functions for on_message
+            on_error_listeners: listener functions for on_error
+            on_close_listeners: listener functions for on_close
+        """
         self.app_token = app_token
         self.logger = logger or logging.getLogger(__name__)
         self.web_client = web_client or WebClient()

--- a/slack_sdk/socket_mode/websockets/__init__.py
+++ b/slack_sdk/socket_mode/websockets/__init__.py
@@ -1,3 +1,10 @@
+"""websockets bassd Socket Mode client
+
+* https://api.slack.com/apis/connections/socket
+* https://slack.dev/python-slack-sdk/socket-mode/
+* https://pypi.org/project/websockets/
+
+"""
 import asyncio
 import logging
 from asyncio import Future
@@ -58,6 +65,15 @@ class SocketModeClient(AsyncBaseSocketModeClient):
         auto_reconnect_enabled: bool = True,
         ping_interval: float = 10,
     ):
+        """Socket Mode client
+
+        Args:
+            app_token: App-level token
+            logger: Custom logger
+            web_client: Web API client
+            auto_reconnect_enabled: True if automatic reconnection is enabled (default: True)
+            ping_interval: interval for ping-pong with Slack servers (seconds)
+        """
         self.app_token = app_token
         self.logger = logger or logging.getLogger(__name__)
         self.web_client = web_client or AsyncWebClient()

--- a/slack_sdk/version.py
+++ b/slack_sdk/version.py
@@ -1,1 +1,2 @@
+"""Check the latest version at https://pypi.org/project/slack-sdk/"""
 __version__ = "3.4.2"

--- a/slack_sdk/web/__init__.py
+++ b/slack_sdk/web/__init__.py
@@ -1,2 +1,4 @@
+"""The Slack Web API allows you to build applications that interact with Slack
+in more complex ways than the integrations we provide out of the box."""
 from .client import WebClient  # noqa
 from .slack_response import SlackResponse  # noqa

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -25,6 +25,8 @@ from .internal_utils import (
 class AsyncWebClient(AsyncBaseClient):
     """A WebClient allows apps to communicate with the Slack Platform's Web API.
 
+    https://api.slack.com/methods
+
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
 

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -16,6 +16,8 @@ from .internal_utils import (
 class WebClient(BaseClient):
     """A WebClient allows apps to communicate with the Slack Platform's Web API.
 
+    https://api.slack.com/methods
+
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
 

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -27,6 +27,8 @@ from .internal_utils import (
 class LegacyWebClient(LegacyBaseClient):
     """A WebClient allows apps to communicate with the Slack Platform's Web API.
 
+    https://api.slack.com/methods
+
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
 

--- a/slack_sdk/webhook/__init__.py
+++ b/slack_sdk/webhook/__init__.py
@@ -1,3 +1,6 @@
+"""You can use slack_sdk.webhook.WebhookClient for Incoming Webhooks
+and message responses using response_url in payloads.
+"""
 # from .async_client import AsyncWebhookClient  # noqa
 from .client import WebhookClient  # noqa
 from .webhook_response import WebhookResponse  # noqa

--- a/slack_sdk/webhook/async_client.py
+++ b/slack_sdk/webhook/async_client.py
@@ -46,6 +46,8 @@ class AsyncWebhookClient:
     ):
         """API client for Incoming Webhooks and `response_url`
 
+        https://api.slack.com/messaging/webhooks
+
         Args:
             url: Complete URL to send data (e.g., `https://hooks.slack.com/XXX`)
             timeout: Request timeout (in seconds)

--- a/slack_sdk/webhook/client.py
+++ b/slack_sdk/webhook/client.py
@@ -41,6 +41,8 @@ class WebhookClient:
     ):
         """API client for Incoming Webhooks and `response_url`
 
+        https://api.slack.com/messaging/webhooks
+
         Args:
             url: Complete URL to send data (e.g., `https://hooks.slack.com/XXX`)
             timeout: Request timeout (in seconds)


### PR DESCRIPTION
## Summary

This pull request adds the script to generate python documents. After merging this, I will publish the initial version of the documents. Resolves #980 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
