### PR TITLE
Fix #1003 threading.Thread.setDaemon has been deprecated in Python 3.10

### DIFF
--- a/integration_tests/rtm/test_issue_569.py
+++ b/integration_tests/rtm/test_issue_569.py
@@ -46,7 +46,7 @@ class TestRTMClient(unittest.TestCase):
             TestRTMClient.cpu_monitor = threading.Thread(
                 target=run_cpu_monitor, args=[self]
             )
-            TestRTMClient.cpu_monitor.setDaemon(True)
+            TestRTMClient.cpu_monitor.daemon = True
             TestRTMClient.cpu_monitor.start()
 
         self.rtm_client = None
@@ -91,7 +91,7 @@ class TestRTMClient(unittest.TestCase):
             self.rtm_client.start()
 
         rtm = threading.Thread(target=connect)
-        rtm.setDaemon(True)
+        rtm.daemon = True
 
         rtm.start()
         time.sleep(5)

--- a/integration_tests/rtm/test_issue_605.py
+++ b/integration_tests/rtm/test_issue_605.py
@@ -49,7 +49,7 @@ class TestRTMClient(unittest.TestCase):
             self.rtm_client.start()
 
         t = threading.Thread(target=connect)
-        t.setDaemon(True)
+        t.daemon = True
         try:
             t.start()
             self.assertFalse(self.called)

--- a/integration_tests/rtm/test_issue_631.py
+++ b/integration_tests/rtm/test_issue_631.py
@@ -97,7 +97,7 @@ class TestRTMClient(unittest.TestCase):
             self.rtm_client.start()
 
         t = threading.Thread(target=connect)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
         try:

--- a/integration_tests/rtm/test_issue_701.py
+++ b/integration_tests/rtm/test_issue_701.py
@@ -50,7 +50,7 @@ class TestRTMClient(unittest.TestCase):
             self.rtm_client.start()
 
         rtm = threading.Thread(target=connect)
-        rtm.setDaemon(True)
+        rtm.daemon = True
 
         rtm.start()
         time.sleep(3)
@@ -70,7 +70,7 @@ class TestRTMClient(unittest.TestCase):
         senders = []
         for sender_num in range(num_of_senders):
             sender = threading.Thread(target=sent_bulk_message)
-            sender.setDaemon(True)
+            sender.daemon = True
             sender.start()
             senders.append(sender)
 
@@ -127,7 +127,7 @@ class TestRTMClient(unittest.TestCase):
         senders = []
         for sender_num in range(num_of_senders):
             sender = threading.Thread(target=sent_bulk_message)
-            sender.setDaemon(True)
+            sender.daemon = True
             sender.start()
             senders.append(sender)
 

--- a/integration_tests/rtm/test_rtm_client.py
+++ b/integration_tests/rtm/test_rtm_client.py
@@ -50,7 +50,7 @@ class TestRTMClient(unittest.TestCase):
             self.rtm_client.start()
 
         t = threading.Thread(target=connect)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
         try:

--- a/slack_sdk/socket_mode/interval_runner.py
+++ b/slack_sdk/socket_mode/interval_runner.py
@@ -13,7 +13,7 @@ class IntervalRunner:
         self.target = target
         self.interval_seconds = interval_seconds
         self.thread = threading.Thread(target=self._run)
-        self.thread.setDaemon(True)
+        self.thread.daemon = True
 
     def _run(self) -> None:
         while not self.event.is_set():


### PR DESCRIPTION
## Summary

This pull request resolves #1003 by getting rid of all `Thread#setDaemon(bool)` usage in this repository. As the `setDaemon` method just does the following, it's safe enough to change the code:

```python
    def setDaemon(self, daemonic):
        self.daemon = daemonic
```

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
