### PR TITLE
Improve error response body parser in WebClient

### DIFF
--- a/slack_sdk/scim/v1/async_client.py
+++ b/slack_sdk/scim/v1/async_client.py
@@ -8,7 +8,6 @@ from urllib.parse import quote
 import aiohttp
 from aiohttp import BasicAuth, ClientSession
 
-from slack_sdk.errors import SlackApiError
 from .internal_utils import (
     _build_request_headers,
     _debug_log_response,
@@ -321,16 +320,13 @@ class AsyncSCIMClient:
                 "proxy": self.proxy,
             }
             async with session.request(http_verb, url, **request_kwargs) as res:
-                response_body = {}
+                response_body: str = ""
                 try:
                     response_body = await res.text()
                 except aiohttp.ContentTypeError:
                     self.logger.debug(
                         f"No response data returned from the following API call: {url}."
                     )
-                except json.decoder.JSONDecodeError as e:
-                    message = f"Failed to parse the response body: {str(e)}"
-                    raise SlackApiError(message, res)
 
                 resp = SCIMResponse(
                     url=url,

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -27,6 +27,7 @@ from .internal_utils import (
     get_user_agent,
     _get_url,
     _build_req_args,
+    _build_unexpected_body_error_message,
 )
 from .slack_response import SlackResponse
 from ..proxy_env_variable_loader import load_http_proxy_from_env
@@ -286,8 +287,10 @@ class BaseClient:
             if body is not None and not isinstance(body, bytes):
                 try:
                     response_body_data = json.loads(response["body"])
-                except json.decoder.JSONDecodeError as e:
-                    message = f"Failed to parse the response body: {str(e)}"
+                except json.decoder.JSONDecodeError:
+                    message = _build_unexpected_body_error_message(
+                        response.get("body", "")
+                    )
                     raise err.SlackApiError(message, response)
 
             if query_params:

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -268,3 +268,13 @@ def _warn_if_text_is_missing(endpoint: str, kwargs: Dict[str, Any]) -> None:
     if skip_deprecation:
         return
     warnings.warn(message, UserWarning)
+
+
+def _build_unexpected_body_error_message(body: str) -> str:
+    body_for_logging = "".join(
+        [line.strip() for line in body.replace("\r", "\n").split("\n")]
+    )
+    if len(body_for_logging) > 100:
+        body_for_logging = body_for_logging[:100] + "..."
+    message = f"Received a response in a non-JSON format: {body_for_logging}"
+    return message

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -31,6 +31,7 @@ from .internal_utils import (
     get_user_agent,
     _get_url,
     _build_req_args,
+    _build_unexpected_body_error_message,
 )
 from .legacy_slack_response import LegacySlackResponse as SlackResponse
 from ..proxy_env_variable_loader import load_http_proxy_from_env
@@ -366,8 +367,10 @@ class LegacyBaseClient:
             if body is not None and not isinstance(body, bytes):
                 try:
                     response_body_data = json.loads(response["body"])
-                except json.decoder.JSONDecodeError as e:
-                    message = f"Failed to parse the response body: {str(e)}"
+                except json.decoder.JSONDecodeError:
+                    message = _build_unexpected_body_error_message(
+                        response.get("body", "")
+                    )
                     raise err.SlackApiError(message, response)
 
             if query_params:

--- a/slack_sdk/webhook/async_client.py
+++ b/slack_sdk/webhook/async_client.py
@@ -6,7 +6,6 @@ from typing import Dict, Union, Optional, Any, Sequence
 import aiohttp
 from aiohttp import BasicAuth, ClientSession
 
-from slack_sdk.errors import SlackApiError
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block
 from .internal_utils import (
@@ -165,16 +164,13 @@ class AsyncWebhookClient:
                 "proxy": self.proxy,
             }
             async with session.request("POST", self.url, **request_kwargs) as res:
-                response_body = {}
+                response_body: str = ""
                 try:
                     response_body = await res.text()
                 except aiohttp.ContentTypeError:
                     self.logger.debug(
-                        f"No response data returned from the following API call: {self.url}."
+                        f"No response data returned from the following API call: {self.url}"
                     )
-                except json.decoder.JSONDecodeError as e:
-                    message = f"Failed to parse the response body: {str(e)}"
-                    raise SlackApiError(message, res)
 
                 resp = WebhookResponse(
                     url=self.url,

--- a/tests/slack_sdk/web/test_internal_utils.py
+++ b/tests/slack_sdk/web/test_internal_utils.py
@@ -1,0 +1,18 @@
+import unittest
+from slack_sdk.web.internal_utils import _build_unexpected_body_error_message
+
+
+class TestInternalUtils(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    error_html_response_body = '<!DOCTYPE html>\n<html lang="en">\n<head>\n\t<meta charset="utf-8">\n\t<title>Server Error | Slack</title>\n\t<meta name="author" content="Slack">\n\t<style></style>\n</head>\n<body>\n\t<nav class="top persistent">\n\t\t<a href="https://status.slack.com/" class="logo" data-qa="logo"></a>\n\t</nav>\n\t<div id="page">\n\t\t<div id="page_contents">\n\t\t\t<h1>\n\t\t\t\t<svg width="30px" height="27px" viewBox="0 0 60 54" class="warning_icon"><path d="" fill="#D94827"/></svg>\n\t\t\t\tServer Error\n\t\t\t</h1>\n\t\t\t<div class="card">\n\t\t\t\t<p>It seems like there’s a problem connecting to our servers, and we’re investigating the issue.</p>\n\t\t\t\t<p>Please <a href="https://status.slack.com/">check our Status page for updates</a>.</p>\n\t\t\t</div>\n\t\t</div>\n\t</div>\n\t<script type="text/javascript">\n\t\tif (window.desktop) {\n\t\t\tdocument.documentElement.className = \'desktop\';\n\t\t}\n\n\t\tvar FIVE_MINS = 5 * 60 * 1000;\n\t\tvar TEN_MINS = 10 * 60 * 1000;\n\n\t\tfunction randomBetween(min, max) {\n\t\t\treturn Math.floor(Math.random() * (max - (min + 1))) + min;\n\t\t}\n\n\t\twindow.setTimeout(function () {\n\t\t\twindow.location.reload(true);\n\t\t}, randomBetween(FIVE_MINS, TEN_MINS));\n\t</script>\n</body>\n</html>'
+
+    def test_build_unexpected_body_error_message(self):
+        message = _build_unexpected_body_error_message(self.error_html_response_body)
+        assert message.startswith(
+            """Received a response in a non-JSON format: <!DOCTYPE html><html lang="en"><head><meta charset="utf-8">"""
+        )

--- a/tests/slack_sdk/web/test_web_client.py
+++ b/tests/slack_sdk/web/test_web_client.py
@@ -157,7 +157,7 @@ class TestWebClient(unittest.TestCase):
         except err.SlackApiError as e:
             self.assertTrue(
                 str(e).startswith(
-                    "Failed to parse the response body: Expecting value: line 1 column 1 (char 0)"
+                    "Received a response in a non-JSON format: <!DOCTYPE HTML PUBLIC"
                 ),
                 e,
             )

--- a/tests/slack_sdk/web/test_web_client_issue_829.py
+++ b/tests/slack_sdk/web/test_web_client_issue_829.py
@@ -22,8 +22,5 @@ class TestWebClient_Issue_829(unittest.TestCase):
             self.fail("SlackApiError expected here")
         except err.SlackApiError as e:
             self.assertTrue(
-                str(e).startswith(
-                    "Failed to parse the response body: Expecting value: "
-                ),
-                e,
+                str(e).startswith("Received a response in a non-JSON format: "), e
             )

--- a/tests/web/test_web_client.py
+++ b/tests/web/test_web_client.py
@@ -273,9 +273,7 @@ class TestWebClient(unittest.TestCase):
             self.fail("SlackApiError expected here")
         except err.SlackApiError as e:
             self.assertTrue(
-                str(e).startswith(
-                    "Failed to parse the response body: Expecting value: line 1 column 1 (char 0)"
-                ),
+                str(e).startswith("Received a response in a non-JSON format: "),
                 e,
             )
 

--- a/tests/web/test_web_client_issue_829.py
+++ b/tests/web/test_web_client_issue_829.py
@@ -32,9 +32,7 @@ class TestWebClient_Issue_829(unittest.TestCase):
             self.fail("SlackApiError expected here")
         except err.SlackApiError as e:
             self.assertTrue(
-                str(e).startswith(
-                    "Failed to parse the response body: Expecting value: "
-                ),
+                str(e).startswith("Received a response in a non-JSON format: "),
                 e,
             )
 


### PR DESCRIPTION
## Summary

The current implementation outputs an error message saying "Failed to parse the response body: ..." when the Slack server-side returns non-JSON response body for some reasons. I think this error message could be confusing. In this scenario, no unexpected error on the API client side is occurring.

This pull request improves the error handling code to generate more precise error message in the above patterns. I will add some comments for reviewers.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
