### PR TITLE
Fix the wrong column data size for bot_token in the built-in SQLAlchemy data model

### DIFF
--- a/slack_sdk/oauth/installation_store/sqlalchemy/__init__.py
+++ b/slack_sdk/oauth/installation_store/sqlalchemy/__init__.py
@@ -89,7 +89,7 @@ class SQLAlchemyInstallationStore(InstallationStore):
             Column("enterprise_name", String(200)),
             Column("team_id", String(32)),
             Column("team_name", String(200)),
-            Column("bot_token", String(32)),
+            Column("bot_token", String(200)),
             Column("bot_id", String(32)),
             Column("bot_user_id", String(32)),
             Column("bot_scopes", String(1000)),


### PR DESCRIPTION
Change the character length of the slack_bots.bot_token column 32 to 200

## Summary

The bot_token column should be set to 200 characters, but it was set to 32 characters.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
