### PR TITLE
Add more tests & fix a data deletion bug in AmazonS3InstallationStore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,10 @@ validate_dependencies = [
     "black==21.6b0",
     "psutil>=5,<6",
     "databases>=0.3",
+    # used only under slack_sdk/*_store
+    "boto3<=2",
+    # TODO: Upgrade to v2
+    "moto<2",  # For AWS tests
 ]
 codegen_dependencies = [
     "black==21.6b0",

--- a/slack_sdk/errors/__init__.py
+++ b/slack_sdk/errors/__init__.py
@@ -52,5 +52,7 @@ class SlackObjectFormationError(SlackClientError):
 
 
 class SlackClientConfigurationError(SlackClientError):
-    """Error raised when attempting to send messages over the websocket when the
-    connection is closed."""
+    """Error raised because of invalid configuration on the client side:
+    * when attempting to send messages over the websocket when the connection is closed.
+    * when external system (e.g., Amazon S3) configuration / credentials are not correct
+    """

--- a/slack_sdk/oauth/authorize_url_generator/__init__.py
+++ b/slack_sdk/oauth/authorize_url_generator/__init__.py
@@ -34,6 +34,7 @@ class AuthorizeUrlGenerator:
 
 class OpenIDConnectAuthorizeUrlGenerator:
     """Refer to https://openid.net/specs/openid-connect-core-1_0.html"""
+
     def __init__(
         self,
         *,

--- a/tests/slack_sdk/audit_logs/mock_web_api_server.py
+++ b/tests/slack_sdk/audit_logs/mock_web_api_server.py
@@ -41,6 +41,12 @@ class MockHandler(SimpleHTTPRequestHandler):
             return
 
         try:
+            if self.path == "/error":
+                self.send_response(500)
+                self.set_common_headers()
+                self.wfile.write("unexpected response body".encode("utf-8"))
+                return
+
             if self.path == "/timeout":
                 time.sleep(2)
 

--- a/tests/slack_sdk/audit_logs/test_client.py
+++ b/tests/slack_sdk/audit_logs/test_client.py
@@ -1,4 +1,5 @@
 import unittest
+from urllib.error import URLError
 
 from slack_sdk.audit_logs import AuditLogsClient, AuditLogsResponse
 from tests.slack_sdk.audit_logs.mock_web_api_server import (
@@ -31,3 +32,14 @@ class TestAuditLogsClient(unittest.TestCase):
         resp: AuditLogsResponse = self.client.schemas()
         self.assertEqual(200, resp.status_code)
         self.assertIsNotNone(resp.body.get("schemas"))
+
+    def test_url_error(self):
+        invalid_url = "http://localhost:9999/"
+        client = AuditLogsClient(token="xoxp-", base_url=invalid_url)
+        with self.assertRaises(URLError):
+            client.logs(limit=1, action="user_login")
+
+    def test_http_error(self):
+        resp: AuditLogsResponse = self.client.api_call(path="error")
+        self.assertEqual(500, resp.status_code)
+        self.assertEqual("unexpected response body", resp.raw_body)

--- a/tests/slack_sdk/oauth/installation_store/test_amazon_s3.py
+++ b/tests/slack_sdk/oauth/installation_store/test_amazon_s3.py
@@ -1,0 +1,270 @@
+import unittest
+
+import boto3
+from moto import mock_s3
+from slack_sdk.oauth.installation_store import Installation
+from slack_sdk.oauth.installation_store.amazon_s3 import AmazonS3InstallationStore
+
+
+class TestAmazonS3(unittest.TestCase):
+    mock_s3 = mock_s3()
+    bucket_name = "test-bucket"
+
+    def setUp(self):
+        self.mock_s3.start()
+        s3 = boto3.resource("s3")
+        bucket = s3.Bucket(self.bucket_name)
+        bucket.create(CreateBucketConfiguration={"LocationConstraint": "af-south-1"})
+
+    def tearDown(self):
+        self.mock_s3.stop()
+
+    def build_store(self) -> AmazonS3InstallationStore:
+        return AmazonS3InstallationStore(
+            s3_client=boto3.client("s3"),
+            bucket_name=self.bucket_name,
+            client_id="111.222",
+        )
+
+    def test_instance(self):
+        store = self.build_store()
+        self.assertIsNotNone(store)
+
+    def test_save_and_find(self):
+        store = self.build_store()
+        installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_id="B111",
+            bot_token="xoxb-111",
+            bot_scopes=["chat:write"],
+            bot_user_id="U222",
+        )
+        store.save(installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="T111")
+        self.assertIsNone(bot)
+
+        # delete bots
+        store.delete_bot(enterprise_id="E111", team_id="T222")
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+
+        # find installations
+        i = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(i)
+        i = store.find_installation(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(i)
+        i = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(i)
+
+        i = store.find_installation(
+            enterprise_id="E111", team_id="T111", user_id="U111"
+        )
+        self.assertIsNotNone(i)
+        i = store.find_installation(
+            enterprise_id="E111", team_id="T111", user_id="U222"
+        )
+        self.assertIsNone(i)
+        i = store.find_installation(
+            enterprise_id="E111", team_id="T222", user_id="U111"
+        )
+        self.assertIsNone(i)
+
+        # delete installations
+        store.delete_installation(enterprise_id="E111", team_id="T111", user_id="U111")
+        i = store.find_installation(
+            enterprise_id="E111", team_id="T111", user_id="U111"
+        )
+        self.assertIsNone(i)
+        i = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNone(i)
+
+        # delete all
+        store.save(installation)
+        store.delete_all(enterprise_id="E111", team_id="T111")
+
+        i = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNone(i)
+        i = store.find_installation(
+            enterprise_id="E111", team_id="T111", user_id="U111"
+        )
+        self.assertIsNone(i)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+
+    def test_org_installation(self):
+        store = self.build_store()
+        installation = Installation(
+            app_id="AO111",
+            enterprise_id="EO111",
+            user_id="UO111",
+            bot_id="BO111",
+            bot_token="xoxb-O111",
+            bot_scopes=["chat:write"],
+            bot_user_id="UO222",
+            is_enterprise_install=True,
+        )
+        store.save(installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="EO111", team_id=None)
+        self.assertIsNotNone(bot)
+        bot = store.find_bot(
+            enterprise_id="EO111", team_id="TO222", is_enterprise_install=True
+        )
+        self.assertIsNotNone(bot)
+        bot = store.find_bot(enterprise_id="EO111", team_id="TO222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="TO111")
+        self.assertIsNone(bot)
+
+        # delete bots
+        store.delete_bot(enterprise_id="EO111", team_id="TO222")
+        bot = store.find_bot(enterprise_id="EO111", team_id=None)
+        self.assertIsNotNone(bot)
+
+        store.delete_bot(enterprise_id="EO111", team_id=None)
+        bot = store.find_bot(enterprise_id="EO111", team_id=None)
+        self.assertIsNone(bot)
+
+        # find installations
+        i = store.find_installation(enterprise_id="EO111", team_id=None)
+        self.assertIsNotNone(i)
+        i = store.find_installation(
+            enterprise_id="EO111", team_id="T111", is_enterprise_install=True
+        )
+        self.assertIsNotNone(i)
+        i = store.find_installation(enterprise_id="EO111", team_id="T222")
+        self.assertIsNone(i)
+        i = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(i)
+
+        i = store.find_installation(
+            enterprise_id="EO111", team_id=None, user_id="UO111"
+        )
+        self.assertIsNotNone(i)
+        i = store.find_installation(
+            enterprise_id="E111",
+            team_id="T111",
+            is_enterprise_install=True,
+            user_id="U222",
+        )
+        self.assertIsNone(i)
+        i = store.find_installation(enterprise_id=None, team_id="T222", user_id="U111")
+        self.assertIsNone(i)
+
+        # delete installations
+        store.delete_installation(enterprise_id="E111", team_id=None)
+        i = store.find_installation(enterprise_id="E111", team_id=None)
+        self.assertIsNone(i)
+
+        # delete all
+        store.save(installation)
+        store.delete_all(enterprise_id="E111", team_id=None)
+
+        i = store.find_installation(enterprise_id="E111", team_id=None)
+        self.assertIsNone(i)
+        i = store.find_installation(enterprise_id="E111", team_id=None, user_id="U111")
+        self.assertIsNone(i)
+        bot = store.find_bot(enterprise_id=None, team_id="T222")
+        self.assertIsNone(bot)
+
+    def test_save_and_find_token_rotation(self):
+        store = self.build_store()
+        installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_id="B111",
+            bot_token="xoxe.xoxp-1-initial",
+            bot_scopes=["chat:write"],
+            bot_user_id="U222",
+            bot_refresh_token="xoxe-1-initial",
+            bot_token_expires_in=43200,
+        )
+        store.save(installation)
+
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot)
+        self.assertEqual(bot.bot_refresh_token, "xoxe-1-initial")
+
+        # Update the existing data
+        refreshed_installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_id="B111",
+            bot_token="xoxe.xoxp-1-refreshed",
+            bot_scopes=["chat:write"],
+            bot_user_id="U222",
+            bot_refresh_token="xoxe-1-refreshed",
+            bot_token_expires_in=43200,
+        )
+        store.save(refreshed_installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot)
+        self.assertEqual(bot.bot_refresh_token, "xoxe-1-refreshed")
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="T111")
+        self.assertIsNone(bot)
+
+        # delete bots
+        store.delete_bot(enterprise_id="E111", team_id="T222")
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+
+        # find installations
+        i = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(i)
+        i = store.find_installation(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(i)
+        i = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(i)
+
+        i = store.find_installation(
+            enterprise_id="E111", team_id="T111", user_id="U111"
+        )
+        self.assertIsNotNone(i)
+        i = store.find_installation(
+            enterprise_id="E111", team_id="T111", user_id="U222"
+        )
+        self.assertIsNone(i)
+        i = store.find_installation(
+            enterprise_id="E111", team_id="T222", user_id="U111"
+        )
+        self.assertIsNone(i)
+
+        # delete installations
+        store.delete_installation(enterprise_id="E111", team_id="T111", user_id="U111")
+        i = store.find_installation(
+            enterprise_id="E111", team_id="T111", user_id="U111"
+        )
+        self.assertIsNone(i)
+        i = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNone(i)
+
+        # delete all
+        store.save(installation)
+        store.delete_all(enterprise_id="E111", team_id="T111")
+
+        i = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNone(i)
+        i = store.find_installation(
+            enterprise_id="E111", team_id="T111", user_id="U111"
+        )
+        self.assertIsNone(i)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)

