### PR TITLE
Fix #982 Add admin.users.session.* API support

### DIFF
--- a/integration_tests/web/test_admin_users_session_settings.py
+++ b/integration_tests/web/test_admin_users_session_settings.py
@@ -1,0 +1,66 @@
+import logging
+import os
+import unittest
+
+from integration_tests.env_variable_names import (
+    SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN,
+    SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN,
+    SLACK_SDK_TEST_GRID_IDP_USERGROUP_ID,
+    SLACK_SDK_TEST_GRID_TEAM_ID,
+)
+from integration_tests.helpers import async_test
+from slack_sdk.web import WebClient
+from slack_sdk.web.async_client import AsyncWebClient
+
+
+class TestWebClient(unittest.TestCase):
+    """Runs integration tests with real Slack API"""
+
+    def setUp(self):
+        self.logger = logging.getLogger(__name__)
+        self.org_admin_token = os.environ[SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN]
+        self.sync_client: WebClient = WebClient(token=self.org_admin_token)
+        self.async_client: AsyncWebClient = AsyncWebClient(token=self.org_admin_token)
+
+        self.team_id = os.environ[SLACK_SDK_TEST_GRID_TEAM_ID]
+        self.idp_usergroup_id = os.environ[SLACK_SDK_TEST_GRID_IDP_USERGROUP_ID]
+
+        if not hasattr(self, "user_ids"):
+            team_admin_token = os.environ[
+                SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN
+            ]
+            client = WebClient(token=team_admin_token)
+            users = client.users_list(exclude_archived=True, limit=50)
+            self.user_ids = [
+                u["id"]
+                for u in users["members"]
+                if not u["is_bot"]
+                and not u["deleted"]
+                and not u["is_app_user"]
+                and not u["is_owner"]
+                and not u.get("is_stranger")
+            ][:3]
+
+    def tearDown(self):
+        pass
+
+    def test_sync(self):
+        client = self.sync_client
+
+        response = client.admin_users_session_getSettings(user_ids=self.user_ids)
+        self.assertIsNotNone(response["session_settings"])
+        client.admin_users_session_setSettings(
+            user_ids=self.user_ids, duration=60 * 60 * 24 * 30
+        )
+        client.admin_users_session_clearSettings(user_ids=self.user_ids)
+
+    @async_test
+    async def test_async(self):
+        client = self.async_client
+
+        response = await client.admin_users_session_getSettings(user_ids=self.user_ids)
+        self.assertIsNotNone(response["session_settings"])
+        await client.admin_users_session_setSettings(
+            user_ids=self.user_ids, duration=60 * 60 * 24 * 30
+        )
+        await client.admin_users_session_clearSettings(user_ids=self.user_ids)

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -508,6 +508,71 @@ class AsyncWebClient(AsyncBaseClient):
         """Lists all active user sessions for an organization"""
         return await self.api_call("admin.users.session.list", params=kwargs)
 
+    async def admin_teams_settings_setDefaultChannels(
+        self, *, team_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
+    ) -> AsyncSlackResponse:
+        """Set the default channels of a workspace.
+
+        Args:
+            team_id (str): ID of the team.
+            channel_ids (str or list): A list of channel_ids.
+                At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
+        """
+        kwargs.update({"team_id": team_id})
+        if isinstance(channel_ids, (list, Tuple)):
+            kwargs.update({"channel_ids": ",".join(channel_ids)})
+        else:
+            kwargs.update({"channel_ids": channel_ids})
+        return await self.api_call(
+            "admin.teams.settings.setDefaultChannels", http_verb="GET", params=kwargs
+        )
+
+    async def admin_users_session_getSettings(
+        self, *, user_ids: Union[str, Sequence[str]], **kwargs
+    ) -> AsyncSlackResponse:
+        """Get user-specific session settings—the session duration
+        and what happens when the client closes—given a list of users.
+
+        Args:
+            user_ids (str or list): The IDs of users you'd like to fetch session settings for.
+                Note: if a user does not have any active sessions, they will not be returned in the response.
+        """
+        if isinstance(user_ids, (list, Tuple)):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        return await self.api_call("admin.users.session.getSettings", json=kwargs)
+
+    async def admin_users_session_setSettings(
+        self, *, user_ids: Union[str, Sequence[str]], **kwargs
+    ) -> AsyncSlackResponse:
+        """Configure the user-level session settings—the session duration
+        and what happens when the client closes—for one or more users.
+
+        Args:
+            user_ids (str or list): The list of user IDs to apply the session settings for.
+        """
+        if isinstance(user_ids, (list, Tuple)):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        return await self.api_call("admin.users.session.setSettings", json=kwargs)
+
+    async def admin_users_session_clearSettings(
+        self, *, user_ids: Union[str, Sequence[str]], **kwargs
+    ) -> AsyncSlackResponse:
+        """Clear user-specific session settings—the session duration
+        and what happens when the client closes—for a list of users.
+
+        Args:
+            user_ids (str or list): The list of user IDs to apply the session settings for.
+        """
+        if isinstance(user_ids, (list, Tuple)):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        return await self.api_call("admin.users.session.clearSettings", json=kwargs)
+
     async def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
     ) -> AsyncSlackResponse:
