### PR TITLE
Updates PythOnBoardingBot tutorial sample to use bolt-python

### DIFF
--- a/tutorial/03-responding-to-slack-events.md
+++ b/tutorial/03-responding-to-slack-events.md
@@ -80,7 +80,7 @@ def start_onboarding(user_id: str, channel: str):
 
 ### Responding to events in Slack
 
-When events occur in Slack there are two primary ways to be notified about them. We can send you an HTTP Request through our Events API (preferred) by way of or you can stream events through a websocket connection with our RTM API. The RTM API is only recommended if you're behind a firewall and cannot receive incoming web requests from Slack.
+When events occur in Slack there are two primary ways to be notified about them. We can send you an HTTP Request through our Events API (preferred) or you can stream events through a websocket connection with our RTM API. The RTM API is only recommended if you're behind a firewall and cannot receive incoming web requests from Slack.
 
 > ⚠️ The RTM API isn't available for default Slack apps. If you need to use RTM (possibly due to corporate firewall limitations), you can do so by creating a [classic Slack app](https://api.slack.com/apps?new_classic_app=1). If you have an existing RTM app, you can continue to use its associated tokens. You can read more [in the documentation](https://slack.dev/python-slack-sdk/real_time_messaging.html).
 

--- a/tutorial/03-responding-to-slack-events.md
+++ b/tutorial/03-responding-to-slack-events.md
@@ -35,10 +35,11 @@ The first thing we'll need to do is import the code our app needs to run.
 ```Python
 import logging
 from slack_bolt import App
+from slack_sdk.web import WebClient
 from onboarding_tutorial import OnboardingTutorial
 ```
 
-- Next, create a Bolt for Python client. Add the following line to `app.py`:
+- Next, create a Bolt for Python application. Add the following line to `app.py`:
 
 ```Python
 app = App()
@@ -57,7 +58,7 @@ Let's add a function that's responsible for creating and sending the onboarding 
 - Add the following lines of code to `app.py`:
 
 ```Python
-def start_onboarding(user_id: str, channel: str):
+def start_onboarding(user_id: str, channel: str, client: WebClient):
     # Create a new onboarding tutorial.
     onboarding_tutorial = OnboardingTutorial(channel)
 
@@ -65,7 +66,7 @@ def start_onboarding(user_id: str, channel: str):
     message = onboarding_tutorial.get_message_payload()
 
     # Post the onboarding message in Slack
-    response = app.client.chat_postMessage(**message)
+    response = client.chat_postMessage(**message)
 
     # Capture the timestamp of the message we've just posted so
     # we can use it to update the message after a user
@@ -94,8 +95,12 @@ Back to our application, it's time to link our onboarding functionality to Slack
 # ================ Team Join Event =============== #
 # When the user first joins a team, the type of the event will be 'team_join'.
 # Here we'll link the onboarding_message callback to the 'team_join' event.
+
+# Note: Bolt provides a WebClient instance as an argument to the listener function
+# we've defined here, which we then use to access Slack Web API methods like conversations_open.
+# For more info, checkout: https://slack.dev/bolt-python/concepts#message-listening
 @app.event("team_join")
-def onboarding_message(event):
+def onboarding_message(event, client):
     """Create and send an onboarding welcome message to new users. Save the
     time stamp of this message so we can update this message in the future.
     """
@@ -103,11 +108,11 @@ def onboarding_message(event):
     user_id = event.get("user", {}).get("id")
 
     # Open a DM with the new user.
-    response = app.client.conversations_open(users=user_id)
+    response = client.conversations_open(users=user_id)
     channel = response["channel"]["id"]
 
     # Post the onboarding message.
-    start_onboarding(user_id, channel)
+    start_onboarding(user_id, channel, client)
 
 
 # ============= Reaction Added Events ============= #
@@ -115,7 +120,7 @@ def onboarding_message(event):
 # the type of the event will be 'reaction_added'.
 # Here we'll link the update_emoji callback to the 'reaction_added' event.
 @app.event("reaction_added")
