### PR TITLE
Add explicit arguments for files_info

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1660,7 +1660,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("emoji.list", http_verb="GET", params=kwargs)
 
     async def files_comments_delete(
-        self, *, file: str, id: str  # skipcq: PYL-W0622
+        self, *, file: str, id: str, **kwargs  # skipcq: PYL-W0622
     ) -> AsyncSlackResponse:
         """Deletes an existing comment on a file.
 
@@ -1668,26 +1668,27 @@ class AsyncWebClient(AsyncBaseClient):
             file (str): The file id. e.g. 'F1234467890'
             id (str): The file comment id. e.g. 'Fc1234567890'
         """
-        return await self.api_call(
-            "files.comments.delete", json={"file": file, "id": id}
-        )
+        kwargs.update({"file": file, "id": id})
+        return await self.api_call("files.comments.delete", json=kwargs)
 
-    async def files_delete(self, *, file: str) -> AsyncSlackResponse:
+    async def files_delete(self, *, file: str, **kwargs) -> AsyncSlackResponse:
         """Deletes a file.
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
         """
-        return await self.api_call("files.delete", json={"file": file})
+        kwargs.update({"file": file})
+        return await self.api_call("files.delete", json=kwargs)
 
     async def files_info(
         self,
         *,
         file: str,
-        count: int = 100,
+        count: Optional[int] = None,
         cursor: Optional[str] = None,
-        limit: int = 0,
-        page: int = 1
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        **kwargs
     ) -> AsyncSlackResponse:
         """Gets information about a team file.
 
@@ -1698,17 +1699,8 @@ class AsyncWebClient(AsyncBaseClient):
             limit (int): An optional parameter defining the maximum number of items to return, defaulting to 0
             page (int): An optional parameter defining the page number of results to return, defaulting to 1
         """
-        return await self.api_call(
-            "files.info",
-            http_verb="GET",
-            params={
-                "file": file,
-                "count": count,
-                "cursor": cursor,
-                "limit": limit,
-                "page": page,
-            },
-        )
+        kwargs.update({"file": file, "count": count, "cursor": cursor, "page": page})
+        return await self.api_call("files.info", http_verb="GET", params=kwargs)
 
     async def files_list(self, **kwargs) -> AsyncSlackResponse:
         """Lists & filters team files."""

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1660,7 +1660,7 @@ class AsyncWebClient(AsyncBaseClient):
         return await self.api_call("emoji.list", http_verb="GET", params=kwargs)
 
     async def files_comments_delete(
-        self, *, file: str, id: str, **kwargs  # skipcq: PYL-W0622
+        self, *, file: str, id: str  # skipcq: PYL-W0622
     ) -> AsyncSlackResponse:
         """Deletes an existing comment on a file.
 
@@ -1668,26 +1668,47 @@ class AsyncWebClient(AsyncBaseClient):
             file (str): The file id. e.g. 'F1234467890'
             id (str): The file comment id. e.g. 'Fc1234567890'
         """
-        kwargs.update({"file": file, "id": id})
-        return await self.api_call("files.comments.delete", json=kwargs)
+        return await self.api_call(
+            "files.comments.delete", json={"file": file, "id": id}
+        )
 
-    async def files_delete(self, *, file: str, **kwargs) -> AsyncSlackResponse:
+    async def files_delete(self, *, file: str) -> AsyncSlackResponse:
         """Deletes a file.
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
         """
-        kwargs.update({"file": file})
-        return await self.api_call("files.delete", json=kwargs)
+        return await self.api_call("files.delete", json={"file": file})
 
-    async def files_info(self, *, file: str, **kwargs) -> AsyncSlackResponse:
+    async def files_info(
+        self,
+        *,
+        file: str,
+        count: int = 100,
+        cursor: Optional[str] = None,
+        limit: int = 0,
+        page: int = 1
+    ) -> AsyncSlackResponse:
         """Gets information about a team file.
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
+            count (int): An optional number of items to return per page, defaulting to 100
+            cursor (str): An optional parameter for pagination
+            limit (int): An optional parameter defining the maximum number of items to return, defaulting to 0
+            page (int): An optional parameter defining the page number of results to return, defaulting to 1
         """
-        kwargs.update({"file": file})
-        return await self.api_call("files.info", http_verb="GET", params=kwargs)
+        return await self.api_call(
+            "files.info",
+            http_verb="GET",
+            params={
+                "file": file,
+                "count": count,
+                "cursor": cursor,
+                "limit": limit,
+                "page": page,
+            },
+        )
 
     async def files_list(self, **kwargs) -> AsyncSlackResponse:
         """Lists & filters team files."""

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1694,12 +1694,20 @@ class AsyncWebClient(AsyncBaseClient):
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
-            count (int): An optional number of items to return per page, defaulting to 100
+            count (int): An optional number of items to return per page
             cursor (str): An optional parameter for pagination
