### PR TITLE
Fix #990 slack_sdk.models.blocks.Option's description value is invalid in blocks

### DIFF
--- a/slack_sdk/models/blocks/basic_components.py
+++ b/slack_sdk/models/blocks/basic_components.py
@@ -249,7 +249,9 @@ class Option(JsonObject):
         self.validate_json()
         if option_type == "dialog":  # skipcq: PYL-R1705
             return {"label": self.label, "value": self.value}
-        elif option_type == "action":
+        elif option_type == "action" or option_type == "attachment":
+            # "action" can be confusing but it means a legacy message action in attachments
+            # we don't remove the type name for backward compatibility though
             json = {"text": self.label, "value": self.value}
             if self.description is not None:
                 json["description"] = self.description
@@ -261,7 +263,9 @@ class Option(JsonObject):
                 "value": self.value,
             }
             if self.description:
-                json["description"] = self.description
+                # self.description is always a str value
+                description = PlainTextObject.from_str(self.description)
+                json["description"] = description.to_dict()
             if self.url:
                 json["url"] = self.url
             return json

--- a/tests/slack_sdk/models/test_objects.py
+++ b/tests/slack_sdk/models/test_objects.py
@@ -414,6 +414,63 @@ class OptionTests(unittest.TestCase):
         with self.assertRaises(SlackObjectFormationError):
             Option(label="option_1", value=STRING_301_CHARS).to_dict("text")
 
+    def test_valid_description_for_blocks(self):
+        option = Option(label="label", value="v", description="this is an option")
+        self.assertDictEqual(
+            option.to_dict(),
+            {
+                "text": {
+                    "type": "plain_text",
+                    "text": "label",
+                    "emoji": True,
+                },
+                "value": "v",
+                "description": {
+                    "type": "plain_text",
+                    "text": "this is an option",
+                    "emoji": True,
+                },
+            },
+        )
+        option = Option(
+            # Note that mrkdwn type is not allowed for this (as of April 2021)
+            text=PlainTextObject(text="label"),
+            value="v",
+            description="this is an option",
+        )
+        self.assertDictEqual(
+            option.to_dict(),
+            {
+                "text": {"type": "plain_text", "text": "label"},
+                "value": "v",
+                "description": {
+                    "type": "plain_text",
+                    "text": "this is an option",
+                    "emoji": True,
+                },
+            },
+        )
+
+    def test_valid_description_for_attachments(self):
+        option = Option(label="label", value="v", description="this is an option")
+        # legacy message actions in attachments
+        self.assertDictEqual(
+            option.to_dict("action"),
+            {
+                "text": "label",
+                "value": "v",
+                "description": "this is an option",
+            },
+        )
+        self.assertDictEqual(
+            option.to_dict("attachment"),
+            {
+                "text": "label",
+                "value": "v",
+                "description": "this is an option",
+            },
+        )
+
 
 class OptionGroupTests(unittest.TestCase):
     maxDiff = None

--- a/tests/slack_sdk/models/test_views.py
+++ b/tests/slack_sdk/models/test_views.py
@@ -352,10 +352,7 @@ class ViewTests(unittest.TestCase):
         self.assertDictEqual(expected, state.to_dict())
 
     def test_view_state_value_empty_selected_options(self):
-        input = {
-            'type': 'checkboxes',
-            'selected_options': []
-        }
+        input = {"type": "checkboxes", "selected_options": []}
 
         view_state_value = ViewStateValue(**input)
         assert view_state_value.selected_options == []
@@ -365,11 +362,8 @@ class ViewTests(unittest.TestCase):
             "type": "checkboxes",
             "selected_options": [
                 {
-                    "text": {
-                        "type": "plain_text",
-                        "text": "test_option_text"
-                    },
-                    "value": "test_option_value"
+                    "text": {"type": "plain_text", "text": "test_option_text"},
+                    "value": "test_option_value",
                 }
             ],
         }
@@ -378,13 +372,10 @@ class ViewTests(unittest.TestCase):
             "type": "checkboxes",
             "selected_options": [
                 {
-                    "text": {
-                        "type": "plain_text",
-                        "text": "test_option_text"
-                    },
-                    "value": "test_option_value"
+                    "text": {"type": "plain_text", "text": "test_option_text"},
+                    "value": "test_option_value",
                 }
-            ]
+            ],
         }
 
         self.assertDictEqual(expected, ViewStateValue(**input).to_dict())


### PR DESCRIPTION
## Summary

This pull request resolves #990 . Refer to the issue for the details.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