@@ -596,25 +661,6 @@ class AsyncWebClient(AsyncBaseClient):
         """
         kwargs.update({"team_id": team_id})
         return await self.api_call("admin.teams.settings.info", json=kwargs)
-
-    async def admin_teams_settings_setDefaultChannels(
-        self, *, team_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
-    ) -> AsyncSlackResponse:
-        """Set the default channels of a workspace.
-
-        Args:
-            team_id (str): ID of the team.
-            channel_ids (str or list): A list of channel_ids.
-                At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
-        """
-        kwargs.update({"team_id": team_id})
-        if isinstance(channel_ids, (list, Tuple)):
-            kwargs.update({"channel_ids": ",".join(channel_ids)})
-        else:
-            kwargs.update({"channel_ids": channel_ids})
-        return await self.api_call(
-            "admin.teams.settings.setDefaultChannels", http_verb="GET", params=kwargs
-        )
 
     async def admin_teams_settings_setDescription(
         self, *, team_id: str, description: str, **kwargs

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -473,6 +473,71 @@ class WebClient(BaseClient):
         """Lists all active user sessions for an organization"""
         return self.api_call("admin.users.session.list", params=kwargs)
 
+    def admin_teams_settings_setDefaultChannels(
+        self, *, team_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
+    ) -> SlackResponse:
+        """Set the default channels of a workspace.
+
+        Args:
+            team_id (str): ID of the team.
+            channel_ids (str or list): A list of channel_ids.
+                At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
+        """
+        kwargs.update({"team_id": team_id})
+        if isinstance(channel_ids, (list, Tuple)):
+            kwargs.update({"channel_ids": ",".join(channel_ids)})
+        else:
+            kwargs.update({"channel_ids": channel_ids})
+        return self.api_call(
+            "admin.teams.settings.setDefaultChannels", http_verb="GET", params=kwargs
+        )
+
+    def admin_users_session_getSettings(
+        self, *, user_ids: Union[str, Sequence[str]], **kwargs
+    ) -> SlackResponse:
+        """Get user-specific session settings—the session duration
+        and what happens when the client closes—given a list of users.
+
+        Args:
+            user_ids (str or list): The IDs of users you'd like to fetch session settings for.
+                Note: if a user does not have any active sessions, they will not be returned in the response.
+        """
+        if isinstance(user_ids, (list, Tuple)):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        return self.api_call("admin.users.session.getSettings", json=kwargs)
+
+    def admin_users_session_setSettings(
+        self, *, user_ids: Union[str, Sequence[str]], **kwargs
+    ) -> SlackResponse:
+        """Configure the user-level session settings—the session duration
+        and what happens when the client closes—for one or more users.
+
+        Args:
+            user_ids (str or list): The list of user IDs to apply the session settings for.
+        """
+        if isinstance(user_ids, (list, Tuple)):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        return self.api_call("admin.users.session.setSettings", json=kwargs)
+
+    def admin_users_session_clearSettings(
+        self, *, user_ids: Union[str, Sequence[str]], **kwargs
+    ) -> SlackResponse:
+        """Clear user-specific session settings—the session duration
+        and what happens when the client closes—for a list of users.
+
+        Args:
+            user_ids (str or list): The list of user IDs to apply the session settings for.
+        """
+        if isinstance(user_ids, (list, Tuple)):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        return self.api_call("admin.users.session.clearSettings", json=kwargs)
+
     def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
     ) -> SlackResponse:
@@ -551,25 +616,6 @@ class WebClient(BaseClient):
         """
         kwargs.update({"team_id": team_id})
         return self.api_call("admin.teams.settings.info", json=kwargs)
