### PR TITLE
Update example code for rate limiting

### DIFF
--- a/docs-src-v2/basic_usage.rst
+++ b/docs-src-v2/basic_usage.rst
@@ -478,7 +478,7 @@ Here's a very basic example of how one might deal with rate limited requests.
     try:
       response = send_slack_message(channel, message)
     except SlackApiError as e:
-      if e.response["error"] == "ratelimited":
+      if e.response.status_code == 429:
         # The `Retry-After` header will tell you how long to wait before retrying
         delay = int(e.response.headers['Retry-After'])
         print(f"Rate limited. Retrying in {delay} seconds")
@@ -491,4 +491,3 @@ Here's a very basic example of how one might deal with rate limited requests.
 See the documentation on `Rate Limiting <https://api.slack.com/docs/rate-limits>`_ for more info.
 
 .. include:: metadata.rst
-

--- a/docs-src/web/index.rst
+++ b/docs-src/web/index.rst
@@ -580,7 +580,7 @@ Here's a very basic example of how one might deal with rate limited requests.
         try:
             response = send_slack_message(channel, message)
         except SlackApiError as e:
-            if e.response["error"] == "ratelimited":
+            if e.response.status_code == 429:
                 # The `Retry-After` header will tell you how long to wait before retrying
                 delay = int(e.response.headers['Retry-After'])
                 print(f"Rate limited. Retrying in {delay} seconds")


### PR DESCRIPTION
The API methods themselves are inconsistent about the spelling of
ratelimited vs rate_limited. chat.postMessage spells it
rate_limited. The API docs on rate limiting itself suggest using the
HTTP status code.

This updates the examples in the doc to use the status_code member of
Response objects, instead of looking in the returned JSON.

Closes #1073

### Category

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs-src` (Documents, have you run `./docs.sh`?)
- [x] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
  - n/a: doc change only