### PR TITLE
Fix #1053 by changing request body format to params

### DIFF
--- a/integration_tests/web/test_issue_1053.py
+++ b/integration_tests/web/test_issue_1053.py
@@ -1,0 +1,48 @@
+import logging
+import os
+import time
+import unittest
+
+from integration_tests.env_variable_names import SLACK_SDK_TEST_BOT_TOKEN
+from slack_sdk.web import WebClient
+
+
+class TestWebClient(unittest.TestCase):
+    """Runs integration tests with real Slack API
+
+    https://github.com/slackapi/python-slack-sdk/issues/1053
+    """
+
+    def setUp(self):
+        self.logger = logging.getLogger(__name__)
+        self.bot_token = os.environ[SLACK_SDK_TEST_BOT_TOKEN]
+
+    def tearDown(self):
+        pass
+
+    def test_issue_1053(self):
+        client: WebClient = WebClient(token=self.bot_token)
+        self_user_id = client.auth_test()["user_id"]
+        channel_name = f"test-channel-{str(time.time()).replace('.', '-')}"
+        channel_id = None
+        try:
+            creation = client.conversations_create(name=channel_name)
+            self.assertIsNone(creation.get("error"))
+            channel_id = creation["channel"]["id"]
+            user_ids = [
+                u["id"]
+                for u in client.users_list(limit=100)["members"]
+                if u["id"] not in {"USLACKBOT", self_user_id}
+                and u.get("is_bot", False) is False
+                and u.get("is_app_user", False) is False
+                and u.get("is_restricted", False) is False
+                and u.get("is_ultra_restricted", False) is False
+                and u.get("is_email_confirmed", False) is True
+            ]
+            invitations = client.conversations_invite(
+                channel=channel_id, users=user_ids
+            )
+            self.assertIsNone(invitations.get("error"))
+        finally:
+            if channel_id is not None:
+                client.conversations_archive(channel=channel_id)

--- a/integration_tests/webhook/test_async_webhook.py
+++ b/integration_tests/webhook/test_async_webhook.py
@@ -26,7 +26,7 @@ class TestAsyncWebhook(unittest.TestCase):
             ].replace("#", "")
             client = AsyncWebClient(token=token)
             self.channel_id = None
-            async for resp in await client.conversations_list(limit=10):
+            async for resp in await client.conversations_list(limit=1000):
                 for c in resp["channels"]:
                     if c["name"] == channel_name:
                         self.channel_id = c["id"]

--- a/integration_tests/webhook/test_webhook.py
+++ b/integration_tests/webhook/test_webhook.py
@@ -24,7 +24,7 @@ class TestWebhook(unittest.TestCase):
             ].replace("#", "")
             client = WebClient(token=token)
             self.channel_id = None
-            for resp in client.conversations_list(limit=10):
+            for resp in client.conversations_list(limit=1000):
                 for c in resp["channels"]:
                     if c["name"] == channel_name:
                         self.channel_id = c["id"]

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -621,7 +621,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
-        return await self.api_call("admin.users.session.getSettings", json=kwargs)
+        return await self.api_call("admin.users.session.getSettings", params=kwargs)
 
     async def admin_users_session_setSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -636,7 +636,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
-        return await self.api_call("admin.users.session.setSettings", json=kwargs)
+        return await self.api_call("admin.users.session.setSettings", params=kwargs)
 
     async def admin_users_session_clearSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -651,7 +651,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
-        return await self.api_call("admin.users.session.clearSettings", json=kwargs)
+        return await self.api_call("admin.users.session.clearSettings", params=kwargs)
 
     async def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
@@ -815,7 +815,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
-        return await self.api_call("admin.usergroups.addChannels", json=kwargs)
+        return await self.api_call("admin.usergroups.addChannels", params=kwargs)
 
     async def admin_usergroups_addTeams(
         self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
@@ -833,7 +833,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"team_ids": ",".join(team_ids)})
         else:
             kwargs.update({"team_ids": team_ids})
