### PR TITLE
Setting a default value for select_options for ViewStateValue

### DIFF
--- a/slack_sdk/models/views/__init__.py
+++ b/slack_sdk/models/views/__init__.py
@@ -231,8 +231,13 @@ class ViewStateValue(JsonObject):
         self.selected_conversations = selected_conversations
         self.selected_channels = selected_channels
         self.selected_users = selected_users
-        if selected_options:
-            if isinstance(selected_options, dict):
-                self.selected_options = [Option(**d) for d in selected_options]
-            else:
-                self.selected_options = selected_options
+
+        if isinstance(selected_options, list):
+            self.selected_options = []
+            for option in selected_options:
+                if isinstance(option, Option):
+                    self.selected_options.append(option)
+                elif isinstance(option, dict):
+                    self.selected_options.append(Option(**option))
+        else:
+            self.selected_options = selected_options

--- a/tests/slack_sdk/models/test_views.py
+++ b/tests/slack_sdk/models/test_views.py
@@ -351,6 +351,44 @@ class ViewTests(unittest.TestCase):
         self.assertDictEqual(expected, ViewState(**expected).to_dict())
         self.assertDictEqual(expected, state.to_dict())
 
+    def test_view_state_value_empty_selected_options(self):
+        input = {
+            'type': 'checkboxes',
+            'selected_options': []
+        }
+
+        view_state_value = ViewStateValue(**input)
+        assert view_state_value.selected_options == []
+
+    def test_view_state_value_with_selected_options(self):
+        expected = {
+            "type": "checkboxes",
+            "selected_options": [
+                {
+                    "text": {
+                        "type": "plain_text",
+                        "text": "test_option_text"
+                    },
+                    "value": "test_option_value"
+                }
+            ],
+        }
+
+        input = {
+            "type": "checkboxes",
+            "selected_options": [
+                {
+                    "text": {
+                        "type": "plain_text",
+                        "text": "test_option_text"
+                    },
+                    "value": "test_option_value"
+                }
+            ]
+        }
+
+        self.assertDictEqual(expected, ViewStateValue(**input).to_dict())
+
     def test_load_modal_view_001(self):
         with open("tests/slack_sdk_fixture/view_modal_001.json") as file:
             self.verify_loaded_view_object(file)


### PR DESCRIPTION
## Summary

This pull request adds a default `selected_options` attribute for `ViewStateValue` objects. This makes it consistent with the other attributes of this class. This is related to [Issue 987](https://github.com/slackapi/python-slack-sdk/issues/987).

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
