### PR TITLE
version 3.8.0 release

### DIFF
--- a/docs/api-docs/slack_sdk/audit_logs/v1/logs.html
+++ b/docs/api-docs/slack_sdk/audit_logs/v1/logs.html
@@ -121,6 +121,7 @@ class Details:
     expires_on: Optional[int]
     mobile_only: Optional[bool]
     web_only: Optional[bool]
+    non_sso_only: Optional[bool]
     type: Optional[str]
     is_workflow: Optional[bool]
     inviter: Optional[User]
@@ -140,7 +141,33 @@ class Details:
     app_previously_resolved: Optional[bool]
     admin_app_id: Optional[str]
     bot_id: Optional[str]
+    installer_user_id: Optional[str]
+    approver_id: Optional[str]
+    approval_type: Optional[str]
+    app_previously_approved: Optional[bool]
+    old_scopes: Optional[List[str]]
+    channels: Optional[List[str]]
+    permissions: Optional[List[Dict[str, Any]]]
+    new_version_id: Optional[str]
+    trigger: Optional[str]
+    export_type: Optional[str]
+    export_start_ts: Optional[str]
+    export_end_ts: Optional[str]
+    barrier_id: Optional[str]
+    primary_usergroup_id: Optional[str]
+    barriered_from_usergroup_ids: Optional[List[str]]
+    restricted_subjects: Optional[List[str]]
+    duration: Optional[int]
+    desktop_app_browser_quit: Optional[bool]
+    invite_id: Optional[str]
+    external_organization_id: Optional[str]
+    external_organization_name: Optional[str]
+    external_user_id: Optional[str]
+    external_user_email: Optional[str]
+    channel_id: Optional[str]
+    added_team_id: Optional[str]
     unknown_fields: Dict[str, Any]
+    is_token_rotation_enabled_app: Optional[bool]
 
     def __init__(
         self,
@@ -151,6 +178,7 @@ class Details:
         expires_on: Optional[int] = None,
         mobile_only: Optional[bool] = None,
         web_only: Optional[bool] = None,
+        non_sso_only: Optional[bool] = None,
         type: Optional[str] = None,
         is_workflow: Optional[bool] = None,
         inviter: Optional[User] = None,
@@ -170,6 +198,32 @@ class Details:
         app_previously_resolved: Optional[bool] = None,
         admin_app_id: Optional[str] = None,
         bot_id: Optional[str] = None,
+        installer_user_id: Optional[str] = None,
+        approver_id: Optional[str] = None,
+        approval_type: Optional[str] = None,
+        app_previously_approved: Optional[bool] = None,
+        old_scopes: Optional[List[str]] = None,
+        channels: Optional[List[str]] = None,
+        permissions: Optional[List[Dict[str, Any]]] = None,
+        new_version_id: Optional[str] = None,
+        trigger: Optional[str] = None,
+        export_type: Optional[str] = None,
+        export_start_ts: Optional[str] = None,
+        export_end_ts: Optional[str] = None,
+        barrier_id: Optional[str] = None,
+        primary_usergroup_id: Optional[str] = None,
+        barriered_from_usergroup_ids: Optional[List[str]] = None,
+        restricted_subjects: Optional[List[str]] = None,
+        duration: Optional[int] = None,
+        desktop_app_browser_quit: Optional[bool] = None,
+        invite_id: Optional[str] = None,
+        external_organization_id: Optional[str] = None,
+        external_organization_name: Optional[str] = None,
+        external_user_id: Optional[str] = None,
+        external_user_email: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        added_team_id: Optional[str] = None,
+        is_token_rotation_enabled_app: Optional[bool] = None,
         **kwargs,
     ) -&gt; None:
         self.name = name
@@ -178,6 +232,7 @@ class Details:
         self.expires_on = expires_on
         self.mobile_only = mobile_only
         self.web_only = web_only
+        self.non_sso_only = non_sso_only
         self.type = type
         self.is_workflow = is_workflow
         self.inviter = inviter
@@ -198,6 +253,32 @@ class Details:
         self.admin_app_id = admin_app_id
         self.bot_id = bot_id
         self.unknown_fields = kwargs
+        self.installer_user_id = installer_user_id
+        self.approver_id = approver_id
+        self.approval_type = approval_type
+        self.app_previously_approved = app_previously_approved
+        self.old_scopes = old_scopes
+        self.channels = channels
+        self.permissions = permissions
+        self.new_version_id = new_version_id
+        self.trigger = trigger
+        self.export_type = export_type
+        self.export_start_ts = export_start_ts
+        self.export_end_ts = export_end_ts
+        self.barrier_id = barrier_id
+        self.primary_usergroup_id = primary_usergroup_id
+        self.barriered_from_usergroup_ids = barriered_from_usergroup_ids
+        self.restricted_subjects = restricted_subjects
+        self.duration = duration
+        self.desktop_app_browser_quit = desktop_app_browser_quit
+        self.invite_id = invite_id
+        self.external_organization_id = external_organization_id
+        self.external_organization_name = external_organization_name
+        self.external_user_id = external_user_id
+        self.external_user_email = external_user_email
+        self.channel_id = channel_id
+        self.added_team_id = added_team_id
+        self.is_token_rotation_enabled_app = is_token_rotation_enabled_app
 
 
 class App:
@@ -284,6 +365,66 @@ class File:
         self.unknown_fields = kwargs
 
 
+class Usergroup:
+    id: Optional[str]
+    name: Optional[str]
+    unknown_fields: Dict[str, Any]
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        name: Optional[str] = None,
+        **kwargs,
+    ) -&gt; None:
+        self.id = id
+        self.name = name
+        self.unknown_fields = kwargs
+
+
+class Workflow:
+    id: Optional[str]
+    name: Optional[str]
+    domain: Optional[str]
+    unknown_fields: Dict[str, Any]
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        name: Optional[str] = None,
+        domain: Optional[str] = None,
+        **kwargs,
+    ) -&gt; None:
+        self.id = id
+        self.name = name
+        self.domain = domain
+        self.unknown_fields = kwargs
+
+
+class InformationBarrier:
+    id: Optional[str]
+    primary_usergroup: Optional[str]
+    barriered_from_usergroups: Optional[List[str]]
+    restricted_subjects: Optional[List[str]]
+    unknown_fields: Dict[str, Any]
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        primary_usergroup: Optional[str] = None,
+        barriered_from_usergroups: Optional[List[str]] = None,
+        restricted_subjects: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; None:
+        self.id = id
+        self.primary_usergroup = primary_usergroup
+        self.barriered_from_usergroups = barriered_from_usergroups
+        self.restricted_subjects = restricted_subjects
+        self.unknown_fields = kwargs
+
+
 class Entity:
     type: Optional[str]
     user: Optional[User]
@@ -292,6 +433,9 @@ class Entity:
     channel: Optional[Channel]
     file: Optional[File]
     app: Optional[App]
+    usergroup: Optional[Usergroup]
+    workflow: Optional[Workflow]
+    barrier: Optional[InformationBarrier]
     unknown_fields: Dict[str, Any]
 
     def __init__(
@@ -304,6 +448,9 @@ class Entity:
         channel: Optional[Union[Channel, dict]] = None,
         file: Optional[Union[File, dict]] = None,
         app: Optional[Union[App, dict]] = None,
+        usergroup: Optional[Usergroup] = None,
+        workflow: Optional[Workflow] = None,
+        barrier: Optional[InformationBarrier] = None,
         **kwargs,
     ) -&gt; None:
         self.type = type
@@ -317,6 +464,13 @@ class Entity:
         self.channel = Channel(**channel) if isinstance(channel, dict) else channel
         self.file = File(**file) if isinstance(file, dict) else file
         self.app = App(**app) if isinstance(app, dict) else app
+        self.usergroup = (
+            Usergroup(**usergroup) if isinstance(usergroup, dict) else usergroup
+        )
+        self.workflow = Workflow(**workflow) if isinstance(workflow, dict) else workflow
+        self.barrier = (
+            InformationBarrier(**barrier) if isinstance(barrier, dict) else barrier
+        )
         self.unknown_fields = kwargs
 
 
@@ -654,7 +808,7 @@ class LogsResponse:
 </dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Details"><code class="flex name class">
 <span>class <span class="ident">Details</span></span>
-<span>(</span><span>*, name: Optional[str] = None, new_value: Union[str, List[str], Dict[str, Any], NoneType] = None, previous_value: Union[str, List[str], Dict[str, Any], NoneType] = None, expires_on: Optional[int] = None, mobile_only: Optional[bool] = None, web_only: Optional[bool] = None, type: Optional[str] = None, is_workflow: Optional[bool] = None, inviter: Optional[<a title="slack_sdk.audit_logs.v1.logs.User" href="#slack_sdk.audit_logs.v1.logs.User">User</a>] = None, kicker: Optional[<a title="slack_sdk.audit_logs.v1.logs.User" href="#slack_sdk.audit_logs.v1.logs.User">User</a>] = None, shared_to: Optional[str] = None, reason: Optional[str] = None, origin_team: Optional[str] = None, target_team: Optional[str] = None, is_internal_integration: Optional[bool] = None, app_owner_id: Optional[str] = None, bot_scopes: Optional[List[str]] = None, new_scopes: Optional[List[str]] = None, previous_scopes: Optional[List[str]] = None, granular_bot_token: Optional[bool] = None, scopes: Optional[List[str]] = None, resolution: Optional[str] = None, app_previously_resolved: Optional[bool] = None, admin_app_id: Optional[str] = None, bot_id: Optional[str] = None, **kwargs)</span>
+<span>(</span><span>*, name: Optional[str] = None, new_value: Union[str, List[str], Dict[str, Any], NoneType] = None, previous_value: Union[str, List[str], Dict[str, Any], NoneType] = None, expires_on: Optional[int] = None, mobile_only: Optional[bool] = None, web_only: Optional[bool] = None, non_sso_only: Optional[bool] = None, type: Optional[str] = None, is_workflow: Optional[bool] = None, inviter: Optional[<a title="slack_sdk.audit_logs.v1.logs.User" href="#slack_sdk.audit_logs.v1.logs.User">User</a>] = None, kicker: Optional[<a title="slack_sdk.audit_logs.v1.logs.User" href="#slack_sdk.audit_logs.v1.logs.User">User</a>] = None, shared_to: Optional[str] = None, reason: Optional[str] = None, origin_team: Optional[str] = None, target_team: Optional[str] = None, is_internal_integration: Optional[bool] = None, app_owner_id: Optional[str] = None, bot_scopes: Optional[List[str]] = None, new_scopes: Optional[List[str]] = None, previous_scopes: Optional[List[str]] = None, granular_bot_token: Optional[bool] = None, scopes: Optional[List[str]] = None, resolution: Optional[str] = None, app_previously_resolved: Optional[bool] = None, admin_app_id: Optional[str] = None, bot_id: Optional[str] = None, installer_user_id: Optional[str] = None, approver_id: Optional[str] = None, approval_type: Optional[str] = None, app_previously_approved: Optional[bool] = None, old_scopes: Optional[List[str]] = None, channels: Optional[List[str]] = None, permissions: Optional[List[Dict[str, Any]]] = None, new_version_id: Optional[str] = None, trigger: Optional[str] = None, export_type: Optional[str] = None, export_start_ts: Optional[str] = None, export_end_ts: Optional[str] = None, barrier_id: Optional[str] = None, primary_usergroup_id: Optional[str] = None, barriered_from_usergroup_ids: Optional[List[str]] = None, restricted_subjects: Optional[List[str]] = None, duration: Optional[int] = None, desktop_app_browser_quit: Optional[bool] = None, invite_id: Optional[str] = None, external_organization_id: Optional[str] = None, external_organization_name: Optional[str] = None, external_user_id: Optional[str] = None, external_user_email: Optional[str] = None, channel_id: Optional[str] = None, added_team_id: Optional[str] = None, is_token_rotation_enabled_app: Optional[bool] = None, **kwargs)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -669,6 +823,7 @@ class LogsResponse:
     expires_on: Optional[int]
     mobile_only: Optional[bool]
     web_only: Optional[bool]
+    non_sso_only: Optional[bool]
     type: Optional[str]
     is_workflow: Optional[bool]
     inviter: Optional[User]
@@ -688,7 +843,33 @@ class LogsResponse:
     app_previously_resolved: Optional[bool]
     admin_app_id: Optional[str]
     bot_id: Optional[str]
+    installer_user_id: Optional[str]
+    approver_id: Optional[str]
+    approval_type: Optional[str]
+    app_previously_approved: Optional[bool]
+    old_scopes: Optional[List[str]]
+    channels: Optional[List[str]]
+    permissions: Optional[List[Dict[str, Any]]]
+    new_version_id: Optional[str]
+    trigger: Optional[str]
+    export_type: Optional[str]
+    export_start_ts: Optional[str]
+    export_end_ts: Optional[str]
+    barrier_id: Optional[str]
+    primary_usergroup_id: Optional[str]
+    barriered_from_usergroup_ids: Optional[List[str]]
+    restricted_subjects: Optional[List[str]]
+    duration: Optional[int]
+    desktop_app_browser_quit: Optional[bool]
+    invite_id: Optional[str]
+    external_organization_id: Optional[str]
+    external_organization_name: Optional[str]
+    external_user_id: Optional[str]
+    external_user_email: Optional[str]
+    channel_id: Optional[str]
+    added_team_id: Optional[str]
     unknown_fields: Dict[str, Any]
+    is_token_rotation_enabled_app: Optional[bool]
 
     def __init__(
         self,
@@ -699,6 +880,7 @@ class LogsResponse:
         expires_on: Optional[int] = None,
         mobile_only: Optional[bool] = None,
         web_only: Optional[bool] = None,
+        non_sso_only: Optional[bool] = None,
         type: Optional[str] = None,
         is_workflow: Optional[bool] = None,
         inviter: Optional[User] = None,
@@ -718,6 +900,32 @@ class LogsResponse:
         app_previously_resolved: Optional[bool] = None,
         admin_app_id: Optional[str] = None,
         bot_id: Optional[str] = None,
+        installer_user_id: Optional[str] = None,
+        approver_id: Optional[str] = None,
+        approval_type: Optional[str] = None,
+        app_previously_approved: Optional[bool] = None,
+        old_scopes: Optional[List[str]] = None,
+        channels: Optional[List[str]] = None,
+        permissions: Optional[List[Dict[str, Any]]] = None,
+        new_version_id: Optional[str] = None,
+        trigger: Optional[str] = None,
+        export_type: Optional[str] = None,
+        export_start_ts: Optional[str] = None,
+        export_end_ts: Optional[str] = None,
+        barrier_id: Optional[str] = None,
+        primary_usergroup_id: Optional[str] = None,
+        barriered_from_usergroup_ids: Optional[List[str]] = None,
+        restricted_subjects: Optional[List[str]] = None,
+        duration: Optional[int] = None,
+        desktop_app_browser_quit: Optional[bool] = None,
+        invite_id: Optional[str] = None,
+        external_organization_id: Optional[str] = None,
+        external_organization_name: Optional[str] = None,
+        external_user_id: Optional[str] = None,
+        external_user_email: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        added_team_id: Optional[str] = None,
+        is_token_rotation_enabled_app: Optional[bool] = None,
         **kwargs,
     ) -&gt; None:
         self.name = name
@@ -726,6 +934,7 @@ class LogsResponse:
         self.expires_on = expires_on
         self.mobile_only = mobile_only
         self.web_only = web_only
+        self.non_sso_only = non_sso_only
         self.type = type
         self.is_workflow = is_workflow
         self.inviter = inviter
@@ -745,10 +954,40 @@ class LogsResponse:
         self.app_previously_resolved = app_previously_resolved
         self.admin_app_id = admin_app_id
         self.bot_id = bot_id
-        self.unknown_fields = kwargs</code></pre>
+        self.unknown_fields = kwargs
+        self.installer_user_id = installer_user_id
+        self.approver_id = approver_id
+        self.approval_type = approval_type
+        self.app_previously_approved = app_previously_approved
+        self.old_scopes = old_scopes
+        self.channels = channels
+        self.permissions = permissions
+        self.new_version_id = new_version_id
+        self.trigger = trigger
+        self.export_type = export_type
+        self.export_start_ts = export_start_ts
+        self.export_end_ts = export_end_ts
+        self.barrier_id = barrier_id
+        self.primary_usergroup_id = primary_usergroup_id
+        self.barriered_from_usergroup_ids = barriered_from_usergroup_ids
+        self.restricted_subjects = restricted_subjects
+        self.duration = duration
+        self.desktop_app_browser_quit = desktop_app_browser_quit
+        self.invite_id = invite_id
+        self.external_organization_id = external_organization_id
+        self.external_organization_name = external_organization_name
+        self.external_user_id = external_user_id
+        self.external_user_email = external_user_email
+        self.channel_id = channel_id
+        self.added_team_id = added_team_id
+        self.is_token_rotation_enabled_app = is_token_rotation_enabled_app</code></pre>
 </details>
 <h3>Class variables</h3>
 <dl>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.added_team_id"><code class="name">var <span class="ident">added_team_id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Details.admin_app_id"><code class="name">var <span class="ident">admin_app_id</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
@@ -757,7 +996,27 @@ class LogsResponse:
 <dd>
 <div class="desc"></div>
 </dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.app_previously_approved"><code class="name">var <span class="ident">app_previously_approved</span> : Optional[bool]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Details.app_previously_resolved"><code class="name">var <span class="ident">app_previously_resolved</span> : Optional[bool]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.approval_type"><code class="name">var <span class="ident">approval_type</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.approver_id"><code class="name">var <span class="ident">approver_id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.barrier_id"><code class="name">var <span class="ident">barrier_id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.barriered_from_usergroup_ids"><code class="name">var <span class="ident">barriered_from_usergroup_ids</span> : Optional[List[str]]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -769,11 +1028,63 @@ class LogsResponse:
 <dd>
 <div class="desc"></div>
 </dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.channel_id"><code class="name">var <span class="ident">channel_id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.channels"><code class="name">var <span class="ident">channels</span> : Optional[List[str]]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.desktop_app_browser_quit"><code class="name">var <span class="ident">desktop_app_browser_quit</span> : Optional[bool]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.duration"><code class="name">var <span class="ident">duration</span> : Optional[int]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Details.expires_on"><code class="name">var <span class="ident">expires_on</span> : Optional[int]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.export_end_ts"><code class="name">var <span class="ident">export_end_ts</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.export_start_ts"><code class="name">var <span class="ident">export_start_ts</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.export_type"><code class="name">var <span class="ident">export_type</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.external_organization_id"><code class="name">var <span class="ident">external_organization_id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.external_organization_name"><code class="name">var <span class="ident">external_organization_name</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.external_user_email"><code class="name">var <span class="ident">external_user_email</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.external_user_id"><code class="name">var <span class="ident">external_user_id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Details.granular_bot_token"><code class="name">var <span class="ident">granular_bot_token</span> : Optional[bool]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.installer_user_id"><code class="name">var <span class="ident">installer_user_id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.invite_id"><code class="name">var <span class="ident">invite_id</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -782,6 +1093,10 @@ class LogsResponse:
 <div class="desc"></div>
 </dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Details.is_internal_integration"><code class="name">var <span class="ident">is_internal_integration</span> : Optional[bool]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.is_token_rotation_enabled_app"><code class="name">var <span class="ident">is_token_rotation_enabled_app</span> : Optional[bool]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -809,7 +1124,23 @@ class LogsResponse:
 <dd>
 <div class="desc"></div>
 </dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.new_version_id"><code class="name">var <span class="ident">new_version_id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.non_sso_only"><code class="name">var <span class="ident">non_sso_only</span> : Optional[bool]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.old_scopes"><code class="name">var <span class="ident">old_scopes</span> : Optional[List[str]]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Details.origin_team"><code class="name">var <span class="ident">origin_team</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.permissions"><code class="name">var <span class="ident">permissions</span> : Optional[List[Dict[str, Any]]]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -821,11 +1152,19 @@ class LogsResponse:
 <dd>
 <div class="desc"></div>
 </dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.primary_usergroup_id"><code class="name">var <span class="ident">primary_usergroup_id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Details.reason"><code class="name">var <span class="ident">reason</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Details.resolution"><code class="name">var <span class="ident">resolution</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.restricted_subjects"><code class="name">var <span class="ident">restricted_subjects</span> : Optional[List[str]]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -838,6 +1177,10 @@ class LogsResponse:
 <div class="desc"></div>
 </dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Details.target_team"><code class="name">var <span class="ident">target_team</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Details.trigger"><code class="name">var <span class="ident">trigger</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -857,7 +1200,7 @@ class LogsResponse:
 </dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Entity"><code class="flex name class">
 <span>class <span class="ident">Entity</span></span>
-<span>(</span><span>*, type: Optional[str] = None, user: Union[<a title="slack_sdk.audit_logs.v1.logs.User" href="#slack_sdk.audit_logs.v1.logs.User">User</a>, dict, NoneType] = None, workspace: Union[<a title="slack_sdk.audit_logs.v1.logs.Location" href="#slack_sdk.audit_logs.v1.logs.Location">Location</a>, dict, NoneType] = None, enterprise: Union[<a title="slack_sdk.audit_logs.v1.logs.Location" href="#slack_sdk.audit_logs.v1.logs.Location">Location</a>, dict, NoneType] = None, channel: Union[<a title="slack_sdk.audit_logs.v1.logs.Channel" href="#slack_sdk.audit_logs.v1.logs.Channel">Channel</a>, dict, NoneType] = None, file: Union[<a title="slack_sdk.audit_logs.v1.logs.File" href="#slack_sdk.audit_logs.v1.logs.File">File</a>, dict, NoneType] = None, app: Union[<a title="slack_sdk.audit_logs.v1.logs.App" href="#slack_sdk.audit_logs.v1.logs.App">App</a>, dict, NoneType] = None, **kwargs)</span>
+<span>(</span><span>*, type: Optional[str] = None, user: Union[<a title="slack_sdk.audit_logs.v1.logs.User" href="#slack_sdk.audit_logs.v1.logs.User">User</a>, dict, NoneType] = None, workspace: Union[<a title="slack_sdk.audit_logs.v1.logs.Location" href="#slack_sdk.audit_logs.v1.logs.Location">Location</a>, dict, NoneType] = None, enterprise: Union[<a title="slack_sdk.audit_logs.v1.logs.Location" href="#slack_sdk.audit_logs.v1.logs.Location">Location</a>, dict, NoneType] = None, channel: Union[<a title="slack_sdk.audit_logs.v1.logs.Channel" href="#slack_sdk.audit_logs.v1.logs.Channel">Channel</a>, dict, NoneType] = None, file: Union[<a title="slack_sdk.audit_logs.v1.logs.File" href="#slack_sdk.audit_logs.v1.logs.File">File</a>, dict, NoneType] = None, app: Union[<a title="slack_sdk.audit_logs.v1.logs.App" href="#slack_sdk.audit_logs.v1.logs.App">App</a>, dict, NoneType] = None, usergroup: Optional[<a title="slack_sdk.audit_logs.v1.logs.Usergroup" href="#slack_sdk.audit_logs.v1.logs.Usergroup">Usergroup</a>] = None, workflow: Optional[<a title="slack_sdk.audit_logs.v1.logs.Workflow" href="#slack_sdk.audit_logs.v1.logs.Workflow">Workflow</a>] = None, barrier: Optional[<a title="slack_sdk.audit_logs.v1.logs.InformationBarrier" href="#slack_sdk.audit_logs.v1.logs.InformationBarrier">InformationBarrier</a>] = None, **kwargs)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -873,6 +1216,9 @@ class LogsResponse:
     channel: Optional[Channel]
     file: Optional[File]
     app: Optional[App]
+    usergroup: Optional[Usergroup]
+    workflow: Optional[Workflow]
+    barrier: Optional[InformationBarrier]
     unknown_fields: Dict[str, Any]
 
     def __init__(
@@ -885,6 +1231,9 @@ class LogsResponse:
         channel: Optional[Union[Channel, dict]] = None,
         file: Optional[Union[File, dict]] = None,
         app: Optional[Union[App, dict]] = None,
+        usergroup: Optional[Usergroup] = None,
+        workflow: Optional[Workflow] = None,
+        barrier: Optional[InformationBarrier] = None,
         **kwargs,
     ) -&gt; None:
         self.type = type
@@ -898,11 +1247,22 @@ class LogsResponse:
         self.channel = Channel(**channel) if isinstance(channel, dict) else channel
         self.file = File(**file) if isinstance(file, dict) else file
         self.app = App(**app) if isinstance(app, dict) else app
+        self.usergroup = (
+            Usergroup(**usergroup) if isinstance(usergroup, dict) else usergroup
+        )
+        self.workflow = Workflow(**workflow) if isinstance(workflow, dict) else workflow
+        self.barrier = (
+            InformationBarrier(**barrier) if isinstance(barrier, dict) else barrier
+        )
         self.unknown_fields = kwargs</code></pre>
 </details>
 <h3>Class variables</h3>
 <dl>
 <dt id="slack_sdk.audit_logs.v1.logs.Entity.app"><code class="name">var <span class="ident">app</span> : Optional[<a title="slack_sdk.audit_logs.v1.logs.App" href="#slack_sdk.audit_logs.v1.logs.App">App</a>]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Entity.barrier"><code class="name">var <span class="ident">barrier</span> : Optional[<a title="slack_sdk.audit_logs.v1.logs.InformationBarrier" href="#slack_sdk.audit_logs.v1.logs.InformationBarrier">InformationBarrier</a>]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -927,6 +1287,14 @@ class LogsResponse:
 <div class="desc"></div>
 </dd>
 <dt id="slack_sdk.audit_logs.v1.logs.Entity.user"><code class="name">var <span class="ident">user</span> : Optional[<a title="slack_sdk.audit_logs.v1.logs.User" href="#slack_sdk.audit_logs.v1.logs.User">User</a>]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Entity.usergroup"><code class="name">var <span class="ident">usergroup</span> : Optional[<a title="slack_sdk.audit_logs.v1.logs.Usergroup" href="#slack_sdk.audit_logs.v1.logs.Usergroup">Usergroup</a>]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Entity.workflow"><code class="name">var <span class="ident">workflow</span> : Optional[<a title="slack_sdk.audit_logs.v1.logs.Workflow" href="#slack_sdk.audit_logs.v1.logs.Workflow">Workflow</a>]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -1064,6 +1432,62 @@ class LogsResponse:
 <div class="desc"></div>
 </dd>
 <dt id="slack_sdk.audit_logs.v1.logs.File.unknown_fields"><code class="name">var <span class="ident">unknown_fields</span> : Dict[str, Any]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.InformationBarrier"><code class="flex name class">
+<span>class <span class="ident">InformationBarrier</span></span>
+<span>(</span><span>*, id: Optional[str] = None, primary_usergroup: Optional[str] = None, barriered_from_usergroups: Optional[List[str]] = None, restricted_subjects: Optional[List[str]] = None, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class InformationBarrier:
+    id: Optional[str]
+    primary_usergroup: Optional[str]
+    barriered_from_usergroups: Optional[List[str]]
+    restricted_subjects: Optional[List[str]]
+    unknown_fields: Dict[str, Any]
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        primary_usergroup: Optional[str] = None,
+        barriered_from_usergroups: Optional[List[str]] = None,
+        restricted_subjects: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; None:
+        self.id = id
+        self.primary_usergroup = primary_usergroup
+        self.barriered_from_usergroups = barriered_from_usergroups
+        self.restricted_subjects = restricted_subjects
+        self.unknown_fields = kwargs</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.audit_logs.v1.logs.InformationBarrier.barriered_from_usergroups"><code class="name">var <span class="ident">barriered_from_usergroups</span> : Optional[List[str]]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.InformationBarrier.id"><code class="name">var <span class="ident">id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.InformationBarrier.primary_usergroup"><code class="name">var <span class="ident">primary_usergroup</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.InformationBarrier.restricted_subjects"><code class="name">var <span class="ident">restricted_subjects</span> : Optional[List[str]]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.InformationBarrier.unknown_fields"><code class="name">var <span class="ident">unknown_fields</span> : Dict[str, Any]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -1290,6 +1714,97 @@ class LogsResponse:
 </dd>
 </dl>
 </dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Usergroup"><code class="flex name class">
+<span>class <span class="ident">Usergroup</span></span>
+<span>(</span><span>*, id: Optional[str] = None, name: Optional[str] = None, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Usergroup:
+    id: Optional[str]
+    name: Optional[str]
+    unknown_fields: Dict[str, Any]
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        name: Optional[str] = None,
+        **kwargs,
+    ) -&gt; None:
+        self.id = id
+        self.name = name
+        self.unknown_fields = kwargs</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.audit_logs.v1.logs.Usergroup.id"><code class="name">var <span class="ident">id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Usergroup.name"><code class="name">var <span class="ident">name</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Usergroup.unknown_fields"><code class="name">var <span class="ident">unknown_fields</span> : Dict[str, Any]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Workflow"><code class="flex name class">
+<span>class <span class="ident">Workflow</span></span>
+<span>(</span><span>*, id: Optional[str] = None, name: Optional[str] = None, domain: Optional[str] = None, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Workflow:
+    id: Optional[str]
+    name: Optional[str]
+    domain: Optional[str]
+    unknown_fields: Dict[str, Any]
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        name: Optional[str] = None,
+        domain: Optional[str] = None,
+        **kwargs,
+    ) -&gt; None:
+        self.id = id
+        self.name = name
+        self.domain = domain
+        self.unknown_fields = kwargs</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.audit_logs.v1.logs.Workflow.domain"><code class="name">var <span class="ident">domain</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Workflow.id"><code class="name">var <span class="ident">id</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Workflow.name"><code class="name">var <span class="ident">name</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.audit_logs.v1.logs.Workflow.unknown_fields"><code class="name">var <span class="ident">unknown_fields</span> : Dict[str, Any]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+</dd>
 </dl>
 </section>
 </article>
@@ -1352,29 +1867,56 @@ class LogsResponse:
 <li>
 <h4><code><a title="slack_sdk.audit_logs.v1.logs.Details" href="#slack_sdk.audit_logs.v1.logs.Details">Details</a></code></h4>
 <ul class="">
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.added_team_id" href="#slack_sdk.audit_logs.v1.logs.Details.added_team_id">added_team_id</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.admin_app_id" href="#slack_sdk.audit_logs.v1.logs.Details.admin_app_id">admin_app_id</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.app_owner_id" href="#slack_sdk.audit_logs.v1.logs.Details.app_owner_id">app_owner_id</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.app_previously_approved" href="#slack_sdk.audit_logs.v1.logs.Details.app_previously_approved">app_previously_approved</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.app_previously_resolved" href="#slack_sdk.audit_logs.v1.logs.Details.app_previously_resolved">app_previously_resolved</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.approval_type" href="#slack_sdk.audit_logs.v1.logs.Details.approval_type">approval_type</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.approver_id" href="#slack_sdk.audit_logs.v1.logs.Details.approver_id">approver_id</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.barrier_id" href="#slack_sdk.audit_logs.v1.logs.Details.barrier_id">barrier_id</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.barriered_from_usergroup_ids" href="#slack_sdk.audit_logs.v1.logs.Details.barriered_from_usergroup_ids">barriered_from_usergroup_ids</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.bot_id" href="#slack_sdk.audit_logs.v1.logs.Details.bot_id">bot_id</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.bot_scopes" href="#slack_sdk.audit_logs.v1.logs.Details.bot_scopes">bot_scopes</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.channel_id" href="#slack_sdk.audit_logs.v1.logs.Details.channel_id">channel_id</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.channels" href="#slack_sdk.audit_logs.v1.logs.Details.channels">channels</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.desktop_app_browser_quit" href="#slack_sdk.audit_logs.v1.logs.Details.desktop_app_browser_quit">desktop_app_browser_quit</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.duration" href="#slack_sdk.audit_logs.v1.logs.Details.duration">duration</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.expires_on" href="#slack_sdk.audit_logs.v1.logs.Details.expires_on">expires_on</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.export_end_ts" href="#slack_sdk.audit_logs.v1.logs.Details.export_end_ts">export_end_ts</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.export_start_ts" href="#slack_sdk.audit_logs.v1.logs.Details.export_start_ts">export_start_ts</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.export_type" href="#slack_sdk.audit_logs.v1.logs.Details.export_type">export_type</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.external_organization_id" href="#slack_sdk.audit_logs.v1.logs.Details.external_organization_id">external_organization_id</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.external_organization_name" href="#slack_sdk.audit_logs.v1.logs.Details.external_organization_name">external_organization_name</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.external_user_email" href="#slack_sdk.audit_logs.v1.logs.Details.external_user_email">external_user_email</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.external_user_id" href="#slack_sdk.audit_logs.v1.logs.Details.external_user_id">external_user_id</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.granular_bot_token" href="#slack_sdk.audit_logs.v1.logs.Details.granular_bot_token">granular_bot_token</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.installer_user_id" href="#slack_sdk.audit_logs.v1.logs.Details.installer_user_id">installer_user_id</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.invite_id" href="#slack_sdk.audit_logs.v1.logs.Details.invite_id">invite_id</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.inviter" href="#slack_sdk.audit_logs.v1.logs.Details.inviter">inviter</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.is_internal_integration" href="#slack_sdk.audit_logs.v1.logs.Details.is_internal_integration">is_internal_integration</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.is_token_rotation_enabled_app" href="#slack_sdk.audit_logs.v1.logs.Details.is_token_rotation_enabled_app">is_token_rotation_enabled_app</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.is_workflow" href="#slack_sdk.audit_logs.v1.logs.Details.is_workflow">is_workflow</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.kicker" href="#slack_sdk.audit_logs.v1.logs.Details.kicker">kicker</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.mobile_only" href="#slack_sdk.audit_logs.v1.logs.Details.mobile_only">mobile_only</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.name" href="#slack_sdk.audit_logs.v1.logs.Details.name">name</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.new_scopes" href="#slack_sdk.audit_logs.v1.logs.Details.new_scopes">new_scopes</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.new_value" href="#slack_sdk.audit_logs.v1.logs.Details.new_value">new_value</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.new_version_id" href="#slack_sdk.audit_logs.v1.logs.Details.new_version_id">new_version_id</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.non_sso_only" href="#slack_sdk.audit_logs.v1.logs.Details.non_sso_only">non_sso_only</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.old_scopes" href="#slack_sdk.audit_logs.v1.logs.Details.old_scopes">old_scopes</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.origin_team" href="#slack_sdk.audit_logs.v1.logs.Details.origin_team">origin_team</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.permissions" href="#slack_sdk.audit_logs.v1.logs.Details.permissions">permissions</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.previous_scopes" href="#slack_sdk.audit_logs.v1.logs.Details.previous_scopes">previous_scopes</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.previous_value" href="#slack_sdk.audit_logs.v1.logs.Details.previous_value">previous_value</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.primary_usergroup_id" href="#slack_sdk.audit_logs.v1.logs.Details.primary_usergroup_id">primary_usergroup_id</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.reason" href="#slack_sdk.audit_logs.v1.logs.Details.reason">reason</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.resolution" href="#slack_sdk.audit_logs.v1.logs.Details.resolution">resolution</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.restricted_subjects" href="#slack_sdk.audit_logs.v1.logs.Details.restricted_subjects">restricted_subjects</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.scopes" href="#slack_sdk.audit_logs.v1.logs.Details.scopes">scopes</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.shared_to" href="#slack_sdk.audit_logs.v1.logs.Details.shared_to">shared_to</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.target_team" href="#slack_sdk.audit_logs.v1.logs.Details.target_team">target_team</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Details.trigger" href="#slack_sdk.audit_logs.v1.logs.Details.trigger">trigger</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.type" href="#slack_sdk.audit_logs.v1.logs.Details.type">type</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.unknown_fields" href="#slack_sdk.audit_logs.v1.logs.Details.unknown_fields">unknown_fields</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Details.web_only" href="#slack_sdk.audit_logs.v1.logs.Details.web_only">web_only</a></code></li>
@@ -1384,12 +1926,15 @@ class LogsResponse:
 <h4><code><a title="slack_sdk.audit_logs.v1.logs.Entity" href="#slack_sdk.audit_logs.v1.logs.Entity">Entity</a></code></h4>
 <ul class="two-column">
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.app" href="#slack_sdk.audit_logs.v1.logs.Entity.app">app</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.barrier" href="#slack_sdk.audit_logs.v1.logs.Entity.barrier">barrier</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.channel" href="#slack_sdk.audit_logs.v1.logs.Entity.channel">channel</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.enterprise" href="#slack_sdk.audit_logs.v1.logs.Entity.enterprise">enterprise</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.file" href="#slack_sdk.audit_logs.v1.logs.Entity.file">file</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.type" href="#slack_sdk.audit_logs.v1.logs.Entity.type">type</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.unknown_fields" href="#slack_sdk.audit_logs.v1.logs.Entity.unknown_fields">unknown_fields</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.user" href="#slack_sdk.audit_logs.v1.logs.Entity.user">user</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.usergroup" href="#slack_sdk.audit_logs.v1.logs.Entity.usergroup">usergroup</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.workflow" href="#slack_sdk.audit_logs.v1.logs.Entity.workflow">workflow</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.Entity.workspace" href="#slack_sdk.audit_logs.v1.logs.Entity.workspace">workspace</a></code></li>
 </ul>
 </li>
@@ -1414,6 +1959,16 @@ class LogsResponse:
 <li><code><a title="slack_sdk.audit_logs.v1.logs.File.name" href="#slack_sdk.audit_logs.v1.logs.File.name">name</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.File.title" href="#slack_sdk.audit_logs.v1.logs.File.title">title</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.File.unknown_fields" href="#slack_sdk.audit_logs.v1.logs.File.unknown_fields">unknown_fields</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.audit_logs.v1.logs.InformationBarrier" href="#slack_sdk.audit_logs.v1.logs.InformationBarrier">InformationBarrier</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.audit_logs.v1.logs.InformationBarrier.barriered_from_usergroups" href="#slack_sdk.audit_logs.v1.logs.InformationBarrier.barriered_from_usergroups">barriered_from_usergroups</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.InformationBarrier.id" href="#slack_sdk.audit_logs.v1.logs.InformationBarrier.id">id</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.InformationBarrier.primary_usergroup" href="#slack_sdk.audit_logs.v1.logs.InformationBarrier.primary_usergroup">primary_usergroup</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.InformationBarrier.restricted_subjects" href="#slack_sdk.audit_logs.v1.logs.InformationBarrier.restricted_subjects">restricted_subjects</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.InformationBarrier.unknown_fields" href="#slack_sdk.audit_logs.v1.logs.InformationBarrier.unknown_fields">unknown_fields</a></code></li>
 </ul>
 </li>
 <li>
@@ -1453,6 +2008,23 @@ class LogsResponse:
 <li><code><a title="slack_sdk.audit_logs.v1.logs.User.name" href="#slack_sdk.audit_logs.v1.logs.User.name">name</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.User.team" href="#slack_sdk.audit_logs.v1.logs.User.team">team</a></code></li>
 <li><code><a title="slack_sdk.audit_logs.v1.logs.User.unknown_fields" href="#slack_sdk.audit_logs.v1.logs.User.unknown_fields">unknown_fields</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.audit_logs.v1.logs.Usergroup" href="#slack_sdk.audit_logs.v1.logs.Usergroup">Usergroup</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Usergroup.id" href="#slack_sdk.audit_logs.v1.logs.Usergroup.id">id</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Usergroup.name" href="#slack_sdk.audit_logs.v1.logs.Usergroup.name">name</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Usergroup.unknown_fields" href="#slack_sdk.audit_logs.v1.logs.Usergroup.unknown_fields">unknown_fields</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.audit_logs.v1.logs.Workflow" href="#slack_sdk.audit_logs.v1.logs.Workflow">Workflow</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Workflow.domain" href="#slack_sdk.audit_logs.v1.logs.Workflow.domain">domain</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Workflow.id" href="#slack_sdk.audit_logs.v1.logs.Workflow.id">id</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Workflow.name" href="#slack_sdk.audit_logs.v1.logs.Workflow.name">name</a></code></li>
+<li><code><a title="slack_sdk.audit_logs.v1.logs.Workflow.unknown_fields" href="#slack_sdk.audit_logs.v1.logs.Workflow.unknown_fields">unknown_fields</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_sdk/errors/index.html
+++ b/docs/api-docs/slack_sdk/errors/index.html
@@ -62,6 +62,15 @@ class SlackApiError(SlackClientError):
         super(SlackApiError, self).__init__(msg)
 
 
+class SlackTokenRotationError(SlackClientError):
+    &#34;&#34;&#34;Error raised when the oauth.v2.access call for token rotation fails&#34;&#34;&#34;
+
+    api_error: SlackApiError
+
+    def __init__(self, api_error: SlackApiError):
+        self.api_error = api_error
+
+
 class SlackClientNotConnectedError(SlackClientError):
     &#34;&#34;&#34;Error raised when attempting to send messages over the websocket when the
     connection is closed.&#34;&#34;&#34;
@@ -199,6 +208,7 @@ connection is closed.</p></div>
 <li><a title="slack_sdk.errors.SlackClientNotConnectedError" href="#slack_sdk.errors.SlackClientNotConnectedError">SlackClientNotConnectedError</a></li>
 <li><a title="slack_sdk.errors.SlackObjectFormationError" href="#slack_sdk.errors.SlackObjectFormationError">SlackObjectFormationError</a></li>
 <li><a title="slack_sdk.errors.SlackRequestError" href="#slack_sdk.errors.SlackRequestError">SlackRequestError</a></li>
+<li><a title="slack_sdk.errors.SlackTokenRotationError" href="#slack_sdk.errors.SlackTokenRotationError">SlackTokenRotationError</a></li>
 </ul>
 </dd>
 <dt id="slack_sdk.errors.SlackClientNotConnectedError"><code class="flex name class">
@@ -263,6 +273,38 @@ connection is closed.</p></div>
 <li>builtins.BaseException</li>
 </ul>
 </dd>
+<dt id="slack_sdk.errors.SlackTokenRotationError"><code class="flex name class">
+<span>class <span class="ident">SlackTokenRotationError</span></span>
+<span>(</span><span>api_error: <a title="slack_sdk.errors.SlackApiError" href="#slack_sdk.errors.SlackApiError">SlackApiError</a>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Error raised when the oauth.v2.access call for token rotation fails</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class SlackTokenRotationError(SlackClientError):
+    &#34;&#34;&#34;Error raised when the oauth.v2.access call for token rotation fails&#34;&#34;&#34;
+
+    api_error: SlackApiError
+
+    def __init__(self, api_error: SlackApiError):
+        self.api_error = api_error</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.errors.SlackClientError" href="#slack_sdk.errors.SlackClientError">SlackClientError</a></li>
+<li>builtins.Exception</li>
+<li>builtins.BaseException</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.errors.SlackTokenRotationError.api_error"><code class="name">var <span class="ident">api_error</span> : <a title="slack_sdk.errors.SlackApiError" href="#slack_sdk.errors.SlackApiError">SlackApiError</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+</dd>
 </dl>
 </section>
 </article>
@@ -299,6 +341,12 @@ connection is closed.</p></div>
 </li>
 <li>
 <h4><code><a title="slack_sdk.errors.SlackRequestError" href="#slack_sdk.errors.SlackRequestError">SlackRequestError</a></code></h4>
+</li>
+<li>
+<h4><code><a title="slack_sdk.errors.SlackTokenRotationError" href="#slack_sdk.errors.SlackTokenRotationError">SlackTokenRotationError</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.errors.SlackTokenRotationError.api_error" href="#slack_sdk.errors.SlackTokenRotationError.api_error">api_error</a></code></li>
+</ul>
 </li>
 </ul>
 </li>

--- a/docs/api-docs/slack_sdk/models/blocks/block_elements.html
+++ b/docs/api-docs/slack_sdk/models/blocks/block_elements.html
@@ -177,10 +177,17 @@ class InteractiveElement(BlockElement):
         subtype: Optional[str] = None,
         **others: dict,
     ):
+        &#34;&#34;&#34;An interactive block element.
+
+        We generally recommend using the concrete subclasses for better supports of available properties.
+        &#34;&#34;&#34;
         if subtype:
             self._subtype_warning()
         super().__init__(type=type or subtype)
-        show_unknown_key_warning(self, others)
+
+        # Note that we don&#39;t intentionally have show_unknown_key_warning for the unknown key warnings here.
+        # It&#39;s fine to pass any kwargs to the held dict here although the class does not do any validation.
+        # show_unknown_key_warning(self, others)
 
         self.action_id = action_id
 
@@ -218,11 +225,17 @@ class InputInteractiveElement(InteractiveElement, metaclass=ABCMeta):
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         **others: dict,
     ):