-def update_emoji(event):
+def update_emoji(event, client):
     """Update the onboarding welcome message after receiving a "reaction_added"
     event from Slack. Update timestamp for welcome message as well.
     """
@@ -136,14 +141,14 @@ def update_emoji(event):
     message = onboarding_tutorial.get_message_payload()
 
     # Post the updated message in Slack
-    updated_message = app.client.chat_update(**message)
+    updated_message = client.chat_update(**message)
 
 
 # =============== Pin Added Events ================ #
 # When a users pins a message the type of the event will be 'pin_added'.
 # Here we'll link the update_pin callback to the 'pin_added' event.
 @app.event("pin_added")
-def update_pin(event):
+def update_pin(event, client):
     """Update the onboarding welcome message after receiving a "pin_added"
     event from Slack. Update timestamp for welcome message as well.
     """
@@ -161,14 +166,14 @@ def update_pin(event):
     message = onboarding_tutorial.get_message_payload()
 
     # Post the updated message in Slack
-    updated_message = app.client.chat_update(**message)
+    updated_message = client.chat_update(**message)
 
 
 # ============== Message Events ============= #
 # When a user sends a DM, the event type will be 'message'.
 # Here we'll link the message callback to the 'message' event.
 @app.event("message")
-def message(event):
+def message(event, client):
     """Display the onboarding welcome message after receiving a message
     that contains "start".
     """
@@ -177,7 +182,7 @@ def message(event):
     text = event.get("text")
 
     if text and text.lower() == "start":
-        return start_onboarding(user_id, channel_id)
+        return start_onboarding(user_id, channel_id, client)
 ```
 
 Finally, we need to make our app runnable.

--- a/tutorial/03-responding-to-slack-events.md
+++ b/tutorial/03-responding-to-slack-events.md
@@ -11,8 +11,8 @@ The code for this step is available [here](PythOnBoardingBot).
 
 ```
 slack_sdk>=3.0
-slackeventsapi>=2.1.0
-Flask>=1.1.2
+slack_bolt>=1.6.1
+certifi
 ```
 
 > 💡 **[Certifi](https://github.com/certifi/python-certifi)** is a carefully curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts. It has been extracted from the Requests project.
@@ -33,23 +33,15 @@ The first thing we'll need to do is import the code our app needs to run.
 - In `app.py` add the following code:
 
 ```Python
-import os
 import logging
-from flask import Flask
-from slack_sdk.web import WebClient
-from slackeventsapi import SlackEventAdapter
+from slack_bolt import App
 from onboarding_tutorial import OnboardingTutorial
 ```
 
-- Next, let's create a Flask server and initialize the WebClient and SlackEventAdapter. Add the following lines to `app.py`:
+- Next, create a Bolt for Python client. Add the following line to `app.py`:
 
 ```Python
-# Initialize a Flask app to host the events adapter
-app = Flask(__name__)
-slack_events_adapter = SlackEventAdapter(os.environ['SLACK_SIGNING_SECRET'], "/slack/events", app)
-
-# Initialize a Web API client
-slack_web_client = WebClient(token=os.environ['SLACK_BOT_TOKEN'])
+app = App()
 ```
 
 Next we'll need our app to store some data. For simplicity we'll store our app data in-memory with the following data structure: `{"channel": {"user_id": OnboardingTutorial}}`.
@@ -73,7 +65,7 @@ def start_onboarding(user_id: str, channel: str):
     message = onboarding_tutorial.get_message_payload()
 
     # Post the onboarding message in Slack
-    response = slack_web_client.chat_postMessage(**message)
+    response = app.client.chat_postMessage(**message)
 
     # Capture the timestamp of the message we've just posted so
     # we can use it to update the message after a user
@@ -86,17 +78,13 @@ def start_onboarding(user_id: str, channel: str):
     onboarding_tutorials_sent[channel][user_id] = onboarding_tutorial
 ```
 
