### PR TITLE
Remove confusing warning messages #1030

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -149,10 +149,17 @@ class InteractiveElement(BlockElement):
         subtype: Optional[str] = None,
         **others: dict,
     ):
+        """An interactive block element.
+
+        We generally recommend using the concrete subclasses for better supports of available properties.
+        """
         if subtype:
             self._subtype_warning()
         super().__init__(type=type or subtype)
-        show_unknown_key_warning(self, others)
+
+        # Note that we don't intentionally have show_unknown_key_warning for the unknown key warnings here.
+        # It's fine to pass any kwargs to the held dict here although the class does not do any validation.
+        # show_unknown_key_warning(self, others)
 
         self.action_id = action_id
 
@@ -190,11 +197,17 @@ class InputInteractiveElement(InteractiveElement, metaclass=ABCMeta):
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         **others: dict,
     ):
-        """InteractiveElement that is usable in input blocks"""
+        """InteractiveElement that is usable in input blocks
+
+        We generally recommend using the concrete subclasses for better supports of available properties.
+        """
         if subtype:
             self._subtype_warning()
         super().__init__(action_id=action_id, type=type or subtype)
-        show_unknown_key_warning(self, others)
+
+        # Note that we don't intentionally have show_unknown_key_warning for the unknown key warnings here.
+        # It's fine to pass any kwargs to the held dict here although the class does not do any validation.
+        # show_unknown_key_warning(self, others)
 
         self.placeholder = TextObject.parse(placeholder)
         self.confirm = ConfirmObject.parse(confirm)

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -23,6 +23,8 @@ from slack_sdk.models.blocks import (
     ChannelSelectElement,
     ConfirmObject,
     Option,
+    InputInteractiveElement,
+    InteractiveElement,
 )
 from . import STRING_3001_CHARS, STRING_301_CHARS
 
@@ -30,6 +32,26 @@ from . import STRING_3001_CHARS, STRING_301_CHARS
 # -------------------------------------------------
 # Interactive Elements
 # -------------------------------------------------
+
+
+class InteractiveElementTests(unittest.TestCase):
+    def test_with_interactive_element(self):
+        input = {
+            "type": "plain_text_input",
+            "action_id": "plain_input",
+            "placeholder": {"type": "plain_text", "text": "Enter some plain text"},
+        }
+        # Any properties should be lost
+        self.assertDictEqual(input, InteractiveElement(**input).to_dict())
+
+    def test_with_input_interactive_element(self):
+        input = {
+            "type": "plain_text_input",
+            "action_id": "plain_input",
+            "placeholder": {"type": "plain_text", "text": "Enter some plain text"},
+        }
+        # Any properties should be lost
+        self.assertDictEqual(input, InputInteractiveElement(**input).to_dict())
 
 
 class InteractiveElementTests(unittest.TestCase):

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -41,7 +41,7 @@ class InteractiveElementTests(unittest.TestCase):
             "action_id": "plain_input",
             "placeholder": {"type": "plain_text", "text": "Enter some plain text"},
         }
-        # Any properties should be lost
+        # Any properties should not be lost
         self.assertDictEqual(input, InteractiveElement(**input).to_dict())
 
     def test_with_input_interactive_element(self):
@@ -50,7 +50,7 @@ class InteractiveElementTests(unittest.TestCase):
             "action_id": "plain_input",
             "placeholder": {"type": "plain_text", "text": "Enter some plain text"},
         }
-        # Any properties should be lost
+        # Any properties should not be lost
         self.assertDictEqual(input, InputInteractiveElement(**input).to_dict())
 
 


### PR DESCRIPTION
## Summary

This pull request removes the confusing warning log messages in the constructors of Block Element base classes. As I mentioned at https://github.com/slackapi/python-slack-sdk/issues/1030#issuecomment-857634173, we generally don't recommend directly using the base classes such as `InteractiveElement` and `InputInteractiveElement` as these classes does not provide optimal ways to construct data for each block element. 

That said, displaying `!!! InputInteractiveElement's constructor args (initial_value) were ignored.If they should be supported by this library, report this issue to the project :bow: https://github.com/slackapi/python-slack-sdk/issues` for valid properties does not help us improve anything. Therefore, we will remove the warnings from the two classes.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
