### PR TITLE
Remove Dead Link From Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Are you looking for [slackclient](https://pypi.org/project/slackclient/)? The we
 * [Basic Usage of the Web Client](#basic-usage-of-the-web-client)
   * [Sending a message to Slack](#sending-a-message-to-slack)
   * [Uploading files to Slack](#uploading-files-to-slack)
-* [Basic Usage of the RTM Client](#basic-usage-of-the-rtm-client)
 * [Async usage](#async-usage)
   * [WebClient as a script](#asyncwebclient-in-a-script)
   * [WebClient in a framework](#asyncwebclient-in-a-framework)


### PR DESCRIPTION
## Summary

Hi Slack developers! 

I noticed that there was a dead anchor link in the readme table of contents for RTM client documentation. I understand RTM is not especially promoted (in favor of socket mode) and a [prior PR understandably deleted the introductory RTM documentation from the readme](https://github.com/slackapi/python-slack-sdk/pull/807). However, it seems this lone dead link to to the now-deleted content was left behind. My PR removes the dead link so nobody is confused trying to click it, like I was. :)

Thanks!


### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes.