-        return await self.api_call("admin.usergroups.addTeams", json=kwargs)
+        return await self.api_call("admin.usergroups.addTeams", params=kwargs)
 
     async def admin_usergroups_listChannels(
         self, *, usergroup_id: str, **kwargs
@@ -860,7 +860,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
-        return await self.api_call("admin.usergroups.removeChannels", json=kwargs)
+        return await self.api_call("admin.usergroups.removeChannels", params=kwargs)
 
     async def admin_users_assign(
         self, *, team_id: str, user_id: str, **kwargs
@@ -895,7 +895,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
-        return await self.api_call("admin.users.invite", json=kwargs)
+        return await self.api_call("admin.users.invite", params=kwargs)
 
     async def admin_users_list(self, *, team_id: str, **kwargs) -> AsyncSlackResponse:
         """List users on a workspace
@@ -1461,7 +1461,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
-        return await self.api_call("conversations.invite", json=kwargs)
+        return await self.api_call("conversations.invite", params=kwargs)
 
     async def conversations_join(self, *, channel: str, **kwargs) -> AsyncSlackResponse:
         """Joins an existing conversation.
@@ -2081,7 +2081,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
-        return await self.api_call("mpim.open", json=kwargs)
+        return await self.api_call("mpim.open", params=kwargs)
 
     async def mpim_replies(
         self, *, channel: str, thread_ts: str, **kwargs
@@ -2431,7 +2431,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
-        return await self.api_call("usergroups.users.update", json=kwargs)
+        return await self.api_call("usergroups.users.update", params=kwargs)
 
     async def users_conversations(self, **kwargs) -> AsyncSlackResponse:
         """List conversations the calling user may access."""

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -584,7 +584,7 @@ class WebClient(BaseClient):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
-        return self.api_call("admin.users.session.getSettings", json=kwargs)
+        return self.api_call("admin.users.session.getSettings", params=kwargs)
 
     def admin_users_session_setSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -599,7 +599,7 @@ class WebClient(BaseClient):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
-        return self.api_call("admin.users.session.setSettings", json=kwargs)
+        return self.api_call("admin.users.session.setSettings", params=kwargs)
 
     def admin_users_session_clearSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -614,7 +614,7 @@ class WebClient(BaseClient):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
-        return self.api_call("admin.users.session.clearSettings", json=kwargs)
+        return self.api_call("admin.users.session.clearSettings", params=kwargs)
 
     def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
@@ -766,7 +766,7 @@ class WebClient(BaseClient):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
-        return self.api_call("admin.usergroups.addChannels", json=kwargs)
+        return self.api_call("admin.usergroups.addChannels", params=kwargs)
 
     def admin_usergroups_addTeams(
         self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
@@ -784,7 +784,7 @@ class WebClient(BaseClient):
             kwargs.update({"team_ids": ",".join(team_ids)})
         else:
             kwargs.update({"team_ids": team_ids})
-        return self.api_call("admin.usergroups.addTeams", json=kwargs)
+        return self.api_call("admin.usergroups.addTeams", params=kwargs)
 
     def admin_usergroups_listChannels(
         self, *, usergroup_id: str, **kwargs
@@ -811,7 +811,7 @@ class WebClient(BaseClient):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
-        return self.api_call("admin.usergroups.removeChannels", json=kwargs)
+        return self.api_call("admin.usergroups.removeChannels", params=kwargs)
 
     def admin_users_assign(
         self, *, team_id: str, user_id: str, **kwargs
@@ -846,7 +846,7 @@ class WebClient(BaseClient):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
-        return self.api_call("admin.users.invite", json=kwargs)
+        return self.api_call("admin.users.invite", params=kwargs)
 
     def admin_users_list(self, *, team_id: str, **kwargs) -> SlackResponse:
         """List users on a workspace
@@ -1374,7 +1374,7 @@ class WebClient(BaseClient):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
-        return self.api_call("conversations.invite", json=kwargs)
+        return self.api_call("conversations.invite", params=kwargs)
 
     def conversations_join(self, *, channel: str, **kwargs) -> SlackResponse:
         """Joins an existing conversation.
@@ -1956,7 +1956,7 @@ class WebClient(BaseClient):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
-        return self.api_call("mpim.open", json=kwargs)
+        return self.api_call("mpim.open", params=kwargs)
 
     def mpim_replies(self, *, channel: str, thread_ts: str, **kwargs) -> SlackResponse:
         """Retrieve a thread of messages posted to a direct message conversation from a
@@ -2288,7 +2288,7 @@ class WebClient(BaseClient):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
-        return self.api_call("usergroups.users.update", json=kwargs)
+        return self.api_call("usergroups.users.update", params=kwargs)
 
     def users_conversations(self, **kwargs) -> SlackResponse:
         """List conversations the calling user may access."""

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -603,7 +603,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
-        return self.api_call("admin.users.session.getSettings", json=kwargs)
+        return self.api_call("admin.users.session.getSettings", params=kwargs)
 
     def admin_users_session_setSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -618,7 +618,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
-        return self.api_call("admin.users.session.setSettings", json=kwargs)
+        return self.api_call("admin.users.session.setSettings", params=kwargs)
 
     def admin_users_session_clearSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -633,7 +633,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
-        return self.api_call("admin.users.session.clearSettings", json=kwargs)
+        return self.api_call("admin.users.session.clearSettings", params=kwargs)
 
     def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
@@ -795,7 +795,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
-        return self.api_call("admin.usergroups.addChannels", json=kwargs)
+        return self.api_call("admin.usergroups.addChannels", params=kwargs)
 
     def admin_usergroups_addTeams(
         self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
@@ -813,7 +813,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"team_ids": ",".join(team_ids)})
         else:
             kwargs.update({"team_ids": team_ids})
-        return self.api_call("admin.usergroups.addTeams", json=kwargs)
+        return self.api_call("admin.usergroups.addTeams", params=kwargs)
 
     def admin_usergroups_listChannels(
         self, *, usergroup_id: str, **kwargs
@@ -840,7 +840,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
-        return self.api_call("admin.usergroups.removeChannels", json=kwargs)
+        return self.api_call("admin.usergroups.removeChannels", params=kwargs)
 
     def admin_users_assign(
         self, *, team_id: str, user_id: str, **kwargs
@@ -875,7 +875,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
         else:
             kwargs.update({"channel_ids": channel_ids})
-        return self.api_call("admin.users.invite", json=kwargs)
+        return self.api_call("admin.users.invite", params=kwargs)
 
     def admin_users_list(
         self, *, team_id: str, **kwargs
@@ -1449,7 +1449,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
-        return self.api_call("conversations.invite", json=kwargs)
+        return self.api_call("conversations.invite", params=kwargs)
 
     def conversations_join(
         self, *, channel: str, **kwargs
@@ -2075,7 +2075,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
-        return self.api_call("mpim.open", json=kwargs)
+        return self.api_call("mpim.open", params=kwargs)
 
     def mpim_replies(
         self, *, channel: str, thread_ts: str, **kwargs
@@ -2425,7 +2425,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"users": ",".join(users)})
         else:
             kwargs.update({"users": users})
-        return self.api_call("usergroups.users.update", json=kwargs)
+        return self.api_call("usergroups.users.update", params=kwargs)
 
     def users_conversations(self, **kwargs) -> Union[Future, SlackResponse]:
         """List conversations the calling user may access."""


### PR DESCRIPTION
## Summary

This pull request fixes #1053 by eliminating the potential issues with a single comma-separated-value format data for a sequence type parameter (e.g., channel_ids, user_ids, etc.) in JSON request body. 

As far as I did tests with the mentioned endpoint, a single CSV format string value works even in the JSON request body. That being said, it should be much safer to switch the content-type from `application/json` to `application/x-www-form-urlencoded` in the long run. It is a proven way in the Java SDK and some others. 

We may want to eventually switch all the API methods to `application/x-www-form-urlencoded` for simplicity but it's out of this pull request's scope.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