-**Note:** We're using the `WebClient` to send messages into Slack.
-
-> 💡 **[WebClient](/slack/web/client.py)** A WebClient allows apps to communicate with the Slack Platform's Web API. This client handles constructing and sending HTTP requests to Slack as well as parsing any responses received into a `SlackResponse` dictionary-like object.
-
 ### Responding to events in Slack
 
-When events occur in Slack there are two primary ways to be notified about them. We can send you an HTTP Request through our Events API (preferred) or you can stream events through a websocket connection with our RTM API. The RTM API is only recommended if you're behind a firewall and cannot receive incoming web requests from Slack.
+When events occur in Slack there are two primary ways to be notified about them. We can send you an HTTP Request through our Events API (preferred) by way of or you can stream events through a websocket connection with our RTM API. The RTM API is only recommended if you're behind a firewall and cannot receive incoming web requests from Slack.
 
 > ⚠️ The RTM API isn't available for default Slack apps. If you need to use RTM (possibly due to corporate firewall limitations), you can do so by creating a [classic Slack app](https://api.slack.com/apps?new_classic_app=1). If you have an existing RTM app, you can continue to use its associated tokens. You can read more [in the documentation](https://slack.dev/python-slack-sdk/real_time_messaging.html).
 
-In this tutorial we'll be using the Events API and the [SlackEventAdapter](https://github.com/slackapi/python-slack-events-api). If you need access to the RTM API, you can access it [via the `RTMClient`](https://slack.dev/python-slack-sdk/real_time_messaging.html).
+In this tutorial we'll be using the Events API and the [Bolt for Python](https://github.com/slackapi/bolt-python). If you need access to the RTM API, you can access it [via the `RTMClient`](https://slack.dev/python-slack-sdk/real_time_messaging.html).
 
 Back to our application, it's time to link our onboarding functionality to Slack events.
 
@@ -106,18 +94,16 @@ Back to our application, it's time to link our onboarding functionality to Slack
 # ================ Team Join Event =============== #
 # When the user first joins a team, the type of the event will be 'team_join'.
 # Here we'll link the onboarding_message callback to the 'team_join' event.
-@slack_events_adapter.on("team_join")
-def onboarding_message(payload):
+@app.event("team_join")
+def onboarding_message(event):
     """Create and send an onboarding welcome message to new users. Save the
     time stamp of this message so we can update this message in the future.
     """
-    event = payload.get("event", {})
-
     # Get the id of the Slack user associated with the incoming event
     user_id = event.get("user", {}).get("id")
 
     # Open a DM with the new user.
-    response = slack_web_client.conversations_open(users=user_id)
+    response = app.client.conversations_open(users=user_id)
     channel = response["channel"]["id"]
 
     # Post the onboarding message.
@@ -128,13 +114,12 @@ def onboarding_message(payload):
 # When a users adds an emoji reaction to the onboarding message,
 # the type of the event will be 'reaction_added'.
 # Here we'll link the update_emoji callback to the 'reaction_added' event.
-@slack_events_adapter.on("reaction_added")
-def update_emoji(payload):
+@app.event("reaction_added")
+def update_emoji(event):
     """Update the onboarding welcome message after receiving a "reaction_added"
     event from Slack. Update timestamp for welcome message as well.
     """
-    event = payload.get("event", {})
-
+    # Get the ids of the Slack user and channel associated with the incoming event
     channel_id = event.get("item", {}).get("channel")
     user_id = event.get("user")
 
@@ -151,22 +136,18 @@ def update_emoji(payload):
     message = onboarding_tutorial.get_message_payload()
 
     # Post the updated message in Slack
-    updated_message = slack_web_client.chat_update(**message)
-
-    # Update the timestamp saved on the onboarding tutorial object
-    onboarding_tutorial.timestamp = updated_message["ts"]
+    updated_message = app.client.chat_update(**message)
 
 
 # =============== Pin Added Events ================ #
 # When a users pins a message the type of the event will be 'pin_added'.