-
-    def admin_teams_settings_setDefaultChannels(
-        self, *, team_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
-    ) -> SlackResponse:
-        """Set the default channels of a workspace.
-
-        Args:
-            team_id (str): ID of the team.
-            channel_ids (str or list): A list of channel_ids.
-                At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
-        """
-        kwargs.update({"team_id": team_id})
-        if isinstance(channel_ids, (list, Tuple)):
-            kwargs.update({"channel_ids": ",".join(channel_ids)})
-        else:
-            kwargs.update({"channel_ids": channel_ids})
-        return self.api_call(
-            "admin.teams.settings.setDefaultChannels", http_verb="GET", params=kwargs
-        )
 
     def admin_teams_settings_setDescription(
         self, *, team_id: str, description: str, **kwargs

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -492,6 +492,71 @@ class LegacyWebClient(LegacyBaseClient):
         """Lists all active user sessions for an organization"""
         return self.api_call("admin.users.session.list", params=kwargs)
 
+    def admin_teams_settings_setDefaultChannels(
+        self, *, team_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Set the default channels of a workspace.
+
+        Args:
+            team_id (str): ID of the team.
+            channel_ids (str or list): A list of channel_ids.
+                At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
+        """
+        kwargs.update({"team_id": team_id})
+        if isinstance(channel_ids, (list, Tuple)):
+            kwargs.update({"channel_ids": ",".join(channel_ids)})
+        else:
+            kwargs.update({"channel_ids": channel_ids})
+        return self.api_call(
+            "admin.teams.settings.setDefaultChannels", http_verb="GET", params=kwargs
+        )
+
+    def admin_users_session_getSettings(
+        self, *, user_ids: Union[str, Sequence[str]], **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Get user-specific session settings—the session duration
+        and what happens when the client closes—given a list of users.
+
+        Args:
+            user_ids (str or list): The IDs of users you'd like to fetch session settings for.
+                Note: if a user does not have any active sessions, they will not be returned in the response.
+        """
+        if isinstance(user_ids, (list, Tuple)):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        return self.api_call("admin.users.session.getSettings", json=kwargs)
+
+    def admin_users_session_setSettings(
+        self, *, user_ids: Union[str, Sequence[str]], **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Configure the user-level session settings—the session duration
+        and what happens when the client closes—for one or more users.
+
+        Args:
+            user_ids (str or list): The list of user IDs to apply the session settings for.
+        """
+        if isinstance(user_ids, (list, Tuple)):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        return self.api_call("admin.users.session.setSettings", json=kwargs)
+
+    def admin_users_session_clearSettings(
+        self, *, user_ids: Union[str, Sequence[str]], **kwargs
+    ) -> Union[Future, SlackResponse]:
+        """Clear user-specific session settings—the session duration
+        and what happens when the client closes—for a list of users.
+
+        Args:
+            user_ids (str or list): The list of user IDs to apply the session settings for.
+        """
+        if isinstance(user_ids, (list, Tuple)):
+            kwargs.update({"user_ids": ",".join(user_ids)})
+        else:
+            kwargs.update({"user_ids": user_ids})
+        return self.api_call("admin.users.session.clearSettings", json=kwargs)
+
     def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
     ) -> Union[Future, SlackResponse]:
@@ -580,25 +645,6 @@ class LegacyWebClient(LegacyBaseClient):
         """
         kwargs.update({"team_id": team_id})
         return self.api_call("admin.teams.settings.info", json=kwargs)
-
-    def admin_teams_settings_setDefaultChannels(
-        self, *, team_id: str, channel_ids: Union[str, Sequence[str]], **kwargs
-    ) -> Union[Future, SlackResponse]:
-        """Set the default channels of a workspace.
-
-        Args:
-            team_id (str): ID of the team.
-            channel_ids (str or list): A list of channel_ids.
-                At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']
-        """
-        kwargs.update({"team_id": team_id})
-        if isinstance(channel_ids, (list, Tuple)):
-            kwargs.update({"channel_ids": ",".join(channel_ids)})
-        else:
-            kwargs.update({"channel_ids": channel_ids})
-        return self.api_call(
-            "admin.teams.settings.setDefaultChannels", http_verb="GET", params=kwargs
-        )
 
     def admin_teams_settings_setDescription(
         self, *, team_id: str, description: str, **kwargs

--- a/tests/slack_sdk_async/web/test_web_client_coverage.py
+++ b/tests/slack_sdk_async/web/test_web_client_coverage.py
@@ -47,10 +47,6 @@ class TestWebClientCoverage(unittest.TestCase):
                 "admin.conversations.getCustomRetention",
                 "admin.conversations.removeCustomRetention",
                 "admin.conversations.setCustomRetention",
-                # TODO: https://github.com/slackapi/python-slack-sdk/issues/982
-                "admin.users.session.clearSettings",
-                "admin.users.session.getSettings",
-                "admin.users.session.setSettings",
             ]:
                 continue
             self.api_methods_to_call.append(api_method)
@@ -293,6 +289,15 @@ class TestWebClientCoverage(unittest.TestCase):
             elif method_name == "admin_users_session_reset":
                 self.api_methods_to_call.remove(method(user_id="W123")["method"])
                 await async_method(user_id="W123")
+            elif method_name == "admin_users_session_getSettings":
+                self.api_methods_to_call.remove(method(user_ids=["W111"])["method"])
+                await async_method(user_ids=["W111"])
+            elif method_name == "admin_users_session_setSettings":
+                self.api_methods_to_call.remove(method(user_ids=["W111"])["method"])
+                await async_method(user_ids=["W111"])
+            elif method_name == "admin_users_session_clearSettings":
+                self.api_methods_to_call.remove(method(user_ids=["W111"])["method"])
+                await async_method(user_ids=["W111"])
             elif method_name == "apps_event_authorizations_list":
                 self.api_methods_to_call.remove(method(event_context="xxx")["method"])
                 await async_method(event_context="xxx")


### PR DESCRIPTION
## Summary

This pull request fixes #982 - refer to the issue for details.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