-        &#34;&#34;&#34;InteractiveElement that is usable in input blocks&#34;&#34;&#34;
+        &#34;&#34;&#34;InteractiveElement that is usable in input blocks
+
+        We generally recommend using the concrete subclasses for better supports of available properties.
+        &#34;&#34;&#34;
         if subtype:
             self._subtype_warning()
         super().__init__(action_id=action_id, type=type or subtype)
-        show_unknown_key_warning(self, others)
+
+        # Note that we don&#39;t intentionally have show_unknown_key_warning for the unknown key warnings here.
+        # It&#39;s fine to pass any kwargs to the held dict here although the class does not do any validation.
+        # show_unknown_key_warning(self, others)
 
         self.placeholder = TextObject.parse(placeholder)
         self.confirm = ConfirmObject.parse(confirm)
@@ -2383,7 +2396,8 @@ def attributes(self) -&gt; Set[str]:
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
 <a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
-<p>InteractiveElement that is usable in input blocks</p></div>
+<p>InteractiveElement that is usable in input blocks</p>
+<p>We generally recommend using the concrete subclasses for better supports of available properties.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2413,11 +2427,17 @@ def attributes(self) -&gt; Set[str]:
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         **others: dict,
     ):
-        &#34;&#34;&#34;InteractiveElement that is usable in input blocks&#34;&#34;&#34;
+        &#34;&#34;&#34;InteractiveElement that is usable in input blocks
+
+        We generally recommend using the concrete subclasses for better supports of available properties.
+        &#34;&#34;&#34;
         if subtype:
             self._subtype_warning()
         super().__init__(action_id=action_id, type=type or subtype)
-        show_unknown_key_warning(self, others)
+
+        # Note that we don&#39;t intentionally have show_unknown_key_warning for the unknown key warnings here.
+        # It&#39;s fine to pass any kwargs to the held dict here although the class does not do any validation.
+        # show_unknown_key_warning(self, others)
 
         self.placeholder = TextObject.parse(placeholder)
         self.confirm = ConfirmObject.parse(confirm)
@@ -2498,7 +2518,9 @@ def subtype(self) -&gt; Optional[str]:
 </code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<p>An interactive block element.</p>
+<p>We generally recommend using the concrete subclasses for better supports of available properties.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2518,10 +2540,17 @@ def subtype(self) -&gt; Optional[str]:
         subtype: Optional[str] = None,
         **others: dict,
     ):
+        &#34;&#34;&#34;An interactive block element.
+
+        We generally recommend using the concrete subclasses for better supports of available properties.
+        &#34;&#34;&#34;
         if subtype:
             self._subtype_warning()
         super().__init__(type=type or subtype)
-        show_unknown_key_warning(self, others)
+
+        # Note that we don&#39;t intentionally have show_unknown_key_warning for the unknown key warnings here.
+        # It&#39;s fine to pass any kwargs to the held dict here although the class does not do any validation.
+        # show_unknown_key_warning(self, others)
 
         self.action_id = action_id
 

--- a/docs/api-docs/slack_sdk/oauth/index.html
+++ b/docs/api-docs/slack_sdk/oauth/index.html
@@ -62,6 +62,10 @@ from .state_utils import OAuthStateUtils  # noqa</code></pre>
 <dd>
 <div class="desc"></div>
 </dd>
+<dt><code class="name"><a title="slack_sdk.oauth.token_rotation" href="token_rotation/index.html">slack_sdk.oauth.token_rotation</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 </dl>
 </section>
 <section>
@@ -89,6 +93,7 @@ from .state_utils import OAuthStateUtils  # noqa</code></pre>
 <li><code><a title="slack_sdk.oauth.redirect_uri_page_renderer" href="redirect_uri_page_renderer/index.html">slack_sdk.oauth.redirect_uri_page_renderer</a></code></li>
 <li><code><a title="slack_sdk.oauth.state_store" href="state_store/index.html">slack_sdk.oauth.state_store</a></code></li>
 <li><code><a title="slack_sdk.oauth.state_utils" href="state_utils/index.html">slack_sdk.oauth.state_utils</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation" href="token_rotation/index.html">slack_sdk.oauth.token_rotation</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/amazon_s3/index.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/amazon_s3/index.html
@@ -66,27 +66,19 @@ class AmazonS3InstallationStore(InstallationStore, AsyncInstallationStore):
     async def async_save(self, installation: Installation):
         return self.save(installation)
 
+    async def async_save_bot(self, bot: Bot):
+        return self.save_bot(bot)
+
     def save(self, installation: Installation):
         none = &#34;none&#34;
         e_id = installation.enterprise_id or none
         t_id = installation.team_id or none
         workspace_path = f&#34;{self.client_id}/{e_id}-{t_id}&#34;
 
+        self.save_bot(installation.to_bot())
+
         if self.historical_data_enabled:
             history_version: str = str(installation.installed_at)
-            entity: str = json.dumps(installation.to_bot().__dict__)
-            response = self.s3_client.put_object(
-                Bucket=self.bucket_name,
-                Body=entity,
-                Key=f&#34;{workspace_path}/bot-latest&#34;,
-            )
-            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
-            response = self.s3_client.put_object(
-                Bucket=self.bucket_name,
-                Body=entity,
-                Key=f&#34;{workspace_path}/bot-{history_version}&#34;,
-            )
-            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
 
             # per workspace
             entity: str = json.dumps(installation.__dict__)
@@ -120,14 +112,6 @@ class AmazonS3InstallationStore(InstallationStore, AsyncInstallationStore):
             self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
 
         else:
-            entity: str = json.dumps(installation.to_bot().__dict__)
-            response = self.s3_client.put_object(
-                Bucket=self.bucket_name,
-                Body=entity,
-                Key=f&#34;{workspace_path}/bot-latest&#34;,
-            )
-            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
-
             # per workspace
             entity: str = json.dumps(installation.__dict__)
             response = self.s3_client.put_object(
@@ -144,6 +128,37 @@ class AmazonS3InstallationStore(InstallationStore, AsyncInstallationStore):
                 Bucket=self.bucket_name,
                 Body=entity,
                 Key=f&#34;{workspace_path}/installer-{u_id}-latest&#34;,
+            )
+            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
+
+    def save_bot(self, bot: Bot):
+        none = &#34;none&#34;
+        e_id = bot.enterprise_id or none
+        t_id = bot.team_id or none
+        workspace_path = f&#34;{self.client_id}/{e_id}-{t_id}&#34;
+
+        if self.historical_data_enabled:
+            history_version: str = str(bot.installed_at)
+            entity: str = json.dumps(bot.__dict__)
+            response = self.s3_client.put_object(
+                Bucket=self.bucket_name,
+                Body=entity,
+                Key=f&#34;{workspace_path}/bot-latest&#34;,
+            )
+            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
+            response = self.s3_client.put_object(
+                Bucket=self.bucket_name,
+                Body=entity,
+                Key=f&#34;{workspace_path}/bot-{history_version}&#34;,
+            )
+            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
+
+        else:
+            entity: str = json.dumps(bot.__dict__)
+            response = self.s3_client.put_object(
+                Bucket=self.bucket_name,
+                Body=entity,
+                Key=f&#34;{workspace_path}/bot-latest&#34;,
             )
             self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
 
@@ -371,27 +386,19 @@ the following methods should be implemented.</p>
     async def async_save(self, installation: Installation):
         return self.save(installation)
 
+    async def async_save_bot(self, bot: Bot):
+        return self.save_bot(bot)
+
     def save(self, installation: Installation):
         none = &#34;none&#34;
         e_id = installation.enterprise_id or none
         t_id = installation.team_id or none
         workspace_path = f&#34;{self.client_id}/{e_id}-{t_id}&#34;
 
+        self.save_bot(installation.to_bot())
+
         if self.historical_data_enabled:
             history_version: str = str(installation.installed_at)
-            entity: str = json.dumps(installation.to_bot().__dict__)
-            response = self.s3_client.put_object(
-                Bucket=self.bucket_name,
-                Body=entity,
-                Key=f&#34;{workspace_path}/bot-latest&#34;,
-            )
-            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
-            response = self.s3_client.put_object(
-                Bucket=self.bucket_name,
-                Body=entity,
-                Key=f&#34;{workspace_path}/bot-{history_version}&#34;,
-            )
-            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
 
             # per workspace
             entity: str = json.dumps(installation.__dict__)
@@ -425,14 +432,6 @@ the following methods should be implemented.</p>
             self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
 
         else:
-            entity: str = json.dumps(installation.to_bot().__dict__)
-            response = self.s3_client.put_object(
-                Bucket=self.bucket_name,
-                Body=entity,
-                Key=f&#34;{workspace_path}/bot-latest&#34;,
-            )
-            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
-
             # per workspace
             entity: str = json.dumps(installation.__dict__)
             response = self.s3_client.put_object(
@@ -449,6 +448,37 @@ the following methods should be implemented.</p>
                 Bucket=self.bucket_name,
                 Body=entity,
                 Key=f&#34;{workspace_path}/installer-{u_id}-latest&#34;,
+            )
+            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
+
+    def save_bot(self, bot: Bot):
+        none = &#34;none&#34;
+        e_id = bot.enterprise_id or none
+        t_id = bot.team_id or none
+        workspace_path = f&#34;{self.client_id}/{e_id}-{t_id}&#34;
+
+        if self.historical_data_enabled:
+            history_version: str = str(bot.installed_at)
+            entity: str = json.dumps(bot.__dict__)
+            response = self.s3_client.put_object(
+                Bucket=self.bucket_name,
+                Body=entity,
+                Key=f&#34;{workspace_path}/bot-latest&#34;,
+            )
+            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
+            response = self.s3_client.put_object(
+                Bucket=self.bucket_name,
+                Body=entity,
+                Key=f&#34;{workspace_path}/bot-{history_version}&#34;,
+            )
+            self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
+
+        else:
+            entity: str = json.dumps(bot.__dict__)
+            response = self.s3_client.put_object(
+                Bucket=self.bucket_name,
+                Body=entity,
+                Key=f&#34;{workspace_path}/bot-latest&#34;,
             )
             self.logger.debug(f&#34;S3 put_object response: {response}&#34;)
 
@@ -640,6 +670,7 @@ def logger(self) -&gt; Logger:
 <li><code><b><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore">InstallationStore</a></b></code>:
 <ul class="hlist">
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save">save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot">save_bot</a></code></li>
 </ul>
 </li>
 <li><code><b><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore">InstallationStore</a></b></code>:
@@ -666,6 +697,7 @@ def logger(self) -&gt; Logger:
 <li><code><b><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore">AsyncInstallationStore</a></b></code>:
 <ul class="hlist">
 <li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save">async_save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot">async_save_bot</a></code></li>
 </ul>
 </li>
 <li><code><b><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore">AsyncInstallationStore</a></b></code>:

--- a/docs/api-docs/slack_sdk/oauth/installation_store/async_cacheable_installation_store.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/async_cacheable_installation_store.html
@@ -55,7 +55,21 @@ class AsyncCacheableInstallationStore(AsyncInstallationStore):
         return self.underlying.logger
 
     async def async_save(self, installation: Installation):
+        # Invalidate cache data for update operations
+        key = f&#34;{installation.enterprise_id or &#39;&#39;}-{installation.team_id or &#39;&#39;}&#34;
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
+        key = f&#34;{installation.enterprise_id or &#39;&#39;}-{installation.team_id or &#39;&#39;}-{installation.user_id or &#39;&#39;}&#34;
+        if key in self.cached_installations:
+            self.cached_installations.pop(key)
         return await self.underlying.async_save(installation)
+
+    async def async_save_bot(self, bot: Bot):
+        # Invalidate cache data for update operations
+        key = f&#34;{bot.enterprise_id or &#39;&#39;}-{bot.team_id or &#39;&#39;}&#34;
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
+        return await self.underlying.async_save_bot(bot)
 
     async def async_find_bot(
         self,
@@ -126,8 +140,10 @@ class AsyncCacheableInstallationStore(AsyncInstallationStore):
             team_id=team_id,
             user_id=user_id,
         )
-        key = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}={user_id or &#39;&#39;}&#34;
-        self.cached_installations.pop(key)
+        key_prefix = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}&#34;
+        for key in list(self.cached_installations.keys()):
+            if key.startswith(key_prefix):
+                self.cached_installations.pop(key)
 
     async def async_delete_all(
         self,
@@ -140,10 +156,10 @@ class AsyncCacheableInstallationStore(AsyncInstallationStore):
             team_id=team_id,
         )
         key_prefix = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}&#34;
-        for key in self.cached_bots.keys():
+        for key in list(self.cached_bots.keys()):
             if key.startswith(key_prefix):
                 self.cached_bots.pop(key)
-        for key in self.cached_installations.keys():
+        for key in list(self.cached_installations.keys()):
             if key.startswith(key_prefix):
                 self.cached_installations.pop(key)</code></pre>
 </details>
@@ -211,7 +227,21 @@ the following methods should be implemented.</p>
         return self.underlying.logger
 
     async def async_save(self, installation: Installation):
+        # Invalidate cache data for update operations
+        key = f&#34;{installation.enterprise_id or &#39;&#39;}-{installation.team_id or &#39;&#39;}&#34;
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
+        key = f&#34;{installation.enterprise_id or &#39;&#39;}-{installation.team_id or &#39;&#39;}-{installation.user_id or &#39;&#39;}&#34;
+        if key in self.cached_installations:
+            self.cached_installations.pop(key)
         return await self.underlying.async_save(installation)
+
+    async def async_save_bot(self, bot: Bot):
+        # Invalidate cache data for update operations
+        key = f&#34;{bot.enterprise_id or &#39;&#39;}-{bot.team_id or &#39;&#39;}&#34;
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
+        return await self.underlying.async_save_bot(bot)
 
     async def async_find_bot(
         self,
@@ -282,8 +312,10 @@ the following methods should be implemented.</p>
             team_id=team_id,
             user_id=user_id,
         )
-        key = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}={user_id or &#39;&#39;}&#34;
-        self.cached_installations.pop(key)
+        key_prefix = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}&#34;
+        for key in list(self.cached_installations.keys()):
+            if key.startswith(key_prefix):
+                self.cached_installations.pop(key)
 
     async def async_delete_all(
         self,
@@ -296,10 +328,10 @@ the following methods should be implemented.</p>
             team_id=team_id,
         )
         key_prefix = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}&#34;
-        for key in self.cached_bots.keys():
+        for key in list(self.cached_bots.keys()):
             if key.startswith(key_prefix):
                 self.cached_bots.pop(key)
-        for key in self.cached_installations.keys():
+        for key in list(self.cached_installations.keys()):
             if key.startswith(key_prefix):
                 self.cached_installations.pop(key)</code></pre>
 </details>
@@ -347,6 +379,7 @@ def logger(self) -&gt; Logger:
 <li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_find_bot" href="async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_find_bot">async_find_bot</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_find_installation" href="async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_find_installation">async_find_installation</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save" href="async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save">async_save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot" href="async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot">async_save_bot</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/async_installation_store.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/async_installation_store.html
@@ -60,7 +60,11 @@ class AsyncInstallationStore:
         raise NotImplementedError()
 
     async def async_save(self, installation: Installation):
-        &#34;&#34;&#34;Saves a new installation data&#34;&#34;&#34;
+        &#34;&#34;&#34;Saves an installation data&#34;&#34;&#34;
+        raise NotImplementedError()
+
+    async def async_save_bot(self, bot: Bot):
+        &#34;&#34;&#34;Saves a bot installation data&#34;&#34;&#34;
         raise NotImplementedError()
 
     async def async_find_bot(
@@ -181,7 +185,11 @@ the following methods should be implemented.</p>
         raise NotImplementedError()
 
     async def async_save(self, installation: Installation):
-        &#34;&#34;&#34;Saves a new installation data&#34;&#34;&#34;
+        &#34;&#34;&#34;Saves an installation data&#34;&#34;&#34;
+        raise NotImplementedError()
+
+    async def async_save_bot(self, bot: Bot):
+        &#34;&#34;&#34;Saves a bot installation data&#34;&#34;&#34;
         raise NotImplementedError()
 
     async def async_find_bot(
@@ -371,13 +379,27 @@ If the user_id is absent, this method may return the latest installation in the 
 <span>async def <span class="ident">async_save</span></span>(<span>self, installation: <a title="slack_sdk.oauth.installation_store.models.installation.Installation" href="models/installation.html#slack_sdk.oauth.installation_store.models.installation.Installation">Installation</a>)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Saves a new installation data</p></div>
+<div class="desc"><p>Saves an installation data</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">async def async_save(self, installation: Installation):
-    &#34;&#34;&#34;Saves a new installation data&#34;&#34;&#34;
+    &#34;&#34;&#34;Saves an installation data&#34;&#34;&#34;
+    raise NotImplementedError()</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot"><code class="name flex">
+<span>async def <span class="ident">async_save_bot</span></span>(<span>self, bot: <a title="slack_sdk.oauth.installation_store.models.bot.Bot" href="models/bot.html#slack_sdk.oauth.installation_store.models.bot.Bot">Bot</a>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Saves a bot installation data</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def async_save_bot(self, bot: Bot):
+    &#34;&#34;&#34;Saves a bot installation data&#34;&#34;&#34;
     raise NotImplementedError()</code></pre>
 </details>
 </dd>
@@ -408,6 +430,7 @@ If the user_id is absent, this method may return the latest installation in the 
 <li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_find_bot" href="#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_find_bot">async_find_bot</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_find_installation" href="#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_find_installation">async_find_installation</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save" href="#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save">async_save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot" href="#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot">async_save_bot</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.logger" href="#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.logger">logger</a></code></li>
 </ul>
 </li>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/cacheable_installation_store.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/cacheable_installation_store.html
@@ -53,7 +53,22 @@ class CacheableInstallationStore(InstallationStore):
         return self.underlying.logger
 
     def save(self, installation: Installation):
+        # Invalidate cache data for update operations
+        key = f&#34;{installation.enterprise_id or &#39;&#39;}-{installation.team_id or &#39;&#39;}&#34;
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
+        key = f&#34;{installation.enterprise_id or &#39;&#39;}-{installation.team_id or &#39;&#39;}-{installation.user_id or &#39;&#39;}&#34;
+        if key in self.cached_installations:
+            self.cached_installations.pop(key)
+
         return self.underlying.save(installation)
+
+    def save_bot(self, bot: Bot):
+        # Invalidate cache data for update operations
+        key = f&#34;{bot.enterprise_id or &#39;&#39;}-{bot.team_id or &#39;&#39;}&#34;
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
+        return self.underlying.save_bot(bot)
 
     def find_bot(
         self,
@@ -86,7 +101,7 @@ class CacheableInstallationStore(InstallationStore):
     ) -&gt; Optional[Installation]:
         if is_enterprise_install or team_id is None:
             team_id = &#34;&#34;
-        key = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}={user_id or &#39;&#39;}&#34;
+        key = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}-{user_id or &#39;&#39;}&#34;
         if key in self.cached_installations:
             return self.cached_installations[key]
         installation = self.underlying.find_installation(
@@ -110,7 +125,8 @@ class CacheableInstallationStore(InstallationStore):
             team_id=team_id,
         )
         key = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}&#34;
-        self.cached_bots.pop(key)
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
 
     def delete_installation(
         self,
@@ -124,8 +140,10 @@ class CacheableInstallationStore(InstallationStore):
             team_id=team_id,
             user_id=user_id,
         )
-        key = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}={user_id or &#39;&#39;}&#34;
-        self.cached_installations.pop(key)
+        key_prefix = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}&#34;
+        for key in list(self.cached_installations.keys()):
+            if key.startswith(key_prefix):
+                self.cached_installations.pop(key)
 
     def delete_all(
         self,
@@ -138,10 +156,10 @@ class CacheableInstallationStore(InstallationStore):
             team_id=team_id,
         )
         key_prefix = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}&#34;
-        for key in self.cached_bots.keys():
+        for key in list(self.cached_bots.keys()):
             if key.startswith(key_prefix):
                 self.cached_bots.pop(key)
-        for key in self.cached_installations.keys():
+        for key in list(self.cached_installations.keys()):
             if key.startswith(key_prefix):
                 self.cached_installations.pop(key)</code></pre>
 </details>
@@ -209,7 +227,22 @@ the following methods should be implemented.</p>
         return self.underlying.logger
 
     def save(self, installation: Installation):
+        # Invalidate cache data for update operations
+        key = f&#34;{installation.enterprise_id or &#39;&#39;}-{installation.team_id or &#39;&#39;}&#34;
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
+        key = f&#34;{installation.enterprise_id or &#39;&#39;}-{installation.team_id or &#39;&#39;}-{installation.user_id or &#39;&#39;}&#34;
+        if key in self.cached_installations:
+            self.cached_installations.pop(key)
+
         return self.underlying.save(installation)
+
+    def save_bot(self, bot: Bot):
+        # Invalidate cache data for update operations
+        key = f&#34;{bot.enterprise_id or &#39;&#39;}-{bot.team_id or &#39;&#39;}&#34;
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
+        return self.underlying.save_bot(bot)
 
     def find_bot(
         self,
@@ -242,7 +275,7 @@ the following methods should be implemented.</p>
     ) -&gt; Optional[Installation]:
         if is_enterprise_install or team_id is None:
             team_id = &#34;&#34;
-        key = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}={user_id or &#39;&#39;}&#34;
+        key = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}-{user_id or &#39;&#39;}&#34;
         if key in self.cached_installations:
             return self.cached_installations[key]
         installation = self.underlying.find_installation(
@@ -266,7 +299,8 @@ the following methods should be implemented.</p>
             team_id=team_id,
         )
         key = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}&#34;
-        self.cached_bots.pop(key)
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
 
     def delete_installation(
         self,
@@ -280,8 +314,10 @@ the following methods should be implemented.</p>
             team_id=team_id,
             user_id=user_id,
         )
-        key = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}={user_id or &#39;&#39;}&#34;
-        self.cached_installations.pop(key)
+        key_prefix = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}&#34;
+        for key in list(self.cached_installations.keys()):
+            if key.startswith(key_prefix):
+                self.cached_installations.pop(key)
 
     def delete_all(
         self,
@@ -294,10 +330,10 @@ the following methods should be implemented.</p>
             team_id=team_id,
         )
         key_prefix = f&#34;{enterprise_id or &#39;&#39;}-{team_id or &#39;&#39;}&#34;
-        for key in self.cached_bots.keys():
+        for key in list(self.cached_bots.keys()):
             if key.startswith(key_prefix):
                 self.cached_bots.pop(key)
-        for key in self.cached_installations.keys():
+        for key in list(self.cached_installations.keys()):
             if key.startswith(key_prefix):
                 self.cached_installations.pop(key)</code></pre>
 </details>
@@ -345,6 +381,7 @@ def logger(self) -&gt; Logger:
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.find_bot" href="installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.find_bot">find_bot</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.find_installation" href="installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.find_installation">find_installation</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save" href="installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save">save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot" href="installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot">save_bot</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/file/index.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/file/index.html
@@ -67,6 +67,9 @@ class FileInstallationStore(InstallationStore, AsyncInstallationStore):
     async def async_save(self, installation: Installation):
         return self.save(installation)
 
+    async def async_save_bot(self, bot: Bot):
+        return self.save_bot(bot)
+
     def save(self, installation: Installation):
         none = &#34;none&#34;
         e_id = installation.enterprise_id or none
@@ -74,14 +77,10 @@ class FileInstallationStore(InstallationStore, AsyncInstallationStore):
         team_installation_dir = f&#34;{self.base_dir}/{e_id}-{t_id}&#34;
         self._mkdir(team_installation_dir)
 
+        self.save_bot(installation.to_bot())
+
         if self.historical_data_enabled:
             history_version: str = str(installation.installed_at)