--- a/tests/slack_sdk/oauth/state_store/test_amazon_s3.py
+++ b/tests/slack_sdk/oauth/state_store/test_amazon_s3.py
@@ -1,0 +1,39 @@
+import unittest
+
+import boto3
+from moto import mock_s3
+from slack_sdk.oauth.state_store.amazon_s3 import AmazonS3OAuthStateStore
+
+
+class TestAmazonS3(unittest.TestCase):
+    mock_s3 = mock_s3()
+    bucket_name = "test-bucket"
+
+    def setUp(self):
+        self.mock_s3.start()
+        s3 = boto3.resource("s3")
+        bucket = s3.Bucket(self.bucket_name)
+        bucket.create(CreateBucketConfiguration={"LocationConstraint": "af-south-1"})
+
+    def tearDown(self):
+        self.mock_s3.stop()
+
+    def test_instance(self):
+        store = AmazonS3OAuthStateStore(
+            s3_client=boto3.client("s3"),
+            bucket_name=self.bucket_name,
+            expiration_seconds=10,
+        )
+        self.assertIsNotNone(store)
+
+    def test_issue_and_consume(self):
+        store = AmazonS3OAuthStateStore(
+            s3_client=boto3.client("s3"),
+            bucket_name=self.bucket_name,
+            expiration_seconds=10,
+        )
+        state = store.issue()
+        result = store.consume(state)
+        self.assertTrue(result)
+        result = store.consume(state)
+        self.assertFalse(result)


### PR DESCRIPTION
## Summary

This pull request adds more unit tests for better code coverage. Particularly, the following patterns are now covered:

* Error patterns in AuditLogsClient
* Amazon S3 backend OAuth stores (installation store & state store)

While writing the tests, I found a bug in AmazonS3InstallationStore's installation deletion methods. This pull request fixes the bug as well.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
