### PR TITLE
Fix #1021 by updating View constructor to convert state as dict to class object

### DIFF
--- a/tests/data/view_modal_009.json
+++ b/tests/data/view_modal_009.json
@@ -35,7 +35,7 @@
   "callback_id": "view_4",
   "external_id": "some-unique-id",
   "state": {
-    "values": []
+    "values": {}
   },
   "hash": "1569362015.55b5e41b",
   "clear_on_close": true,

--- a/tests/data/view_modal_010.json
+++ b/tests/data/view_modal_010.json
@@ -30,7 +30,7 @@
   "callback_id": "identify_your_modals",
   "external_id": "some-unique-id",
   "state": {
-    "values": []
+    "values": {}
   },
   "hash": "156772938.1827394",
   "clear_on_close": false,

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -228,7 +228,10 @@ class TimePickerElementTests(unittest.TestCase):
             "type": "timepicker",
             "action_id": "timepicker123",
             "initial_time": "11:40",
-            "placeholder": {"type": "plain_text", "text": "Select a time",},
+            "placeholder": {
+                "type": "plain_text",
+                "text": "Select a time",
+            },
         }
         self.assertDictEqual(input, TimePickerElement(**input).to_dict())
 

--- a/tests/slack_sdk/models/test_views.py
+++ b/tests/slack_sdk/models/test_views.py
@@ -30,6 +30,7 @@ class ViewTests(unittest.TestCase):
     def verify_loaded_view_object(self, file):
         input = json.load(file)
         view = View(**input)
+        self.assertTrue(view.state is None or isinstance(view.state, ViewState))
         self.assertDictEqual(input, view.to_dict())
 
     # --------------------------------
@@ -110,6 +111,18 @@ class ViewTests(unittest.TestCase):
                     ),
                 ),
             ],
+            state=ViewState(
+                values={
+                    "b1": {
+                        "a1": ViewStateValue(type="plain_text_input", value="Title")
+                    },
+                    "b2": {
+                        "a2": ViewStateValue(
+                            type="plain_text_input", value="Description"
+                        )
+                    },
+                }
+            ),
         )
         modal_view.validate_json()
 

--- a/tests/slack_sdk_fixture/view_modal_009.json
+++ b/tests/slack_sdk_fixture/view_modal_009.json
@@ -35,7 +35,7 @@
   "callback_id": "view_4",
   "external_id": "some-unique-id",
   "state": {
-    "values": []
+    "values": {}
   },
   "hash": "1569362015.55b5e41b",
   "clear_on_close": true,

--- a/tests/slack_sdk_fixture/view_modal_010.json
+++ b/tests/slack_sdk_fixture/view_modal_010.json
@@ -30,7 +30,7 @@
   "callback_id": "identify_your_modals",
   "external_id": "some-unique-id",
   "state": {
-    "values": []
+    "values": {}
   },
   "hash": "156772938.1827394",
   "clear_on_close": false,


### PR DESCRIPTION
## Summary

This pull request fixes #1021 by updating the `slack_sdk.models.views.View`'s constructor to convert a given `state` dict value to the `ViewState` class object. 

As all other properties in `View` class are already converted to class objects, changing this part would be a great improvement in terms of consistency. The changed property is still compatible with the current type hint - `Optional[Union[dict, ViewState]]`. We are going to apply this change in the next minor version - 3.6.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
