### PR TITLE
socket_mode Connection: Add support for IPv6

### DIFF
--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -81,7 +81,7 @@ def _establish_new_socket_connection(
                 f"Failed to connect to the proxy (proxy: {proxy}, connect status code: {status})"
             )
 
-        sock = ssl.SSLContext(ssl.PROTOCOL_SSLv23).wrap_socket(
+        sock = ssl.create_default_context().wrap_socket(
             sock,
             do_handshake_on_connect=True,
             suppress_ragged_eofs=True,
@@ -98,7 +98,7 @@ def _establish_new_socket_connection(
         return sock
 
     sock = socket.create_connection((server_hostname, server_port), receive_timeout)
-    sock = ssl.SSLContext(ssl.PROTOCOL_SSLv23).wrap_socket(
+    sock = ssl.create_default_context().wrap_socket(
         sock,
         do_handshake_on_connect=True,
         suppress_ragged_eofs=True,


### PR DESCRIPTION
## Summary

The current implementation uses hardcoded AF_INET (IPv4) family and a first DNS record for connection. This doesn't work in IPv6-only environments (via NAT64):
```
ERROR:slack_sdk.rtm_v2:Failed to establish a connection (session id: <STRIPPED>, error: [Errno -2] Name or service not known)
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/slack_sdk/socket_mode/builtin/connection.py", line 116, in connect
    trace_enabled=self.trace_enabled,
  File "/usr/lib/python3/dist-packages/slack_sdk/socket_mode/builtin/internals.py", line 123, in _establish_new_socket_connection
    sock.connect((server_hostname, server_port))
  File "/usr/lib/python3.6/ssl.py", line 1109, in connect
    self._real_connect(addr, False)
  File "/usr/lib/python3.6/ssl.py", line 1096, in _real_connect
    socket.connect(self, addr)
socket.gaierror: [Errno -2] Name or service not known
```

This is fixed here by switching to the `socket.create_connection` function, which correctly handles IPv4+IPv6 families and additionally iterates through all DNS records until the connection is made.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.rtm** (RTM client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python setup.py validate` after making the changes. **[Some e2e tests don't pass with a `ConnectionResetError: [Errno 54] Connection reset by peer` error]**