-
-            entity: str = json.dumps(installation.to_bot().__dict__)
-            with open(f&#34;{team_installation_dir}/bot-latest&#34;, &#34;w&#34;) as f:
-                f.write(entity)
-            with open(f&#34;{team_installation_dir}/bot-{history_version}&#34;, &#34;w&#34;) as f:
-                f.write(entity)
 
             # per workspace
             entity: str = json.dumps(installation.__dict__)
@@ -101,14 +100,30 @@ class FileInstallationStore(InstallationStore, AsyncInstallationStore):
                 f.write(entity)
 
         else:
-            with open(f&#34;{team_installation_dir}/bot-latest&#34;, &#34;w&#34;) as f:
-                entity: str = json.dumps(installation.to_bot().__dict__)
-                f.write(entity)
-
             u_id = installation.user_id or none
             installer_filepath = f&#34;{team_installation_dir}/installer-{u_id}-latest&#34;
             with open(installer_filepath, &#34;w&#34;) as f:
                 entity: str = json.dumps(installation.__dict__)
+                f.write(entity)
+
+    def save_bot(self, bot: Bot):
+        none = &#34;none&#34;
+        e_id = bot.enterprise_id or none
+        t_id = bot.team_id or none
+        team_installation_dir = f&#34;{self.base_dir}/{e_id}-{t_id}&#34;
+        self._mkdir(team_installation_dir)
+
+        if self.historical_data_enabled:
+            history_version: str = str(bot.installed_at)
+
+            entity: str = json.dumps(bot.__dict__)
+            with open(f&#34;{team_installation_dir}/bot-latest&#34;, &#34;w&#34;) as f:
+                f.write(entity)
+            with open(f&#34;{team_installation_dir}/bot-{history_version}&#34;, &#34;w&#34;) as f:
+                f.write(entity)
+        else:
+            with open(f&#34;{team_installation_dir}/bot-latest&#34;, &#34;w&#34;) as f:
+                entity: str = json.dumps(bot.__dict__)
                 f.write(entity)
 
     async def async_find_bot(
@@ -307,6 +322,9 @@ the following methods should be implemented.</p>
     async def async_save(self, installation: Installation):
         return self.save(installation)
 
+    async def async_save_bot(self, bot: Bot):
+        return self.save_bot(bot)
+
     def save(self, installation: Installation):
         none = &#34;none&#34;
         e_id = installation.enterprise_id or none
@@ -314,14 +332,10 @@ the following methods should be implemented.</p>
         team_installation_dir = f&#34;{self.base_dir}/{e_id}-{t_id}&#34;
         self._mkdir(team_installation_dir)
 
+        self.save_bot(installation.to_bot())
+
         if self.historical_data_enabled:
             history_version: str = str(installation.installed_at)
-
-            entity: str = json.dumps(installation.to_bot().__dict__)
-            with open(f&#34;{team_installation_dir}/bot-latest&#34;, &#34;w&#34;) as f:
-                f.write(entity)
-            with open(f&#34;{team_installation_dir}/bot-{history_version}&#34;, &#34;w&#34;) as f:
-                f.write(entity)
 
             # per workspace
             entity: str = json.dumps(installation.__dict__)
@@ -341,14 +355,30 @@ the following methods should be implemented.</p>
                 f.write(entity)
 
         else:
-            with open(f&#34;{team_installation_dir}/bot-latest&#34;, &#34;w&#34;) as f:
-                entity: str = json.dumps(installation.to_bot().__dict__)
-                f.write(entity)
-
             u_id = installation.user_id or none
             installer_filepath = f&#34;{team_installation_dir}/installer-{u_id}-latest&#34;
             with open(installer_filepath, &#34;w&#34;) as f:
                 entity: str = json.dumps(installation.__dict__)
+                f.write(entity)
+
+    def save_bot(self, bot: Bot):
+        none = &#34;none&#34;
+        e_id = bot.enterprise_id or none
+        t_id = bot.team_id or none
+        team_installation_dir = f&#34;{self.base_dir}/{e_id}-{t_id}&#34;
+        self._mkdir(team_installation_dir)
+
+        if self.historical_data_enabled:
+            history_version: str = str(bot.installed_at)
+
+            entity: str = json.dumps(bot.__dict__)
+            with open(f&#34;{team_installation_dir}/bot-latest&#34;, &#34;w&#34;) as f:
+                f.write(entity)
+            with open(f&#34;{team_installation_dir}/bot-{history_version}&#34;, &#34;w&#34;) as f:
+                f.write(entity)
+        else:
+            with open(f&#34;{team_installation_dir}/bot-latest&#34;, &#34;w&#34;) as f:
+                entity: str = json.dumps(bot.__dict__)
                 f.write(entity)
 
     async def async_find_bot(
@@ -511,6 +541,7 @@ def logger(self) -&gt; Logger:
 <li><code><b><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore">InstallationStore</a></b></code>:
 <ul class="hlist">
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save">save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot">save_bot</a></code></li>
 </ul>
 </li>
 <li><code><b><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore">InstallationStore</a></b></code>:
@@ -537,6 +568,7 @@ def logger(self) -&gt; Logger:
 <li><code><b><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore">AsyncInstallationStore</a></b></code>:
 <ul class="hlist">
 <li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save">async_save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot">async_save_bot</a></code></li>
 </ul>
 </li>
 <li><code><b><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore">AsyncInstallationStore</a></b></code>:

--- a/docs/api-docs/slack_sdk/oauth/installation_store/index.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/index.html
@@ -58,6 +58,10 @@ from .models import Bot, Installation  # noqa</code></pre>
 <dd>
 <div class="desc"><p>Slack installation data store …</p></div>
 </dd>
+<dt><code class="name"><a title="slack_sdk.oauth.installation_store.internals" href="internals.html">slack_sdk.oauth.installation_store.internals</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt><code class="name"><a title="slack_sdk.oauth.installation_store.models" href="models/index.html">slack_sdk.oauth.installation_store.models</a></code></dt>
 <dd>
 <div class="desc"></div>
@@ -98,6 +102,7 @@ from .models import Bot, Installation  # noqa</code></pre>
 <li><code><a title="slack_sdk.oauth.installation_store.cacheable_installation_store" href="cacheable_installation_store.html">slack_sdk.oauth.installation_store.cacheable_installation_store</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.file" href="file/index.html">slack_sdk.oauth.installation_store.file</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store" href="installation_store.html">slack_sdk.oauth.installation_store.installation_store</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.internals" href="internals.html">slack_sdk.oauth.installation_store.internals</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models" href="models/index.html">slack_sdk.oauth.installation_store.models</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.sqlalchemy" href="sqlalchemy/index.html">slack_sdk.oauth.installation_store.sqlalchemy</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.sqlite3" href="sqlite3/index.html">slack_sdk.oauth.installation_store.sqlite3</a></code></li>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/installation_store.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/installation_store.html
@@ -66,7 +66,11 @@ class InstallationStore:
         raise NotImplementedError()
 
     def save(self, installation: Installation):
-        &#34;&#34;&#34;Saves a new installation data&#34;&#34;&#34;
+        &#34;&#34;&#34;Saves an installation data&#34;&#34;&#34;
+        raise NotImplementedError()
+
+    def save_bot(self, bot: Bot):
+        &#34;&#34;&#34;Saves a bot installation data&#34;&#34;&#34;
         raise NotImplementedError()
 
     def find_bot(
@@ -185,7 +189,11 @@ the following methods should be implemented.</p>
         raise NotImplementedError()
 
     def save(self, installation: Installation):
-        &#34;&#34;&#34;Saves a new installation data&#34;&#34;&#34;
+        &#34;&#34;&#34;Saves an installation data&#34;&#34;&#34;
+        raise NotImplementedError()
+
+    def save_bot(self, bot: Bot):
+        &#34;&#34;&#34;Saves a bot installation data&#34;&#34;&#34;
         raise NotImplementedError()
 
     def find_bot(
@@ -372,13 +380,27 @@ If the user_id is absent, this method may return the latest installation in the 
 <span>def <span class="ident">save</span></span>(<span>self, installation: <a title="slack_sdk.oauth.installation_store.models.installation.Installation" href="models/installation.html#slack_sdk.oauth.installation_store.models.installation.Installation">Installation</a>)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Saves a new installation data</p></div>
+<div class="desc"><p>Saves an installation data</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def save(self, installation: Installation):
-    &#34;&#34;&#34;Saves a new installation data&#34;&#34;&#34;
+    &#34;&#34;&#34;Saves an installation data&#34;&#34;&#34;
+    raise NotImplementedError()</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot"><code class="name flex">
+<span>def <span class="ident">save_bot</span></span>(<span>self, bot: <a title="slack_sdk.oauth.installation_store.models.bot.Bot" href="models/bot.html#slack_sdk.oauth.installation_store.models.bot.Bot">Bot</a>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Saves a bot installation data</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def save_bot(self, bot: Bot):
+    &#34;&#34;&#34;Saves a bot installation data&#34;&#34;&#34;
     raise NotImplementedError()</code></pre>
 </details>
 </dd>
@@ -410,6 +432,7 @@ If the user_id is absent, this method may return the latest installation in the 
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.find_installation" href="#slack_sdk.oauth.installation_store.installation_store.InstallationStore.find_installation">find_installation</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.logger" href="#slack_sdk.oauth.installation_store.installation_store.InstallationStore.logger">logger</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save" href="#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save">save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot" href="#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot">save_bot</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/internals.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/internals.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
-<title>slack_sdk.version API documentation</title>
-<meta name="description" content="Check the latest version at https://pypi.org/project/slack-sdk/" />
+<title>slack_sdk.oauth.installation_store.internals API documentation</title>
+<meta name="description" content="" />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -19,16 +19,45 @@
 <main>
 <article id="content">
 <header>
-<h1 class="title">Module <code>slack_sdk.version</code></h1>
+<h1 class="title">Module <code>slack_sdk.oauth.installation_store.internals</code></h1>
 </header>
 <section id="section-intro">
-<p>Check the latest version at <a href="https://pypi.org/project/slack-sdk/">https://pypi.org/project/slack-sdk/</a></p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">&#34;&#34;&#34;Check the latest version at https://pypi.org/project/slack-sdk/&#34;&#34;&#34;
-__version__ = &#34;3.8.0rc2&#34;</code></pre>
+<pre><code class="python">import platform
+import datetime
+
+(major, minor, patch) = platform.python_version_tuple()
+is_python_3_6: bool = int(major) == 3 and int(minor) &gt;= 6
+
+utc_timezone = datetime.timezone.utc
+
+
+def _from_iso_format_to_datetime(iso_datetime_str: str) -&gt; datetime:
+    if is_python_3_6:
+        elements = iso_datetime_str.split(&#34; &#34;)
+        ymd = elements[0].split(&#34;-&#34;)
+        hms = elements[1].split(&#34;:&#34;)
+        return datetime.datetime(
+            int(ymd[0]),
+            int(ymd[1]),
+            int(ymd[2]),
+            int(hms[0]),
+            int(hms[1]),
+            int(hms[2]),
+            0,
+            utc_timezone,
+        )
+    else:
+        if &#34;+&#34; not in iso_datetime_str:
+            iso_datetime_str += &#34;+00:00&#34;
+        return datetime.datetime.fromisoformat(iso_datetime_str)
+
+
+def _from_iso_format_to_unix_timestamp(iso_datetime_str: str) -&gt; float:
+    return _from_iso_format_to_datetime(iso_datetime_str).timestamp()</code></pre>
 </details>
 </section>
 <section>
@@ -48,7 +77,7 @@ __version__ = &#34;3.8.0rc2&#34;</code></pre>
 <ul id="index">
 <li><h3>Super-module</h3>
 <ul>
-<li><code><a title="slack_sdk" href="index.html">slack_sdk</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store" href="index.html">slack_sdk.oauth.installation_store</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/models/bot.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/models/bot.html
@@ -26,8 +26,14 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from datetime import datetime
+<pre><code class="python">import re
+from datetime import datetime
+from time import time
 from typing import Optional, Union, Dict, Any, Sequence
+
+from slack_sdk.oauth.installation_store.internals import (
+    _from_iso_format_to_unix_timestamp,
+)
 
 
 class Bot:
@@ -40,6 +46,10 @@ class Bot:
     bot_id: str
     bot_user_id: str
     bot_scopes: Sequence[str]
+    # only when token rotation is enabled
+    bot_refresh_token: Optional[str]
+    # only when token rotation is enabled
+    bot_token_expires_at: Optional[int]
     is_enterprise_install: bool
     installed_at: float
 
@@ -59,11 +69,20 @@ class Bot:
         bot_id: str,
         bot_user_id: str,
         bot_scopes: Union[str, Sequence[str]] = &#34;&#34;,
+        # only when token rotation is enabled
+        bot_refresh_token: Optional[str] = None,
+        # only when token rotation is enabled
+        bot_token_expires_in: Optional[int] = None,
+        # only for duplicating this object
+        # only when token rotation is enabled
+        bot_token_expires_at: Optional[Union[int, datetime, str]] = None,
         is_enterprise_install: Optional[bool] = False,
         # timestamps
-        installed_at: float,
+        # The expected value type is float but the internals handle other types too
+        # for str values, we supports only ISO datetime format.
+        installed_at: Union[float, datetime, str],
         # custom values
-        custom_values: Optional[Dict[str, Any]] = None
+        custom_values: Optional[Dict[str, Any]] = None,
     ):
         self.app_id = app_id
         self.enterprise_id = enterprise_id
@@ -78,8 +97,36 @@ class Bot:
             self.bot_scopes = bot_scopes.split(&#34;,&#34;) if len(bot_scopes) &gt; 0 else []
         else:
             self.bot_scopes = bot_scopes
+        self.bot_refresh_token = bot_refresh_token
+        if bot_token_expires_at is not None:
+            if type(bot_token_expires_at) == datetime:
+                self.bot_token_expires_at = int(bot_token_expires_at.timestamp())
+            elif type(bot_token_expires_at) == str and not re.match(
+                &#34;^\\d+$&#34;, bot_token_expires_at
+            ):
+                self.bot_token_expires_at = int(
+                    _from_iso_format_to_unix_timestamp(bot_token_expires_at)
+                )
+            else:
+                self.bot_token_expires_at = int(bot_token_expires_at)
+        elif bot_token_expires_in is not None:
+            self.bot_token_expires_at = int(time()) + bot_token_expires_in
+        else:
+            self.bot_token_expires_at = None
         self.is_enterprise_install = is_enterprise_install or False
-        self.installed_at = installed_at
+
+        if type(installed_at) == float:
+            self.installed_at = installed_at
+        elif type(installed_at) == datetime:
+            self.installed_at = installed_at.timestamp()
+        elif type(installed_at) == str:
+            if re.match(&#34;^\\d+.\\d+$&#34;, installed_at):
+                self.installed_at = float(installed_at)
+            else:
+                self.installed_at = _from_iso_format_to_unix_timestamp(installed_at)
+        else:
+            raise ValueError(f&#34;Unsupported data format for installed_at {installed_at}&#34;)
+
         self.custom_values = custom_values if custom_values is not None else {}
 
     def set_custom_value(self, name: str, value: Any):
@@ -99,6 +146,10 @@ class Bot:
             &#34;bot_id&#34;: self.bot_id,
             &#34;bot_user_id&#34;: self.bot_user_id,
             &#34;bot_scopes&#34;: &#34;,&#34;.join(self.bot_scopes) if self.bot_scopes else None,
+            &#34;bot_refresh_token&#34;: self.bot_refresh_token,
+            &#34;bot_token_expires_at&#34;: datetime.utcfromtimestamp(self.bot_token_expires_at)
+            if self.bot_token_expires_at is not None
+            else None,
             &#34;is_enterprise_install&#34;: self.is_enterprise_install,
             &#34;installed_at&#34;: datetime.utcfromtimestamp(self.installed_at),
         }
@@ -118,7 +169,7 @@ class Bot:
 <dl>
 <dt id="slack_sdk.oauth.installation_store.models.bot.Bot"><code class="flex name class">
 <span>class <span class="ident">Bot</span></span>
-<span>(</span><span>*, app_id: Optional[str] = None, enterprise_id: Optional[str] = None, enterprise_name: Optional[str] = None, team_id: Optional[str] = None, team_name: Optional[str] = None, bot_token: str, bot_id: str, bot_user_id: str, bot_scopes: Union[str, Sequence[str]] = '', is_enterprise_install: Optional[bool] = False, installed_at: float, custom_values: Optional[Dict[str, Any]] = None)</span>
+<span>(</span><span>*, app_id: Optional[str] = None, enterprise_id: Optional[str] = None, enterprise_name: Optional[str] = None, team_id: Optional[str] = None, team_name: Optional[str] = None, bot_token: str, bot_id: str, bot_user_id: str, bot_scopes: Union[str, Sequence[str]] = '', bot_refresh_token: Optional[str] = None, bot_token_expires_in: Optional[int] = None, bot_token_expires_at: Union[int, datetime.datetime, str, NoneType] = None, is_enterprise_install: Optional[bool] = False, installed_at: Union[float, datetime.datetime, str], custom_values: Optional[Dict[str, Any]] = None)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -136,6 +187,10 @@ class Bot:
     bot_id: str
     bot_user_id: str
     bot_scopes: Sequence[str]
+    # only when token rotation is enabled
+    bot_refresh_token: Optional[str]
+    # only when token rotation is enabled
+    bot_token_expires_at: Optional[int]
     is_enterprise_install: bool
     installed_at: float
 
@@ -155,11 +210,20 @@ class Bot:
         bot_id: str,
         bot_user_id: str,
         bot_scopes: Union[str, Sequence[str]] = &#34;&#34;,
+        # only when token rotation is enabled
+        bot_refresh_token: Optional[str] = None,
+        # only when token rotation is enabled
+        bot_token_expires_in: Optional[int] = None,
+        # only for duplicating this object
+        # only when token rotation is enabled
+        bot_token_expires_at: Optional[Union[int, datetime, str]] = None,
         is_enterprise_install: Optional[bool] = False,
         # timestamps
-        installed_at: float,
+        # The expected value type is float but the internals handle other types too
+        # for str values, we supports only ISO datetime format.
+        installed_at: Union[float, datetime, str],
         # custom values
-        custom_values: Optional[Dict[str, Any]] = None
+        custom_values: Optional[Dict[str, Any]] = None,
     ):
         self.app_id = app_id
         self.enterprise_id = enterprise_id
@@ -174,8 +238,36 @@ class Bot:
             self.bot_scopes = bot_scopes.split(&#34;,&#34;) if len(bot_scopes) &gt; 0 else []
         else:
             self.bot_scopes = bot_scopes
+        self.bot_refresh_token = bot_refresh_token
+        if bot_token_expires_at is not None:
+            if type(bot_token_expires_at) == datetime:
+                self.bot_token_expires_at = int(bot_token_expires_at.timestamp())
+            elif type(bot_token_expires_at) == str and not re.match(
+                &#34;^\\d+$&#34;, bot_token_expires_at
+            ):
+                self.bot_token_expires_at = int(
+                    _from_iso_format_to_unix_timestamp(bot_token_expires_at)
+                )
+            else:
+                self.bot_token_expires_at = int(bot_token_expires_at)
+        elif bot_token_expires_in is not None:
+            self.bot_token_expires_at = int(time()) + bot_token_expires_in
+        else:
+            self.bot_token_expires_at = None
         self.is_enterprise_install = is_enterprise_install or False
-        self.installed_at = installed_at
+
+        if type(installed_at) == float:
+            self.installed_at = installed_at
+        elif type(installed_at) == datetime:
+            self.installed_at = installed_at.timestamp()
+        elif type(installed_at) == str:
+            if re.match(&#34;^\\d+.\\d+$&#34;, installed_at):
+                self.installed_at = float(installed_at)
+            else:
+                self.installed_at = _from_iso_format_to_unix_timestamp(installed_at)
+        else:
+            raise ValueError(f&#34;Unsupported data format for installed_at {installed_at}&#34;)
+
         self.custom_values = custom_values if custom_values is not None else {}
 
     def set_custom_value(self, name: str, value: Any):
@@ -195,6 +287,10 @@ class Bot:
             &#34;bot_id&#34;: self.bot_id,
             &#34;bot_user_id&#34;: self.bot_user_id,
             &#34;bot_scopes&#34;: &#34;,&#34;.join(self.bot_scopes) if self.bot_scopes else None,
+            &#34;bot_refresh_token&#34;: self.bot_refresh_token,
+            &#34;bot_token_expires_at&#34;: datetime.utcfromtimestamp(self.bot_token_expires_at)
+            if self.bot_token_expires_at is not None
+            else None,
             &#34;is_enterprise_install&#34;: self.is_enterprise_install,
             &#34;installed_at&#34;: datetime.utcfromtimestamp(self.installed_at),
         }
@@ -212,11 +308,19 @@ class Bot:
 <dd>
 <div class="desc"></div>
 </dd>
+<dt id="slack_sdk.oauth.installation_store.models.bot.Bot.bot_refresh_token"><code class="name">var <span class="ident">bot_refresh_token</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt id="slack_sdk.oauth.installation_store.models.bot.Bot.bot_scopes"><code class="name">var <span class="ident">bot_scopes</span> : Sequence[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
 <dt id="slack_sdk.oauth.installation_store.models.bot.Bot.bot_token"><code class="name">var <span class="ident">bot_token</span> : str</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.oauth.installation_store.models.bot.Bot.bot_token_expires_at"><code class="name">var <span class="ident">bot_token_expires_at</span> : Optional[int]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -301,6 +405,10 @@ class Bot:
         &#34;bot_id&#34;: self.bot_id,
         &#34;bot_user_id&#34;: self.bot_user_id,
         &#34;bot_scopes&#34;: &#34;,&#34;.join(self.bot_scopes) if self.bot_scopes else None,
+        &#34;bot_refresh_token&#34;: self.bot_refresh_token,
+        &#34;bot_token_expires_at&#34;: datetime.utcfromtimestamp(self.bot_token_expires_at)
+        if self.bot_token_expires_at is not None
+        else None,
         &#34;is_enterprise_install&#34;: self.is_enterprise_install,
         &#34;installed_at&#34;: datetime.utcfromtimestamp(self.installed_at),
     }
@@ -332,8 +440,10 @@ class Bot:
 <ul class="">
 <li><code><a title="slack_sdk.oauth.installation_store.models.bot.Bot.app_id" href="#slack_sdk.oauth.installation_store.models.bot.Bot.app_id">app_id</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.bot.Bot.bot_id" href="#slack_sdk.oauth.installation_store.models.bot.Bot.bot_id">bot_id</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.models.bot.Bot.bot_refresh_token" href="#slack_sdk.oauth.installation_store.models.bot.Bot.bot_refresh_token">bot_refresh_token</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.bot.Bot.bot_scopes" href="#slack_sdk.oauth.installation_store.models.bot.Bot.bot_scopes">bot_scopes</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.bot.Bot.bot_token" href="#slack_sdk.oauth.installation_store.models.bot.Bot.bot_token">bot_token</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.models.bot.Bot.bot_token_expires_at" href="#slack_sdk.oauth.installation_store.models.bot.Bot.bot_token_expires_at">bot_token_expires_at</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.bot.Bot.bot_user_id" href="#slack_sdk.oauth.installation_store.models.bot.Bot.bot_user_id">bot_user_id</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.bot.Bot.custom_values" href="#slack_sdk.oauth.installation_store.models.bot.Bot.custom_values">custom_values</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.bot.Bot.enterprise_id" href="#slack_sdk.oauth.installation_store.models.bot.Bot.enterprise_id">enterprise_id</a></code></li>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/models/installation.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/models/installation.html
@@ -26,10 +26,14 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from datetime import datetime
+<pre><code class="python">import re
+from datetime import datetime
 from time import time
 from typing import Optional, Union, Dict, Any, Sequence
 
+from slack_sdk.oauth.installation_store.internals import (
+    _from_iso_format_to_unix_timestamp,
+)
 from slack_sdk.oauth.installation_store.models.bot import Bot
 
 
@@ -44,9 +48,16 @@ class Installation:
     bot_id: Optional[str]
     bot_user_id: Optional[str]
     bot_scopes: Optional[Sequence[str]]
+    bot_refresh_token: Optional[str]  # only when token rotation is enabled
+    # only when token rotation is enabled
+    # Unix time (seconds): only when token rotation is enabled
+    bot_token_expires_at: Optional[int]
     user_id: str
     user_token: Optional[str]
     user_scopes: Optional[Sequence[str]]
+    user_refresh_token: Optional[str]  # only when token rotation is enabled
+    # Unix time (seconds): only when token rotation is enabled
+    user_token_expires_at: Optional[int]
     incoming_webhook_url: Optional[str]
     incoming_webhook_channel: Optional[str]
     incoming_webhook_channel_id: Optional[str]
@@ -72,10 +83,22 @@ class Installation:
         bot_id: Optional[str] = None,
         bot_user_id: Optional[str] = None,
         bot_scopes: Union[str, Sequence[str]] = &#34;&#34;,
+        bot_refresh_token: Optional[str] = None,  # only when token rotation is enabled
+        # only when token rotation is enabled
+        bot_token_expires_in: Optional[int] = None,
+        # only for duplicating this object
+        # only when token rotation is enabled
+        bot_token_expires_at: Optional[Union[int, datetime, str]] = None,
         # installer
         user_id: str,
         user_token: Optional[str] = None,
         user_scopes: Union[str, Sequence[str]] = &#34;&#34;,
+        user_refresh_token: Optional[str] = None,  # only when token rotation is enabled
+        # only when token rotation is enabled
+        user_token_expires_in: Optional[int] = None,
+        # only for duplicating this object
+        # only when token rotation is enabled
+        user_token_expires_at: Optional[Union[int, datetime, str]] = None,
         # incoming webhook
         incoming_webhook_url: Optional[str] = None,
         incoming_webhook_channel: Optional[str] = None,
@@ -85,9 +108,11 @@ class Installation:
         is_enterprise_install: Optional[bool] = False,
         token_type: Optional[str] = None,
         # timestamps
-        installed_at: Optional[float] = None,
+        # The expected value type is float but the internals handle other types too
+        # for str values, we supports only ISO datetime format.
+        installed_at: Optional[Union[float, datetime, str]] = None,
         # custom values
-        custom_values: Optional[Dict[str, Any]] = None
+        custom_values: Optional[Dict[str, Any]] = None,
     ):
         self.app_id = app_id
         self.enterprise_id = enterprise_id
@@ -102,6 +127,22 @@ class Installation:
             self.bot_scopes = bot_scopes.split(&#34;,&#34;) if len(bot_scopes) &gt; 0 else []
         else:
             self.bot_scopes = bot_scopes
+        self.bot_refresh_token = bot_refresh_token
+        if bot_token_expires_at is not None:
+            if type(bot_token_expires_at) == datetime:
+                self.bot_token_expires_at = int(bot_token_expires_at.timestamp())
+            elif type(bot_token_expires_at) == str and not re.match(
+                &#34;^\\d+$&#34;, bot_token_expires_at
+            ):
+                self.bot_token_expires_at = int(
+                    _from_iso_format_to_unix_timestamp(bot_token_expires_at)
+                )
+            else:
+                self.bot_token_expires_at = bot_token_expires_at
+        elif bot_token_expires_in is not None:
+            self.bot_token_expires_at = int(time()) + bot_token_expires_in
+        else:
+            self.bot_token_expires_at = None
 
         self.user_id = user_id
         self.user_token = user_token
@@ -109,6 +150,22 @@ class Installation:
             self.user_scopes = user_scopes.split(&#34;,&#34;) if len(user_scopes) &gt; 0 else []
         else:
             self.user_scopes = user_scopes
+        self.user_refresh_token = user_refresh_token
+        if user_token_expires_at is not None:
+            if type(user_token_expires_at) == datetime:
+                self.user_token_expires_at = int(user_token_expires_at.timestamp())
+            elif type(user_token_expires_at) == str and not re.match(
+                &#34;^\\d+$&#34;, user_token_expires_at
+            ):
+                self.user_token_expires_at = int(
+                    _from_iso_format_to_unix_timestamp(user_token_expires_at)
+                )
+            else:
+                self.user_token_expires_at = user_token_expires_at
+        elif user_token_expires_in is not None:
+            self.user_token_expires_at = int(time()) + user_token_expires_in
+        else:
+            self.user_token_expires_at = None
 
         self.incoming_webhook_url = incoming_webhook_url
         self.incoming_webhook_channel = incoming_webhook_channel
@@ -118,7 +175,20 @@ class Installation:
         self.is_enterprise_install = is_enterprise_install or False
         self.token_type = token_type
 
-        self.installed_at = time() if installed_at is None else installed_at
+        if installed_at is None:
+            self.installed_at = datetime.now().timestamp()
+        elif type(installed_at) == float:
+            self.installed_at = installed_at
+        elif type(installed_at) == datetime:
+            self.installed_at = installed_at.timestamp()
+        elif type(installed_at) == str:
+            if re.match(&#34;^\\d+.\\d+$&#34;, installed_at):
+                self.installed_at = float(installed_at)
+            else:
+                self.installed_at = _from_iso_format_to_unix_timestamp(installed_at)
+        else:
+            raise ValueError(f&#34;Unsupported data format for installed_at {installed_at}&#34;)
+
         self.custom_values = custom_values if custom_values is not None else {}
 
     def to_bot(self) -&gt; Bot:
@@ -132,6 +202,8 @@ class Installation:
             bot_id=self.bot_id,
             bot_user_id=self.bot_user_id,
             bot_scopes=self.bot_scopes,
+            bot_refresh_token=self.bot_refresh_token,
+            bot_token_expires_at=self.bot_token_expires_at,
             is_enterprise_install=self.is_enterprise_install,
             installed_at=self.installed_at,
             custom_values=self.custom_values,
@@ -155,9 +227,19 @@ class Installation:
             &#34;bot_id&#34;: self.bot_id,
             &#34;bot_user_id&#34;: self.bot_user_id,
             &#34;bot_scopes&#34;: &#34;,&#34;.join(self.bot_scopes) if self.bot_scopes else None,
+            &#34;bot_refresh_token&#34;: self.bot_refresh_token,
+            &#34;bot_token_expires_at&#34;: datetime.utcfromtimestamp(self.bot_token_expires_at)
+            if self.bot_token_expires_at is not None
+            else None,
             &#34;user_id&#34;: self.user_id,
             &#34;user_token&#34;: self.user_token,
             &#34;user_scopes&#34;: &#34;,&#34;.join(self.user_scopes) if self.user_scopes else None,
+            &#34;user_refresh_token&#34;: self.user_refresh_token,
+            &#34;user_token_expires_at&#34;: datetime.utcfromtimestamp(
+                self.user_token_expires_at
+            )
+            if self.user_token_expires_at is not None
+            else None,
             &#34;incoming_webhook_url&#34;: self.incoming_webhook_url,
             &#34;incoming_webhook_channel&#34;: self.incoming_webhook_channel,
             &#34;incoming_webhook_channel_id&#34;: self.incoming_webhook_channel_id,
@@ -182,7 +264,7 @@ class Installation:
 <dl>
 <dt id="slack_sdk.oauth.installation_store.models.installation.Installation"><code class="flex name class">
 <span>class <span class="ident">Installation</span></span>
-<span>(</span><span>*, app_id: Optional[str] = None, enterprise_id: Optional[str] = None, enterprise_name: Optional[str] = None, enterprise_url: Optional[str] = None, team_id: Optional[str] = None, team_name: Optional[str] = None, bot_token: Optional[str] = None, bot_id: Optional[str] = None, bot_user_id: Optional[str] = None, bot_scopes: Union[str, Sequence[str]] = '', user_id: str, user_token: Optional[str] = None, user_scopes: Union[str, Sequence[str]] = '', incoming_webhook_url: Optional[str] = None, incoming_webhook_channel: Optional[str] = None, incoming_webhook_channel_id: Optional[str] = None, incoming_webhook_configuration_url: Optional[str] = None, is_enterprise_install: Optional[bool] = False, token_type: Optional[str] = None, installed_at: Optional[float] = None, custom_values: Optional[Dict[str, Any]] = None)</span>
+<span>(</span><span>*, app_id: Optional[str] = None, enterprise_id: Optional[str] = None, enterprise_name: Optional[str] = None, enterprise_url: Optional[str] = None, team_id: Optional[str] = None, team_name: Optional[str] = None, bot_token: Optional[str] = None, bot_id: Optional[str] = None, bot_user_id: Optional[str] = None, bot_scopes: Union[str, Sequence[str]] = '', bot_refresh_token: Optional[str] = None, bot_token_expires_in: Optional[int] = None, bot_token_expires_at: Union[int, datetime.datetime, str, NoneType] = None, user_id: str, user_token: Optional[str] = None, user_scopes: Union[str, Sequence[str]] = '', user_refresh_token: Optional[str] = None, user_token_expires_in: Optional[int] = None, user_token_expires_at: Union[int, datetime.datetime, str, NoneType] = None, incoming_webhook_url: Optional[str] = None, incoming_webhook_channel: Optional[str] = None, incoming_webhook_channel_id: Optional[str] = None, incoming_webhook_configuration_url: Optional[str] = None, is_enterprise_install: Optional[bool] = False, token_type: Optional[str] = None, installed_at: Union[float, datetime.datetime, str, NoneType] = None, custom_values: Optional[Dict[str, Any]] = None)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -201,9 +283,16 @@ class Installation:
     bot_id: Optional[str]
     bot_user_id: Optional[str]
     bot_scopes: Optional[Sequence[str]]
+    bot_refresh_token: Optional[str]  # only when token rotation is enabled
+    # only when token rotation is enabled
+    # Unix time (seconds): only when token rotation is enabled
+    bot_token_expires_at: Optional[int]
     user_id: str
     user_token: Optional[str]
     user_scopes: Optional[Sequence[str]]
+    user_refresh_token: Optional[str]  # only when token rotation is enabled
+    # Unix time (seconds): only when token rotation is enabled
+    user_token_expires_at: Optional[int]
     incoming_webhook_url: Optional[str]
     incoming_webhook_channel: Optional[str]
     incoming_webhook_channel_id: Optional[str]
@@ -229,10 +318,22 @@ class Installation:
         bot_id: Optional[str] = None,
         bot_user_id: Optional[str] = None,
         bot_scopes: Union[str, Sequence[str]] = &#34;&#34;,
+        bot_refresh_token: Optional[str] = None,  # only when token rotation is enabled
+        # only when token rotation is enabled
+        bot_token_expires_in: Optional[int] = None,
+        # only for duplicating this object
+        # only when token rotation is enabled
+        bot_token_expires_at: Optional[Union[int, datetime, str]] = None,
         # installer
         user_id: str,
         user_token: Optional[str] = None,
         user_scopes: Union[str, Sequence[str]] = &#34;&#34;,
+        user_refresh_token: Optional[str] = None,  # only when token rotation is enabled
+        # only when token rotation is enabled
+        user_token_expires_in: Optional[int] = None,
+        # only for duplicating this object
+        # only when token rotation is enabled
+        user_token_expires_at: Optional[Union[int, datetime, str]] = None,
         # incoming webhook
         incoming_webhook_url: Optional[str] = None,
         incoming_webhook_channel: Optional[str] = None,
@@ -242,9 +343,11 @@ class Installation:
         is_enterprise_install: Optional[bool] = False,
         token_type: Optional[str] = None,
         # timestamps
-        installed_at: Optional[float] = None,
+        # The expected value type is float but the internals handle other types too
+        # for str values, we supports only ISO datetime format.
+        installed_at: Optional[Union[float, datetime, str]] = None,
         # custom values
-        custom_values: Optional[Dict[str, Any]] = None
+        custom_values: Optional[Dict[str, Any]] = None,
     ):
         self.app_id = app_id
         self.enterprise_id = enterprise_id
@@ -259,6 +362,22 @@ class Installation:
             self.bot_scopes = bot_scopes.split(&#34;,&#34;) if len(bot_scopes) &gt; 0 else []
         else:
             self.bot_scopes = bot_scopes
+        self.bot_refresh_token = bot_refresh_token
+        if bot_token_expires_at is not None:
+            if type(bot_token_expires_at) == datetime:
+                self.bot_token_expires_at = int(bot_token_expires_at.timestamp())
+            elif type(bot_token_expires_at) == str and not re.match(
+                &#34;^\\d+$&#34;, bot_token_expires_at
+            ):
+                self.bot_token_expires_at = int(
+                    _from_iso_format_to_unix_timestamp(bot_token_expires_at)
+                )
+            else:
+                self.bot_token_expires_at = bot_token_expires_at
+        elif bot_token_expires_in is not None:
+            self.bot_token_expires_at = int(time()) + bot_token_expires_in
+        else:
+            self.bot_token_expires_at = None
 
         self.user_id = user_id
         self.user_token = user_token
@@ -266,6 +385,22 @@ class Installation:
             self.user_scopes = user_scopes.split(&#34;,&#34;) if len(user_scopes) &gt; 0 else []
         else:
             self.user_scopes = user_scopes
+        self.user_refresh_token = user_refresh_token
+        if user_token_expires_at is not None:
+            if type(user_token_expires_at) == datetime:
+                self.user_token_expires_at = int(user_token_expires_at.timestamp())
+            elif type(user_token_expires_at) == str and not re.match(
+                &#34;^\\d+$&#34;, user_token_expires_at
+            ):
+                self.user_token_expires_at = int(
+                    _from_iso_format_to_unix_timestamp(user_token_expires_at)
+                )
+            else:
+                self.user_token_expires_at = user_token_expires_at
+        elif user_token_expires_in is not None:
+            self.user_token_expires_at = int(time()) + user_token_expires_in
+        else:
+            self.user_token_expires_at = None
 
         self.incoming_webhook_url = incoming_webhook_url
         self.incoming_webhook_channel = incoming_webhook_channel
@@ -275,7 +410,20 @@ class Installation:
         self.is_enterprise_install = is_enterprise_install or False
         self.token_type = token_type
 
-        self.installed_at = time() if installed_at is None else installed_at
+        if installed_at is None:
+            self.installed_at = datetime.now().timestamp()
+        elif type(installed_at) == float:
+            self.installed_at = installed_at
+        elif type(installed_at) == datetime:
+            self.installed_at = installed_at.timestamp()
+        elif type(installed_at) == str:
+            if re.match(&#34;^\\d+.\\d+$&#34;, installed_at):
+                self.installed_at = float(installed_at)
+            else:
+                self.installed_at = _from_iso_format_to_unix_timestamp(installed_at)
+        else:
+            raise ValueError(f&#34;Unsupported data format for installed_at {installed_at}&#34;)
+
         self.custom_values = custom_values if custom_values is not None else {}
 
     def to_bot(self) -&gt; Bot:
@@ -289,6 +437,8 @@ class Installation:
             bot_id=self.bot_id,
             bot_user_id=self.bot_user_id,
             bot_scopes=self.bot_scopes,
+            bot_refresh_token=self.bot_refresh_token,
+            bot_token_expires_at=self.bot_token_expires_at,
             is_enterprise_install=self.is_enterprise_install,
             installed_at=self.installed_at,
             custom_values=self.custom_values,
@@ -312,9 +462,19 @@ class Installation:
             &#34;bot_id&#34;: self.bot_id,
             &#34;bot_user_id&#34;: self.bot_user_id,
             &#34;bot_scopes&#34;: &#34;,&#34;.join(self.bot_scopes) if self.bot_scopes else None,
+            &#34;bot_refresh_token&#34;: self.bot_refresh_token,
+            &#34;bot_token_expires_at&#34;: datetime.utcfromtimestamp(self.bot_token_expires_at)
+            if self.bot_token_expires_at is not None
+            else None,
             &#34;user_id&#34;: self.user_id,
             &#34;user_token&#34;: self.user_token,
             &#34;user_scopes&#34;: &#34;,&#34;.join(self.user_scopes) if self.user_scopes else None,
+            &#34;user_refresh_token&#34;: self.user_refresh_token,
+            &#34;user_token_expires_at&#34;: datetime.utcfromtimestamp(
+                self.user_token_expires_at
+            )
+            if self.user_token_expires_at is not None
+            else None,
             &#34;incoming_webhook_url&#34;: self.incoming_webhook_url,
             &#34;incoming_webhook_channel&#34;: self.incoming_webhook_channel,
             &#34;incoming_webhook_channel_id&#34;: self.incoming_webhook_channel_id,
@@ -337,11 +497,19 @@ class Installation:
 <dd>
 <div class="desc"></div>
 </dd>
+<dt id="slack_sdk.oauth.installation_store.models.installation.Installation.bot_refresh_token"><code class="name">var <span class="ident">bot_refresh_token</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt id="slack_sdk.oauth.installation_store.models.installation.Installation.bot_scopes"><code class="name">var <span class="ident">bot_scopes</span> : Optional[Sequence[str]]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
 <dt id="slack_sdk.oauth.installation_store.models.installation.Installation.bot_token"><code class="name">var <span class="ident">bot_token</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.oauth.installation_store.models.installation.Installation.bot_token_expires_at"><code class="name">var <span class="ident">bot_token_expires_at</span> : Optional[int]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -405,11 +573,19 @@ class Installation:
 <dd>
 <div class="desc"></div>
 </dd>
+<dt id="slack_sdk.oauth.installation_store.models.installation.Installation.user_refresh_token"><code class="name">var <span class="ident">user_refresh_token</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt id="slack_sdk.oauth.installation_store.models.installation.Installation.user_scopes"><code class="name">var <span class="ident">user_scopes</span> : Optional[Sequence[str]]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
 <dt id="slack_sdk.oauth.installation_store.models.installation.Installation.user_token"><code class="name">var <span class="ident">user_token</span> : Optional[str]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.oauth.installation_store.models.installation.Installation.user_token_expires_at"><code class="name">var <span class="ident">user_token_expires_at</span> : Optional[int]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -462,6 +638,8 @@ class Installation:
         bot_id=self.bot_id,
         bot_user_id=self.bot_user_id,
         bot_scopes=self.bot_scopes,
+        bot_refresh_token=self.bot_refresh_token,
+        bot_token_expires_at=self.bot_token_expires_at,
         is_enterprise_install=self.is_enterprise_install,
         installed_at=self.installed_at,
         custom_values=self.custom_values,
@@ -489,9 +667,19 @@ class Installation:
         &#34;bot_id&#34;: self.bot_id,
         &#34;bot_user_id&#34;: self.bot_user_id,
         &#34;bot_scopes&#34;: &#34;,&#34;.join(self.bot_scopes) if self.bot_scopes else None,
+        &#34;bot_refresh_token&#34;: self.bot_refresh_token,
+        &#34;bot_token_expires_at&#34;: datetime.utcfromtimestamp(self.bot_token_expires_at)
+        if self.bot_token_expires_at is not None
+        else None,
         &#34;user_id&#34;: self.user_id,
         &#34;user_token&#34;: self.user_token,
         &#34;user_scopes&#34;: &#34;,&#34;.join(self.user_scopes) if self.user_scopes else None,
+        &#34;user_refresh_token&#34;: self.user_refresh_token,
+        &#34;user_token_expires_at&#34;: datetime.utcfromtimestamp(
+            self.user_token_expires_at
+        )
+        if self.user_token_expires_at is not None
+        else None,
         &#34;incoming_webhook_url&#34;: self.incoming_webhook_url,
         &#34;incoming_webhook_channel&#34;: self.incoming_webhook_channel,
         &#34;incoming_webhook_channel_id&#34;: self.incoming_webhook_channel_id,
@@ -528,8 +716,10 @@ class Installation:
 <ul class="">
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.app_id" href="#slack_sdk.oauth.installation_store.models.installation.Installation.app_id">app_id</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.bot_id" href="#slack_sdk.oauth.installation_store.models.installation.Installation.bot_id">bot_id</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.bot_refresh_token" href="#slack_sdk.oauth.installation_store.models.installation.Installation.bot_refresh_token">bot_refresh_token</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.bot_scopes" href="#slack_sdk.oauth.installation_store.models.installation.Installation.bot_scopes">bot_scopes</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.bot_token" href="#slack_sdk.oauth.installation_store.models.installation.Installation.bot_token">bot_token</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.bot_token_expires_at" href="#slack_sdk.oauth.installation_store.models.installation.Installation.bot_token_expires_at">bot_token_expires_at</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.bot_user_id" href="#slack_sdk.oauth.installation_store.models.installation.Installation.bot_user_id">bot_user_id</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.custom_values" href="#slack_sdk.oauth.installation_store.models.installation.Installation.custom_values">custom_values</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.enterprise_id" href="#slack_sdk.oauth.installation_store.models.installation.Installation.enterprise_id">enterprise_id</a></code></li>
@@ -549,8 +739,10 @@ class Installation:
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.to_dict" href="#slack_sdk.oauth.installation_store.models.installation.Installation.to_dict">to_dict</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.token_type" href="#slack_sdk.oauth.installation_store.models.installation.Installation.token_type">token_type</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.user_id" href="#slack_sdk.oauth.installation_store.models.installation.Installation.user_id">user_id</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.user_refresh_token" href="#slack_sdk.oauth.installation_store.models.installation.Installation.user_refresh_token">user_refresh_token</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.user_scopes" href="#slack_sdk.oauth.installation_store.models.installation.Installation.user_scopes">user_scopes</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.user_token" href="#slack_sdk.oauth.installation_store.models.installation.Installation.user_token">user_token</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.models.installation.Installation.user_token_expires_at" href="#slack_sdk.oauth.installation_store.models.installation.Installation.user_token_expires_at">user_token_expires_at</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/sqlalchemy/index.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/sqlalchemy/index.html
@@ -65,26 +65,30 @@ class SQLAlchemyInstallationStore(InstallationStore):
             table_name,
             metadata,
             Column(&#34;id&#34;, Integer, primary_key=True, autoincrement=True),
-            Column(&#34;client_id&#34;, String, nullable=False),
-            Column(&#34;app_id&#34;, String, nullable=False),
-            Column(&#34;enterprise_id&#34;, String),
-            Column(&#34;enterprise_name&#34;, String),
-            Column(&#34;enterprise_url&#34;, String),
-            Column(&#34;team_id&#34;, String),
-            Column(&#34;team_name&#34;, String),
-            Column(&#34;bot_token&#34;, String),
-            Column(&#34;bot_id&#34;, String),
-            Column(&#34;bot_user_id&#34;, String),
-            Column(&#34;bot_scopes&#34;, String),
-            Column(&#34;user_id&#34;, String, nullable=False),
-            Column(&#34;user_token&#34;, String),
-            Column(&#34;user_scopes&#34;, String),
-            Column(&#34;incoming_webhook_url&#34;, String),
-            Column(&#34;incoming_webhook_channel&#34;, String),
-            Column(&#34;incoming_webhook_channel_id&#34;, String),
-            Column(&#34;incoming_webhook_configuration_url&#34;, String),
+            Column(&#34;client_id&#34;, String(32), nullable=False),
+            Column(&#34;app_id&#34;, String(32), nullable=False),
+            Column(&#34;enterprise_id&#34;, String(32)),
+            Column(&#34;enterprise_name&#34;, String(200)),
+            Column(&#34;enterprise_url&#34;, String(200)),
+            Column(&#34;team_id&#34;, String(32)),
+            Column(&#34;team_name&#34;, String(200)),
+            Column(&#34;bot_token&#34;, String(200)),
+            Column(&#34;bot_id&#34;, String(32)),
+            Column(&#34;bot_user_id&#34;, String(32)),
+            Column(&#34;bot_scopes&#34;, String(1000)),
+            Column(&#34;bot_refresh_token&#34;, String(200)),  # added in v3.8.0
+            Column(&#34;bot_token_expires_at&#34;, DateTime),  # added in v3.8.0
+            Column(&#34;user_id&#34;, String(32), nullable=False),
+            Column(&#34;user_token&#34;, String(200)),
+            Column(&#34;user_scopes&#34;, String(1000)),
+            Column(&#34;user_refresh_token&#34;, String(200)),  # added in v3.8.0
+            Column(&#34;user_token_expires_at&#34;, DateTime),  # added in v3.8.0
+            Column(&#34;incoming_webhook_url&#34;, String(200)),
+            Column(&#34;incoming_webhook_channel&#34;, String(200)),
+            Column(&#34;incoming_webhook_channel_id&#34;, String(200)),
+            Column(&#34;incoming_webhook_configuration_url&#34;, String(200)),
             Column(&#34;is_enterprise_install&#34;, Boolean, default=False, nullable=False),
-            Column(&#34;token_type&#34;, String),
+            Column(&#34;token_type&#34;, String(32)),
             Column(
                 &#34;installed_at&#34;,
                 DateTime,
@@ -107,16 +111,18 @@ class SQLAlchemyInstallationStore(InstallationStore):
             table_name,
             metadata,
             Column(&#34;id&#34;, Integer, primary_key=True, autoincrement=True),
-            Column(&#34;client_id&#34;, String, nullable=False),
-            Column(&#34;app_id&#34;, String, nullable=False),
-            Column(&#34;enterprise_id&#34;, String),
-            Column(&#34;enterprise_name&#34;, String),
-            Column(&#34;team_id&#34;, String),
-            Column(&#34;team_name&#34;, String),
-            Column(&#34;bot_token&#34;, String),
-            Column(&#34;bot_id&#34;, String),
-            Column(&#34;bot_user_id&#34;, String),
-            Column(&#34;bot_scopes&#34;, String),
+            Column(&#34;client_id&#34;, String(32), nullable=False),
+            Column(&#34;app_id&#34;, String(32), nullable=False),
+            Column(&#34;enterprise_id&#34;, String(32)),
+            Column(&#34;enterprise_name&#34;, String(200)),
+            Column(&#34;team_id&#34;, String(32)),
+            Column(&#34;team_name&#34;, String(200)),
+            Column(&#34;bot_token&#34;, String(32)),
+            Column(&#34;bot_id&#34;, String(32)),
+            Column(&#34;bot_user_id&#34;, String(32)),
+            Column(&#34;bot_scopes&#34;, String(1000)),
+            Column(&#34;bot_refresh_token&#34;, String(200)),  # added in v3.8.0
+            Column(&#34;bot_token_expires_at&#34;, DateTime),  # added in v3.8.0
             Column(&#34;is_enterprise_install&#34;, Boolean, default=False, nullable=False),
             Column(
                 &#34;installed_at&#34;,
@@ -163,10 +169,65 @@ class SQLAlchemyInstallationStore(InstallationStore):
         with self.engine.begin() as conn:
             i = installation.to_dict()
             i[&#34;client_id&#34;] = self.client_id
-            conn.execute(self.installations.insert(), i)
-            b = installation.to_bot().to_dict()
+
+            i_column = self.installations.c
+            installations_rows = conn.execute(
+                sqlalchemy.select([i_column.id])
+                .where(
+                    and_(
+                        i_column.client_id == self.client_id,
+                        i_column.enterprise_id == installation.enterprise_id,
+                        i_column.team_id == installation.team_id,
+                        i_column.installed_at == i.get(&#34;installed_at&#34;),
+                    )
+                )
+                .limit(1)
+            )
+            installations_row_id: Optional[str] = None
+            for row in installations_rows:
+                installations_row_id = row[&#34;id&#34;]
+            if installations_row_id is None:
+                conn.execute(self.installations.insert(), i)
+            else:
+                update_statement = (
+                    self.installations.update()
+                    .where(i_column.id == installations_row_id)
+                    .values(**i)
+                )
+                conn.execute(update_statement, i)
+
+        # bots
+        self.save_bot(installation.to_bot())
+
+    def save_bot(self, bot: Bot):
+        with self.engine.begin() as conn:
+            # bots
+            b = bot.to_dict()
             b[&#34;client_id&#34;] = self.client_id
-            conn.execute(self.bots.insert(), b)
+
+            b_column = self.bots.c
+            bots_rows = conn.execute(
+                sqlalchemy.select([b_column.id])
+                .where(
+                    and_(
+                        b_column.client_id == self.client_id,
+                        b_column.enterprise_id == bot.enterprise_id,
+                        b_column.team_id == bot.team_id,
+                        b_column.installed_at == b.get(&#34;installed_at&#34;),
+                    )
+                )
+                .limit(1)
+            )
+            bots_row_id: Optional[str] = None
+            for row in bots_rows:
+                bots_row_id = row[&#34;id&#34;]
+            if bots_row_id is None:
+                conn.execute(self.bots.insert(), b)
+            else:
+                update_statement = (
+                    self.bots.update().where(b_column.id == bots_row_id).values(**b)
+                )
+                conn.execute(update_statement, b)
 
     def find_bot(
         self,
@@ -181,7 +242,13 @@ class SQLAlchemyInstallationStore(InstallationStore):
         c = self.bots.c
         query = (
             self.bots.select()
-            .where(and_(c.enterprise_id == enterprise_id, c.team_id == team_id))
+            .where(
+                and_(
+                    c.client_id == self.client_id,
+                    c.enterprise_id == enterprise_id,
+                    c.team_id == team_id,
+                )
+            )
             .order_by(desc(c.installed_at))
             .limit(1)
         )
@@ -199,6 +266,8 @@ class SQLAlchemyInstallationStore(InstallationStore):
                     bot_id=row[&#34;bot_id&#34;],
                     bot_user_id=row[&#34;bot_user_id&#34;],
                     bot_scopes=row[&#34;bot_scopes&#34;],
+                    bot_refresh_token=row[&#34;bot_refresh_token&#34;],
+                    bot_token_expires_at=row[&#34;bot_token_expires_at&#34;],
                     is_enterprise_install=row[&#34;is_enterprise_install&#34;],
                     installed_at=row[&#34;installed_at&#34;],
                 )
@@ -219,6 +288,7 @@ class SQLAlchemyInstallationStore(InstallationStore):
         where_clause = and_(c.enterprise_id == enterprise_id, c.team_id == team_id)
         if user_id is not None:
             where_clause = and_(
+                c.client_id == self.client_id,
                 c.enterprise_id == enterprise_id,
                 c.team_id == team_id,
                 c.user_id == user_id,
@@ -245,9 +315,13 @@ class SQLAlchemyInstallationStore(InstallationStore):
                     bot_id=row[&#34;bot_id&#34;],
                     bot_user_id=row[&#34;bot_user_id&#34;],
                     bot_scopes=row[&#34;bot_scopes&#34;],
+                    bot_refresh_token=row[&#34;bot_refresh_token&#34;],
+                    bot_token_expires_at=row[&#34;bot_token_expires_at&#34;],
                     user_id=row[&#34;user_id&#34;],
                     user_token=row[&#34;user_token&#34;],
                     user_scopes=row[&#34;user_scopes&#34;],
+                    user_refresh_token=row[&#34;user_refresh_token&#34;],
+                    user_token_expires_at=row[&#34;user_token_expires_at&#34;],
                     # Only the incoming webhook issued in the latest installation is set in this logic
                     incoming_webhook_url=row[&#34;incoming_webhook_url&#34;],
                     incoming_webhook_channel=row[&#34;incoming_webhook_channel&#34;],
@@ -359,26 +433,30 @@ the following methods should be implemented.</p>
             table_name,
             metadata,
             Column(&#34;id&#34;, Integer, primary_key=True, autoincrement=True),
-            Column(&#34;client_id&#34;, String, nullable=False),
-            Column(&#34;app_id&#34;, String, nullable=False),
-            Column(&#34;enterprise_id&#34;, String),
-            Column(&#34;enterprise_name&#34;, String),
-            Column(&#34;enterprise_url&#34;, String),
-            Column(&#34;team_id&#34;, String),
-            Column(&#34;team_name&#34;, String),
-            Column(&#34;bot_token&#34;, String),
-            Column(&#34;bot_id&#34;, String),
-            Column(&#34;bot_user_id&#34;, String),
-            Column(&#34;bot_scopes&#34;, String),
-            Column(&#34;user_id&#34;, String, nullable=False),
-            Column(&#34;user_token&#34;, String),
-            Column(&#34;user_scopes&#34;, String),
-            Column(&#34;incoming_webhook_url&#34;, String),
-            Column(&#34;incoming_webhook_channel&#34;, String),
-            Column(&#34;incoming_webhook_channel_id&#34;, String),
-            Column(&#34;incoming_webhook_configuration_url&#34;, String),
+            Column(&#34;client_id&#34;, String(32), nullable=False),
+            Column(&#34;app_id&#34;, String(32), nullable=False),
+            Column(&#34;enterprise_id&#34;, String(32)),
+            Column(&#34;enterprise_name&#34;, String(200)),
+            Column(&#34;enterprise_url&#34;, String(200)),
+            Column(&#34;team_id&#34;, String(32)),
+            Column(&#34;team_name&#34;, String(200)),
+            Column(&#34;bot_token&#34;, String(200)),
+            Column(&#34;bot_id&#34;, String(32)),
+            Column(&#34;bot_user_id&#34;, String(32)),
+            Column(&#34;bot_scopes&#34;, String(1000)),
+            Column(&#34;bot_refresh_token&#34;, String(200)),  # added in v3.8.0
+            Column(&#34;bot_token_expires_at&#34;, DateTime),  # added in v3.8.0
+            Column(&#34;user_id&#34;, String(32), nullable=False),
+            Column(&#34;user_token&#34;, String(200)),
+            Column(&#34;user_scopes&#34;, String(1000)),
+            Column(&#34;user_refresh_token&#34;, String(200)),  # added in v3.8.0
+            Column(&#34;user_token_expires_at&#34;, DateTime),  # added in v3.8.0
+            Column(&#34;incoming_webhook_url&#34;, String(200)),
+            Column(&#34;incoming_webhook_channel&#34;, String(200)),
+            Column(&#34;incoming_webhook_channel_id&#34;, String(200)),
+            Column(&#34;incoming_webhook_configuration_url&#34;, String(200)),
             Column(&#34;is_enterprise_install&#34;, Boolean, default=False, nullable=False),
-            Column(&#34;token_type&#34;, String),
+            Column(&#34;token_type&#34;, String(32)),
             Column(
                 &#34;installed_at&#34;,
                 DateTime,
@@ -401,16 +479,18 @@ the following methods should be implemented.</p>
             table_name,
             metadata,
             Column(&#34;id&#34;, Integer, primary_key=True, autoincrement=True),
-            Column(&#34;client_id&#34;, String, nullable=False),
-            Column(&#34;app_id&#34;, String, nullable=False),
-            Column(&#34;enterprise_id&#34;, String),
-            Column(&#34;enterprise_name&#34;, String),
-            Column(&#34;team_id&#34;, String),
-            Column(&#34;team_name&#34;, String),
-            Column(&#34;bot_token&#34;, String),
-            Column(&#34;bot_id&#34;, String),
-            Column(&#34;bot_user_id&#34;, String),
-            Column(&#34;bot_scopes&#34;, String),
+            Column(&#34;client_id&#34;, String(32), nullable=False),
+            Column(&#34;app_id&#34;, String(32), nullable=False),
+            Column(&#34;enterprise_id&#34;, String(32)),
+            Column(&#34;enterprise_name&#34;, String(200)),
+            Column(&#34;team_id&#34;, String(32)),
+            Column(&#34;team_name&#34;, String(200)),
+            Column(&#34;bot_token&#34;, String(32)),
+            Column(&#34;bot_id&#34;, String(32)),
+            Column(&#34;bot_user_id&#34;, String(32)),
+            Column(&#34;bot_scopes&#34;, String(1000)),
+            Column(&#34;bot_refresh_token&#34;, String(200)),  # added in v3.8.0
+            Column(&#34;bot_token_expires_at&#34;, DateTime),  # added in v3.8.0
             Column(&#34;is_enterprise_install&#34;, Boolean, default=False, nullable=False),
             Column(
                 &#34;installed_at&#34;,
@@ -457,10 +537,65 @@ the following methods should be implemented.</p>
         with self.engine.begin() as conn:
             i = installation.to_dict()
             i[&#34;client_id&#34;] = self.client_id
-            conn.execute(self.installations.insert(), i)
-            b = installation.to_bot().to_dict()
+
+            i_column = self.installations.c
+            installations_rows = conn.execute(
+                sqlalchemy.select([i_column.id])
+                .where(
+                    and_(
+                        i_column.client_id == self.client_id,
+                        i_column.enterprise_id == installation.enterprise_id,
+                        i_column.team_id == installation.team_id,
+                        i_column.installed_at == i.get(&#34;installed_at&#34;),
+                    )
+                )
+                .limit(1)
+            )
+            installations_row_id: Optional[str] = None
+            for row in installations_rows:
+                installations_row_id = row[&#34;id&#34;]
+            if installations_row_id is None:
+                conn.execute(self.installations.insert(), i)
+            else:
+                update_statement = (
+                    self.installations.update()
+                    .where(i_column.id == installations_row_id)
+                    .values(**i)
+                )
+                conn.execute(update_statement, i)
+
+        # bots
+        self.save_bot(installation.to_bot())
+
+    def save_bot(self, bot: Bot):
+        with self.engine.begin() as conn:
+            # bots
+            b = bot.to_dict()
             b[&#34;client_id&#34;] = self.client_id
-            conn.execute(self.bots.insert(), b)
+
+            b_column = self.bots.c
+            bots_rows = conn.execute(
+                sqlalchemy.select([b_column.id])
+                .where(
+                    and_(
+                        b_column.client_id == self.client_id,
+                        b_column.enterprise_id == bot.enterprise_id,
+                        b_column.team_id == bot.team_id,
+                        b_column.installed_at == b.get(&#34;installed_at&#34;),
+                    )
+                )
+                .limit(1)
+            )
+            bots_row_id: Optional[str] = None
+            for row in bots_rows:
+                bots_row_id = row[&#34;id&#34;]
+            if bots_row_id is None:
+                conn.execute(self.bots.insert(), b)
+            else:
+                update_statement = (
+                    self.bots.update().where(b_column.id == bots_row_id).values(**b)
+                )
+                conn.execute(update_statement, b)
 
     def find_bot(
         self,
@@ -475,7 +610,13 @@ the following methods should be implemented.</p>
         c = self.bots.c
         query = (
             self.bots.select()
-            .where(and_(c.enterprise_id == enterprise_id, c.team_id == team_id))
+            .where(
+                and_(
+                    c.client_id == self.client_id,
+                    c.enterprise_id == enterprise_id,
+                    c.team_id == team_id,
+                )
+            )
             .order_by(desc(c.installed_at))
             .limit(1)
         )
@@ -493,6 +634,8 @@ the following methods should be implemented.</p>
                     bot_id=row[&#34;bot_id&#34;],
                     bot_user_id=row[&#34;bot_user_id&#34;],
                     bot_scopes=row[&#34;bot_scopes&#34;],
+                    bot_refresh_token=row[&#34;bot_refresh_token&#34;],
+                    bot_token_expires_at=row[&#34;bot_token_expires_at&#34;],
                     is_enterprise_install=row[&#34;is_enterprise_install&#34;],
                     installed_at=row[&#34;installed_at&#34;],
                 )
@@ -513,6 +656,7 @@ the following methods should be implemented.</p>
         where_clause = and_(c.enterprise_id == enterprise_id, c.team_id == team_id)
         if user_id is not None:
             where_clause = and_(
+                c.client_id == self.client_id,
                 c.enterprise_id == enterprise_id,
                 c.team_id == team_id,
                 c.user_id == user_id,
@@ -539,9 +683,13 @@ the following methods should be implemented.</p>
                     bot_id=row[&#34;bot_id&#34;],
                     bot_user_id=row[&#34;bot_user_id&#34;],
                     bot_scopes=row[&#34;bot_scopes&#34;],
+                    bot_refresh_token=row[&#34;bot_refresh_token&#34;],
+                    bot_token_expires_at=row[&#34;bot_token_expires_at&#34;],
                     user_id=row[&#34;user_id&#34;],
                     user_token=row[&#34;user_token&#34;],
                     user_scopes=row[&#34;user_scopes&#34;],
+                    user_refresh_token=row[&#34;user_refresh_token&#34;],
+                    user_token_expires_at=row[&#34;user_token_expires_at&#34;],
                     # Only the incoming webhook issued in the latest installation is set in this logic
                     incoming_webhook_url=row[&#34;incoming_webhook_url&#34;],
                     incoming_webhook_channel=row[&#34;incoming_webhook_channel&#34;],
@@ -648,16 +796,18 @@ def build_bots_table(cls, metadata: MetaData, table_name: str) -&gt; Table:
         table_name,
         metadata,
         Column(&#34;id&#34;, Integer, primary_key=True, autoincrement=True),
-        Column(&#34;client_id&#34;, String, nullable=False),
-        Column(&#34;app_id&#34;, String, nullable=False),
-        Column(&#34;enterprise_id&#34;, String),
-        Column(&#34;enterprise_name&#34;, String),
-        Column(&#34;team_id&#34;, String),
-        Column(&#34;team_name&#34;, String),
-        Column(&#34;bot_token&#34;, String),
-        Column(&#34;bot_id&#34;, String),
-        Column(&#34;bot_user_id&#34;, String),
-        Column(&#34;bot_scopes&#34;, String),
+        Column(&#34;client_id&#34;, String(32), nullable=False),
+        Column(&#34;app_id&#34;, String(32), nullable=False),
+        Column(&#34;enterprise_id&#34;, String(32)),
+        Column(&#34;enterprise_name&#34;, String(200)),
+        Column(&#34;team_id&#34;, String(32)),
+        Column(&#34;team_name&#34;, String(200)),
+        Column(&#34;bot_token&#34;, String(32)),
+        Column(&#34;bot_id&#34;, String(32)),
+        Column(&#34;bot_user_id&#34;, String(32)),
+        Column(&#34;bot_scopes&#34;, String(1000)),
+        Column(&#34;bot_refresh_token&#34;, String(200)),  # added in v3.8.0
+        Column(&#34;bot_token_expires_at&#34;, DateTime),  # added in v3.8.0
         Column(&#34;is_enterprise_install&#34;, Boolean, default=False, nullable=False),
         Column(
             &#34;installed_at&#34;,
@@ -690,26 +840,30 @@ def build_installations_table(cls, metadata: MetaData, table_name: str) -&gt; Ta
         table_name,
         metadata,
         Column(&#34;id&#34;, Integer, primary_key=True, autoincrement=True),
-        Column(&#34;client_id&#34;, String, nullable=False),
-        Column(&#34;app_id&#34;, String, nullable=False),
-        Column(&#34;enterprise_id&#34;, String),
-        Column(&#34;enterprise_name&#34;, String),
-        Column(&#34;enterprise_url&#34;, String),
-        Column(&#34;team_id&#34;, String),
-        Column(&#34;team_name&#34;, String),
-        Column(&#34;bot_token&#34;, String),
-        Column(&#34;bot_id&#34;, String),
-        Column(&#34;bot_user_id&#34;, String),
-        Column(&#34;bot_scopes&#34;, String),
-        Column(&#34;user_id&#34;, String, nullable=False),
-        Column(&#34;user_token&#34;, String),
-        Column(&#34;user_scopes&#34;, String),
-        Column(&#34;incoming_webhook_url&#34;, String),
-        Column(&#34;incoming_webhook_channel&#34;, String),
-        Column(&#34;incoming_webhook_channel_id&#34;, String),
-        Column(&#34;incoming_webhook_configuration_url&#34;, String),
+        Column(&#34;client_id&#34;, String(32), nullable=False),
+        Column(&#34;app_id&#34;, String(32), nullable=False),
+        Column(&#34;enterprise_id&#34;, String(32)),
+        Column(&#34;enterprise_name&#34;, String(200)),
+        Column(&#34;enterprise_url&#34;, String(200)),
+        Column(&#34;team_id&#34;, String(32)),
+        Column(&#34;team_name&#34;, String(200)),
+        Column(&#34;bot_token&#34;, String(200)),
+        Column(&#34;bot_id&#34;, String(32)),
+        Column(&#34;bot_user_id&#34;, String(32)),
+        Column(&#34;bot_scopes&#34;, String(1000)),
+        Column(&#34;bot_refresh_token&#34;, String(200)),  # added in v3.8.0
+        Column(&#34;bot_token_expires_at&#34;, DateTime),  # added in v3.8.0
+        Column(&#34;user_id&#34;, String(32), nullable=False),
+        Column(&#34;user_token&#34;, String(200)),
+        Column(&#34;user_scopes&#34;, String(1000)),
+        Column(&#34;user_refresh_token&#34;, String(200)),  # added in v3.8.0
+        Column(&#34;user_token_expires_at&#34;, DateTime),  # added in v3.8.0
+        Column(&#34;incoming_webhook_url&#34;, String(200)),
+        Column(&#34;incoming_webhook_channel&#34;, String(200)),
+        Column(&#34;incoming_webhook_channel_id&#34;, String(200)),
+        Column(&#34;incoming_webhook_configuration_url&#34;, String(200)),
         Column(&#34;is_enterprise_install&#34;, Boolean, default=False, nullable=False),
-        Column(&#34;token_type&#34;, String),
+        Column(&#34;token_type&#34;, String(32)),
         Column(
             &#34;installed_at&#34;,
             DateTime,
@@ -769,6 +923,7 @@ def logger(self) -&gt; Logger:
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.find_bot" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.find_bot">find_bot</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.find_installation" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.find_installation">find_installation</a></code></li>
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save">save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot">save_bot</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/sqlite3/index.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/sqlite3/index.html
@@ -93,9 +93,13 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 bot_id text not null,
                 bot_user_id text not null,
                 bot_scopes text,
+                bot_refresh_token text,  -- since v3.8
+                bot_token_expires_at datetime,  -- since v3.8
                 user_id text not null,
                 user_token text,
                 user_scopes text,
+                user_refresh_token text,  -- since v3.8
+                user_token_expires_at datetime,  -- since v3.8
                 incoming_webhook_url text,
                 incoming_webhook_channel text,
                 incoming_webhook_channel_id text,
@@ -131,6 +135,8 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 bot_id text not null,
                 bot_user_id text not null,
                 bot_scopes text,
+                bot_refresh_token text,  -- since v3.8
+                bot_token_expires_at datetime,  -- since v3.8
                 is_enterprise_install boolean not null default 0,
                 installed_at datetime not null default current_timestamp
             );
@@ -152,52 +158,11 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
     async def async_save(self, installation: Installation):
         return self.save(installation)
 
+    async def async_save_bot(self, bot: Bot):
+        return self.save_bot(bot)
+
     def save(self, installation: Installation):
         with self.connect() as conn:
-            conn.execute(
-                &#34;&#34;&#34;
-                insert into slack_bots (
-                    client_id,
-                    app_id,
-                    enterprise_id,
-                    enterprise_name,
-                    team_id,
-                    team_name,
-                    bot_token,
-                    bot_id,
-                    bot_user_id,
-                    bot_scopes,
-                    is_enterprise_install
-                )
-                values
-                (
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?
-                );
-                &#34;&#34;&#34;,
-                [
-                    self.client_id,
-                    installation.app_id,
-                    installation.enterprise_id or &#34;&#34;,
-                    installation.enterprise_name,
-                    installation.team_id or &#34;&#34;,
-                    installation.team_name,
-                    installation.bot_token,
-                    installation.bot_id,
-                    installation.bot_user_id,
-                    &#34;,&#34;.join(installation.bot_scopes),
-                    installation.is_enterprise_install,
-                ],
-            )
             conn.execute(
                 &#34;&#34;&#34;
                 insert into slack_installations (
@@ -212,9 +177,13 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                     bot_id,
                     bot_user_id,
                     bot_scopes,
+                    bot_refresh_token,  -- since v3.8
+                    bot_token_expires_at,  -- since v3.8
                     user_id,
                     user_token,
                     user_scopes,
+                    user_refresh_token,  -- since v3.8
+                    user_token_expires_at,  -- since v3.8
                     incoming_webhook_url,
                     incoming_webhook_channel,
                     incoming_webhook_channel_id,
@@ -224,6 +193,10 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 )
                 values
                 (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -258,11 +231,15 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                     installation.bot_id,
                     installation.bot_user_id,
                     &#34;,&#34;.join(installation.bot_scopes),
+                    installation.bot_refresh_token,
+                    installation.bot_token_expires_at,
                     installation.user_id,
                     installation.user_token,
                     &#34;,&#34;.join(installation.user_scopes)
                     if installation.user_scopes
                     else None,
+                    installation.user_refresh_token,
+                    installation.user_token_expires_at,
                     installation.incoming_webhook_url,
                     installation.incoming_webhook_channel,
                     installation.incoming_webhook_channel_id,
@@ -273,6 +250,62 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
             )
             self.logger.debug(
                 f&#34;New rows in slack_bots and slack_installations have been created (database: {self.database})&#34;
+            )
+            conn.commit()
+
+        self.save_bot(installation.to_bot())
+
+    def save_bot(self, bot: Bot):
+        with self.connect() as conn:
+            conn.execute(
+                &#34;&#34;&#34;
+                insert into slack_bots (
+                    client_id,
+                    app_id,
+                    enterprise_id,
+                    enterprise_name,
+                    team_id,
+                    team_name,
+                    bot_token,
+                    bot_id,
+                    bot_user_id,
+                    bot_scopes,
+                    bot_refresh_token,  -- since v3.8
+                    bot_token_expires_at,  -- since v3.8
+                    is_enterprise_install
+                )
+                values
+                (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );
+                &#34;&#34;&#34;,
+                [
+                    self.client_id,
+                    bot.app_id,
+                    bot.enterprise_id or &#34;&#34;,
+                    bot.enterprise_name,
+                    bot.team_id or &#34;&#34;,
+                    bot.team_name,
+                    bot.bot_token,
+                    bot.bot_id,
+                    bot.bot_user_id,
+                    &#34;,&#34;.join(bot.bot_scopes),
+                    bot.bot_refresh_token,
+                    bot.bot_token_expires_at,
+                    bot.is_enterprise_install,
+                ],
             )
             conn.commit()
 
@@ -313,6 +346,8 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                         bot_id,
                         bot_user_id,
                         bot_scopes,
+                        bot_refresh_token,  -- since v3.8
+                        bot_token_expires_at,  -- since v3.8
                         is_enterprise_install,
                         installed_at
                     from
@@ -344,15 +379,20 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                         bot_id=row[6],
                         bot_user_id=row[7],
                         bot_scopes=row[8],
-                        is_enterprise_install=row[9],
-                        installed_at=row[10],
+                        bot_refresh_token=row[9],
+                        bot_token_expires_at=row[10],
+                        is_enterprise_install=row[11],
+                        installed_at=row[12],
                     )
                     return bot
                 return None
 
         except Exception as e:  # skipcq: PYL-W0703
             message = f&#34;Failed to find bot installation data for enterprise: {enterprise_id}, team: {team_id}: {e}&#34;
-            self.logger.warning(message)
+            if self.logger.level &lt;= logging.DEBUG:
+                self.logger.exception(message)
+            else:
+                self.logger.warning(message)
             return None
 
     async def async_find_installation(
@@ -395,9 +435,13 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                     bot_id,
                     bot_user_id,
                     bot_scopes,
+                    bot_refresh_token,  -- since v3.8
+                    bot_token_expires_at,  -- since v3.8
                     user_id,
                     user_token,
                     user_scopes,
+                    user_refresh_token,  -- since v3.8
+                    user_token_expires_at,  -- since v3.8
                     incoming_webhook_url,
                     incoming_webhook_channel,
                     incoming_webhook_channel_id,
@@ -466,23 +510,30 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                         bot_id=row[7],
                         bot_user_id=row[8],
                         bot_scopes=row[9],
-                        user_id=row[10],
-                        user_token=row[11],
-                        user_scopes=row[12],
-                        incoming_webhook_url=row[13],
-                        incoming_webhook_channel=row[14],
-                        incoming_webhook_channel_id=row[15],
-                        incoming_webhook_configuration_url=row[16],
-                        is_enterprise_install=row[17],
-                        token_type=row[18],
-                        installed_at=row[19],
+                        bot_refresh_token=row[10],
+                        bot_token_expires_at=row[11],
+                        user_id=row[12],
+                        user_token=row[13],
+                        user_scopes=row[14],
+                        user_refresh_token=row[15],
+                        user_token_expires_at=row[16],
+                        incoming_webhook_url=row[17],
+                        incoming_webhook_channel=row[18],
+                        incoming_webhook_channel_id=row[19],
+                        incoming_webhook_configuration_url=row[20],
+                        is_enterprise_install=row[21],
+                        token_type=row[22],
+                        installed_at=row[23],
                     )
                     return installation
                 return None
 
         except Exception as e:  # skipcq: PYL-W0703
             message = f&#34;Failed to find an installation data for enterprise: {enterprise_id}, team: {team_id}: {e}&#34;
-            self.logger.warning(message)
+            if self.logger.level &lt;= logging.DEBUG:
+                self.logger.exception(message)
+            else:
+                self.logger.warning(message)
             return None
 
     def delete_bot(
@@ -507,7 +558,10 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 conn.commit()
         except Exception as e:  # skipcq: PYL-W0703
             message = f&#34;Failed to delete bot installation data for enterprise: {enterprise_id}, team: {team_id}: {e}&#34;
-            self.logger.warning(message)
+            if self.logger.level &lt;= logging.DEBUG:
+                self.logger.exception(message)
+            else:
+                self.logger.warning(message)
 
     def delete_installation(
         self,
@@ -553,7 +607,10 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 conn.commit()
         except Exception as e:  # skipcq: PYL-W0703
             message = f&#34;Failed to delete installation data for enterprise: {enterprise_id}, team: {team_id}: {e}&#34;
-            self.logger.warning(message)</code></pre>
+            if self.logger.level &lt;= logging.DEBUG:
+                self.logger.exception(message)
+            else:
+                self.logger.warning(message)</code></pre>
 </details>
 </section>
 <section>
@@ -646,9 +703,13 @@ the following methods should be implemented.</p>
                 bot_id text not null,
                 bot_user_id text not null,
                 bot_scopes text,
+                bot_refresh_token text,  -- since v3.8
+                bot_token_expires_at datetime,  -- since v3.8
                 user_id text not null,
                 user_token text,
                 user_scopes text,
+                user_refresh_token text,  -- since v3.8
+                user_token_expires_at datetime,  -- since v3.8
                 incoming_webhook_url text,
                 incoming_webhook_channel text,
                 incoming_webhook_channel_id text,
@@ -684,6 +745,8 @@ the following methods should be implemented.</p>
                 bot_id text not null,
                 bot_user_id text not null,
                 bot_scopes text,
+                bot_refresh_token text,  -- since v3.8
+                bot_token_expires_at datetime,  -- since v3.8
                 is_enterprise_install boolean not null default 0,
                 installed_at datetime not null default current_timestamp
             );
@@ -705,52 +768,11 @@ the following methods should be implemented.</p>
     async def async_save(self, installation: Installation):
         return self.save(installation)
 
+    async def async_save_bot(self, bot: Bot):
+        return self.save_bot(bot)
+
     def save(self, installation: Installation):
         with self.connect() as conn:
-            conn.execute(
-                &#34;&#34;&#34;
-                insert into slack_bots (
-                    client_id,
-                    app_id,
-                    enterprise_id,
-                    enterprise_name,
-                    team_id,
-                    team_name,
-                    bot_token,
-                    bot_id,
-                    bot_user_id,
-                    bot_scopes,
-                    is_enterprise_install
-                )
-                values
-                (
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?,
-                    ?
-                );
-                &#34;&#34;&#34;,
-                [
-                    self.client_id,
-                    installation.app_id,
-                    installation.enterprise_id or &#34;&#34;,
-                    installation.enterprise_name,
-                    installation.team_id or &#34;&#34;,
-                    installation.team_name,
-                    installation.bot_token,
-                    installation.bot_id,
-                    installation.bot_user_id,
-                    &#34;,&#34;.join(installation.bot_scopes),
-                    installation.is_enterprise_install,
-                ],
-            )
             conn.execute(
                 &#34;&#34;&#34;
                 insert into slack_installations (
@@ -765,9 +787,13 @@ the following methods should be implemented.</p>
                     bot_id,
                     bot_user_id,
                     bot_scopes,
+                    bot_refresh_token,  -- since v3.8
+                    bot_token_expires_at,  -- since v3.8
                     user_id,
                     user_token,
                     user_scopes,
+                    user_refresh_token,  -- since v3.8
+                    user_token_expires_at,  -- since v3.8
                     incoming_webhook_url,
                     incoming_webhook_channel,
                     incoming_webhook_channel_id,
@@ -777,6 +803,10 @@ the following methods should be implemented.</p>
                 )
                 values
                 (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -811,11 +841,15 @@ the following methods should be implemented.</p>
                     installation.bot_id,
                     installation.bot_user_id,
                     &#34;,&#34;.join(installation.bot_scopes),
+                    installation.bot_refresh_token,
+                    installation.bot_token_expires_at,
                     installation.user_id,
                     installation.user_token,
                     &#34;,&#34;.join(installation.user_scopes)
                     if installation.user_scopes
                     else None,
+                    installation.user_refresh_token,
+                    installation.user_token_expires_at,
                     installation.incoming_webhook_url,
                     installation.incoming_webhook_channel,
                     installation.incoming_webhook_channel_id,
@@ -826,6 +860,62 @@ the following methods should be implemented.</p>
             )
             self.logger.debug(
                 f&#34;New rows in slack_bots and slack_installations have been created (database: {self.database})&#34;
+            )
+            conn.commit()
+
+        self.save_bot(installation.to_bot())
+
+    def save_bot(self, bot: Bot):
+        with self.connect() as conn:
+            conn.execute(
+                &#34;&#34;&#34;
+                insert into slack_bots (
+                    client_id,
+                    app_id,
+                    enterprise_id,
+                    enterprise_name,
+                    team_id,
+                    team_name,
+                    bot_token,
+                    bot_id,
+                    bot_user_id,
+                    bot_scopes,
+                    bot_refresh_token,  -- since v3.8
+                    bot_token_expires_at,  -- since v3.8
+                    is_enterprise_install
+                )
+                values
+                (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );
+                &#34;&#34;&#34;,
+                [
+                    self.client_id,
+                    bot.app_id,
+                    bot.enterprise_id or &#34;&#34;,
+                    bot.enterprise_name,
+                    bot.team_id or &#34;&#34;,
+                    bot.team_name,
+                    bot.bot_token,
+                    bot.bot_id,
+                    bot.bot_user_id,
+                    &#34;,&#34;.join(bot.bot_scopes),
+                    bot.bot_refresh_token,
+                    bot.bot_token_expires_at,
+                    bot.is_enterprise_install,
+                ],
             )
             conn.commit()
 
@@ -866,6 +956,8 @@ the following methods should be implemented.</p>
                         bot_id,
                         bot_user_id,
                         bot_scopes,
+                        bot_refresh_token,  -- since v3.8
+                        bot_token_expires_at,  -- since v3.8
                         is_enterprise_install,
                         installed_at
                     from
@@ -897,15 +989,20 @@ the following methods should be implemented.</p>
                         bot_id=row[6],
                         bot_user_id=row[7],
                         bot_scopes=row[8],
-                        is_enterprise_install=row[9],
-                        installed_at=row[10],
+                        bot_refresh_token=row[9],
+                        bot_token_expires_at=row[10],
+                        is_enterprise_install=row[11],
+                        installed_at=row[12],
                     )
                     return bot
                 return None
 
         except Exception as e:  # skipcq: PYL-W0703
             message = f&#34;Failed to find bot installation data for enterprise: {enterprise_id}, team: {team_id}: {e}&#34;
-            self.logger.warning(message)
+            if self.logger.level &lt;= logging.DEBUG:
+                self.logger.exception(message)
+            else:
+                self.logger.warning(message)
             return None
 
     async def async_find_installation(
@@ -948,9 +1045,13 @@ the following methods should be implemented.</p>
                     bot_id,
                     bot_user_id,
                     bot_scopes,
+                    bot_refresh_token,  -- since v3.8
+                    bot_token_expires_at,  -- since v3.8
                     user_id,
                     user_token,
                     user_scopes,
+                    user_refresh_token,  -- since v3.8
+                    user_token_expires_at,  -- since v3.8
                     incoming_webhook_url,
                     incoming_webhook_channel,
                     incoming_webhook_channel_id,
@@ -1019,23 +1120,30 @@ the following methods should be implemented.</p>
                         bot_id=row[7],
                         bot_user_id=row[8],
                         bot_scopes=row[9],
-                        user_id=row[10],
-                        user_token=row[11],
-                        user_scopes=row[12],
-                        incoming_webhook_url=row[13],
-                        incoming_webhook_channel=row[14],
-                        incoming_webhook_channel_id=row[15],
-                        incoming_webhook_configuration_url=row[16],
-                        is_enterprise_install=row[17],
-                        token_type=row[18],
-                        installed_at=row[19],
+                        bot_refresh_token=row[10],
+                        bot_token_expires_at=row[11],
+                        user_id=row[12],
+                        user_token=row[13],
+                        user_scopes=row[14],
+                        user_refresh_token=row[15],
+                        user_token_expires_at=row[16],
+                        incoming_webhook_url=row[17],
+                        incoming_webhook_channel=row[18],
+                        incoming_webhook_channel_id=row[19],
+                        incoming_webhook_configuration_url=row[20],
+                        is_enterprise_install=row[21],
+                        token_type=row[22],
+                        installed_at=row[23],
                     )
                     return installation
                 return None
 
         except Exception as e:  # skipcq: PYL-W0703
             message = f&#34;Failed to find an installation data for enterprise: {enterprise_id}, team: {team_id}: {e}&#34;
-            self.logger.warning(message)
+            if self.logger.level &lt;= logging.DEBUG:
+                self.logger.exception(message)
+            else:
+                self.logger.warning(message)
             return None
 
     def delete_bot(
@@ -1060,7 +1168,10 @@ the following methods should be implemented.</p>
                 conn.commit()
         except Exception as e:  # skipcq: PYL-W0703
             message = f&#34;Failed to delete bot installation data for enterprise: {enterprise_id}, team: {team_id}: {e}&#34;
-            self.logger.warning(message)
+            if self.logger.level &lt;= logging.DEBUG:
+                self.logger.exception(message)
+            else:
+                self.logger.warning(message)
 
     def delete_installation(
         self,
@@ -1106,7 +1217,10 @@ the following methods should be implemented.</p>
                 conn.commit()
         except Exception as e:  # skipcq: PYL-W0703
             message = f&#34;Failed to delete installation data for enterprise: {enterprise_id}, team: {team_id}: {e}&#34;
-            self.logger.warning(message)</code></pre>
+            if self.logger.level &lt;= logging.DEBUG:
+                self.logger.exception(message)
+            else:
+                self.logger.warning(message)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -1173,9 +1287,13 @@ def logger(self) -&gt; Logger:
             bot_id text not null,
             bot_user_id text not null,
             bot_scopes text,
+            bot_refresh_token text,  -- since v3.8
+            bot_token_expires_at datetime,  -- since v3.8
             user_id text not null,
             user_token text,
             user_scopes text,
+            user_refresh_token text,  -- since v3.8
+            user_token_expires_at datetime,  -- since v3.8
             incoming_webhook_url text,
             incoming_webhook_channel text,
             incoming_webhook_channel_id text,
@@ -1211,6 +1329,8 @@ def logger(self) -&gt; Logger:
             bot_id text not null,
             bot_user_id text not null,
             bot_scopes text,
+            bot_refresh_token text,  -- since v3.8
+            bot_token_expires_at datetime,  -- since v3.8
             is_enterprise_install boolean not null default 0,
             installed_at datetime not null default current_timestamp
         );
@@ -1258,6 +1378,7 @@ def logger(self) -&gt; Logger:
 <li><code><b><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore">InstallationStore</a></b></code>:
 <ul class="hlist">
 <li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save">save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore.save_bot">save_bot</a></code></li>
 </ul>
 </li>
 <li><code><b><a title="slack_sdk.oauth.installation_store.installation_store.InstallationStore" href="../installation_store.html#slack_sdk.oauth.installation_store.installation_store.InstallationStore">InstallationStore</a></b></code>:
@@ -1276,6 +1397,7 @@ def logger(self) -&gt; Logger:
 <li><code><b><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore">AsyncInstallationStore</a></b></code>:
 <ul class="hlist">
 <li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save">async_save</a></code></li>
+<li><code><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore.async_save_bot">async_save_bot</a></code></li>
 </ul>
 </li>
 <li><code><b><a title="slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore" href="../async_installation_store.html#slack_sdk.oauth.installation_store.async_installation_store.AsyncInstallationStore">AsyncInstallationStore</a></b></code>:

--- a/docs/api-docs/slack_sdk/oauth/state_store/sqlalchemy/index.html
+++ b/docs/api-docs/slack_sdk/oauth/state_store/sqlalchemy/index.html
@@ -53,7 +53,7 @@ class SQLAlchemyOAuthStateStore(OAuthStateStore):
             metadata,
             metadata,
             Column(&#34;id&#34;, Integer, primary_key=True, autoincrement=True),
-            Column(&#34;state&#34;, String, nullable=False),
+            Column(&#34;state&#34;, String(200), nullable=False),
             Column(&#34;expire_at&#34;, DateTime, nullable=False),
         )
 
@@ -139,7 +139,7 @@ class SQLAlchemyOAuthStateStore(OAuthStateStore):
             metadata,
             metadata,
             Column(&#34;id&#34;, Integer, primary_key=True, autoincrement=True),
-            Column(&#34;state&#34;, String, nullable=False),
+            Column(&#34;state&#34;, String(200), nullable=False),
             Column(&#34;expire_at&#34;, DateTime, nullable=False),
         )
 
@@ -235,7 +235,7 @@ def build_oauth_states_table(cls, metadata: MetaData, table_name: str) -&gt; Tab
         metadata,
         metadata,
         Column(&#34;id&#34;, Integer, primary_key=True, autoincrement=True),
-        Column(&#34;state&#34;, String, nullable=False),
+        Column(&#34;state&#34;, String(200), nullable=False),
         Column(&#34;expire_at&#34;, DateTime, nullable=False),
     )</code></pre>
 </details>

--- a/docs/api-docs/slack_sdk/oauth/token_rotation/async_rotator.html
+++ b/docs/api-docs/slack_sdk/oauth/token_rotation/async_rotator.html
@@ -1,0 +1,582 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>slack_sdk.oauth.token_rotation.async_rotator API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>slack_sdk.oauth.token_rotation.async_rotator</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from time import time
+from typing import Optional
+
+from slack_sdk.errors import SlackApiError, SlackTokenRotationError
+from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.oauth.installation_store import Installation, Bot
+
+
+class AsyncTokenRotator:
+    client: AsyncWebClient
+    client_id: str
+    client_secret: str
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        client: Optional[AsyncWebClient] = None,
+    ):
+        self.client = client if client is not None else AsyncWebClient(token=None)
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    async def perform_token_rotation(
+        self,
+        *,
+        installation: Installation,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Installation]:
+        &#34;&#34;&#34;Performs token rotation if the underlying tokens (bot / user) are expired / expiring.
+
+        Args:
+            installation: the current installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+
+        # TODO: make the following two calls in parallel for better performance
+
+        # bot
+        rotated_bot: Optional[Bot] = await self.perform_bot_token_rotation(
+            bot=installation.to_bot(),
+            minutes_before_expiration=minutes_before_expiration,
+        )
+
+        # user
+        rotated_installation: Optional[
+            Installation
+        ] = await self.perform_user_token_rotation(
+            installation=installation,
+            minutes_before_expiration=minutes_before_expiration,
+        )
+
+        if rotated_bot is not None:
+            if rotated_installation is None:
+                rotated_installation = Installation(**installation.to_dict())
+            rotated_installation.bot_token = rotated_bot.bot_token
+            rotated_installation.bot_refresh_token = rotated_bot.bot_refresh_token
+            rotated_installation.bot_token_expires_at = rotated_bot.bot_token_expires_at
+
+        return rotated_installation
+
+    async def perform_bot_token_rotation(
+        self,
+        *,
+        bot: Bot,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Bot]:
+        &#34;&#34;&#34;Performs bot token rotation if the underlying bot token is expired / expiring.
+
+        Args:
+            bot: the current bot installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+        if bot.bot_token_expires_at is None:
+            return None
+        if bot.bot_token_expires_at &gt; time() + minutes_before_expiration * 60:
+            return None
+
+        try:
+            refresh_response = await self.client.oauth_v2_access(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                grant_type=&#34;refresh_token&#34;,
+                refresh_token=bot.bot_refresh_token,
+            )
+            # TODO: error handling
+
+            if refresh_response.get(&#34;token_type&#34;) != &#34;bot&#34;:
+                return None
+
+            refreshed_bot = Bot(**bot.to_dict())
+            refreshed_bot.bot_token = refresh_response.get(&#34;access_token&#34;)
+            refreshed_bot.bot_refresh_token = refresh_response.get(&#34;refresh_token&#34;)
+            refreshed_bot.bot_token_expires_at = int(time()) + int(
+                refresh_response.get(&#34;expires_in&#34;)
+            )
+            return refreshed_bot
+
+        except SlackApiError as e:
+            raise SlackTokenRotationError(e)
+
+    async def perform_user_token_rotation(
+        self,
+        *,
+        installation: Installation,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Bot]:
+        &#34;&#34;&#34;Performs user token rotation if the underlying user token is expired / expiring.
+
+        Args:
+            installation: the current installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+        if installation.user_token_expires_at is None:
+            return None
+        if installation.user_token_expires_at &gt; time() + minutes_before_expiration * 60:
+            return None
+
+        try:
+            refresh_response = await self.client.oauth_v2_access(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                grant_type=&#34;refresh_token&#34;,
+                refresh_token=installation.user_refresh_token,
+            )
+            if refresh_response.get(&#34;token_type&#34;) != &#34;user&#34;:
+                return None
+
+            refreshed_installation = Installation(**installation.to_dict())
+            refreshed_installation.user_token = refresh_response.get(&#34;access_token&#34;)
+            refreshed_installation.user_refresh_token = refresh_response.get(
+                &#34;refresh_token&#34;
+            )
+            refreshed_installation.user_token_expires_at = int(time()) + int(
+                refresh_response.get(&#34;expires_in&#34;)
+            )
+            return refreshed_installation
+
+        except SlackApiError as e:
+            raise SlackTokenRotationError(e)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator"><code class="flex name class">
+<span>class <span class="ident">AsyncTokenRotator</span></span>
+<span>(</span><span>*, client_id: str, client_secret: str, client: Optional[<a title="slack_sdk.web.async_client.AsyncWebClient" href="../../web/async_client.html#slack_sdk.web.async_client.AsyncWebClient">AsyncWebClient</a>] = None)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class AsyncTokenRotator:
+    client: AsyncWebClient
+    client_id: str
+    client_secret: str
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        client: Optional[AsyncWebClient] = None,
+    ):
+        self.client = client if client is not None else AsyncWebClient(token=None)
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    async def perform_token_rotation(
+        self,
+        *,
+        installation: Installation,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Installation]:
+        &#34;&#34;&#34;Performs token rotation if the underlying tokens (bot / user) are expired / expiring.
+
+        Args:
+            installation: the current installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+
+        # TODO: make the following two calls in parallel for better performance
+
+        # bot
+        rotated_bot: Optional[Bot] = await self.perform_bot_token_rotation(
+            bot=installation.to_bot(),
+            minutes_before_expiration=minutes_before_expiration,
+        )
+
+        # user
+        rotated_installation: Optional[
+            Installation
+        ] = await self.perform_user_token_rotation(
+            installation=installation,
+            minutes_before_expiration=minutes_before_expiration,
+        )
+
+        if rotated_bot is not None:
+            if rotated_installation is None:
+                rotated_installation = Installation(**installation.to_dict())
+            rotated_installation.bot_token = rotated_bot.bot_token
+            rotated_installation.bot_refresh_token = rotated_bot.bot_refresh_token
+            rotated_installation.bot_token_expires_at = rotated_bot.bot_token_expires_at
+
+        return rotated_installation
+
+    async def perform_bot_token_rotation(
+        self,
+        *,
+        bot: Bot,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Bot]:
+        &#34;&#34;&#34;Performs bot token rotation if the underlying bot token is expired / expiring.
+
+        Args:
+            bot: the current bot installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+        if bot.bot_token_expires_at is None:
+            return None
+        if bot.bot_token_expires_at &gt; time() + minutes_before_expiration * 60:
+            return None
+
+        try:
+            refresh_response = await self.client.oauth_v2_access(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                grant_type=&#34;refresh_token&#34;,
+                refresh_token=bot.bot_refresh_token,
+            )
+            # TODO: error handling
+
+            if refresh_response.get(&#34;token_type&#34;) != &#34;bot&#34;:
+                return None
+
+            refreshed_bot = Bot(**bot.to_dict())
+            refreshed_bot.bot_token = refresh_response.get(&#34;access_token&#34;)
+            refreshed_bot.bot_refresh_token = refresh_response.get(&#34;refresh_token&#34;)
+            refreshed_bot.bot_token_expires_at = int(time()) + int(
+                refresh_response.get(&#34;expires_in&#34;)
+            )
+            return refreshed_bot
+
+        except SlackApiError as e:
+            raise SlackTokenRotationError(e)
+
+    async def perform_user_token_rotation(
+        self,
+        *,
+        installation: Installation,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Bot]:
+        &#34;&#34;&#34;Performs user token rotation if the underlying user token is expired / expiring.
+
+        Args:
+            installation: the current installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+        if installation.user_token_expires_at is None:
+            return None
+        if installation.user_token_expires_at &gt; time() + minutes_before_expiration * 60:
+            return None
+
+        try:
+            refresh_response = await self.client.oauth_v2_access(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                grant_type=&#34;refresh_token&#34;,
+                refresh_token=installation.user_refresh_token,
+            )
+            if refresh_response.get(&#34;token_type&#34;) != &#34;user&#34;:
+                return None
+
+            refreshed_installation = Installation(**installation.to_dict())
+            refreshed_installation.user_token = refresh_response.get(&#34;access_token&#34;)
+            refreshed_installation.user_refresh_token = refresh_response.get(
+                &#34;refresh_token&#34;
+            )
+            refreshed_installation.user_token_expires_at = int(time()) + int(
+                refresh_response.get(&#34;expires_in&#34;)
+            )
+            return refreshed_installation
+
+        except SlackApiError as e:
+            raise SlackTokenRotationError(e)</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.client"><code class="name">var <span class="ident">client</span> : <a title="slack_sdk.web.async_client.AsyncWebClient" href="../../web/async_client.html#slack_sdk.web.async_client.AsyncWebClient">AsyncWebClient</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.client_id"><code class="name">var <span class="ident">client_id</span> : str</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.client_secret"><code class="name">var <span class="ident">client_secret</span> : str</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.perform_bot_token_rotation"><code class="name flex">
+<span>async def <span class="ident">perform_bot_token_rotation</span></span>(<span>self, *, bot: <a title="slack_sdk.oauth.installation_store.models.bot.Bot" href="../installation_store/models/bot.html#slack_sdk.oauth.installation_store.models.bot.Bot">Bot</a>, minutes_before_expiration: int = 120) ‑> Optional[<a title="slack_sdk.oauth.installation_store.models.bot.Bot" href="../installation_store/models/bot.html#slack_sdk.oauth.installation_store.models.bot.Bot">Bot</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Performs bot token rotation if the underlying bot token is expired / expiring.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>bot</code></strong></dt>
+<dd>the current bot installation data</dd>
+<dt><strong><code>minutes_before_expiration</code></strong></dt>
+<dd>the minutes before the token expiration</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>None if no rotation is necessary for now.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def perform_bot_token_rotation(
+    self,
+    *,
+    bot: Bot,
+    minutes_before_expiration: int = 120,  # 2 hours by default
+) -&gt; Optional[Bot]:
+    &#34;&#34;&#34;Performs bot token rotation if the underlying bot token is expired / expiring.
+
+    Args:
+        bot: the current bot installation data
+        minutes_before_expiration: the minutes before the token expiration
+
+    Returns:
+        None if no rotation is necessary for now.
+    &#34;&#34;&#34;
+    if bot.bot_token_expires_at is None:
+        return None
+    if bot.bot_token_expires_at &gt; time() + minutes_before_expiration * 60:
+        return None
+
+    try:
+        refresh_response = await self.client.oauth_v2_access(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            grant_type=&#34;refresh_token&#34;,
+            refresh_token=bot.bot_refresh_token,
+        )
+        # TODO: error handling
+
+        if refresh_response.get(&#34;token_type&#34;) != &#34;bot&#34;:
+            return None
+
+        refreshed_bot = Bot(**bot.to_dict())
+        refreshed_bot.bot_token = refresh_response.get(&#34;access_token&#34;)
+        refreshed_bot.bot_refresh_token = refresh_response.get(&#34;refresh_token&#34;)
+        refreshed_bot.bot_token_expires_at = int(time()) + int(
+            refresh_response.get(&#34;expires_in&#34;)
+        )
+        return refreshed_bot
+
+    except SlackApiError as e:
+        raise SlackTokenRotationError(e)</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.perform_token_rotation"><code class="name flex">
+<span>async def <span class="ident">perform_token_rotation</span></span>(<span>self, *, installation: <a title="slack_sdk.oauth.installation_store.models.installation.Installation" href="../installation_store/models/installation.html#slack_sdk.oauth.installation_store.models.installation.Installation">Installation</a>, minutes_before_expiration: int = 120) ‑> Optional[<a title="slack_sdk.oauth.installation_store.models.installation.Installation" href="../installation_store/models/installation.html#slack_sdk.oauth.installation_store.models.installation.Installation">Installation</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Performs token rotation if the underlying tokens (bot / user) are expired / expiring.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>installation</code></strong></dt>
+<dd>the current installation data</dd>
+<dt><strong><code>minutes_before_expiration</code></strong></dt>
+<dd>the minutes before the token expiration</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>None if no rotation is necessary for now.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def perform_token_rotation(
+    self,
+    *,
+    installation: Installation,
+    minutes_before_expiration: int = 120,  # 2 hours by default
+) -&gt; Optional[Installation]:
+    &#34;&#34;&#34;Performs token rotation if the underlying tokens (bot / user) are expired / expiring.
+
+    Args:
+        installation: the current installation data
+        minutes_before_expiration: the minutes before the token expiration
+
+    Returns:
+        None if no rotation is necessary for now.
+    &#34;&#34;&#34;
+
+    # TODO: make the following two calls in parallel for better performance
+
+    # bot
+    rotated_bot: Optional[Bot] = await self.perform_bot_token_rotation(
+        bot=installation.to_bot(),
+        minutes_before_expiration=minutes_before_expiration,
+    )
+
+    # user
+    rotated_installation: Optional[
+        Installation
+    ] = await self.perform_user_token_rotation(
+        installation=installation,
+        minutes_before_expiration=minutes_before_expiration,
+    )
+
+    if rotated_bot is not None:
+        if rotated_installation is None:
+            rotated_installation = Installation(**installation.to_dict())
+        rotated_installation.bot_token = rotated_bot.bot_token
+        rotated_installation.bot_refresh_token = rotated_bot.bot_refresh_token
+        rotated_installation.bot_token_expires_at = rotated_bot.bot_token_expires_at
+
+    return rotated_installation</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.perform_user_token_rotation"><code class="name flex">
+<span>async def <span class="ident">perform_user_token_rotation</span></span>(<span>self, *, installation: <a title="slack_sdk.oauth.installation_store.models.installation.Installation" href="../installation_store/models/installation.html#slack_sdk.oauth.installation_store.models.installation.Installation">Installation</a>, minutes_before_expiration: int = 120) ‑> Optional[<a title="slack_sdk.oauth.installation_store.models.bot.Bot" href="../installation_store/models/bot.html#slack_sdk.oauth.installation_store.models.bot.Bot">Bot</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Performs user token rotation if the underlying user token is expired / expiring.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>installation</code></strong></dt>
+<dd>the current installation data</dd>
+<dt><strong><code>minutes_before_expiration</code></strong></dt>
+<dd>the minutes before the token expiration</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>None if no rotation is necessary for now.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def perform_user_token_rotation(
+    self,
+    *,
+    installation: Installation,
+    minutes_before_expiration: int = 120,  # 2 hours by default
+) -&gt; Optional[Bot]:
+    &#34;&#34;&#34;Performs user token rotation if the underlying user token is expired / expiring.
+
+    Args:
+        installation: the current installation data
+        minutes_before_expiration: the minutes before the token expiration
+
+    Returns:
+        None if no rotation is necessary for now.
+    &#34;&#34;&#34;
+    if installation.user_token_expires_at is None:
+        return None
+    if installation.user_token_expires_at &gt; time() + minutes_before_expiration * 60:
+        return None
+
+    try:
+        refresh_response = await self.client.oauth_v2_access(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            grant_type=&#34;refresh_token&#34;,
+            refresh_token=installation.user_refresh_token,
+        )
+        if refresh_response.get(&#34;token_type&#34;) != &#34;user&#34;:
+            return None
+
+        refreshed_installation = Installation(**installation.to_dict())
+        refreshed_installation.user_token = refresh_response.get(&#34;access_token&#34;)
+        refreshed_installation.user_refresh_token = refresh_response.get(
+            &#34;refresh_token&#34;
+        )
+        refreshed_installation.user_token_expires_at = int(time()) + int(
+            refresh_response.get(&#34;expires_in&#34;)
+        )
+        return refreshed_installation
+
+    except SlackApiError as e:
+        raise SlackTokenRotationError(e)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="slack_sdk.oauth.token_rotation" href="index.html">slack_sdk.oauth.token_rotation</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator" href="#slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator">AsyncTokenRotator</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.client" href="#slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.client">client</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.client_id" href="#slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.client_id">client_id</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.client_secret" href="#slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.client_secret">client_secret</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.perform_bot_token_rotation" href="#slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.perform_bot_token_rotation">perform_bot_token_rotation</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.perform_token_rotation" href="#slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.perform_token_rotation">perform_token_rotation</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.perform_user_token_rotation" href="#slack_sdk.oauth.token_rotation.async_rotator.AsyncTokenRotator.perform_user_token_rotation">perform_user_token_rotation</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/api-docs/slack_sdk/oauth/token_rotation/index.html
+++ b/docs/api-docs/slack_sdk/oauth/token_rotation/index.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <meta name="generator" content="pdoc 0.9.2" />
-<title>slack_sdk.version API documentation</title>
-<meta name="description" content="Check the latest version at https://pypi.org/project/slack-sdk/" />
+<title>slack_sdk.oauth.token_rotation API documentation</title>
+<meta name="description" content="" />
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
 <link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
 <link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
@@ -19,19 +19,28 @@
 <main>
 <article id="content">
 <header>
-<h1 class="title">Module <code>slack_sdk.version</code></h1>
+<h1 class="title">Module <code>slack_sdk.oauth.token_rotation</code></h1>
 </header>
 <section id="section-intro">
-<p>Check the latest version at <a href="https://pypi.org/project/slack-sdk/">https://pypi.org/project/slack-sdk/</a></p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">&#34;&#34;&#34;Check the latest version at https://pypi.org/project/slack-sdk/&#34;&#34;&#34;
-__version__ = &#34;3.8.0rc2&#34;</code></pre>
+<pre><code class="python">from .rotator import TokenRotator  # noqa</code></pre>
 </details>
 </section>
 <section>
+<h2 class="section-title" id="header-submodules">Sub-modules</h2>
+<dl>
+<dt><code class="name"><a title="slack_sdk.oauth.token_rotation.async_rotator" href="async_rotator.html">slack_sdk.oauth.token_rotation.async_rotator</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="slack_sdk.oauth.token_rotation.rotator" href="rotator.html">slack_sdk.oauth.token_rotation.rotator</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
 </section>
 <section>
 </section>
@@ -48,7 +57,13 @@ __version__ = &#34;3.8.0rc2&#34;</code></pre>
 <ul id="index">
 <li><h3>Super-module</h3>
 <ul>
-<li><code><a title="slack_sdk" href="index.html">slack_sdk</a></code></li>
+<li><code><a title="slack_sdk.oauth" href="../index.html">slack_sdk.oauth</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-submodules">Sub-modules</a></h3>
+<ul>
+<li><code><a title="slack_sdk.oauth.token_rotation.async_rotator" href="async_rotator.html">slack_sdk.oauth.token_rotation.async_rotator</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.rotator" href="rotator.html">slack_sdk.oauth.token_rotation.rotator</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/api-docs/slack_sdk/oauth/token_rotation/rotator.html
+++ b/docs/api-docs/slack_sdk/oauth/token_rotation/rotator.html
@@ -1,0 +1,565 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2" />
+<title>slack_sdk.oauth.token_rotation.rotator API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>slack_sdk.oauth.token_rotation.rotator</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from time import time
+from typing import Optional
+
+from slack_sdk.errors import SlackApiError, SlackTokenRotationError
+from slack_sdk.web import WebClient
+from slack_sdk.oauth.installation_store import Installation, Bot
+
+
+class TokenRotator:
+    client: WebClient
+    client_id: str
+    client_secret: str
+
+    def __init__(
+        self, *, client_id: str, client_secret: str, client: Optional[WebClient] = None
+    ):
+        self.client = client if client is not None else WebClient(token=None)
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    def perform_token_rotation(
+        self,
+        *,
+        installation: Installation,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Installation]:
+        &#34;&#34;&#34;Performs token rotation if the underlying tokens (bot / user) are expired / expiring.
+
+        Args:
+            installation: the current installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+
+        # TODO: make the following two calls in parallel for better performance
+
+        # bot
+        rotated_bot: Optional[Bot] = self.perform_bot_token_rotation(
+            bot=installation.to_bot(),
+            minutes_before_expiration=minutes_before_expiration,
+        )
+
+        # user
+        rotated_installation: Optional[Installation] = self.perform_user_token_rotation(
+            installation=installation,
+            minutes_before_expiration=minutes_before_expiration,
+        )
+
+        if rotated_bot is not None:
+            if rotated_installation is None:
+                rotated_installation = Installation(**installation.to_dict())
+            rotated_installation.bot_token = rotated_bot.bot_token
+            rotated_installation.bot_refresh_token = rotated_bot.bot_refresh_token
+            rotated_installation.bot_token_expires_at = rotated_bot.bot_token_expires_at
+
+        return rotated_installation
+
+    def perform_bot_token_rotation(
+        self,
+        *,
+        bot: Bot,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Bot]:
+        &#34;&#34;&#34;Performs bot token rotation if the underlying bot token is expired / expiring.
+
+        Args:
+            bot: the current bot installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+        if bot.bot_token_expires_at is None:
+            return None
+        if bot.bot_token_expires_at &gt; time() + minutes_before_expiration * 60:
+            return None
+
+        try:
+            refresh_response = self.client.oauth_v2_access(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                grant_type=&#34;refresh_token&#34;,
+                refresh_token=bot.bot_refresh_token,
+            )
+            if refresh_response.get(&#34;token_type&#34;) != &#34;bot&#34;:
+                return None
+
+            refreshed_bot = Bot(**bot.to_dict())
+            refreshed_bot.bot_token = refresh_response.get(&#34;access_token&#34;)
+            refreshed_bot.bot_refresh_token = refresh_response.get(&#34;refresh_token&#34;)
+            refreshed_bot.bot_token_expires_at = int(time()) + int(
+                refresh_response.get(&#34;expires_in&#34;)
+            )
+            return refreshed_bot
+
+        except SlackApiError as e:
+            raise SlackTokenRotationError(e)
+
+    def perform_user_token_rotation(
+        self,
+        *,
+        installation: Installation,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Bot]:
+        &#34;&#34;&#34;Performs user token rotation if the underlying user token is expired / expiring.
+
+        Args:
+            installation: the current installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+        if installation.user_token_expires_at is None:
+            return None
+        if installation.user_token_expires_at &gt; time() + minutes_before_expiration * 60:
+            return None
+
+        try:
+            refresh_response = self.client.oauth_v2_access(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                grant_type=&#34;refresh_token&#34;,
+                refresh_token=installation.user_refresh_token,
+            )
+
+            if refresh_response.get(&#34;token_type&#34;) != &#34;user&#34;:
+                return None
+
+            refreshed_installation = Installation(**installation.to_dict())
+            refreshed_installation.user_token = refresh_response.get(&#34;access_token&#34;)
+            refreshed_installation.user_refresh_token = refresh_response.get(
+                &#34;refresh_token&#34;
+            )
+            refreshed_installation.user_token_expires_at = int(time()) + int(
+                refresh_response.get(&#34;expires_in&#34;)
+            )
+            return refreshed_installation
+
+        except SlackApiError as e:
+            raise SlackTokenRotationError(e)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="slack_sdk.oauth.token_rotation.rotator.TokenRotator"><code class="flex name class">
+<span>class <span class="ident">TokenRotator</span></span>
+<span>(</span><span>*, client_id: str, client_secret: str, client: Optional[<a title="slack_sdk.web.client.WebClient" href="../../web/client.html#slack_sdk.web.client.WebClient">WebClient</a>] = None)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TokenRotator:
+    client: WebClient
+    client_id: str
+    client_secret: str
+
+    def __init__(
+        self, *, client_id: str, client_secret: str, client: Optional[WebClient] = None
+    ):
+        self.client = client if client is not None else WebClient(token=None)
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    def perform_token_rotation(
+        self,
+        *,
+        installation: Installation,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Installation]:
+        &#34;&#34;&#34;Performs token rotation if the underlying tokens (bot / user) are expired / expiring.
+
+        Args:
+            installation: the current installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+
+        # TODO: make the following two calls in parallel for better performance
+
+        # bot
+        rotated_bot: Optional[Bot] = self.perform_bot_token_rotation(
+            bot=installation.to_bot(),
+            minutes_before_expiration=minutes_before_expiration,
+        )
+
+        # user
+        rotated_installation: Optional[Installation] = self.perform_user_token_rotation(
+            installation=installation,
+            minutes_before_expiration=minutes_before_expiration,
+        )
+
+        if rotated_bot is not None:
+            if rotated_installation is None:
+                rotated_installation = Installation(**installation.to_dict())
+            rotated_installation.bot_token = rotated_bot.bot_token
+            rotated_installation.bot_refresh_token = rotated_bot.bot_refresh_token
+            rotated_installation.bot_token_expires_at = rotated_bot.bot_token_expires_at
+
+        return rotated_installation
+
+    def perform_bot_token_rotation(
+        self,
+        *,
+        bot: Bot,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Bot]:
+        &#34;&#34;&#34;Performs bot token rotation if the underlying bot token is expired / expiring.
+
+        Args:
+            bot: the current bot installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+        if bot.bot_token_expires_at is None:
+            return None
+        if bot.bot_token_expires_at &gt; time() + minutes_before_expiration * 60:
+            return None
+
+        try:
+            refresh_response = self.client.oauth_v2_access(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                grant_type=&#34;refresh_token&#34;,
+                refresh_token=bot.bot_refresh_token,
+            )
+            if refresh_response.get(&#34;token_type&#34;) != &#34;bot&#34;:
+                return None
+
+            refreshed_bot = Bot(**bot.to_dict())
+            refreshed_bot.bot_token = refresh_response.get(&#34;access_token&#34;)
+            refreshed_bot.bot_refresh_token = refresh_response.get(&#34;refresh_token&#34;)
+            refreshed_bot.bot_token_expires_at = int(time()) + int(
+                refresh_response.get(&#34;expires_in&#34;)
+            )
+            return refreshed_bot
+
+        except SlackApiError as e:
+            raise SlackTokenRotationError(e)
+
+    def perform_user_token_rotation(
+        self,
+        *,
+        installation: Installation,
+        minutes_before_expiration: int = 120,  # 2 hours by default
+    ) -&gt; Optional[Bot]:
+        &#34;&#34;&#34;Performs user token rotation if the underlying user token is expired / expiring.
+
+        Args:
+            installation: the current installation data
+            minutes_before_expiration: the minutes before the token expiration
+
+        Returns:
+            None if no rotation is necessary for now.
+        &#34;&#34;&#34;
+        if installation.user_token_expires_at is None:
+            return None
+        if installation.user_token_expires_at &gt; time() + minutes_before_expiration * 60:
+            return None
+
+        try:
+            refresh_response = self.client.oauth_v2_access(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                grant_type=&#34;refresh_token&#34;,
+                refresh_token=installation.user_refresh_token,
+            )
+
+            if refresh_response.get(&#34;token_type&#34;) != &#34;user&#34;:
+                return None
+
+            refreshed_installation = Installation(**installation.to_dict())
+            refreshed_installation.user_token = refresh_response.get(&#34;access_token&#34;)
+            refreshed_installation.user_refresh_token = refresh_response.get(
+                &#34;refresh_token&#34;
+            )
+            refreshed_installation.user_token_expires_at = int(time()) + int(
+                refresh_response.get(&#34;expires_in&#34;)
+            )
+            return refreshed_installation
+
+        except SlackApiError as e:
+            raise SlackTokenRotationError(e)</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.oauth.token_rotation.rotator.TokenRotator.client"><code class="name">var <span class="ident">client</span> : <a title="slack_sdk.web.client.WebClient" href="../../web/client.html#slack_sdk.web.client.WebClient">WebClient</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.oauth.token_rotation.rotator.TokenRotator.client_id"><code class="name">var <span class="ident">client_id</span> : str</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="slack_sdk.oauth.token_rotation.rotator.TokenRotator.client_secret"><code class="name">var <span class="ident">client_secret</span> : str</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="slack_sdk.oauth.token_rotation.rotator.TokenRotator.perform_bot_token_rotation"><code class="name flex">
+<span>def <span class="ident">perform_bot_token_rotation</span></span>(<span>self, *, bot: <a title="slack_sdk.oauth.installation_store.models.bot.Bot" href="../installation_store/models/bot.html#slack_sdk.oauth.installation_store.models.bot.Bot">Bot</a>, minutes_before_expiration: int = 120) ‑> Optional[<a title="slack_sdk.oauth.installation_store.models.bot.Bot" href="../installation_store/models/bot.html#slack_sdk.oauth.installation_store.models.bot.Bot">Bot</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Performs bot token rotation if the underlying bot token is expired / expiring.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>bot</code></strong></dt>
+<dd>the current bot installation data</dd>
+<dt><strong><code>minutes_before_expiration</code></strong></dt>
+<dd>the minutes before the token expiration</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>None if no rotation is necessary for now.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def perform_bot_token_rotation(
+    self,
+    *,
+    bot: Bot,
+    minutes_before_expiration: int = 120,  # 2 hours by default
+) -&gt; Optional[Bot]:
+    &#34;&#34;&#34;Performs bot token rotation if the underlying bot token is expired / expiring.
+
+    Args:
+        bot: the current bot installation data
+        minutes_before_expiration: the minutes before the token expiration
+
+    Returns:
+        None if no rotation is necessary for now.
+    &#34;&#34;&#34;
+    if bot.bot_token_expires_at is None:
+        return None
+    if bot.bot_token_expires_at &gt; time() + minutes_before_expiration * 60:
+        return None
+
+    try:
+        refresh_response = self.client.oauth_v2_access(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            grant_type=&#34;refresh_token&#34;,
+            refresh_token=bot.bot_refresh_token,
+        )
+        if refresh_response.get(&#34;token_type&#34;) != &#34;bot&#34;:
+            return None
+
+        refreshed_bot = Bot(**bot.to_dict())
+        refreshed_bot.bot_token = refresh_response.get(&#34;access_token&#34;)
+        refreshed_bot.bot_refresh_token = refresh_response.get(&#34;refresh_token&#34;)
+        refreshed_bot.bot_token_expires_at = int(time()) + int(
+            refresh_response.get(&#34;expires_in&#34;)
+        )
+        return refreshed_bot
+
+    except SlackApiError as e:
+        raise SlackTokenRotationError(e)</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.oauth.token_rotation.rotator.TokenRotator.perform_token_rotation"><code class="name flex">
+<span>def <span class="ident">perform_token_rotation</span></span>(<span>self, *, installation: <a title="slack_sdk.oauth.installation_store.models.installation.Installation" href="../installation_store/models/installation.html#slack_sdk.oauth.installation_store.models.installation.Installation">Installation</a>, minutes_before_expiration: int = 120) ‑> Optional[<a title="slack_sdk.oauth.installation_store.models.installation.Installation" href="../installation_store/models/installation.html#slack_sdk.oauth.installation_store.models.installation.Installation">Installation</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Performs token rotation if the underlying tokens (bot / user) are expired / expiring.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>installation</code></strong></dt>
+<dd>the current installation data</dd>
+<dt><strong><code>minutes_before_expiration</code></strong></dt>
+<dd>the minutes before the token expiration</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>None if no rotation is necessary for now.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def perform_token_rotation(
+    self,
+    *,
+    installation: Installation,
+    minutes_before_expiration: int = 120,  # 2 hours by default
+) -&gt; Optional[Installation]:
+    &#34;&#34;&#34;Performs token rotation if the underlying tokens (bot / user) are expired / expiring.
+
+    Args:
+        installation: the current installation data
+        minutes_before_expiration: the minutes before the token expiration
+
+    Returns:
+        None if no rotation is necessary for now.
+    &#34;&#34;&#34;
+
+    # TODO: make the following two calls in parallel for better performance
+
+    # bot
+    rotated_bot: Optional[Bot] = self.perform_bot_token_rotation(
+        bot=installation.to_bot(),
+        minutes_before_expiration=minutes_before_expiration,
+    )
+
+    # user
+    rotated_installation: Optional[Installation] = self.perform_user_token_rotation(
+        installation=installation,
+        minutes_before_expiration=minutes_before_expiration,
+    )
+
+    if rotated_bot is not None:
+        if rotated_installation is None:
+            rotated_installation = Installation(**installation.to_dict())
+        rotated_installation.bot_token = rotated_bot.bot_token
+        rotated_installation.bot_refresh_token = rotated_bot.bot_refresh_token
+        rotated_installation.bot_token_expires_at = rotated_bot.bot_token_expires_at
+
+    return rotated_installation</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.oauth.token_rotation.rotator.TokenRotator.perform_user_token_rotation"><code class="name flex">
+<span>def <span class="ident">perform_user_token_rotation</span></span>(<span>self, *, installation: <a title="slack_sdk.oauth.installation_store.models.installation.Installation" href="../installation_store/models/installation.html#slack_sdk.oauth.installation_store.models.installation.Installation">Installation</a>, minutes_before_expiration: int = 120) ‑> Optional[<a title="slack_sdk.oauth.installation_store.models.bot.Bot" href="../installation_store/models/bot.html#slack_sdk.oauth.installation_store.models.bot.Bot">Bot</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Performs user token rotation if the underlying user token is expired / expiring.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>installation</code></strong></dt>
+<dd>the current installation data</dd>
+<dt><strong><code>minutes_before_expiration</code></strong></dt>
+<dd>the minutes before the token expiration</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>None if no rotation is necessary for now.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def perform_user_token_rotation(
+    self,
+    *,
+    installation: Installation,
+    minutes_before_expiration: int = 120,  # 2 hours by default
+) -&gt; Optional[Bot]:
+    &#34;&#34;&#34;Performs user token rotation if the underlying user token is expired / expiring.
+
+    Args:
+        installation: the current installation data
+        minutes_before_expiration: the minutes before the token expiration
+
+    Returns:
+        None if no rotation is necessary for now.
+    &#34;&#34;&#34;
+    if installation.user_token_expires_at is None:
+        return None
+    if installation.user_token_expires_at &gt; time() + minutes_before_expiration * 60:
+        return None
+
+    try:
+        refresh_response = self.client.oauth_v2_access(
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            grant_type=&#34;refresh_token&#34;,
+            refresh_token=installation.user_refresh_token,
+        )
+
+        if refresh_response.get(&#34;token_type&#34;) != &#34;user&#34;:
+            return None
+
+        refreshed_installation = Installation(**installation.to_dict())
+        refreshed_installation.user_token = refresh_response.get(&#34;access_token&#34;)
+        refreshed_installation.user_refresh_token = refresh_response.get(
+            &#34;refresh_token&#34;
+        )
+        refreshed_installation.user_token_expires_at = int(time()) + int(
+            refresh_response.get(&#34;expires_in&#34;)
+        )
+        return refreshed_installation
+
+    except SlackApiError as e:
+        raise SlackTokenRotationError(e)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="slack_sdk.oauth.token_rotation" href="index.html">slack_sdk.oauth.token_rotation</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="slack_sdk.oauth.token_rotation.rotator.TokenRotator" href="#slack_sdk.oauth.token_rotation.rotator.TokenRotator">TokenRotator</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.oauth.token_rotation.rotator.TokenRotator.client" href="#slack_sdk.oauth.token_rotation.rotator.TokenRotator.client">client</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.rotator.TokenRotator.client_id" href="#slack_sdk.oauth.token_rotation.rotator.TokenRotator.client_id">client_id</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.rotator.TokenRotator.client_secret" href="#slack_sdk.oauth.token_rotation.rotator.TokenRotator.client_secret">client_secret</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.rotator.TokenRotator.perform_bot_token_rotation" href="#slack_sdk.oauth.token_rotation.rotator.TokenRotator.perform_bot_token_rotation">perform_bot_token_rotation</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.rotator.TokenRotator.perform_token_rotation" href="#slack_sdk.oauth.token_rotation.rotator.TokenRotator.perform_token_rotation">perform_token_rotation</a></code></li>
+<li><code><a title="slack_sdk.oauth.token_rotation.rotator.TokenRotator.perform_user_token_rotation" href="#slack_sdk.oauth.token_rotation.rotator.TokenRotator.perform_user_token_rotation">perform_user_token_rotation</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/api-docs/slack_sdk/socket_mode/builtin/internals.html
+++ b/docs/api-docs/slack_sdk/socket_mode/builtin/internals.html
@@ -79,20 +79,11 @@ def _establish_new_socket_connection(
     if proxy is not None:
         parsed_proxy = urlparse(proxy)
         proxy_host, proxy_port = parsed_proxy.hostname, parsed_proxy.port or 80
-        proxy_addr = socket.getaddrinfo(
-            proxy_host,
-            proxy_port,
-            0,
-            socket.SOCK_STREAM,
-            socket.SOL_TCP,
-        )[0]
-        sock = socket.socket(proxy_addr[0], proxy_addr[1], proxy_addr[2])
+        sock = socket.create_connection((proxy_host, proxy_port), receive_timeout)
         if hasattr(socket, &#34;TCP_NODELAY&#34;):
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         if hasattr(socket, &#34;SO_KEEPALIVE&#34;):
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-        sock.settimeout(receive_timeout)
-        sock.connect(proxy_addr[4])  # proxy address
         message = [f&#34;CONNECT {server_hostname}:{server_port} HTTP/1.0&#34;]
         if parsed_proxy.username is not None and parsed_proxy.password is not None:
             # In the case where the proxy is &#34;http://{username}:{password}@{hostname}:{port}&#34;
@@ -118,7 +109,7 @@ def _establish_new_socket_connection(
                 f&#34;Failed to connect to the proxy (proxy: {proxy}, connect status code: {status})&#34;
             )
 
-        sock = ssl.SSLContext(ssl.PROTOCOL_SSLv23).wrap_socket(
+        sock = ssl.create_default_context().wrap_socket(
             sock,
             do_handshake_on_connect=True,
             suppress_ragged_eofs=True,
@@ -127,27 +118,20 @@ def _establish_new_socket_connection(
         return sock
 
     if server_port != 443:
-        addr = socket.getaddrinfo(
-            server_hostname, server_port, 0, socket.SOCK_STREAM, socket.SOL_TCP
-        )[0]
         # only for library testing
         logger.info(
             f&#34;Using non-ssl socket to connect ({server_hostname}:{server_port})&#34;
         )
-        sock = Socket(addr[0], addr[1], addr[2])
-        sock.settimeout(3)
-        sock.connect((server_hostname, server_port))
+        sock = socket.create_connection((server_hostname, server_port), timeout=3)
         return sock
 
-    sock = Socket(type=ssl.SOCK_STREAM)
-    sock = ssl.SSLContext(ssl.PROTOCOL_SSLv23).wrap_socket(
+    sock = socket.create_connection((server_hostname, server_port), receive_timeout)
+    sock = ssl.create_default_context().wrap_socket(
         sock,
         do_handshake_on_connect=True,
         suppress_ragged_eofs=True,
         server_hostname=server_hostname,
     )
-    sock.settimeout(receive_timeout)
-    sock.connect((server_hostname, server_port))
     return sock
 
 

--- a/docs/api-docs/slack_sdk/socket_mode/interval_runner.html
+++ b/docs/api-docs/slack_sdk/socket_mode/interval_runner.html
@@ -27,7 +27,6 @@
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">import threading
-import time
 from threading import Thread, Event
 from typing import Callable
 
@@ -46,7 +45,7 @@ class IntervalRunner:
     def _run(self) -&gt; None:
         while not self.event.is_set():
             self.target()
-            time.sleep(self.interval_seconds)
+            self.event.wait(self.interval_seconds)
 
     def start(self) -&gt; &#34;IntervalRunner&#34;:
         self.thread.start()
@@ -95,7 +94,7 @@ class IntervalRunner:
     def _run(self) -&gt; None:
         while not self.event.is_set():
             self.target()
-            time.sleep(self.interval_seconds)
+            self.event.wait(self.interval_seconds)
 
     def start(self) -&gt; &#34;IntervalRunner&#34;:
         self.thread.start()

--- a/docs/api-docs/slack_sdk/socket_mode/websockets/index.html
+++ b/docs/api-docs/slack_sdk/socket_mode/websockets/index.html
@@ -411,7 +411,7 @@ class SocketModeClient(AsyncBaseSocketModeClient):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="slack_sdk.socket_mode.websockets.SocketModeClient.current_session"><code class="name">var <span class="ident">current_session</span> : Optional[websockets.client.WebSocketClientProtocol]</code></dt>
+<dt id="slack_sdk.socket_mode.websockets.SocketModeClient.current_session"><code class="name">var <span class="ident">current_session</span> : Optional[websockets.legacy.client.WebSocketClientProtocol]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>

--- a/docs/api-docs/slack_sdk/web/async_client.html
+++ b/docs/api-docs/slack_sdk/web/async_client.html
@@ -211,6 +211,65 @@ class AsyncWebClient(AsyncBaseClient):
             &#34;admin.apps.uninstall&#34;, http_verb=&#34;POST&#34;, params=kwargs
         )
 
+    async def admin_auth_policy_getEntities(
+        self,
+        *,
+        policy_name: str,
+        cursor: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.&#34;&#34;&#34;
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        if cursor is not None:
+            kwargs.update({&#34;cursor&#34;: cursor})
+        if entity_type is not None:
+            kwargs.update({&#34;entity_type&#34;: entity_type})
+        if limit is not None:
+            kwargs.update({&#34;limit&#34;: limit})
+        return await self.api_call(
+            &#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    async def admin_auth_policy_assignEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Assign entities to a particular authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return await self.api_call(
+            &#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    async def admin_auth_policy_removeEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Remove specified entities from a specified authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return await self.api_call(
+            &#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
     async def admin_barriers_create(
         self,
         *,
@@ -363,7 +422,7 @@ class AsyncWebClient(AsyncBaseClient):
 
     async def admin_conversations_search(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.&#34;&#34;&#34;
-        return await self.api_call(&#34;admin.conversations.search&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)
 
     async def admin_conversations_convertToPrivate(
         self, *, channel_id: str, **kwargs
@@ -508,7 +567,7 @@ class AsyncWebClient(AsyncBaseClient):
 
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
-        return await self.api_call(&#34;admin.conversations.getTeams&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)
 
     async def admin_emoji_add(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add an emoji.&#34;&#34;&#34;
@@ -591,7 +650,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return await self.api_call(&#34;admin.users.session.getSettings&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.users.session.getSettings&#34;, params=kwargs)
 
     async def admin_users_session_setSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -606,7 +665,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return await self.api_call(&#34;admin.users.session.setSettings&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.users.session.setSettings&#34;, params=kwargs)
 
     async def admin_users_session_clearSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -621,7 +680,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return await self.api_call(&#34;admin.users.session.clearSettings&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.users.session.clearSettings&#34;, params=kwargs)
 
     async def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
@@ -638,11 +697,11 @@ class AsyncWebClient(AsyncBaseClient):
 
     async def admin_inviteRequests_approved_list(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all approved workspace invite requests.&#34;&#34;&#34;
-        return await self.api_call(&#34;admin.inviteRequests.approved.list&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)
 
     async def admin_inviteRequests_denied_list(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all denied workspace invite requests.&#34;&#34;&#34;
-        return await self.api_call(&#34;admin.inviteRequests.denied.list&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)
 
     async def admin_inviteRequests_deny(
         self, *, invite_request_id: str, **kwargs
@@ -657,7 +716,7 @@ class AsyncWebClient(AsyncBaseClient):
 
     async def admin_inviteRequests_list(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all pending workspace invite requests.&#34;&#34;&#34;
-        return await self.api_call(&#34;admin.inviteRequests.list&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.inviteRequests.list&#34;, params=kwargs)
 
     async def admin_teams_admins_list(
         self, *, team_id: str, **kwargs
@@ -686,7 +745,7 @@ class AsyncWebClient(AsyncBaseClient):
 
     async def admin_teams_list(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all teams on an Enterprise organization.&#34;&#34;&#34;
-        return await self.api_call(&#34;admin.teams.list&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
 
     async def admin_teams_owners_list(
         self, *, team_id: str, **kwargs
@@ -785,7 +844,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return await self.api_call(&#34;admin.usergroups.addChannels&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)
 
     async def admin_usergroups_addTeams(
         self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
@@ -803,7 +862,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({&#34;team_ids&#34;: &#34;,&#34;.join(team_ids)})
         else:
             kwargs.update({&#34;team_ids&#34;: team_ids})
-        return await self.api_call(&#34;admin.usergroups.addTeams&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)
 
     async def admin_usergroups_listChannels(
         self, *, usergroup_id: str, **kwargs
@@ -830,7 +889,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return await self.api_call(&#34;admin.usergroups.removeChannels&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)
 
     async def admin_users_assign(
         self, *, team_id: str, user_id: str, **kwargs
@@ -865,7 +924,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return await self.api_call(&#34;admin.users.invite&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.users.invite&#34;, params=kwargs)
 
     async def admin_users_list(self, *, team_id: str, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List users on a workspace
@@ -874,7 +933,7 @@ class AsyncWebClient(AsyncBaseClient):
             team_id (str): ID of the team. e.g. &#39;T1234&#39;
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
-        return await self.api_call(&#34;admin.users.list&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.users.list&#34;, params=kwargs)
 
     async def admin_users_remove(
         self, *, team_id: str, user_id: str, **kwargs
@@ -1362,7 +1421,7 @@ class AsyncWebClient(AsyncBaseClient):
 
     async def chat_scheduledMessages_list(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists all scheduled messages.&#34;&#34;&#34;
-        return await self.api_call(&#34;chat.scheduledMessages.list&#34;, json=kwargs)
+        return await self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)
 
     async def conversations_archive(
         self, *, channel: str, **kwargs
@@ -1431,7 +1490,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return await self.api_call(&#34;conversations.invite&#34;, json=kwargs)
+        return await self.api_call(&#34;conversations.invite&#34;, params=kwargs)
 
     async def conversations_join(self, *, channel: str, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Joins an existing conversation.
@@ -2051,7 +2110,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return await self.api_call(&#34;mpim.open&#34;, json=kwargs)
+        return await self.api_call(&#34;mpim.open&#34;, params=kwargs)
 
     async def mpim_replies(
         self, *, channel: str, thread_ts: str, **kwargs
@@ -2073,8 +2132,14 @@ class AsyncWebClient(AsyncBaseClient):
         *,
         client_id: str,
         client_secret: str,
-        code: str,
+        # This field is required when processing the OAuth redirect URL requests
+        # while it&#39;s absent for token rotation
+        code: Optional[str] = None,
         redirect_uri: Optional[str] = None,
+        # This field is required for token rotation
+        grant_type: Optional[str] = None,
+        # This field is required for token rotation
+        refresh_token: Optional[str] = None,
         **kwargs
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
@@ -2085,10 +2150,17 @@ class AsyncWebClient(AsyncBaseClient):
             code (str): The code param returned via the OAuth callback. e.g. &#39;ccdaa72ad&#39;
             redirect_uri (optional str): Must match the originally submitted URI
                 (if one was sent). e.g. &#39;https://example.com&#39;
+            grant_type: The grant type. The possible value is only &#39;refresh_token&#39; as of July 2021.
+            refresh_token: The refresh token for token rotation.
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
-        kwargs.update({&#34;code&#34;: code})
+        if code is not None:
+            kwargs.update({&#34;code&#34;: code})
+        if grant_type is not None:
+            kwargs.update({&#34;grant_type&#34;: grant_type})
+        if refresh_token is not None:
+            kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return await self.api_call(
             &#34;oauth.v2.access&#34;,
             data=kwargs,
@@ -2121,6 +2193,21 @@ class AsyncWebClient(AsyncBaseClient):
             data=kwargs,
             auth={&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret},
         )
+
+    async def oauth_v2_exchange(
+        self, *, token: str, client_id: str, client_secret: str, **kwargs
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
+
+        Args:
+            token: The legacy xoxb or xoxp token being migrated to use token rotation.
+            client_id: Issued when you created your application.
+            client_secret: Issued when you created your application.
+        &#34;&#34;&#34;
+        kwargs.update(
+            {&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token}
+        )
+        return await self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
 
     async def pins_add(self, *, channel: str, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Pins an item to a channel.
@@ -2401,7 +2488,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return await self.api_call(&#34;usergroups.users.update&#34;, json=kwargs)
+        return await self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)
 
     async def users_conversations(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List conversations the calling user may access.&#34;&#34;&#34;
@@ -2865,6 +2952,65 @@ removed at anytime.</p></div>
             &#34;admin.apps.uninstall&#34;, http_verb=&#34;POST&#34;, params=kwargs
         )
 
+    async def admin_auth_policy_getEntities(
+        self,
+        *,
+        policy_name: str,
+        cursor: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.&#34;&#34;&#34;
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        if cursor is not None:
+            kwargs.update({&#34;cursor&#34;: cursor})
+        if entity_type is not None:
+            kwargs.update({&#34;entity_type&#34;: entity_type})
+        if limit is not None:
+            kwargs.update({&#34;limit&#34;: limit})
+        return await self.api_call(
+            &#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    async def admin_auth_policy_assignEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Assign entities to a particular authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return await self.api_call(
+            &#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    async def admin_auth_policy_removeEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Remove specified entities from a specified authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return await self.api_call(
+            &#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
     async def admin_barriers_create(
         self,
         *,
@@ -3017,7 +3163,7 @@ removed at anytime.</p></div>
 
     async def admin_conversations_search(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.&#34;&#34;&#34;
-        return await self.api_call(&#34;admin.conversations.search&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)
 
     async def admin_conversations_convertToPrivate(
         self, *, channel_id: str, **kwargs
@@ -3162,7 +3308,7 @@ removed at anytime.</p></div>
 
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
-        return await self.api_call(&#34;admin.conversations.getTeams&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)
 
     async def admin_emoji_add(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add an emoji.&#34;&#34;&#34;
@@ -3245,7 +3391,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return await self.api_call(&#34;admin.users.session.getSettings&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.users.session.getSettings&#34;, params=kwargs)
 
     async def admin_users_session_setSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -3260,7 +3406,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return await self.api_call(&#34;admin.users.session.setSettings&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.users.session.setSettings&#34;, params=kwargs)
 
     async def admin_users_session_clearSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -3275,7 +3421,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return await self.api_call(&#34;admin.users.session.clearSettings&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.users.session.clearSettings&#34;, params=kwargs)
 
     async def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
@@ -3292,11 +3438,11 @@ removed at anytime.</p></div>
 
     async def admin_inviteRequests_approved_list(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all approved workspace invite requests.&#34;&#34;&#34;
-        return await self.api_call(&#34;admin.inviteRequests.approved.list&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)
 
     async def admin_inviteRequests_denied_list(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all denied workspace invite requests.&#34;&#34;&#34;
-        return await self.api_call(&#34;admin.inviteRequests.denied.list&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)
 
     async def admin_inviteRequests_deny(
         self, *, invite_request_id: str, **kwargs
@@ -3311,7 +3457,7 @@ removed at anytime.</p></div>
 
     async def admin_inviteRequests_list(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all pending workspace invite requests.&#34;&#34;&#34;
-        return await self.api_call(&#34;admin.inviteRequests.list&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.inviteRequests.list&#34;, params=kwargs)
 
     async def admin_teams_admins_list(
         self, *, team_id: str, **kwargs
@@ -3340,7 +3486,7 @@ removed at anytime.</p></div>
 
     async def admin_teams_list(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all teams on an Enterprise organization.&#34;&#34;&#34;
-        return await self.api_call(&#34;admin.teams.list&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
 
     async def admin_teams_owners_list(
         self, *, team_id: str, **kwargs
@@ -3439,7 +3585,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return await self.api_call(&#34;admin.usergroups.addChannels&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)
 
     async def admin_usergroups_addTeams(
         self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
@@ -3457,7 +3603,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;team_ids&#34;: &#34;,&#34;.join(team_ids)})
         else:
             kwargs.update({&#34;team_ids&#34;: team_ids})
-        return await self.api_call(&#34;admin.usergroups.addTeams&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)
 
     async def admin_usergroups_listChannels(
         self, *, usergroup_id: str, **kwargs
@@ -3484,7 +3630,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return await self.api_call(&#34;admin.usergroups.removeChannels&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)
 
     async def admin_users_assign(
         self, *, team_id: str, user_id: str, **kwargs
@@ -3519,7 +3665,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return await self.api_call(&#34;admin.users.invite&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.users.invite&#34;, params=kwargs)
 
     async def admin_users_list(self, *, team_id: str, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List users on a workspace
@@ -3528,7 +3674,7 @@ removed at anytime.</p></div>
             team_id (str): ID of the team. e.g. &#39;T1234&#39;
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
-        return await self.api_call(&#34;admin.users.list&#34;, json=kwargs)
+        return await self.api_call(&#34;admin.users.list&#34;, params=kwargs)
 
     async def admin_users_remove(
         self, *, team_id: str, user_id: str, **kwargs
@@ -4016,7 +4162,7 @@ removed at anytime.</p></div>
 
     async def chat_scheduledMessages_list(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists all scheduled messages.&#34;&#34;&#34;
-        return await self.api_call(&#34;chat.scheduledMessages.list&#34;, json=kwargs)
+        return await self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)
 
     async def conversations_archive(
         self, *, channel: str, **kwargs
@@ -4085,7 +4231,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return await self.api_call(&#34;conversations.invite&#34;, json=kwargs)
+        return await self.api_call(&#34;conversations.invite&#34;, params=kwargs)
 
     async def conversations_join(self, *, channel: str, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Joins an existing conversation.
@@ -4705,7 +4851,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return await self.api_call(&#34;mpim.open&#34;, json=kwargs)
+        return await self.api_call(&#34;mpim.open&#34;, params=kwargs)
 
     async def mpim_replies(
         self, *, channel: str, thread_ts: str, **kwargs
@@ -4727,8 +4873,14 @@ removed at anytime.</p></div>
         *,
         client_id: str,
         client_secret: str,
-        code: str,
+        # This field is required when processing the OAuth redirect URL requests
+        # while it&#39;s absent for token rotation
+        code: Optional[str] = None,
         redirect_uri: Optional[str] = None,
+        # This field is required for token rotation
+        grant_type: Optional[str] = None,
+        # This field is required for token rotation
+        refresh_token: Optional[str] = None,
         **kwargs
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
@@ -4739,10 +4891,17 @@ removed at anytime.</p></div>
             code (str): The code param returned via the OAuth callback. e.g. &#39;ccdaa72ad&#39;
             redirect_uri (optional str): Must match the originally submitted URI
                 (if one was sent). e.g. &#39;https://example.com&#39;
+            grant_type: The grant type. The possible value is only &#39;refresh_token&#39; as of July 2021.
+            refresh_token: The refresh token for token rotation.
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
-        kwargs.update({&#34;code&#34;: code})
+        if code is not None:
+            kwargs.update({&#34;code&#34;: code})
+        if grant_type is not None:
+            kwargs.update({&#34;grant_type&#34;: grant_type})
+        if refresh_token is not None:
+            kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return await self.api_call(
             &#34;oauth.v2.access&#34;,
             data=kwargs,
@@ -4775,6 +4934,21 @@ removed at anytime.</p></div>
             data=kwargs,
             auth={&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret},
         )
+
+    async def oauth_v2_exchange(
+        self, *, token: str, client_id: str, client_secret: str, **kwargs
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
+
+        Args:
+            token: The legacy xoxb or xoxp token being migrated to use token rotation.
+            client_id: Issued when you created your application.
+            client_secret: Issued when you created your application.
+        &#34;&#34;&#34;
+        kwargs.update(
+            {&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token}
+        )
+        return await self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
 
     async def pins_add(self, *, channel: str, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Pins an item to a channel.
@@ -5055,7 +5229,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return await self.api_call(&#34;usergroups.users.update&#34;, json=kwargs)
+        return await self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)
 
     async def users_conversations(self, **kwargs) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List conversations the calling user may access.&#34;&#34;&#34;
@@ -5513,6 +5687,95 @@ or by the admin.apps.requests.list method.</p>
     )</code></pre>
 </details>
 </dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_assignEntities"><code class="name flex">
+<span>async def <span class="ident">admin_auth_policy_assignEntities</span></span>(<span>self, *, entity_ids: Union[str, Sequence[str]], policy_name: str, entity_type: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Assign entities to a particular authentication policy.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def admin_auth_policy_assignEntities(
+    self,
+    *,
+    entity_ids: Union[str, Sequence[str]],
+    policy_name: str,
+    entity_type: str,
+    **kwargs
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Assign entities to a particular authentication policy.&#34;&#34;&#34;
+    if isinstance(entity_ids, (list, Tuple)):
+        kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+    else:
+        kwargs.update({&#34;entity_ids&#34;: entity_ids})
+    kwargs.update({&#34;policy_name&#34;: policy_name})
+    kwargs.update({&#34;entity_type&#34;: entity_type})
+    return await self.api_call(
+        &#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+    )</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_getEntities"><code class="name flex">
+<span>async def <span class="ident">admin_auth_policy_getEntities</span></span>(<span>self, *, policy_name: str, cursor: Optional[str] = None, entity_type: Optional[str] = None, limit: Optional[int] = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Fetch all the entities assigned to a particular authentication policy by name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def admin_auth_policy_getEntities(
+    self,
+    *,
+    policy_name: str,
+    cursor: Optional[str] = None,
+    entity_type: Optional[str] = None,
+    limit: Optional[int] = None,
+    **kwargs
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.&#34;&#34;&#34;
+    kwargs.update({&#34;policy_name&#34;: policy_name})
+    if cursor is not None:
+        kwargs.update({&#34;cursor&#34;: cursor})
+    if entity_type is not None:
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+    if limit is not None:
+        kwargs.update({&#34;limit&#34;: limit})
+    return await self.api_call(
+        &#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+    )</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_removeEntities"><code class="name flex">
+<span>async def <span class="ident">admin_auth_policy_removeEntities</span></span>(<span>self, *, entity_ids: Union[str, Sequence[str]], policy_name: str, entity_type: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Remove specified entities from a specified authentication policy.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def admin_auth_policy_removeEntities(
+    self,
+    *,
+    entity_ids: Union[str, Sequence[str]],
+    policy_name: str,
+    entity_type: str,
+    **kwargs
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Remove specified entities from a specified authentication policy.&#34;&#34;&#34;
+    if isinstance(entity_ids, (list, Tuple)):
+        kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+    else:
+        kwargs.update({&#34;entity_ids&#34;: entity_ids})
+    kwargs.update({&#34;policy_name&#34;: policy_name})
+    kwargs.update({&#34;entity_type&#34;: entity_type})
+    return await self.api_call(
+        &#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+    )</code></pre>
+</details>
+</dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_barriers_create"><code class="name flex">
 <span>async def <span class="ident">admin_barriers_create</span></span>(<span>self, *, barriered_from_usergroup_ids: Union[str, Sequence[str]], primary_usergroup_id: str, restricted_subjects: Union[str, Sequence[str]], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
@@ -5843,7 +6106,7 @@ the corresponding original channel IDs for key revocation with EKM.</p></div>
 
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
-    return await self.api_call(&#34;admin.conversations.getTeams&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_invite"><code class="name flex">
@@ -6045,7 +6308,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">async def admin_conversations_search(self, **kwargs) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.&#34;&#34;&#34;
-    return await self.api_call(&#34;admin.conversations.search&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_setConversationPrefs"><code class="name flex">
@@ -6244,7 +6507,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">async def admin_inviteRequests_approved_list(self, **kwargs) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all approved workspace invite requests.&#34;&#34;&#34;
-    return await self.api_call(&#34;admin.inviteRequests.approved.list&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_inviteRequests_denied_list"><code class="name flex">
@@ -6258,7 +6521,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">async def admin_inviteRequests_denied_list(self, **kwargs) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all denied workspace invite requests.&#34;&#34;&#34;
-    return await self.api_call(&#34;admin.inviteRequests.denied.list&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_inviteRequests_deny"><code class="name flex">
@@ -6298,7 +6561,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">async def admin_inviteRequests_list(self, **kwargs) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all pending workspace invite requests.&#34;&#34;&#34;
-    return await self.api_call(&#34;admin.inviteRequests.list&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.inviteRequests.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_admins_list"><code class="name flex">
@@ -6369,7 +6632,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">async def admin_teams_list(self, **kwargs) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all teams on an Enterprise organization.&#34;&#34;&#34;
-    return await self.api_call(&#34;admin.teams.list&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_owners_list"><code class="name flex">
@@ -6623,7 +6886,7 @@ It must be set to one of open, invite_only, closed, or unlisted.</dd>
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
     else:
         kwargs.update({&#34;channel_ids&#34;: channel_ids})
-    return await self.api_call(&#34;admin.usergroups.addChannels&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_usergroups_addTeams"><code class="name flex">
@@ -6660,7 +6923,7 @@ e.g. 'T12345678,T98765432' or ['T12345678', 'T98765432']</dd>
         kwargs.update({&#34;team_ids&#34;: &#34;,&#34;.join(team_ids)})
     else:
         kwargs.update({&#34;team_ids&#34;: team_ids})
-    return await self.api_call(&#34;admin.usergroups.addTeams&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_usergroups_listChannels"><code class="name flex">
@@ -6719,7 +6982,7 @@ e.g. 'T12345678,T98765432' or ['T12345678', 'T98765432']</dd>
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
     else:
         kwargs.update({&#34;channel_ids&#34;: channel_ids})
-    return await self.api_call(&#34;admin.usergroups.removeChannels&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_assign"><code class="name flex">
@@ -6791,7 +7054,7 @@ At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']</dd>
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
     else:
         kwargs.update({&#34;channel_ids&#34;: channel_ids})
-    return await self.api_call(&#34;admin.users.invite&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.users.invite&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_list"><code class="name flex">
@@ -6815,7 +7078,7 @@ At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']</dd>
         team_id (str): ID of the team. e.g. &#39;T1234&#39;
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
-    return await self.api_call(&#34;admin.users.list&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.users.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_remove"><code class="name flex">
@@ -6875,7 +7138,7 @@ and what happens when the client closes—for a list of users.</p>
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
     else:
         kwargs.update({&#34;user_ids&#34;: user_ids})
-    return await self.api_call(&#34;admin.users.session.clearSettings&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.users.session.clearSettings&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_session_getSettings"><code class="name flex">
@@ -6908,7 +7171,7 @@ Note: if a user does not have any active sessions, they will not be returned in 
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
     else:
         kwargs.update({&#34;user_ids&#34;: user_ids})
-    return await self.api_call(&#34;admin.users.session.getSettings&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.users.session.getSettings&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_session_invalidate"><code class="name flex">
@@ -7007,7 +7270,7 @@ and what happens when the client closes—for one or more users.</p>
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
     else:
         kwargs.update({&#34;user_ids&#34;: user_ids})
-    return await self.api_call(&#34;admin.users.session.setSettings&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;admin.users.session.setSettings&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_setAdmin"><code class="name flex">
@@ -8080,7 +8343,7 @@ e.g. [{"type": "section", "text": {"type": "plain_text", "text": "Hello world"}}
 </summary>
 <pre><code class="python">async def chat_scheduledMessages_list(self, **kwargs) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists all scheduled messages.&#34;&#34;&#34;
-    return await self.api_call(&#34;chat.scheduledMessages.list&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_unfurl"><code class="name flex">
@@ -8318,7 +8581,7 @@ e.g. [{"type": "section", "text": {"type": "plain_text", "text": "Hello world"}}
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
     else:
         kwargs.update({&#34;users&#34;: users})
-    return await self.api_call(&#34;conversations.invite&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_join"><code class="name flex">
@@ -9844,7 +10107,7 @@ e.g. ['W1234567890', 'U2345678901', 'U3456789012']</dd>
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
     else:
         kwargs.update({&#34;users&#34;: users})
-    return await self.api_call(&#34;mpim.open&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;mpim.open&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.mpim_replies"><code class="name flex">
@@ -9932,7 +10195,7 @@ e.g. '1234567890.123456'</dd>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.oauth_v2_access"><code class="name flex">
-<span>async def <span class="ident">oauth_v2_access</span></span>(<span>self, *, client_id: str, client_secret: str, code: str, redirect_uri: Optional[str] = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">oauth_v2_access</span></span>(<span>self, *, client_id: str, client_secret: str, code: Optional[str] = None, redirect_uri: Optional[str] = None, grant_type: Optional[str] = None, refresh_token: Optional[str] = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.</p>
@@ -9947,6 +10210,10 @@ e.g. '1234567890.123456'</dd>
 <dt><strong><code>redirect_uri</code></strong> :&ensp;<code>optional str</code></dt>
 <dd>Must match the originally submitted URI
 (if one was sent). e.g. 'https://example.com'</dd>
+<dt><strong><code>grant_type</code></strong></dt>
+<dd>The grant type. The possible value is only 'refresh_token' as of July 2021.</dd>
+<dt><strong><code>refresh_token</code></strong></dt>
+<dd>The refresh token for token rotation.</dd>
 </dl></div>
 <details class="source">
 <summary>
@@ -9957,8 +10224,14 @@ e.g. '1234567890.123456'</dd>
     *,
     client_id: str,
     client_secret: str,
-    code: str,
+    # This field is required when processing the OAuth redirect URL requests
+    # while it&#39;s absent for token rotation
+    code: Optional[str] = None,
     redirect_uri: Optional[str] = None,
+    # This field is required for token rotation
+    grant_type: Optional[str] = None,
+    # This field is required for token rotation
+    refresh_token: Optional[str] = None,
     **kwargs
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
@@ -9969,15 +10242,56 @@ e.g. '1234567890.123456'</dd>
         code (str): The code param returned via the OAuth callback. e.g. &#39;ccdaa72ad&#39;
         redirect_uri (optional str): Must match the originally submitted URI
             (if one was sent). e.g. &#39;https://example.com&#39;
+        grant_type: The grant type. The possible value is only &#39;refresh_token&#39; as of July 2021.
+        refresh_token: The refresh token for token rotation.
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
-    kwargs.update({&#34;code&#34;: code})
+    if code is not None:
+        kwargs.update({&#34;code&#34;: code})
+    if grant_type is not None:
+        kwargs.update({&#34;grant_type&#34;: grant_type})
+    if refresh_token is not None:
+        kwargs.update({&#34;refresh_token&#34;: refresh_token})
     return await self.api_call(
         &#34;oauth.v2.access&#34;,
         data=kwargs,
         auth={&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret},
     )</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.oauth_v2_exchange"><code class="name flex">
+<span>async def <span class="ident">oauth_v2_exchange</span></span>(<span>self, *, token: str, client_id: str, client_secret: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exchanges a legacy access token for a new expiring access token and refresh token</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>token</code></strong></dt>
+<dd>The legacy xoxb or xoxp token being migrated to use token rotation.</dd>
+<dt><strong><code>client_id</code></strong></dt>
+<dd>Issued when you created your application.</dd>
+<dt><strong><code>client_secret</code></strong></dt>
+<dd>Issued when you created your application.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def oauth_v2_exchange(
+    self, *, token: str, client_id: str, client_secret: str, **kwargs
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
+
+    Args:
+        token: The legacy xoxb or xoxp token being migrated to use token rotation.
+        client_id: Issued when you created your application.
+        client_secret: Issued when you created your application.
+    &#34;&#34;&#34;
+    kwargs.update(
+        {&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token}
+    )
+    return await self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.pins_add"><code class="name flex">
@@ -10727,7 +11041,7 @@ users for the User Group. e.g. ['U060R4BJ4', 'U060RNRCZ']</dd>
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
     else:
         kwargs.update({&#34;users&#34;: users})
-    return await self.api_call(&#34;usergroups.users.update&#34;, json=kwargs)</code></pre>
+    return await self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_conversations"><code class="name flex">
@@ -11295,6 +11609,9 @@ e.g. [{ 'type': 'text', 'name': 'title', 'label': 'Title' }]</dd>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.admin_apps_restrict" href="#slack_sdk.web.async_client.AsyncWebClient.admin_apps_restrict">admin_apps_restrict</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.admin_apps_restricted_list" href="#slack_sdk.web.async_client.AsyncWebClient.admin_apps_restricted_list">admin_apps_restricted_list</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.admin_apps_uninstall" href="#slack_sdk.web.async_client.AsyncWebClient.admin_apps_uninstall">admin_apps_uninstall</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_assignEntities" href="#slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_assignEntities">admin_auth_policy_assignEntities</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_getEntities" href="#slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_getEntities">admin_auth_policy_getEntities</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_removeEntities" href="#slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_removeEntities">admin_auth_policy_removeEntities</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.admin_barriers_create" href="#slack_sdk.web.async_client.AsyncWebClient.admin_barriers_create">admin_barriers_create</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.admin_barriers_delete" href="#slack_sdk.web.async_client.AsyncWebClient.admin_barriers_delete">admin_barriers_delete</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.admin_barriers_list" href="#slack_sdk.web.async_client.AsyncWebClient.admin_barriers_list">admin_barriers_list</a></code></li>
@@ -11461,6 +11778,7 @@ e.g. [{ 'type': 'text', 'name': 'title', 'label': 'Title' }]</dd>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.mpim_replies" href="#slack_sdk.web.async_client.AsyncWebClient.mpim_replies">mpim_replies</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.oauth_access" href="#slack_sdk.web.async_client.AsyncWebClient.oauth_access">oauth_access</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.oauth_v2_access" href="#slack_sdk.web.async_client.AsyncWebClient.oauth_v2_access">oauth_v2_access</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.oauth_v2_exchange" href="#slack_sdk.web.async_client.AsyncWebClient.oauth_v2_exchange">oauth_v2_exchange</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.pins_add" href="#slack_sdk.web.async_client.AsyncWebClient.pins_add">pins_add</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.pins_list" href="#slack_sdk.web.async_client.AsyncWebClient.pins_list">pins_list</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.pins_remove" href="#slack_sdk.web.async_client.AsyncWebClient.pins_remove">pins_remove</a></code></li>

--- a/docs/api-docs/slack_sdk/web/client.html
+++ b/docs/api-docs/slack_sdk/web/client.html
@@ -194,6 +194,65 @@ class WebClient(BaseClient):
                 kwargs.update({&#34;team_ids&#34;: team_ids})
         return self.api_call(&#34;admin.apps.uninstall&#34;, http_verb=&#34;POST&#34;, params=kwargs)
 
+    def admin_auth_policy_getEntities(
+        self,
+        *,
+        policy_name: str,
+        cursor: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.&#34;&#34;&#34;
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        if cursor is not None:
+            kwargs.update({&#34;cursor&#34;: cursor})
+        if entity_type is not None:
+            kwargs.update({&#34;entity_type&#34;: entity_type})
+        if limit is not None:
+            kwargs.update({&#34;limit&#34;: limit})
+        return self.api_call(
+            &#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    def admin_auth_policy_assignEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Assign entities to a particular authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return self.api_call(
+            &#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    def admin_auth_policy_removeEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Remove specified entities from a specified authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return self.api_call(
+            &#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
     def admin_barriers_create(
         self,
         *,
@@ -334,7 +393,7 @@ class WebClient(BaseClient):
 
     def admin_conversations_search(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.conversations.search&#34;, json=kwargs)
+        return self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)
 
     def admin_conversations_convertToPrivate(
         self, *, channel_id: str, **kwargs
@@ -475,7 +534,7 @@ class WebClient(BaseClient):
 
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
-        return self.api_call(&#34;admin.conversations.getTeams&#34;, json=kwargs)
+        return self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)
 
     def admin_emoji_add(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an emoji.&#34;&#34;&#34;
@@ -554,7 +613,7 @@ class WebClient(BaseClient):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.getSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.getSettings&#34;, params=kwargs)
 
     def admin_users_session_setSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -569,7 +628,7 @@ class WebClient(BaseClient):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.setSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.setSettings&#34;, params=kwargs)
 
     def admin_users_session_clearSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -584,7 +643,7 @@ class WebClient(BaseClient):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.clearSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.clearSettings&#34;, params=kwargs)
 
     def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
@@ -601,11 +660,11 @@ class WebClient(BaseClient):
 
     def admin_inviteRequests_approved_list(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all approved workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)
 
     def admin_inviteRequests_denied_list(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all denied workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)
 
     def admin_inviteRequests_deny(
         self, *, invite_request_id: str, **kwargs
@@ -620,7 +679,7 @@ class WebClient(BaseClient):
 
     def admin_inviteRequests_list(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all pending workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.list&#34;, params=kwargs)
 
     def admin_teams_admins_list(self, *, team_id: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
@@ -645,7 +704,7 @@ class WebClient(BaseClient):
 
     def admin_teams_list(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all teams on an Enterprise organization.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.teams.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
 
     def admin_teams_owners_list(self, *, team_id: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
@@ -736,7 +795,7 @@ class WebClient(BaseClient):
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.usergroups.addChannels&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)
 
     def admin_usergroups_addTeams(
         self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
@@ -754,7 +813,7 @@ class WebClient(BaseClient):
             kwargs.update({&#34;team_ids&#34;: &#34;,&#34;.join(team_ids)})
         else:
             kwargs.update({&#34;team_ids&#34;: team_ids})
-        return self.api_call(&#34;admin.usergroups.addTeams&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)
 
     def admin_usergroups_listChannels(
         self, *, usergroup_id: str, **kwargs
@@ -781,7 +840,7 @@ class WebClient(BaseClient):
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.usergroups.removeChannels&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)
 
     def admin_users_assign(
         self, *, team_id: str, user_id: str, **kwargs
@@ -816,7 +875,7 @@ class WebClient(BaseClient):
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.users.invite&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.invite&#34;, params=kwargs)
 
     def admin_users_list(self, *, team_id: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List users on a workspace
@@ -825,7 +884,7 @@ class WebClient(BaseClient):
             team_id (str): ID of the team. e.g. &#39;T1234&#39;
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
-        return self.api_call(&#34;admin.users.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.list&#34;, params=kwargs)
 
     def admin_users_remove(
         self, *, team_id: str, user_id: str, **kwargs
@@ -1283,7 +1342,7 @@ class WebClient(BaseClient):
 
     def chat_scheduledMessages_list(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all scheduled messages.&#34;&#34;&#34;
-        return self.api_call(&#34;chat.scheduledMessages.list&#34;, json=kwargs)
+        return self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)
 
     def conversations_archive(self, *, channel: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Archives a conversation.
@@ -1344,7 +1403,7 @@ class WebClient(BaseClient):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;conversations.invite&#34;, json=kwargs)
+        return self.api_call(&#34;conversations.invite&#34;, params=kwargs)
 
     def conversations_join(self, *, channel: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Joins an existing conversation.
@@ -1926,7 +1985,7 @@ class WebClient(BaseClient):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;mpim.open&#34;, json=kwargs)
+        return self.api_call(&#34;mpim.open&#34;, params=kwargs)
 
     def mpim_replies(self, *, channel: str, thread_ts: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a thread of messages posted to a direct message conversation from a
@@ -1946,8 +2005,14 @@ class WebClient(BaseClient):
         *,
         client_id: str,
         client_secret: str,
-        code: str,
+        # This field is required when processing the OAuth redirect URL requests
+        # while it&#39;s absent for token rotation
+        code: Optional[str] = None,
         redirect_uri: Optional[str] = None,
+        # This field is required for token rotation
+        grant_type: Optional[str] = None,
+        # This field is required for token rotation
+        refresh_token: Optional[str] = None,
         **kwargs
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
@@ -1958,10 +2023,17 @@ class WebClient(BaseClient):
             code (str): The code param returned via the OAuth callback. e.g. &#39;ccdaa72ad&#39;
             redirect_uri (optional str): Must match the originally submitted URI
                 (if one was sent). e.g. &#39;https://example.com&#39;
+            grant_type: The grant type. The possible value is only &#39;refresh_token&#39; as of July 2021.
+            refresh_token: The refresh token for token rotation.
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
-        kwargs.update({&#34;code&#34;: code})
+        if code is not None:
+            kwargs.update({&#34;code&#34;: code})
+        if grant_type is not None:
+            kwargs.update({&#34;grant_type&#34;: grant_type})
+        if refresh_token is not None:
+            kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return self.api_call(
             &#34;oauth.v2.access&#34;,
             data=kwargs,
@@ -1994,6 +2066,21 @@ class WebClient(BaseClient):
             data=kwargs,
             auth={&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret},
         )
+
+    def oauth_v2_exchange(
+        self, *, token: str, client_id: str, client_secret: str, **kwargs
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
+
+        Args:
+            token: The legacy xoxb or xoxp token being migrated to use token rotation.
+            client_id: Issued when you created your application.
+            client_secret: Issued when you created your application.
+        &#34;&#34;&#34;
+        kwargs.update(
+            {&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token}
+        )
+        return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
 
     def pins_add(self, *, channel: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Pins an item to a channel.
@@ -2258,7 +2345,7 @@ class WebClient(BaseClient):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;usergroups.users.update&#34;, json=kwargs)
+        return self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)
 
     def users_conversations(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List conversations the calling user may access.&#34;&#34;&#34;
@@ -2706,6 +2793,65 @@ removed at anytime.</p></div>
                 kwargs.update({&#34;team_ids&#34;: team_ids})
         return self.api_call(&#34;admin.apps.uninstall&#34;, http_verb=&#34;POST&#34;, params=kwargs)
 
+    def admin_auth_policy_getEntities(
+        self,
+        *,
+        policy_name: str,
+        cursor: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.&#34;&#34;&#34;
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        if cursor is not None:
+            kwargs.update({&#34;cursor&#34;: cursor})
+        if entity_type is not None:
+            kwargs.update({&#34;entity_type&#34;: entity_type})
+        if limit is not None:
+            kwargs.update({&#34;limit&#34;: limit})
+        return self.api_call(
+            &#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    def admin_auth_policy_assignEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Assign entities to a particular authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return self.api_call(
+            &#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    def admin_auth_policy_removeEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Remove specified entities from a specified authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return self.api_call(
+            &#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
     def admin_barriers_create(
         self,
         *,
@@ -2846,7 +2992,7 @@ removed at anytime.</p></div>
 
     def admin_conversations_search(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.conversations.search&#34;, json=kwargs)
+        return self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)
 
     def admin_conversations_convertToPrivate(
         self, *, channel_id: str, **kwargs
@@ -2987,7 +3133,7 @@ removed at anytime.</p></div>
 
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
-        return self.api_call(&#34;admin.conversations.getTeams&#34;, json=kwargs)
+        return self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)
 
     def admin_emoji_add(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an emoji.&#34;&#34;&#34;
@@ -3066,7 +3212,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.getSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.getSettings&#34;, params=kwargs)
 
     def admin_users_session_setSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -3081,7 +3227,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.setSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.setSettings&#34;, params=kwargs)
 
     def admin_users_session_clearSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -3096,7 +3242,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.clearSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.clearSettings&#34;, params=kwargs)
 
     def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
@@ -3113,11 +3259,11 @@ removed at anytime.</p></div>
 
     def admin_inviteRequests_approved_list(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all approved workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)
 
     def admin_inviteRequests_denied_list(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all denied workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)
 
     def admin_inviteRequests_deny(
         self, *, invite_request_id: str, **kwargs
@@ -3132,7 +3278,7 @@ removed at anytime.</p></div>
 
     def admin_inviteRequests_list(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all pending workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.list&#34;, params=kwargs)
 
     def admin_teams_admins_list(self, *, team_id: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
@@ -3157,7 +3303,7 @@ removed at anytime.</p></div>
 
     def admin_teams_list(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all teams on an Enterprise organization.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.teams.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
 
     def admin_teams_owners_list(self, *, team_id: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
@@ -3248,7 +3394,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.usergroups.addChannels&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)
 
     def admin_usergroups_addTeams(
         self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
@@ -3266,7 +3412,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;team_ids&#34;: &#34;,&#34;.join(team_ids)})
         else:
             kwargs.update({&#34;team_ids&#34;: team_ids})
-        return self.api_call(&#34;admin.usergroups.addTeams&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)
 
     def admin_usergroups_listChannels(
         self, *, usergroup_id: str, **kwargs
@@ -3293,7 +3439,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.usergroups.removeChannels&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)
 
     def admin_users_assign(
         self, *, team_id: str, user_id: str, **kwargs
@@ -3328,7 +3474,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.users.invite&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.invite&#34;, params=kwargs)
 
     def admin_users_list(self, *, team_id: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List users on a workspace
@@ -3337,7 +3483,7 @@ removed at anytime.</p></div>
             team_id (str): ID of the team. e.g. &#39;T1234&#39;
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
-        return self.api_call(&#34;admin.users.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.list&#34;, params=kwargs)
 
     def admin_users_remove(
         self, *, team_id: str, user_id: str, **kwargs
@@ -3795,7 +3941,7 @@ removed at anytime.</p></div>
 
     def chat_scheduledMessages_list(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all scheduled messages.&#34;&#34;&#34;
-        return self.api_call(&#34;chat.scheduledMessages.list&#34;, json=kwargs)
+        return self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)
 
     def conversations_archive(self, *, channel: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Archives a conversation.
@@ -3856,7 +4002,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;conversations.invite&#34;, json=kwargs)
+        return self.api_call(&#34;conversations.invite&#34;, params=kwargs)
 
     def conversations_join(self, *, channel: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Joins an existing conversation.
@@ -4438,7 +4584,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;mpim.open&#34;, json=kwargs)
+        return self.api_call(&#34;mpim.open&#34;, params=kwargs)
 
     def mpim_replies(self, *, channel: str, thread_ts: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a thread of messages posted to a direct message conversation from a
@@ -4458,8 +4604,14 @@ removed at anytime.</p></div>
         *,
         client_id: str,
         client_secret: str,
-        code: str,
+        # This field is required when processing the OAuth redirect URL requests
+        # while it&#39;s absent for token rotation
+        code: Optional[str] = None,
         redirect_uri: Optional[str] = None,
+        # This field is required for token rotation
+        grant_type: Optional[str] = None,
+        # This field is required for token rotation
+        refresh_token: Optional[str] = None,
         **kwargs
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
@@ -4470,10 +4622,17 @@ removed at anytime.</p></div>
             code (str): The code param returned via the OAuth callback. e.g. &#39;ccdaa72ad&#39;
             redirect_uri (optional str): Must match the originally submitted URI
                 (if one was sent). e.g. &#39;https://example.com&#39;
+            grant_type: The grant type. The possible value is only &#39;refresh_token&#39; as of July 2021.
+            refresh_token: The refresh token for token rotation.
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
-        kwargs.update({&#34;code&#34;: code})
+        if code is not None:
+            kwargs.update({&#34;code&#34;: code})
+        if grant_type is not None:
+            kwargs.update({&#34;grant_type&#34;: grant_type})
+        if refresh_token is not None:
+            kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return self.api_call(
             &#34;oauth.v2.access&#34;,
             data=kwargs,
@@ -4506,6 +4665,21 @@ removed at anytime.</p></div>
             data=kwargs,
             auth={&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret},
         )
+
+    def oauth_v2_exchange(
+        self, *, token: str, client_id: str, client_secret: str, **kwargs
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
+
+        Args:
+            token: The legacy xoxb or xoxp token being migrated to use token rotation.
+            client_id: Issued when you created your application.
+            client_secret: Issued when you created your application.
+        &#34;&#34;&#34;
+        kwargs.update(
+            {&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token}
+        )
+        return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
 
     def pins_add(self, *, channel: str, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;Pins an item to a channel.
@@ -4770,7 +4944,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;usergroups.users.update&#34;, json=kwargs)
+        return self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)
 
     def users_conversations(self, **kwargs) -&gt; SlackResponse:
         &#34;&#34;&#34;List conversations the calling user may access.&#34;&#34;&#34;
@@ -5212,6 +5386,95 @@ or by the admin.apps.requests.list method.</p>
     return self.api_call(&#34;admin.apps.uninstall&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
+<dt id="slack_sdk.web.client.WebClient.admin_auth_policy_assignEntities"><code class="name flex">
+<span>def <span class="ident">admin_auth_policy_assignEntities</span></span>(<span>self, *, entity_ids: Union[str, Sequence[str]], policy_name: str, entity_type: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Assign entities to a particular authentication policy.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def admin_auth_policy_assignEntities(
+    self,
+    *,
+    entity_ids: Union[str, Sequence[str]],
+    policy_name: str,
+    entity_type: str,
+    **kwargs
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Assign entities to a particular authentication policy.&#34;&#34;&#34;
+    if isinstance(entity_ids, (list, Tuple)):
+        kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+    else:
+        kwargs.update({&#34;entity_ids&#34;: entity_ids})
+    kwargs.update({&#34;policy_name&#34;: policy_name})
+    kwargs.update({&#34;entity_type&#34;: entity_type})
+    return self.api_call(
+        &#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+    )</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.admin_auth_policy_getEntities"><code class="name flex">
+<span>def <span class="ident">admin_auth_policy_getEntities</span></span>(<span>self, *, policy_name: str, cursor: Optional[str] = None, entity_type: Optional[str] = None, limit: Optional[int] = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Fetch all the entities assigned to a particular authentication policy by name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def admin_auth_policy_getEntities(
+    self,
+    *,
+    policy_name: str,
+    cursor: Optional[str] = None,
+    entity_type: Optional[str] = None,
+    limit: Optional[int] = None,
+    **kwargs
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.&#34;&#34;&#34;
+    kwargs.update({&#34;policy_name&#34;: policy_name})
+    if cursor is not None:
+        kwargs.update({&#34;cursor&#34;: cursor})
+    if entity_type is not None:
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+    if limit is not None:
+        kwargs.update({&#34;limit&#34;: limit})
+    return self.api_call(
+        &#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+    )</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.admin_auth_policy_removeEntities"><code class="name flex">
+<span>def <span class="ident">admin_auth_policy_removeEntities</span></span>(<span>self, *, entity_ids: Union[str, Sequence[str]], policy_name: str, entity_type: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Remove specified entities from a specified authentication policy.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def admin_auth_policy_removeEntities(
+    self,
+    *,
+    entity_ids: Union[str, Sequence[str]],
+    policy_name: str,
+    entity_type: str,
+    **kwargs
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Remove specified entities from a specified authentication policy.&#34;&#34;&#34;
+    if isinstance(entity_ids, (list, Tuple)):
+        kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+    else:
+        kwargs.update({&#34;entity_ids&#34;: entity_ids})
+    kwargs.update({&#34;policy_name&#34;: policy_name})
+    kwargs.update({&#34;entity_type&#34;: entity_type})
+    return self.api_call(
+        &#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+    )</code></pre>
+</details>
+</dd>
 <dt id="slack_sdk.web.client.WebClient.admin_barriers_create"><code class="name flex">
 <span>def <span class="ident">admin_barriers_create</span></span>(<span>self, *, barriered_from_usergroup_ids: Union[str, Sequence[str]], primary_usergroup_id: str, restricted_subjects: Union[str, Sequence[str]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
@@ -5528,7 +5791,7 @@ the corresponding original channel IDs for key revocation with EKM.</p></div>
 
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
-    return self.api_call(&#34;admin.conversations.getTeams&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_invite"><code class="name flex">
@@ -5730,7 +5993,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">def admin_conversations_search(self, **kwargs) -&gt; SlackResponse:
     &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.&#34;&#34;&#34;
-    return self.api_call(&#34;admin.conversations.search&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_setConversationPrefs"><code class="name flex">
@@ -5925,7 +6188,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">def admin_inviteRequests_approved_list(self, **kwargs) -&gt; SlackResponse:
     &#34;&#34;&#34;List all approved workspace invite requests.&#34;&#34;&#34;
-    return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_inviteRequests_denied_list"><code class="name flex">
@@ -5939,7 +6202,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">def admin_inviteRequests_denied_list(self, **kwargs) -&gt; SlackResponse:
     &#34;&#34;&#34;List all denied workspace invite requests.&#34;&#34;&#34;
-    return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_inviteRequests_deny"><code class="name flex">
@@ -5979,7 +6242,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">def admin_inviteRequests_list(self, **kwargs) -&gt; SlackResponse:
     &#34;&#34;&#34;List all pending workspace invite requests.&#34;&#34;&#34;
-    return self.api_call(&#34;admin.inviteRequests.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.inviteRequests.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_admins_list"><code class="name flex">
@@ -6046,7 +6309,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">def admin_teams_list(self, **kwargs) -&gt; SlackResponse:
     &#34;&#34;&#34;List all teams on an Enterprise organization.&#34;&#34;&#34;
-    return self.api_call(&#34;admin.teams.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_owners_list"><code class="name flex">
@@ -6292,7 +6555,7 @@ It must be set to one of open, invite_only, closed, or unlisted.</dd>
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
     else:
         kwargs.update({&#34;channel_ids&#34;: channel_ids})
-    return self.api_call(&#34;admin.usergroups.addChannels&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_usergroups_addTeams"><code class="name flex">
@@ -6329,7 +6592,7 @@ e.g. 'T12345678,T98765432' or ['T12345678', 'T98765432']</dd>
         kwargs.update({&#34;team_ids&#34;: &#34;,&#34;.join(team_ids)})
     else:
         kwargs.update({&#34;team_ids&#34;: team_ids})
-    return self.api_call(&#34;admin.usergroups.addTeams&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_usergroups_listChannels"><code class="name flex">
@@ -6388,7 +6651,7 @@ e.g. 'T12345678,T98765432' or ['T12345678', 'T98765432']</dd>
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
     else:
         kwargs.update({&#34;channel_ids&#34;: channel_ids})
-    return self.api_call(&#34;admin.usergroups.removeChannels&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_assign"><code class="name flex">
@@ -6460,7 +6723,7 @@ At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']</dd>
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
     else:
         kwargs.update({&#34;channel_ids&#34;: channel_ids})
-    return self.api_call(&#34;admin.users.invite&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.users.invite&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_list"><code class="name flex">
@@ -6484,7 +6747,7 @@ At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']</dd>
         team_id (str): ID of the team. e.g. &#39;T1234&#39;
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
-    return self.api_call(&#34;admin.users.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.users.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_remove"><code class="name flex">
@@ -6544,7 +6807,7 @@ and what happens when the client closes—for a list of users.</p>
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
     else:
         kwargs.update({&#34;user_ids&#34;: user_ids})
-    return self.api_call(&#34;admin.users.session.clearSettings&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.users.session.clearSettings&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_session_getSettings"><code class="name flex">
@@ -6577,7 +6840,7 @@ Note: if a user does not have any active sessions, they will not be returned in 
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
     else:
         kwargs.update({&#34;user_ids&#34;: user_ids})
-    return self.api_call(&#34;admin.users.session.getSettings&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.users.session.getSettings&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_session_invalidate"><code class="name flex">
@@ -6674,7 +6937,7 @@ and what happens when the client closes—for one or more users.</p>
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
     else:
         kwargs.update({&#34;user_ids&#34;: user_ids})
-    return self.api_call(&#34;admin.users.session.setSettings&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.users.session.setSettings&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_setAdmin"><code class="name flex">
@@ -7719,7 +7982,7 @@ e.g. [{"type": "section", "text": {"type": "plain_text", "text": "Hello world"}}
 </summary>
 <pre><code class="python">def chat_scheduledMessages_list(self, **kwargs) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all scheduled messages.&#34;&#34;&#34;
-    return self.api_call(&#34;chat.scheduledMessages.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_unfurl"><code class="name flex">
@@ -7947,7 +8210,7 @@ e.g. [{"type": "section", "text": {"type": "plain_text", "text": "Hello world"}}
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
     else:
         kwargs.update({&#34;users&#34;: users})
-    return self.api_call(&#34;conversations.invite&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_join"><code class="name flex">
@@ -9435,7 +9698,7 @@ e.g. ['W1234567890', 'U2345678901', 'U3456789012']</dd>
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
     else:
         kwargs.update({&#34;users&#34;: users})
-    return self.api_call(&#34;mpim.open&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;mpim.open&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.mpim_replies"><code class="name flex">
@@ -9521,7 +9784,7 @@ e.g. '1234567890.123456'</dd>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.oauth_v2_access"><code class="name flex">
-<span>def <span class="ident">oauth_v2_access</span></span>(<span>self, *, client_id: str, client_secret: str, code: str, redirect_uri: Optional[str] = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">oauth_v2_access</span></span>(<span>self, *, client_id: str, client_secret: str, code: Optional[str] = None, redirect_uri: Optional[str] = None, grant_type: Optional[str] = None, refresh_token: Optional[str] = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.</p>
@@ -9536,6 +9799,10 @@ e.g. '1234567890.123456'</dd>
 <dt><strong><code>redirect_uri</code></strong> :&ensp;<code>optional str</code></dt>
 <dd>Must match the originally submitted URI
 (if one was sent). e.g. 'https://example.com'</dd>
+<dt><strong><code>grant_type</code></strong></dt>
+<dd>The grant type. The possible value is only 'refresh_token' as of July 2021.</dd>
+<dt><strong><code>refresh_token</code></strong></dt>
+<dd>The refresh token for token rotation.</dd>
 </dl></div>
 <details class="source">
 <summary>
@@ -9546,8 +9813,14 @@ e.g. '1234567890.123456'</dd>
     *,
     client_id: str,
     client_secret: str,
-    code: str,
+    # This field is required when processing the OAuth redirect URL requests
+    # while it&#39;s absent for token rotation
+    code: Optional[str] = None,
     redirect_uri: Optional[str] = None,
+    # This field is required for token rotation
+    grant_type: Optional[str] = None,
+    # This field is required for token rotation
+    refresh_token: Optional[str] = None,
     **kwargs
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
@@ -9558,15 +9831,56 @@ e.g. '1234567890.123456'</dd>
         code (str): The code param returned via the OAuth callback. e.g. &#39;ccdaa72ad&#39;
         redirect_uri (optional str): Must match the originally submitted URI
             (if one was sent). e.g. &#39;https://example.com&#39;
+        grant_type: The grant type. The possible value is only &#39;refresh_token&#39; as of July 2021.
+        refresh_token: The refresh token for token rotation.
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
-    kwargs.update({&#34;code&#34;: code})
+    if code is not None:
+        kwargs.update({&#34;code&#34;: code})
+    if grant_type is not None:
+        kwargs.update({&#34;grant_type&#34;: grant_type})
+    if refresh_token is not None:
+        kwargs.update({&#34;refresh_token&#34;: refresh_token})
     return self.api_call(
         &#34;oauth.v2.access&#34;,
         data=kwargs,
         auth={&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret},
     )</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.oauth_v2_exchange"><code class="name flex">
+<span>def <span class="ident">oauth_v2_exchange</span></span>(<span>self, *, token: str, client_id: str, client_secret: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exchanges a legacy access token for a new expiring access token and refresh token</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>token</code></strong></dt>
+<dd>The legacy xoxb or xoxp token being migrated to use token rotation.</dd>
+<dt><strong><code>client_id</code></strong></dt>
+<dd>Issued when you created your application.</dd>
+<dt><strong><code>client_secret</code></strong></dt>
+<dd>Issued when you created your application.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def oauth_v2_exchange(
+    self, *, token: str, client_id: str, client_secret: str, **kwargs
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
+
+    Args:
+        token: The legacy xoxb or xoxp token being migrated to use token rotation.
+        client_id: Issued when you created your application.
+        client_secret: Issued when you created your application.
+    &#34;&#34;&#34;
+    kwargs.update(
+        {&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token}
+    )
+    return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.pins_add"><code class="name flex">
@@ -10300,7 +10614,7 @@ users for the User Group. e.g. ['U060R4BJ4', 'U060RNRCZ']</dd>
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
     else:
         kwargs.update({&#34;users&#34;: users})
-    return self.api_call(&#34;usergroups.users.update&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_conversations"><code class="name flex">
@@ -10861,6 +11175,9 @@ e.g. [{ 'type': 'text', 'name': 'title', 'label': 'Title' }]</dd>
 <li><code><a title="slack_sdk.web.client.WebClient.admin_apps_restrict" href="#slack_sdk.web.client.WebClient.admin_apps_restrict">admin_apps_restrict</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.admin_apps_restricted_list" href="#slack_sdk.web.client.WebClient.admin_apps_restricted_list">admin_apps_restricted_list</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.admin_apps_uninstall" href="#slack_sdk.web.client.WebClient.admin_apps_uninstall">admin_apps_uninstall</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.admin_auth_policy_assignEntities" href="#slack_sdk.web.client.WebClient.admin_auth_policy_assignEntities">admin_auth_policy_assignEntities</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.admin_auth_policy_getEntities" href="#slack_sdk.web.client.WebClient.admin_auth_policy_getEntities">admin_auth_policy_getEntities</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.admin_auth_policy_removeEntities" href="#slack_sdk.web.client.WebClient.admin_auth_policy_removeEntities">admin_auth_policy_removeEntities</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.admin_barriers_create" href="#slack_sdk.web.client.WebClient.admin_barriers_create">admin_barriers_create</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.admin_barriers_delete" href="#slack_sdk.web.client.WebClient.admin_barriers_delete">admin_barriers_delete</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.admin_barriers_list" href="#slack_sdk.web.client.WebClient.admin_barriers_list">admin_barriers_list</a></code></li>
@@ -11027,6 +11344,7 @@ e.g. [{ 'type': 'text', 'name': 'title', 'label': 'Title' }]</dd>
 <li><code><a title="slack_sdk.web.client.WebClient.mpim_replies" href="#slack_sdk.web.client.WebClient.mpim_replies">mpim_replies</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.oauth_access" href="#slack_sdk.web.client.WebClient.oauth_access">oauth_access</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.oauth_v2_access" href="#slack_sdk.web.client.WebClient.oauth_v2_access">oauth_v2_access</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.oauth_v2_exchange" href="#slack_sdk.web.client.WebClient.oauth_v2_exchange">oauth_v2_exchange</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.pins_add" href="#slack_sdk.web.client.WebClient.pins_add">pins_add</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.pins_list" href="#slack_sdk.web.client.WebClient.pins_list">pins_list</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.pins_remove" href="#slack_sdk.web.client.WebClient.pins_remove">pins_remove</a></code></li>

--- a/docs/api-docs/slack_sdk/web/internal_utils.html
+++ b/docs/api-docs/slack_sdk/web/internal_utils.html
@@ -247,7 +247,8 @@ def _next_cursor_is_present(data) -&gt; bool:
     Returns:
         A boolean value.
     &#34;&#34;&#34;
-    present = (
+    # Only admin.conversations.search returns next_cursor at the top level
+    present = (&#34;next_cursor&#34; in data and data[&#34;next_cursor&#34;] != &#34;&#34;) or (
         &#34;response_metadata&#34; in data
         and &#34;next_cursor&#34; in data[&#34;response_metadata&#34;]
         and data[&#34;response_metadata&#34;][&#34;next_cursor&#34;] != &#34;&#34;

--- a/docs/api-docs/slack_sdk/web/legacy_client.html
+++ b/docs/api-docs/slack_sdk/web/legacy_client.html
@@ -206,6 +206,65 @@ class LegacyWebClient(LegacyBaseClient):
                 kwargs.update({&#34;team_ids&#34;: team_ids})
         return self.api_call(&#34;admin.apps.uninstall&#34;, http_verb=&#34;POST&#34;, params=kwargs)
 
+    def admin_auth_policy_getEntities(
+        self,
+        *,
+        policy_name: str,
+        cursor: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.&#34;&#34;&#34;
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        if cursor is not None:
+            kwargs.update({&#34;cursor&#34;: cursor})
+        if entity_type is not None:
+            kwargs.update({&#34;entity_type&#34;: entity_type})
+        if limit is not None:
+            kwargs.update({&#34;limit&#34;: limit})
+        return self.api_call(
+            &#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    def admin_auth_policy_assignEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Assign entities to a particular authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return self.api_call(
+            &#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    def admin_auth_policy_removeEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Remove specified entities from a specified authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return self.api_call(
+            &#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
     def admin_barriers_create(
         self,
         *,
@@ -350,7 +409,7 @@ class LegacyWebClient(LegacyBaseClient):
 
     def admin_conversations_search(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.conversations.search&#34;, json=kwargs)
+        return self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)
 
     def admin_conversations_convertToPrivate(
         self, *, channel_id: str, **kwargs
@@ -491,7 +550,7 @@ class LegacyWebClient(LegacyBaseClient):
 
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
-        return self.api_call(&#34;admin.conversations.getTeams&#34;, json=kwargs)
+        return self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)
 
     def admin_emoji_add(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add an emoji.&#34;&#34;&#34;
@@ -572,7 +631,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.getSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.getSettings&#34;, params=kwargs)
 
     def admin_users_session_setSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -587,7 +646,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.setSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.setSettings&#34;, params=kwargs)
 
     def admin_users_session_clearSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -602,7 +661,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.clearSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.clearSettings&#34;, params=kwargs)
 
     def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
@@ -621,13 +680,13 @@ class LegacyWebClient(LegacyBaseClient):
         self, **kwargs
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all approved workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)
 
     def admin_inviteRequests_denied_list(
         self, **kwargs
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all denied workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)
 
     def admin_inviteRequests_deny(
         self, *, invite_request_id: str, **kwargs
@@ -642,7 +701,7 @@ class LegacyWebClient(LegacyBaseClient):
 
     def admin_inviteRequests_list(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all pending workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.list&#34;, params=kwargs)
 
     def admin_teams_admins_list(
         self, *, team_id: str, **kwargs
@@ -669,7 +728,7 @@ class LegacyWebClient(LegacyBaseClient):
 
     def admin_teams_list(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all teams on an Enterprise organization.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.teams.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
 
     def admin_teams_owners_list(
         self, *, team_id: str, **kwargs
@@ -764,7 +823,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.usergroups.addChannels&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)
 
     def admin_usergroups_addTeams(
         self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
@@ -782,7 +841,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({&#34;team_ids&#34;: &#34;,&#34;.join(team_ids)})
         else:
             kwargs.update({&#34;team_ids&#34;: team_ids})
-        return self.api_call(&#34;admin.usergroups.addTeams&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)
 
     def admin_usergroups_listChannels(
         self, *, usergroup_id: str, **kwargs
@@ -809,7 +868,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.usergroups.removeChannels&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)
 
     def admin_users_assign(
         self, *, team_id: str, user_id: str, **kwargs
@@ -844,7 +903,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.users.invite&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.invite&#34;, params=kwargs)
 
     def admin_users_list(
         self, *, team_id: str, **kwargs
@@ -855,7 +914,7 @@ class LegacyWebClient(LegacyBaseClient):
             team_id (str): ID of the team. e.g. &#39;T1234&#39;
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
-        return self.api_call(&#34;admin.users.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.list&#34;, params=kwargs)
 
     def admin_users_remove(
         self, *, team_id: str, user_id: str, **kwargs
@@ -1347,7 +1406,7 @@ class LegacyWebClient(LegacyBaseClient):
 
     def chat_scheduledMessages_list(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists all scheduled messages.&#34;&#34;&#34;
-        return self.api_call(&#34;chat.scheduledMessages.list&#34;, json=kwargs)
+        return self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)
 
     def conversations_archive(
         self, *, channel: str, **kwargs
@@ -1418,7 +1477,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;conversations.invite&#34;, json=kwargs)
+        return self.api_call(&#34;conversations.invite&#34;, params=kwargs)
 
     def conversations_join(
         self, *, channel: str, **kwargs
@@ -2044,7 +2103,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;mpim.open&#34;, json=kwargs)
+        return self.api_call(&#34;mpim.open&#34;, params=kwargs)
 
     def mpim_replies(
         self, *, channel: str, thread_ts: str, **kwargs
@@ -2066,8 +2125,14 @@ class LegacyWebClient(LegacyBaseClient):
         *,
         client_id: str,
         client_secret: str,
-        code: str,
+        # This field is required when processing the OAuth redirect URL requests
+        # while it&#39;s absent for token rotation
+        code: Optional[str] = None,
         redirect_uri: Optional[str] = None,
+        # This field is required for token rotation
+        grant_type: Optional[str] = None,
+        # This field is required for token rotation
+        refresh_token: Optional[str] = None,
         **kwargs
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
@@ -2078,10 +2143,17 @@ class LegacyWebClient(LegacyBaseClient):
             code (str): The code param returned via the OAuth callback. e.g. &#39;ccdaa72ad&#39;
             redirect_uri (optional str): Must match the originally submitted URI
                 (if one was sent). e.g. &#39;https://example.com&#39;
+            grant_type: The grant type. The possible value is only &#39;refresh_token&#39; as of July 2021.
+            refresh_token: The refresh token for token rotation.
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
-        kwargs.update({&#34;code&#34;: code})
+        if code is not None:
+            kwargs.update({&#34;code&#34;: code})
+        if grant_type is not None:
+            kwargs.update({&#34;grant_type&#34;: grant_type})
+        if refresh_token is not None:
+            kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return self.api_call(
             &#34;oauth.v2.access&#34;,
             data=kwargs,
@@ -2114,6 +2186,21 @@ class LegacyWebClient(LegacyBaseClient):
             data=kwargs,
             auth={&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret},
         )
+
+    def oauth_v2_exchange(
+        self, *, token: str, client_id: str, client_secret: str, **kwargs
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
+
+        Args:
+            token: The legacy xoxb or xoxp token being migrated to use token rotation.
+            client_id: Issued when you created your application.
+            client_secret: Issued when you created your application.
+        &#34;&#34;&#34;
+        kwargs.update(
+            {&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token}
+        )
+        return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
 
     def pins_add(self, *, channel: str, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Pins an item to a channel.
@@ -2394,7 +2481,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;usergroups.users.update&#34;, json=kwargs)
+        return self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)
 
     def users_conversations(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List conversations the calling user may access.&#34;&#34;&#34;
@@ -2850,6 +2937,65 @@ removed at anytime.</p></div>
                 kwargs.update({&#34;team_ids&#34;: team_ids})
         return self.api_call(&#34;admin.apps.uninstall&#34;, http_verb=&#34;POST&#34;, params=kwargs)
 
+    def admin_auth_policy_getEntities(
+        self,
+        *,
+        policy_name: str,
+        cursor: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.&#34;&#34;&#34;
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        if cursor is not None:
+            kwargs.update({&#34;cursor&#34;: cursor})
+        if entity_type is not None:
+            kwargs.update({&#34;entity_type&#34;: entity_type})
+        if limit is not None:
+            kwargs.update({&#34;limit&#34;: limit})
+        return self.api_call(
+            &#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    def admin_auth_policy_assignEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Assign entities to a particular authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return self.api_call(
+            &#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
+    def admin_auth_policy_removeEntities(
+        self,
+        *,
+        entity_ids: Union[str, Sequence[str]],
+        policy_name: str,
+        entity_type: str,
+        **kwargs
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Remove specified entities from a specified authentication policy.&#34;&#34;&#34;
+        if isinstance(entity_ids, (list, Tuple)):
+            kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+        else:
+            kwargs.update({&#34;entity_ids&#34;: entity_ids})
+        kwargs.update({&#34;policy_name&#34;: policy_name})
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+        return self.api_call(
+            &#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+        )
+
     def admin_barriers_create(
         self,
         *,
@@ -2994,7 +3140,7 @@ removed at anytime.</p></div>
 
     def admin_conversations_search(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.conversations.search&#34;, json=kwargs)
+        return self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)
 
     def admin_conversations_convertToPrivate(
         self, *, channel_id: str, **kwargs
@@ -3135,7 +3281,7 @@ removed at anytime.</p></div>
 
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
-        return self.api_call(&#34;admin.conversations.getTeams&#34;, json=kwargs)
+        return self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)
 
     def admin_emoji_add(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add an emoji.&#34;&#34;&#34;
@@ -3216,7 +3362,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.getSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.getSettings&#34;, params=kwargs)
 
     def admin_users_session_setSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -3231,7 +3377,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.setSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.setSettings&#34;, params=kwargs)
 
     def admin_users_session_clearSettings(
         self, *, user_ids: Union[str, Sequence[str]], **kwargs
@@ -3246,7 +3392,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
         else:
             kwargs.update({&#34;user_ids&#34;: user_ids})
-        return self.api_call(&#34;admin.users.session.clearSettings&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.session.clearSettings&#34;, params=kwargs)
 
     def admin_inviteRequests_approve(
         self, *, invite_request_id: str, **kwargs
@@ -3265,13 +3411,13 @@ removed at anytime.</p></div>
         self, **kwargs
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all approved workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)
 
     def admin_inviteRequests_denied_list(
         self, **kwargs
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all denied workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)
 
     def admin_inviteRequests_deny(
         self, *, invite_request_id: str, **kwargs
@@ -3286,7 +3432,7 @@ removed at anytime.</p></div>
 
     def admin_inviteRequests_list(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all pending workspace invite requests.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.inviteRequests.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.inviteRequests.list&#34;, params=kwargs)
 
     def admin_teams_admins_list(
         self, *, team_id: str, **kwargs
@@ -3313,7 +3459,7 @@ removed at anytime.</p></div>
 
     def admin_teams_list(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all teams on an Enterprise organization.&#34;&#34;&#34;
-        return self.api_call(&#34;admin.teams.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
 
     def admin_teams_owners_list(
         self, *, team_id: str, **kwargs
@@ -3408,7 +3554,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.usergroups.addChannels&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)
 
     def admin_usergroups_addTeams(
         self, *, usergroup_id: str, team_ids: Union[str, Sequence[str]], **kwargs
@@ -3426,7 +3572,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;team_ids&#34;: &#34;,&#34;.join(team_ids)})
         else:
             kwargs.update({&#34;team_ids&#34;: team_ids})
-        return self.api_call(&#34;admin.usergroups.addTeams&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)
 
     def admin_usergroups_listChannels(
         self, *, usergroup_id: str, **kwargs
@@ -3453,7 +3599,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.usergroups.removeChannels&#34;, json=kwargs)
+        return self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)
 
     def admin_users_assign(
         self, *, team_id: str, user_id: str, **kwargs
@@ -3488,7 +3634,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
         else:
             kwargs.update({&#34;channel_ids&#34;: channel_ids})
-        return self.api_call(&#34;admin.users.invite&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.invite&#34;, params=kwargs)
 
     def admin_users_list(
         self, *, team_id: str, **kwargs
@@ -3499,7 +3645,7 @@ removed at anytime.</p></div>
             team_id (str): ID of the team. e.g. &#39;T1234&#39;
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
-        return self.api_call(&#34;admin.users.list&#34;, json=kwargs)
+        return self.api_call(&#34;admin.users.list&#34;, params=kwargs)
 
     def admin_users_remove(
         self, *, team_id: str, user_id: str, **kwargs
@@ -3991,7 +4137,7 @@ removed at anytime.</p></div>
 
     def chat_scheduledMessages_list(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists all scheduled messages.&#34;&#34;&#34;
-        return self.api_call(&#34;chat.scheduledMessages.list&#34;, json=kwargs)
+        return self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)
 
     def conversations_archive(
         self, *, channel: str, **kwargs
@@ -4062,7 +4208,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;conversations.invite&#34;, json=kwargs)
+        return self.api_call(&#34;conversations.invite&#34;, params=kwargs)
 
     def conversations_join(
         self, *, channel: str, **kwargs
@@ -4688,7 +4834,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;mpim.open&#34;, json=kwargs)
+        return self.api_call(&#34;mpim.open&#34;, params=kwargs)
 
     def mpim_replies(
         self, *, channel: str, thread_ts: str, **kwargs
@@ -4710,8 +4856,14 @@ removed at anytime.</p></div>
         *,
         client_id: str,
         client_secret: str,
-        code: str,
+        # This field is required when processing the OAuth redirect URL requests
+        # while it&#39;s absent for token rotation
+        code: Optional[str] = None,
         redirect_uri: Optional[str] = None,
+        # This field is required for token rotation
+        grant_type: Optional[str] = None,
+        # This field is required for token rotation
+        refresh_token: Optional[str] = None,
         **kwargs
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
@@ -4722,10 +4874,17 @@ removed at anytime.</p></div>
             code (str): The code param returned via the OAuth callback. e.g. &#39;ccdaa72ad&#39;
             redirect_uri (optional str): Must match the originally submitted URI
                 (if one was sent). e.g. &#39;https://example.com&#39;
+            grant_type: The grant type. The possible value is only &#39;refresh_token&#39; as of July 2021.
+            refresh_token: The refresh token for token rotation.
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
-        kwargs.update({&#34;code&#34;: code})
+        if code is not None:
+            kwargs.update({&#34;code&#34;: code})
+        if grant_type is not None:
+            kwargs.update({&#34;grant_type&#34;: grant_type})
+        if refresh_token is not None:
+            kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return self.api_call(
             &#34;oauth.v2.access&#34;,
             data=kwargs,
@@ -4758,6 +4917,21 @@ removed at anytime.</p></div>
             data=kwargs,
             auth={&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret},
         )
+
+    def oauth_v2_exchange(
+        self, *, token: str, client_id: str, client_secret: str, **kwargs
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
+
+        Args:
+            token: The legacy xoxb or xoxp token being migrated to use token rotation.
+            client_id: Issued when you created your application.
+            client_secret: Issued when you created your application.
+        &#34;&#34;&#34;
+        kwargs.update(
+            {&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token}
+        )
+        return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
 
     def pins_add(self, *, channel: str, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Pins an item to a channel.
@@ -5038,7 +5212,7 @@ removed at anytime.</p></div>
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
         else:
             kwargs.update({&#34;users&#34;: users})
-        return self.api_call(&#34;usergroups.users.update&#34;, json=kwargs)
+        return self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)
 
     def users_conversations(self, **kwargs) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List conversations the calling user may access.&#34;&#34;&#34;
@@ -5488,6 +5662,95 @@ or by the admin.apps.requests.list method.</p>
     return self.api_call(&#34;admin.apps.uninstall&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_assignEntities"><code class="name flex">
+<span>def <span class="ident">admin_auth_policy_assignEntities</span></span>(<span>self, *, entity_ids: Union[str, Sequence[str]], policy_name: str, entity_type: str, **kwargs) ‑> Union[_asyncio.Future, <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Assign entities to a particular authentication policy.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def admin_auth_policy_assignEntities(
+    self,
+    *,
+    entity_ids: Union[str, Sequence[str]],
+    policy_name: str,
+    entity_type: str,
+    **kwargs
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Assign entities to a particular authentication policy.&#34;&#34;&#34;
+    if isinstance(entity_ids, (list, Tuple)):
+        kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+    else:
+        kwargs.update({&#34;entity_ids&#34;: entity_ids})
+    kwargs.update({&#34;policy_name&#34;: policy_name})
+    kwargs.update({&#34;entity_type&#34;: entity_type})
+    return self.api_call(
+        &#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+    )</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_getEntities"><code class="name flex">
+<span>def <span class="ident">admin_auth_policy_getEntities</span></span>(<span>self, *, policy_name: str, cursor: Optional[str] = None, entity_type: Optional[str] = None, limit: Optional[int] = None, **kwargs) ‑> Union[_asyncio.Future, <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Fetch all the entities assigned to a particular authentication policy by name.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def admin_auth_policy_getEntities(
+    self,
+    *,
+    policy_name: str,
+    cursor: Optional[str] = None,
+    entity_type: Optional[str] = None,
+    limit: Optional[int] = None,
+    **kwargs
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.&#34;&#34;&#34;
+    kwargs.update({&#34;policy_name&#34;: policy_name})
+    if cursor is not None:
+        kwargs.update({&#34;cursor&#34;: cursor})
+    if entity_type is not None:
+        kwargs.update({&#34;entity_type&#34;: entity_type})
+    if limit is not None:
+        kwargs.update({&#34;limit&#34;: limit})
+    return self.api_call(
+        &#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+    )</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_removeEntities"><code class="name flex">
+<span>def <span class="ident">admin_auth_policy_removeEntities</span></span>(<span>self, *, entity_ids: Union[str, Sequence[str]], policy_name: str, entity_type: str, **kwargs) ‑> Union[_asyncio.Future, <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Remove specified entities from a specified authentication policy.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def admin_auth_policy_removeEntities(
+    self,
+    *,
+    entity_ids: Union[str, Sequence[str]],
+    policy_name: str,
+    entity_type: str,
+    **kwargs
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Remove specified entities from a specified authentication policy.&#34;&#34;&#34;
+    if isinstance(entity_ids, (list, Tuple)):
+        kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
+    else:
+        kwargs.update({&#34;entity_ids&#34;: entity_ids})
+    kwargs.update({&#34;policy_name&#34;: policy_name})
+    kwargs.update({&#34;entity_type&#34;: entity_type})
+    return self.api_call(
+        &#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs
+    )</code></pre>
+</details>
+</dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_create"><code class="name flex">
 <span>def <span class="ident">admin_barriers_create</span></span>(<span>self, *, barriered_from_usergroup_ids: Union[str, Sequence[str]], primary_usergroup_id: str, restricted_subjects: Union[str, Sequence[str]], **kwargs) ‑> Union[_asyncio.Future, <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a>]</span>
 </code></dt>
@@ -5808,7 +6071,7 @@ the corresponding original channel IDs for key revocation with EKM.</p></div>
 
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
-    return self.api_call(&#34;admin.conversations.getTeams&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_invite"><code class="name flex">
@@ -6010,7 +6273,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">def admin_conversations_search(self, **kwargs) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.&#34;&#34;&#34;
-    return self.api_call(&#34;admin.conversations.search&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_setConversationPrefs"><code class="name flex">
@@ -6207,7 +6470,7 @@ e.g 'T1234'</dd>
     self, **kwargs
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all approved workspace invite requests.&#34;&#34;&#34;
-    return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_inviteRequests_denied_list"><code class="name flex">
@@ -6223,7 +6486,7 @@ e.g 'T1234'</dd>
     self, **kwargs
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all denied workspace invite requests.&#34;&#34;&#34;
-    return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_inviteRequests_deny"><code class="name flex">
@@ -6263,7 +6526,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">def admin_inviteRequests_list(self, **kwargs) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all pending workspace invite requests.&#34;&#34;&#34;
-    return self.api_call(&#34;admin.inviteRequests.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.inviteRequests.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_admins_list"><code class="name flex">
@@ -6332,7 +6595,7 @@ e.g 'T1234'</dd>
 </summary>
 <pre><code class="python">def admin_teams_list(self, **kwargs) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all teams on an Enterprise organization.&#34;&#34;&#34;
-    return self.api_call(&#34;admin.teams.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_owners_list"><code class="name flex">
@@ -6582,7 +6845,7 @@ It must be set to one of open, invite_only, closed, or unlisted.</dd>
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
     else:
         kwargs.update({&#34;channel_ids&#34;: channel_ids})
-    return self.api_call(&#34;admin.usergroups.addChannels&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_usergroups_addTeams"><code class="name flex">
@@ -6619,7 +6882,7 @@ e.g. 'T12345678,T98765432' or ['T12345678', 'T98765432']</dd>
         kwargs.update({&#34;team_ids&#34;: &#34;,&#34;.join(team_ids)})
     else:
         kwargs.update({&#34;team_ids&#34;: team_ids})
-    return self.api_call(&#34;admin.usergroups.addTeams&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_usergroups_listChannels"><code class="name flex">
@@ -6678,7 +6941,7 @@ e.g. 'T12345678,T98765432' or ['T12345678', 'T98765432']</dd>
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
     else:
         kwargs.update({&#34;channel_ids&#34;: channel_ids})
-    return self.api_call(&#34;admin.usergroups.removeChannels&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_assign"><code class="name flex">
@@ -6750,7 +7013,7 @@ At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']</dd>
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
     else:
         kwargs.update({&#34;channel_ids&#34;: channel_ids})
-    return self.api_call(&#34;admin.users.invite&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.users.invite&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_list"><code class="name flex">
@@ -6776,7 +7039,7 @@ At least one channel is required. e.g. ['C1A2B3C4D', 'C26Z25Y24']</dd>
         team_id (str): ID of the team. e.g. &#39;T1234&#39;
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
-    return self.api_call(&#34;admin.users.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.users.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_remove"><code class="name flex">
@@ -6836,7 +7099,7 @@ and what happens when the client closes—for a list of users.</p>
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
     else:
         kwargs.update({&#34;user_ids&#34;: user_ids})
-    return self.api_call(&#34;admin.users.session.clearSettings&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.users.session.clearSettings&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_session_getSettings"><code class="name flex">
@@ -6869,7 +7132,7 @@ Note: if a user does not have any active sessions, they will not be returned in 
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
     else:
         kwargs.update({&#34;user_ids&#34;: user_ids})
-    return self.api_call(&#34;admin.users.session.getSettings&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.users.session.getSettings&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_session_invalidate"><code class="name flex">
@@ -6968,7 +7231,7 @@ and what happens when the client closes—for one or more users.</p>
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
     else:
         kwargs.update({&#34;user_ids&#34;: user_ids})
-    return self.api_call(&#34;admin.users.session.setSettings&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;admin.users.session.setSettings&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_setAdmin"><code class="name flex">
@@ -8045,7 +8308,7 @@ e.g. [{"type": "section", "text": {"type": "plain_text", "text": "Hello world"}}
 </summary>
 <pre><code class="python">def chat_scheduledMessages_list(self, **kwargs) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists all scheduled messages.&#34;&#34;&#34;
-    return self.api_call(&#34;chat.scheduledMessages.list&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_unfurl"><code class="name flex">
@@ -8285,7 +8548,7 @@ e.g. [{"type": "section", "text": {"type": "plain_text", "text": "Hello world"}}
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
     else:
         kwargs.update({&#34;users&#34;: users})
-    return self.api_call(&#34;conversations.invite&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_join"><code class="name flex">
@@ -9817,7 +10080,7 @@ e.g. ['W1234567890', 'U2345678901', 'U3456789012']</dd>
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
     else:
         kwargs.update({&#34;users&#34;: users})
-    return self.api_call(&#34;mpim.open&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;mpim.open&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.mpim_replies"><code class="name flex">
@@ -9905,7 +10168,7 @@ e.g. '1234567890.123456'</dd>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.oauth_v2_access"><code class="name flex">
-<span>def <span class="ident">oauth_v2_access</span></span>(<span>self, *, client_id: str, client_secret: str, code: str, redirect_uri: Optional[str] = None, **kwargs) ‑> Union[_asyncio.Future, <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a>]</span>
+<span>def <span class="ident">oauth_v2_access</span></span>(<span>self, *, client_id: str, client_secret: str, code: Optional[str] = None, redirect_uri: Optional[str] = None, grant_type: Optional[str] = None, refresh_token: Optional[str] = None, **kwargs) ‑> Union[_asyncio.Future, <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a>]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.</p>
@@ -9920,6 +10183,10 @@ e.g. '1234567890.123456'</dd>
 <dt><strong><code>redirect_uri</code></strong> :&ensp;<code>optional str</code></dt>
 <dd>Must match the originally submitted URI
 (if one was sent). e.g. 'https://example.com'</dd>
+<dt><strong><code>grant_type</code></strong></dt>
+<dd>The grant type. The possible value is only 'refresh_token' as of July 2021.</dd>
+<dt><strong><code>refresh_token</code></strong></dt>
+<dd>The refresh token for token rotation.</dd>
 </dl></div>
 <details class="source">
 <summary>
@@ -9930,8 +10197,14 @@ e.g. '1234567890.123456'</dd>
     *,
     client_id: str,
     client_secret: str,
-    code: str,
+    # This field is required when processing the OAuth redirect URL requests
+    # while it&#39;s absent for token rotation
+    code: Optional[str] = None,
     redirect_uri: Optional[str] = None,
+    # This field is required for token rotation
+    grant_type: Optional[str] = None,
+    # This field is required for token rotation
+    refresh_token: Optional[str] = None,
     **kwargs
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
@@ -9942,15 +10215,56 @@ e.g. '1234567890.123456'</dd>
         code (str): The code param returned via the OAuth callback. e.g. &#39;ccdaa72ad&#39;
         redirect_uri (optional str): Must match the originally submitted URI
             (if one was sent). e.g. &#39;https://example.com&#39;
+        grant_type: The grant type. The possible value is only &#39;refresh_token&#39; as of July 2021.
+        refresh_token: The refresh token for token rotation.
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
-    kwargs.update({&#34;code&#34;: code})
+    if code is not None:
+        kwargs.update({&#34;code&#34;: code})
+    if grant_type is not None:
+        kwargs.update({&#34;grant_type&#34;: grant_type})
+    if refresh_token is not None:
+        kwargs.update({&#34;refresh_token&#34;: refresh_token})
     return self.api_call(
         &#34;oauth.v2.access&#34;,
         data=kwargs,
         auth={&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret},
     )</code></pre>
+</details>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.oauth_v2_exchange"><code class="name flex">
+<span>def <span class="ident">oauth_v2_exchange</span></span>(<span>self, *, token: str, client_id: str, client_secret: str, **kwargs) ‑> Union[_asyncio.Future, <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Exchanges a legacy access token for a new expiring access token and refresh token</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>token</code></strong></dt>
+<dd>The legacy xoxb or xoxp token being migrated to use token rotation.</dd>
+<dt><strong><code>client_id</code></strong></dt>
+<dd>Issued when you created your application.</dd>
+<dt><strong><code>client_secret</code></strong></dt>
+<dd>Issued when you created your application.</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def oauth_v2_exchange(
+    self, *, token: str, client_id: str, client_secret: str, **kwargs
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
+
+    Args:
+        token: The legacy xoxb or xoxp token being migrated to use token rotation.
+        client_id: Issued when you created your application.
+        client_secret: Issued when you created your application.
+    &#34;&#34;&#34;
+    kwargs.update(
+        {&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token}
+    )
+    return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.pins_add"><code class="name flex">
@@ -10700,7 +11014,7 @@ users for the User Group. e.g. ['U060R4BJ4', 'U060RNRCZ']</dd>
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
     else:
         kwargs.update({&#34;users&#34;: users})
-    return self.api_call(&#34;usergroups.users.update&#34;, json=kwargs)</code></pre>
+    return self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_conversations"><code class="name flex">
@@ -11267,6 +11581,9 @@ e.g. [{ 'type': 'text', 'name': 'title', 'label': 'Title' }]</dd>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_restrict" href="#slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_restrict">admin_apps_restrict</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_restricted_list" href="#slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_restricted_list">admin_apps_restricted_list</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_uninstall" href="#slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_uninstall">admin_apps_uninstall</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_assignEntities" href="#slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_assignEntities">admin_auth_policy_assignEntities</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_getEntities" href="#slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_getEntities">admin_auth_policy_getEntities</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_removeEntities" href="#slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_removeEntities">admin_auth_policy_removeEntities</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_create" href="#slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_create">admin_barriers_create</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_delete" href="#slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_delete">admin_barriers_delete</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_list" href="#slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_list">admin_barriers_list</a></code></li>
@@ -11433,6 +11750,7 @@ e.g. [{ 'type': 'text', 'name': 'title', 'label': 'Title' }]</dd>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.mpim_replies" href="#slack_sdk.web.legacy_client.LegacyWebClient.mpim_replies">mpim_replies</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.oauth_access" href="#slack_sdk.web.legacy_client.LegacyWebClient.oauth_access">oauth_access</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.oauth_v2_access" href="#slack_sdk.web.legacy_client.LegacyWebClient.oauth_v2_access">oauth_v2_access</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.oauth_v2_exchange" href="#slack_sdk.web.legacy_client.LegacyWebClient.oauth_v2_exchange">oauth_v2_exchange</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.pins_add" href="#slack_sdk.web.legacy_client.LegacyWebClient.pins_add">pins_add</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.pins_list" href="#slack_sdk.web.legacy_client.LegacyWebClient.pins_list">pins_list</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.pins_remove" href="#slack_sdk.web.legacy_client.LegacyWebClient.pins_remove">pins_remove</a></code></li>

--- a/docs/api-docs/slack_sdk/web/slack_response.html
+++ b/docs/api-docs/slack_sdk/web/slack_response.html
@@ -171,7 +171,10 @@ class SlackResponse:
             params = self.req_args.get(&#34;params&#34;, {})
             if params is None:
                 params = {}
-            params.update({&#34;cursor&#34;: self.data[&#34;response_metadata&#34;][&#34;next_cursor&#34;]})
+            next_cursor = self.data.get(&#34;response_metadata&#34;, {}).get(
+                &#34;next_cursor&#34;
+            ) or self.data.get(&#34;next_cursor&#34;)
+            params.update({&#34;cursor&#34;: next_cursor})
             self.req_args.update({&#34;params&#34;: params})
 
             # This method sends a request in a synchronous way
@@ -421,7 +424,10 @@ removed at anytime.</p></div>
             params = self.req_args.get(&#34;params&#34;, {})
             if params is None:
                 params = {}
-            params.update({&#34;cursor&#34;: self.data[&#34;response_metadata&#34;][&#34;next_cursor&#34;]})
+            next_cursor = self.data.get(&#34;response_metadata&#34;, {}).get(
+                &#34;next_cursor&#34;
+            ) or self.data.get(&#34;next_cursor&#34;)
+            params.update({&#34;cursor&#34;: next_cursor})
             self.req_args.update({&#34;params&#34;: params})
 
             # This method sends a request in a synchronous way

--- a/docs/api-docs/slack_sdk/webhook/async_client.html
+++ b/docs/api-docs/slack_sdk/webhook/async_client.html
@@ -115,6 +115,8 @@ class AsyncWebhookClient:
         response_type: Optional[str] = None,
         replace_original: Optional[bool] = None,
         delete_original: Optional[bool] = None,
+        unfurl_links: Optional[bool] = None,
+        unfurl_media: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -&gt; WebhookResponse:
         &#34;&#34;&#34;Performs a Slack API request and returns the result.
@@ -126,6 +128,8 @@ class AsyncWebhookClient:
             response_type: The type of message (either &#39;in_channel&#39; or &#39;ephemeral&#39;)
             replace_original: True if you use this option for response_url requests
             delete_original: True if you use this option for response_url requests
+            unfurl_links: Option to indicate whether text url should unfurl
+            unfurl_media: Option to indicate whether media url should unfurl
             headers: Request headers to append only for this request
 
         Returns:
@@ -141,6 +145,8 @@ class AsyncWebhookClient:
                 &#34;response_type&#34;: response_type,
                 &#34;replace_original&#34;: replace_original,
                 &#34;delete_original&#34;: delete_original,
+                &#34;unfurl_links&#34;: unfurl_links,
+                &#34;unfurl_media&#34;: unfurl_media,
             },
             headers=headers,
         )
@@ -328,6 +334,8 @@ class AsyncWebhookClient:
         response_type: Optional[str] = None,
         replace_original: Optional[bool] = None,
         delete_original: Optional[bool] = None,
+        unfurl_links: Optional[bool] = None,
+        unfurl_media: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -&gt; WebhookResponse:
         &#34;&#34;&#34;Performs a Slack API request and returns the result.
@@ -339,6 +347,8 @@ class AsyncWebhookClient:
             response_type: The type of message (either &#39;in_channel&#39; or &#39;ephemeral&#39;)
             replace_original: True if you use this option for response_url requests
             delete_original: True if you use this option for response_url requests
+            unfurl_links: Option to indicate whether text url should unfurl
+            unfurl_media: Option to indicate whether media url should unfurl
             headers: Request headers to append only for this request
 
         Returns:
@@ -354,6 +364,8 @@ class AsyncWebhookClient:
                 &#34;response_type&#34;: response_type,
                 &#34;replace_original&#34;: replace_original,
                 &#34;delete_original&#34;: delete_original,
+                &#34;unfurl_links&#34;: unfurl_links,
+                &#34;unfurl_media&#34;: unfurl_media,
             },
             headers=headers,
         )
@@ -468,7 +480,7 @@ class AsyncWebhookClient:
 <h3>Methods</h3>
 <dl>
 <dt id="slack_sdk.webhook.async_client.AsyncWebhookClient.send"><code class="name flex">
-<span>async def <span class="ident">send</span></span>(<span>self, *, text: Optional[str] = None, attachments: Optional[Sequence[Union[Dict[str, Any], <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>]]] = None, blocks: Optional[Sequence[Union[Dict[str, Any], <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>]]] = None, response_type: Optional[str] = None, replace_original: Optional[bool] = None, delete_original: Optional[bool] = None, headers: Optional[Dict[str, str]] = None) ‑> <a title="slack_sdk.webhook.webhook_response.WebhookResponse" href="webhook_response.html#slack_sdk.webhook.webhook_response.WebhookResponse">WebhookResponse</a></span>
+<span>async def <span class="ident">send</span></span>(<span>self, *, text: Optional[str] = None, attachments: Optional[Sequence[Union[Dict[str, Any], <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>]]] = None, blocks: Optional[Sequence[Union[Dict[str, Any], <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>]]] = None, response_type: Optional[str] = None, replace_original: Optional[bool] = None, delete_original: Optional[bool] = None, unfurl_links: Optional[bool] = None, unfurl_media: Optional[bool] = None, headers: Optional[Dict[str, str]] = None) ‑> <a title="slack_sdk.webhook.webhook_response.WebhookResponse" href="webhook_response.html#slack_sdk.webhook.webhook_response.WebhookResponse">WebhookResponse</a></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Performs a Slack API request and returns the result.</p>
@@ -486,6 +498,10 @@ class AsyncWebhookClient:
 <dd>True if you use this option for response_url requests</dd>
 <dt><strong><code>delete_original</code></strong></dt>
 <dd>True if you use this option for response_url requests</dd>
+<dt><strong><code>unfurl_links</code></strong></dt>
+<dd>Option to indicate whether text url should unfurl</dd>
+<dt><strong><code>unfurl_media</code></strong></dt>
+<dd>Option to indicate whether media url should unfurl</dd>
 <dt><strong><code>headers</code></strong></dt>
 <dd>Request headers to append only for this request</dd>
 </dl>
@@ -504,6 +520,8 @@ class AsyncWebhookClient:
     response_type: Optional[str] = None,
     replace_original: Optional[bool] = None,
     delete_original: Optional[bool] = None,
+    unfurl_links: Optional[bool] = None,
+    unfurl_media: Optional[bool] = None,
     headers: Optional[Dict[str, str]] = None,
 ) -&gt; WebhookResponse:
     &#34;&#34;&#34;Performs a Slack API request and returns the result.
@@ -515,6 +533,8 @@ class AsyncWebhookClient:
         response_type: The type of message (either &#39;in_channel&#39; or &#39;ephemeral&#39;)
         replace_original: True if you use this option for response_url requests
         delete_original: True if you use this option for response_url requests
+        unfurl_links: Option to indicate whether text url should unfurl
+        unfurl_media: Option to indicate whether media url should unfurl
         headers: Request headers to append only for this request
 
     Returns:
@@ -530,6 +550,8 @@ class AsyncWebhookClient:
             &#34;response_type&#34;: response_type,
             &#34;replace_original&#34;: replace_original,
             &#34;delete_original&#34;: delete_original,
+            &#34;unfurl_links&#34;: unfurl_links,
+            &#34;unfurl_media&#34;: unfurl_media,
         },
         headers=headers,
     )</code></pre>

--- a/docs/api-docs/slack_sdk/webhook/client.html
+++ b/docs/api-docs/slack_sdk/webhook/client.html
@@ -105,6 +105,8 @@ class WebhookClient:
         response_type: Optional[str] = None,
         replace_original: Optional[bool] = None,
         delete_original: Optional[bool] = None,
+        unfurl_links: Optional[bool] = None,
+        unfurl_media: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -&gt; WebhookResponse:
         &#34;&#34;&#34;Performs a Slack API request and returns the result.
@@ -117,6 +119,8 @@ class WebhookClient:
             response_type: The type of message (either &#39;in_channel&#39; or &#39;ephemeral&#39;)
             replace_original: True if you use this option for response_url requests
             delete_original: True if you use this option for response_url requests
+            unfurl_links: Option to indicate whether text url should unfurl
+            unfurl_media: Option to indicate whether media url should unfurl
             headers: Request headers to append only for this request
 
         Returns:
@@ -132,6 +136,8 @@ class WebhookClient:
                 &#34;response_type&#34;: response_type,
                 &#34;replace_original&#34;: replace_original,
                 &#34;delete_original&#34;: delete_original,
+                &#34;unfurl_links&#34;: unfurl_links,
+                &#34;unfurl_media&#34;: unfurl_media,
             },
             headers=headers,
         )
@@ -320,6 +326,8 @@ class WebhookClient:
         response_type: Optional[str] = None,
         replace_original: Optional[bool] = None,
         delete_original: Optional[bool] = None,
+        unfurl_links: Optional[bool] = None,
+        unfurl_media: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -&gt; WebhookResponse:
         &#34;&#34;&#34;Performs a Slack API request and returns the result.
@@ -332,6 +340,8 @@ class WebhookClient:
             response_type: The type of message (either &#39;in_channel&#39; or &#39;ephemeral&#39;)
             replace_original: True if you use this option for response_url requests
             delete_original: True if you use this option for response_url requests
+            unfurl_links: Option to indicate whether text url should unfurl
+            unfurl_media: Option to indicate whether media url should unfurl
             headers: Request headers to append only for this request
 
         Returns:
@@ -347,6 +357,8 @@ class WebhookClient:
                 &#34;response_type&#34;: response_type,
                 &#34;replace_original&#34;: replace_original,
                 &#34;delete_original&#34;: delete_original,
+                &#34;unfurl_links&#34;: unfurl_links,
+                &#34;unfurl_media&#34;: unfurl_media,
             },
             headers=headers,
         )
@@ -468,7 +480,7 @@ class WebhookClient:
 <h3>Methods</h3>
 <dl>
 <dt id="slack_sdk.webhook.client.WebhookClient.send"><code class="name flex">
-<span>def <span class="ident">send</span></span>(<span>self, *, text: Optional[str] = None, attachments: Optional[Sequence[Union[Dict[str, <built-in function any>], <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>]]] = None, blocks: Optional[Sequence[Union[Dict[str, <built-in function any>], <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>]]] = None, response_type: Optional[str] = None, replace_original: Optional[bool] = None, delete_original: Optional[bool] = None, headers: Optional[Dict[str, str]] = None) ‑> <a title="slack_sdk.webhook.webhook_response.WebhookResponse" href="webhook_response.html#slack_sdk.webhook.webhook_response.WebhookResponse">WebhookResponse</a></span>
+<span>def <span class="ident">send</span></span>(<span>self, *, text: Optional[str] = None, attachments: Optional[Sequence[Union[Dict[str, <built-in function any>], <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>]]] = None, blocks: Optional[Sequence[Union[Dict[str, <built-in function any>], <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>]]] = None, response_type: Optional[str] = None, replace_original: Optional[bool] = None, delete_original: Optional[bool] = None, unfurl_links: Optional[bool] = None, unfurl_media: Optional[bool] = None, headers: Optional[Dict[str, str]] = None) ‑> <a title="slack_sdk.webhook.webhook_response.WebhookResponse" href="webhook_response.html#slack_sdk.webhook.webhook_response.WebhookResponse">WebhookResponse</a></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Performs a Slack API request and returns the result.</p>
@@ -487,6 +499,10 @@ class WebhookClient:
 <dd>True if you use this option for response_url requests</dd>
 <dt><strong><code>delete_original</code></strong></dt>
 <dd>True if you use this option for response_url requests</dd>
+<dt><strong><code>unfurl_links</code></strong></dt>
+<dd>Option to indicate whether text url should unfurl</dd>
+<dt><strong><code>unfurl_media</code></strong></dt>
+<dd>Option to indicate whether media url should unfurl</dd>
 <dt><strong><code>headers</code></strong></dt>
 <dd>Request headers to append only for this request</dd>
 </dl>
@@ -505,6 +521,8 @@ class WebhookClient:
     response_type: Optional[str] = None,
     replace_original: Optional[bool] = None,
     delete_original: Optional[bool] = None,
+    unfurl_links: Optional[bool] = None,
+    unfurl_media: Optional[bool] = None,
     headers: Optional[Dict[str, str]] = None,
 ) -&gt; WebhookResponse:
     &#34;&#34;&#34;Performs a Slack API request and returns the result.
@@ -517,6 +535,8 @@ class WebhookClient:
         response_type: The type of message (either &#39;in_channel&#39; or &#39;ephemeral&#39;)
         replace_original: True if you use this option for response_url requests
         delete_original: True if you use this option for response_url requests
+        unfurl_links: Option to indicate whether text url should unfurl
+        unfurl_media: Option to indicate whether media url should unfurl
         headers: Request headers to append only for this request
 
     Returns:
@@ -532,6 +552,8 @@ class WebhookClient:
             &#34;response_type&#34;: response_type,
             &#34;replace_original&#34;: replace_original,
             &#34;delete_original&#34;: delete_original,
+            &#34;unfurl_links&#34;: unfurl_links,
+            &#34;unfurl_media&#34;: unfurl_media,
         },
         headers=headers,
     )</code></pre>

--- a/docs/api-docs/slack_sdk/webhook/internal_utils.html
+++ b/docs/api-docs/slack_sdk/webhook/internal_utils.html
@@ -32,7 +32,6 @@ from typing import Optional, Dict, Any
 from slack_sdk.web.internal_utils import (
     _parse_web_class_objects,
     get_user_agent,
-    convert_bool_to_0_or_1,
 )
 from .webhook_response import WebhookResponse
 
@@ -40,7 +39,6 @@ from .webhook_response import WebhookResponse
 def _build_body(original_body: Optional[Dict[str, Any]]) -&gt; Optional[Dict[str, Any]]:
     if original_body:
         body = {k: v for k, v in original_body.items() if v is not None}
-        body = convert_bool_to_0_or_1(body)
         _parse_web_class_objects(body)
         return body
     return None

--- a/slack_sdk/version.py
+++ b/slack_sdk/version.py
@@ -1,2 +1,2 @@
 """Check the latest version at https://pypi.org/project/slack-sdk/"""
-__version__ = "3.8.0rc2"
+__version__ = "3.8.0"


### PR DESCRIPTION
## Summary

We are going to ship a new minor version soon. Here is the draft of the release note for v3.8.0.

```
## New Features

### Token Rotation Support (more info to come soon!)

This version includes the support for the apps enabling the newly released token rotation for better security. Refer to [the API document](https://api.slack.com/) for the general information about the feature.

#### How to handle token rotation with this SDK

Apart from the column additions for the feature (specifically, refresh token + expiration date time) and the corresponding changes in your app code, no significant code is needed. Checking the example apps using Flask, Sanic in [this directory](https://github.com/slackapi/python-slack-sdk/tree/main/integration_tests/samples/token_rotation) can be helpful to learn what to do.

In a nutshell, you can call the following `rotate_tokens` method before handling every single incoming request from Slack. As long as your `InstallationStore` support the token rotation patterns, the code below should work as-is. 

```python
from slack_sdk.oauth.token_rotation import TokenRotator
from slack_sdk.oauth.installation_store import FileInstallationStore

# This instance can be singleton; thread-safe
token_rotator = TokenRotator(
    # These are required for refreshing tokens
    client_id=client_id,
    client_secret=client_secret,
)
# Your own InstallationStore here
installation_store = FileInstallationStore()

def rotate_tokens(
    enterprise_id: Optional[str] = None,
    team_id: Optional[str] = None,
    user_id: Optional[str] = None,
    is_enterprise_install: Optional[bool] = None,
):
    installation = installation_store.find_installation(
        enterprise_id=enterprise_id,
        team_id=team_id,
        user_id=user_id,
        is_enterprise_install=is_enterprise_install,
    )
    if installation is not None:
        # If rotation does not occur, refreshed_installation is None
        refreshed_installation = token_rotator.perform_token_rotation(installation=installation)
        if refreshed_installation is not None:
            # Save the new access token for the following processes
            installation_store.save(refreshed_installation)
# TODO: remove this comment ```

#### Migration guide for `SQLAlchemyInstallationStore` users

If your app uses the built-in `SQLAlchemyInstallationStore` for managing Slack app installations, adding the following database columns is required for this version upgrade. Refer to [the code](https://github.com/slackapi/python-slack-sdk/tree/main/slack_sdk/oauth/installation_store/sqlalchemy) to check the complete ones. 

Also, since this version, all the table columns for string data have their max length for better compatibility with MySQL. We recommend setting the same ones for your models.

##### slack_installations

* `Column("bot_refresh_token", String(200)),  # added in v3.8.0`
* `Column("bot_token_expires_at", DateTime),  # added in v3.8.0`
* `Column("user_refresh_token", String(200)),  # added in v3.8.0`
* `Column("user_token_expires_at", DateTime),  # added in v3.8.0`

##### slack_bots

* `Column("bot_refresh_token", String(200)),  # added in v3.8.0`
* `Column("bot_token_expires_at", DateTime),  # added in v3.8.0`

## Changes

* #1060 Add token rotation feature support - Thanks @seratch
* #1040 Set max length for string columns in SQLAlchemy models for MySQL compatibility - Thanks @tattee
* #1047 Make WebhookClient (sync/async) #send method accept link unfurl params - Thanks @srajiang 
* #1061 WebClient's paginated response iterator does not work for admin.conversations.search API - Thanks @seratch 
* #1054 #1053 conversations_invite() fails with "error: no_user" - Thanks @seratch @noperator 
* #1044 Updates PythOnBoardingBot tutorial sample to use bolt-python - Thanks @srajiang 
* #1048 Update command in maintainers guide - Thanks @srajiang 

---
* All issues/pull requests: https://github.com/slackapi/python-slack-sdk/milestone/38?closed=1
* All changes: https://github.com/slackapi/python-slack-sdk/compare/v3.7.0...v3.8.0
```



### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [x] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
