### PR TITLE
IntervalRunner: don't wait for `interval_seconds` on shutdown

### DIFF
--- a/slack_sdk/socket_mode/interval_runner.py
+++ b/slack_sdk/socket_mode/interval_runner.py
@@ -1,5 +1,4 @@
 import threading
-import time
 from threading import Thread, Event
 from typing import Callable
 
@@ -18,7 +17,7 @@ class IntervalRunner:
     def _run(self) -> None:
         while not self.event.is_set():
             self.target()
-            time.sleep(self.interval_seconds)
+            self.event.wait(self.interval_seconds)
 
     def start(self) -> "IntervalRunner":
         self.thread.start()


### PR DESCRIPTION
## Summary

`IntervalRunner.shutdown` method currently has to wait the full `interval_seconds` period due to using a `time.sleep` call. This change speeds up the shutdown by replacing it with a `threading.Event.wait` call.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes. **[Some e2e tests don't pass with a `ConnectionResetError: [Errno 54] Connection reset by peer` error]**