-# Here we'll link the update_pin callback to the 'reaction_added' event.
-@slack_events_adapter.on("pin_added")
-def update_pin(payload):
+# Here we'll link the update_pin callback to the 'pin_added' event.
+@app.event("pin_added")
+def update_pin(event):
     """Update the onboarding welcome message after receiving a "pin_added"
     event from Slack. Update timestamp for welcome message as well.
     """
-    event = payload.get("event", {})
-
+    # Get the ids of the Slack user and channel associated with the incoming event
     channel_id = event.get("channel_id")
     user_id = event.get("user")
 
@@ -180,26 +161,20 @@ def update_pin(payload):
     message = onboarding_tutorial.get_message_payload()
 
     # Post the updated message in Slack
-    updated_message = slack_web_client.chat_update(**message)
-
-    # Update the timestamp saved on the onboarding tutorial object
-    onboarding_tutorial.timestamp = updated_message["ts"]
+    updated_message = app.client.chat_update(**message)
 
 
 # ============== Message Events ============= #
 # When a user sends a DM, the event type will be 'message'.
 # Here we'll link the message callback to the 'message' event.
-@slack_events_adapter.on("message")
-def message(payload):
+@app.event("message")
+def message(event):
     """Display the onboarding welcome message after receiving a message
     that contains "start".
     """
-    event = payload.get("event", {})
-
     channel_id = event.get("channel")
     user_id = event.get("user")
     text = event.get("text")
-
 
     if text and text.lower() == "start":
         return start_onboarding(user_id, channel_id)
@@ -207,14 +182,14 @@ def message(payload):
 
 Finally, we need to make our app runnable.
 
-- 🏁 Add the following lines of code to the end of `app.py` and run `FLASK_ENV=development python app.py`.
+- 🏁 Add the following lines of code to the end of `app.py`.
 
 ```Python
 if __name__ == "__main__":
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(logging.StreamHandler())
-    app.run(port=3000)
+    app.start(3000)
 ```
 
 **Note:** When running in a virtual environment you often need to specify the location of the SSL Certificate(`cacert.pem`). To make this easy we use Certifi's built-in `where()` function to locate the installed certificate authority (CA) bundle.

--- a/tutorial/PythOnBoardingBot/app.py
+++ b/tutorial/PythOnBoardingBot/app.py
@@ -3,7 +3,7 @@ from slack_bolt import App
 from slack_sdk.web import WebClient
 from onboarding_tutorial import OnboardingTutorial
 
-# Initalize a Bolt for Python app
+# Initialize a Bolt for Python app
 app = App()
 
 # For simplicity we'll store our app data in-memory with the following data structure.

--- a/tutorial/PythOnBoardingBot/app.py
+++ b/tutorial/PythOnBoardingBot/app.py
@@ -1,16 +1,9 @@
-import os
 import logging
-from flask import Flask
-from slack_sdk.web import WebClient
-from slackeventsapi import SlackEventAdapter
+from slack_bolt import App
 from onboarding_tutorial import OnboardingTutorial
 
-# Initialize a Flask app to host the events adapter
-app = Flask(__name__)
-slack_events_adapter = SlackEventAdapter(os.environ["SLACK_SIGNING_SECRET"], "/slack/events", app)
-
-# Initialize a Web API client
-slack_web_client = WebClient(token=os.environ['SLACK_BOT_TOKEN'])
+# Initalize a Bolt for Python app
+app = App()
 
 # For simplicity we'll store our app data in-memory with the following data structure.
 # onboarding_tutorials_sent = {"channel": {"user_id": OnboardingTutorial}}
@@ -25,7 +18,7 @@ def start_onboarding(user_id: str, channel: str):
     message = onboarding_tutorial.get_message_payload()
 
     # Post the onboarding message in Slack
-    response = slack_web_client.chat_postMessage(**message)
+    response = app.client.chat_postMessage(**message)
 
     # Capture the timestamp of the message we've just posted so
     # we can use it to update the message after a user
@@ -41,18 +34,16 @@ def start_onboarding(user_id: str, channel: str):
 # ================ Team Join Event =============== #
 # When the user first joins a team, the type of the event will be 'team_join'.
 # Here we'll link the onboarding_message callback to the 'team_join' event.