-            limit (int): An optional parameter defining the maximum number of items to return, defaulting to 0
-            page (int): An optional parameter defining the page number of results to return, defaulting to 1
+            limit (int): An optional parameter defining the maximum number of items to return
+            page (int): An optional parameter defining the page number of results to return,
         """
-        kwargs.update({"file": file, "count": count, "cursor": cursor, "page": page})
+        kwargs.update(
+            {
+                "file": file,
+                "count": count,
+                "cursor": cursor,
+                "limit": limit,
+                "page": page,
+            }
+        )
         return await self.api_call("files.info", http_verb="GET", params=kwargs)
 
     async def files_list(self, **kwargs) -> AsyncSlackResponse:

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1697,7 +1697,7 @@ class AsyncWebClient(AsyncBaseClient):
             count (int): An optional number of items to return per page
             cursor (str): An optional parameter for pagination
             limit (int): An optional parameter defining the maximum number of items to return
-            page (int): An optional parameter defining the page number of results to return,
+            page (int): An optional parameter defining the page number of results to return
         """
         kwargs.update(
             {

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1589,12 +1589,20 @@ class WebClient(BaseClient):
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
-            count (int): An optional number of items to return per page, defaulting to 100
+            count (int): An optional number of items to return per page
             cursor (str): An optional parameter for pagination
-            limit (int): An optional parameter defining the maximum number of items to return, defaulting to 0
-            page (int): An optional parameter defining the page number of results to return, defaulting to 1
+            limit (int): An optional parameter defining the maximum number of items to return
+            page (int): An optional parameter defining the page number of results to return,
         """
-        kwargs.update({"file": file, "count": count, "cursor": cursor, "page": page})
+        kwargs.update(
+            {
+                "file": file,
+                "count": count,
+                "cursor": cursor,
+                "limit": limit,
+                "page": page,
+            }
+        )
         return self.api_call("files.info", http_verb="GET", params=kwargs)
 
     def files_list(self, **kwargs) -> SlackResponse:

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1592,7 +1592,7 @@ class WebClient(BaseClient):
             count (int): An optional number of items to return per page
             cursor (str): An optional parameter for pagination
             limit (int): An optional parameter defining the maximum number of items to return
-            page (int): An optional parameter defining the page number of results to return,
+            page (int): An optional parameter defining the page number of results to return
         """
         kwargs.update(
             {

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1555,7 +1555,7 @@ class WebClient(BaseClient):
         return self.api_call("emoji.list", http_verb="GET", params=kwargs)
 
     def files_comments_delete(
-        self, *, file: str, id: str, **kwargs  # skipcq: PYL-W0622
+        self, *, file: str, id: str  # skipcq: PYL-W0622
     ) -> SlackResponse:
         """Deletes an existing comment on a file.
 
@@ -1563,26 +1563,45 @@ class WebClient(BaseClient):
             file (str): The file id. e.g. 'F1234467890'
             id (str): The file comment id. e.g. 'Fc1234567890'
         """
-        kwargs.update({"file": file, "id": id})
-        return self.api_call("files.comments.delete", json=kwargs)
+        return self.api_call("files.comments.delete", json={"file": file, "id": id})
 
-    def files_delete(self, *, file: str, **kwargs) -> SlackResponse:
+    def files_delete(self, *, file: str) -> SlackResponse:
         """Deletes a file.
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
         """
-        kwargs.update({"file": file})
-        return self.api_call("files.delete", json=kwargs)
+        return self.api_call("files.delete", json={"file": file})
 
-    def files_info(self, *, file: str, **kwargs) -> SlackResponse:
+    def files_info(
+        self,
+        *,
+        file: str,
+        count: int = 100,
+        cursor: Optional[str] = None,
+        limit: int = 0,
+        page: int = 1
+    ) -> SlackResponse:
         """Gets information about a team file.
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
+            count (int): An optional number of items to return per page, defaulting to 100
+            cursor (str): An optional parameter for pagination
+            limit (int): An optional parameter defining the maximum number of items to return, defaulting to 0
+            page (int): An optional parameter defining the page number of results to return, defaulting to 1
         """
-        kwargs.update({"file": file})
-        return self.api_call("files.info", http_verb="GET", params=kwargs)
+        return self.api_call(
+            "files.info",
+            http_verb="GET",
+            params={
+                "file": file,
+                "count": count,
+                "cursor": cursor,
+                "limit": limit,
+                "page": page,
+            },
+        )
 
     def files_list(self, **kwargs) -> SlackResponse:
         """Lists & filters team files."""

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1577,10 +1577,10 @@ class WebClient(BaseClient):
         self,
         *,
         file: str,
-        count: int = 100,
+        count: Optional[int] = None,
         cursor: Optional[str] = None,
-        limit: int = 0,
-        page: int = 1
+        limit: Optional[int] = None,
+        page: Optional[int] = None
     ) -> SlackResponse:
         """Gets information about a team file.
 

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1555,7 +1555,7 @@ class WebClient(BaseClient):
         return self.api_call("emoji.list", http_verb="GET", params=kwargs)
 
     def files_comments_delete(
-        self, *, file: str, id: str  # skipcq: PYL-W0622
+        self, *, file: str, id: str, **kwargs  # skipcq: PYL-W0622
     ) -> SlackResponse:
         """Deletes an existing comment on a file.
 
@@ -1563,15 +1563,17 @@ class WebClient(BaseClient):
             file (str): The file id. e.g. 'F1234467890'
             id (str): The file comment id. e.g. 'Fc1234567890'
         """
-        return self.api_call("files.comments.delete", json={"file": file, "id": id})
+        kwargs.update({"file": file, "id": id})
+        return self.api_call("files.comments.delete", json=kwargs)
 
-    def files_delete(self, *, file: str) -> SlackResponse:
+    def files_delete(self, *, file: str, **kwargs) -> SlackResponse:
         """Deletes a file.
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
         """
-        return self.api_call("files.delete", json={"file": file})
+        kwargs.update({"file": file})
+        return self.api_call("files.delete", json=kwargs)
 
     def files_info(
         self,
@@ -1580,7 +1582,8 @@ class WebClient(BaseClient):
         count: Optional[int] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        page: Optional[int] = None
+        page: Optional[int] = None,
+        **kwargs
     ) -> SlackResponse:
         """Gets information about a team file.
 
@@ -1591,17 +1594,8 @@ class WebClient(BaseClient):
             limit (int): An optional parameter defining the maximum number of items to return, defaulting to 0
             page (int): An optional parameter defining the page number of results to return, defaulting to 1
         """
-        return self.api_call(
-            "files.info",
-            http_verb="GET",
-            params={
-                "file": file,
-                "count": count,
-                "cursor": cursor,
-                "limit": limit,
-                "page": page,
-            },
-        )
+        kwargs.update({"file": file, "count": count, "cursor": cursor, "page": page})
+        return self.api_call("files.info", http_verb="GET", params=kwargs)
 
     def files_list(self, **kwargs) -> SlackResponse:
         """Lists & filters team files."""

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1648,7 +1648,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("emoji.list", http_verb="GET", params=kwargs)
 
     def files_comments_delete(
-        self, *, file: str, id: str, **kwargs  # skipcq: PYL-W0622
+        self, *, file: str, id: str  # skipcq: PYL-W0622
     ) -> Union[Future, SlackResponse]:
         """Deletes an existing comment on a file.
 
@@ -1656,26 +1656,45 @@ class LegacyWebClient(LegacyBaseClient):
             file (str): The file id. e.g. 'F1234467890'
             id (str): The file comment id. e.g. 'Fc1234567890'
         """
-        kwargs.update({"file": file, "id": id})
-        return self.api_call("files.comments.delete", json=kwargs)
+        return self.api_call("files.comments.delete", json={"file": file, "id": id})
 
-    def files_delete(self, *, file: str, **kwargs) -> Union[Future, SlackResponse]:
+    def files_delete(self, *, file: str) -> Union[Future, SlackResponse]:
         """Deletes a file.
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
         """
-        kwargs.update({"file": file})
-        return self.api_call("files.delete", json=kwargs)
+        return self.api_call("files.delete", json={"file": file})
 
-    def files_info(self, *, file: str, **kwargs) -> Union[Future, SlackResponse]:
+    def files_info(
+        self,
+        *,
+        file: str,
+        count: int = 100,
+        cursor: Optional[str] = None,
+        limit: int = 0,
+        page: int = 1
+    ) -> Union[Future, SlackResponse]:
         """Gets information about a team file.
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
+            count (int): An optional number of items to return per page, defaulting to 100
+            cursor (str): An optional parameter for pagination
+            limit (int): An optional parameter defining the maximum number of items to return, defaulting to 0
+            page (int): An optional parameter defining the page number of results to return, defaulting to 1
         """
-        kwargs.update({"file": file})
-        return self.api_call("files.info", http_verb="GET", params=kwargs)
+        return self.api_call(
+            "files.info",
+            http_verb="GET",
+            params={
+                "file": file,
+                "count": count,
+                "cursor": cursor,
+                "limit": limit,
+                "page": page,
+            },
+        )
 
     def files_list(self, **kwargs) -> Union[Future, SlackResponse]:
         """Lists & filters team files."""

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1682,12 +1682,20 @@ class LegacyWebClient(LegacyBaseClient):
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
-            count (int): An optional number of items to return per page, defaulting to 100
+            count (int): An optional number of items to return per page
             cursor (str): An optional parameter for pagination
-            limit (int): An optional parameter defining the maximum number of items to return, defaulting to 0
-            page (int): An optional parameter defining the page number of results to return, defaulting to 1
+            limit (int): An optional parameter defining the maximum number of items to return
+            page (int): An optional parameter defining the page number of results to return,
         """
-        kwargs.update({"file": file, "count": count, "cursor": cursor, "page": page})
+        kwargs.update(
+            {
+                "file": file,
+                "count": count,
+                "cursor": cursor,
+                "limit": limit,
+                "page": page,
+            }
+        )
         return self.api_call("files.info", http_verb="GET", params=kwargs)
 
     def files_list(self, **kwargs) -> Union[Future, SlackResponse]:

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1648,7 +1648,7 @@ class LegacyWebClient(LegacyBaseClient):
         return self.api_call("emoji.list", http_verb="GET", params=kwargs)
 
     def files_comments_delete(
-        self, *, file: str, id: str  # skipcq: PYL-W0622
+        self, *, file: str, id: str, **kwargs  # skipcq: PYL-W0622
     ) -> Union[Future, SlackResponse]:
         """Deletes an existing comment on a file.
 
@@ -1656,24 +1656,27 @@ class LegacyWebClient(LegacyBaseClient):
             file (str): The file id. e.g. 'F1234467890'
             id (str): The file comment id. e.g. 'Fc1234567890'
         """
-        return self.api_call("files.comments.delete", json={"file": file, "id": id})
+        kwargs.update({"file": file, "id": id})
+        return self.api_call("files.comments.delete", json=kwargs)
 
-    def files_delete(self, *, file: str) -> Union[Future, SlackResponse]:
+    def files_delete(self, *, file: str, **kwargs) -> Union[Future, SlackResponse]:
         """Deletes a file.
 
         Args:
             file (str): The file id. e.g. 'F1234467890'
         """
-        return self.api_call("files.delete", json={"file": file})
+        kwargs.update({"file": file})
+        return self.api_call("files.delete", json=kwargs)
 
     def files_info(
         self,
         *,
         file: str,
-        count: int = 100,
+        count: Optional[int] = None,
         cursor: Optional[str] = None,
-        limit: int = 0,
-        page: int = 1
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        **kwargs
     ) -> Union[Future, SlackResponse]:
         """Gets information about a team file.
 
@@ -1684,17 +1687,8 @@ class LegacyWebClient(LegacyBaseClient):
             limit (int): An optional parameter defining the maximum number of items to return, defaulting to 0
             page (int): An optional parameter defining the page number of results to return, defaulting to 1
         """
-        return self.api_call(
-            "files.info",
-            http_verb="GET",
-            params={
-                "file": file,
-                "count": count,
-                "cursor": cursor,
-                "limit": limit,
-                "page": page,
-            },
-        )
+        kwargs.update({"file": file, "count": count, "cursor": cursor, "page": page})
+        return self.api_call("files.info", http_verb="GET", params=kwargs)
 
     def files_list(self, **kwargs) -> Union[Future, SlackResponse]:
         """Lists & filters team files."""

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1685,7 +1685,7 @@ class LegacyWebClient(LegacyBaseClient):
             count (int): An optional number of items to return per page
             cursor (str): An optional parameter for pagination
             limit (int): An optional parameter defining the maximum number of items to return
-            page (int): An optional parameter defining the page number of results to return,
+            page (int): An optional parameter defining the page number of results to return
         """
         kwargs.update(
             {


### PR DESCRIPTION
## Summary

Tangentially related to https://github.com/slackapi/python-slack-sdk/issues/1018 , the main purpose was to potentially clean up the public interface for some `files_*` methods as well as expand and clarify my understanding of those API methods.

Based on the public API documentation available (like [the API documentation page for the `files_info` method](https://api.slack.com/methods/files.info)) I attempted to clean up the arguments for the `files_comments_delete`, `files_delete`, and `files_info` methods.

This is technically a breaking change. To keep this non-breaking, I could keep the `kwargs` in addition to defining the explicit method arguments.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
