### PR TITLE
Fix #1002 ConversationFilter missing new optional field exclude_external_shared_channels

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -756,7 +756,7 @@ class UserMultiSelectElement(InputInteractiveElement):
 
 
 class ConversationFilter(JsonObject):
-    attributes = {"include", "exclude_bot_users"}
+    attributes = {"include", "exclude_bot_users", "exclude_external_shared_channels"}
     logger = logging.getLogger(__name__)
 
     def __init__(
@@ -764,9 +764,11 @@ class ConversationFilter(JsonObject):
         *,
         include: Optional[Sequence[str]] = None,
         exclude_bot_users: Optional[bool] = None,
+        exclude_external_shared_channels: Optional[bool] = None,
     ):
         self.include = include
         self.exclude_bot_users = exclude_bot_users
+        self.exclude_external_shared_channels = exclude_external_shared_channels
 
     @classmethod
     def parse(cls, filter: Union[dict, "ConversationFilter"]):  # skipcq: PYL-W0622


### PR DESCRIPTION
## Summary

This pull request resolves #1002 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