-@slack_events_adapter.on("team_join")
-def onboarding_message(payload):
+@app.event("team_join")
+def onboarding_message(event):
     """Create and send an onboarding welcome message to new users. Save the
     time stamp of this message so we can update this message in the future.
     """
-    event = payload.get("event", {})
-
     # Get the id of the Slack user associated with the incoming event
     user_id = event.get("user", {}).get("id")
 
     # Open a DM with the new user.
-    response = slack_web_client.conversations_open(users=user_id)
+    response = app.client.conversations_open(users=user_id)
     channel = response["channel"]["id"]
 
     # Post the onboarding message.
@@ -63,13 +54,12 @@ def onboarding_message(payload):
 # When a users adds an emoji reaction to the onboarding message,
 # the type of the event will be 'reaction_added'.
 # Here we'll link the update_emoji callback to the 'reaction_added' event.
-@slack_events_adapter.on("reaction_added")
-def update_emoji(payload):
+@app.event("reaction_added")
+def update_emoji(event):
     """Update the onboarding welcome message after receiving a "reaction_added"
     event from Slack. Update timestamp for welcome message as well.
     """
-    event = payload.get("event", {})
-
+    # Get the ids of the Slack user and channel associated with the incoming event
     channel_id = event.get("item", {}).get("channel")
     user_id = event.get("user")
 
@@ -86,19 +76,18 @@ def update_emoji(payload):
     message = onboarding_tutorial.get_message_payload()
 
     # Post the updated message in Slack
-    updated_message = slack_web_client.chat_update(**message)
+    updated_message = app.client.chat_update(**message)
 
 
 # =============== Pin Added Events ================ #
 # When a users pins a message the type of the event will be 'pin_added'.
 # Here we'll link the update_pin callback to the 'pin_added' event.
-@slack_events_adapter.on("pin_added")
-def update_pin(payload):
+@app.event("pin_added")
+def update_pin(event):
     """Update the onboarding welcome message after receiving a "pin_added"
     event from Slack. Update timestamp for welcome message as well.
     """
-    event = payload.get("event", {})
-
+    # Get the ids of the Slack user and channel associated with the incoming event
     channel_id = event.get("channel_id")
     user_id = event.get("user")
 
@@ -112,23 +101,20 @@ def update_pin(payload):
     message = onboarding_tutorial.get_message_payload()
 
     # Post the updated message in Slack
-    updated_message = slack_web_client.chat_update(**message)
+    updated_message = app.client.chat_update(**message)
 
 
 # ============== Message Events ============= #
 # When a user sends a DM, the event type will be 'message'.
 # Here we'll link the message callback to the 'message' event.
-@slack_events_adapter.on("message")
-def message(payload):
+@app.event("message")
+def message(event):
     """Display the onboarding welcome message after receiving a message
     that contains "start".
     """
-    event = payload.get("event", {})
-
     channel_id = event.get("channel")
     user_id = event.get("user")
     text = event.get("text")
-
 
     if text and text.lower() == "start":
         return start_onboarding(user_id, channel_id)
@@ -138,4 +124,4 @@ if __name__ == "__main__":
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(logging.StreamHandler())
-    app.run(port=3000)
+    app.start(3000)

--- a/tutorial/PythOnBoardingBot/requirements.txt
+++ b/tutorial/PythOnBoardingBot/requirements.txt
@@ -1,4 +1,3 @@
 slack_sdk>=3.0
-slackeventsapi>=2.1.0
-Flask>=1.1.1
+slack_bolt>=1.6.1
 certifi


### PR DESCRIPTION
## Summary

This PR updates the dependencies and handlers on the PythOnBoardingBot tutorial app sample `app.py` to use bolt-python instead of slackeventsapi as described in #1037. I've also updated the `**.md` documentation code snippets accordingly.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [x] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes. <--- I tried running this but the tests stalled out for some reason.
