### PR TITLE
Improve #1084 by removing globally mutable lists

### DIFF
--- a/slack_sdk/audit_logs/v1/async_client.py
+++ b/slack_sdk/audit_logs/v1/async_client.py
@@ -55,7 +55,7 @@ class AsyncAuditLogsClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[AsyncRetryHandler] = async_default_handlers,
+        retry_handlers: List[AsyncRetryHandler] = async_default_handlers(),
     ):
         """API client for Audit Logs API
         See https://api.slack.com/admins/audit-logs for more details

--- a/slack_sdk/audit_logs/v1/client.py
+++ b/slack_sdk/audit_logs/v1/client.py
@@ -50,7 +50,7 @@ class AuditLogsClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[RetryHandler] = default_retry_handlers,
+        retry_handlers: List[RetryHandler] = default_retry_handlers(),
     ):
         """API client for Audit Logs API
         See https://api.slack.com/admins/audit-logs for more details

--- a/slack_sdk/http_retry/__init__.py
+++ b/slack_sdk/http_retry/__init__.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from .handler import RetryHandler  # noqa
 from .builtin_handlers import (
     ConnectionErrorRetryHandler,  # noqa
@@ -16,11 +18,13 @@ from .state import RetryState  # noqa
 connect_error_retry_handler = ConnectionErrorRetryHandler()  # noqa
 rate_limit_error_retry_handler = RateLimitErrorRetryHandler()  # noqa
 
-default_retry_handlers = [  # noqa
-    connect_error_retry_handler,  # noqa
-]  # noqa
 
-all_builtin_retry_handlers = [  # noqa
-    connect_error_retry_handler,  # noqa
-    rate_limit_error_retry_handler,  # noqa
-]  # noqa
+def default_retry_handlers() -> List[RetryHandler]:
+    return [connect_error_retry_handler]
+
+
+def all_builtin_retry_handlers() -> List[RetryHandler]:
+    return [
+        connect_error_retry_handler,
+        rate_limit_error_retry_handler,
+    ]

--- a/slack_sdk/http_retry/builtin_async_handlers.py
+++ b/slack_sdk/http_retry/builtin_async_handlers.py
@@ -87,4 +87,5 @@ class AsyncRateLimitErrorRetryHandler(AsyncRetryHandler):
         await asyncio.sleep(duration)
 
 
-async_default_handlers = [AsyncConnectionErrorRetryHandler()]
+def async_default_handlers() -> List[AsyncRetryHandler]:
+    return [AsyncConnectionErrorRetryHandler()]

--- a/slack_sdk/scim/v1/async_client.py
+++ b/slack_sdk/scim/v1/async_client.py
@@ -70,7 +70,7 @@ class AsyncSCIMClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[AsyncRetryHandler] = async_default_handlers,
+        retry_handlers: List[AsyncRetryHandler] = async_default_handlers(),
     ):
         """API client for SCIM API
         See https://api.slack.com/scim for more details

--- a/slack_sdk/scim/v1/client.py
+++ b/slack_sdk/scim/v1/client.py
@@ -72,7 +72,7 @@ class SCIMClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[RetryHandler] = default_retry_handlers,
+        retry_handlers: List[RetryHandler] = default_retry_handlers(),
     ):
         """API client for SCIM API
         See https://api.slack.com/scim for more details

--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -41,7 +41,7 @@ class AsyncBaseClient:
         # for Org-Wide App installation
         team_id: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[RetryHandler] = async_default_handlers,
+        retry_handlers: List[RetryHandler] = async_default_handlers(),
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -54,7 +54,7 @@ class BaseClient:
         # for Org-Wide App installation
         team_id: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[RetryHandler] = default_retry_handlers,
+        retry_handlers: List[RetryHandler] = default_retry_handlers(),
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url

--- a/slack_sdk/webhook/async_client.py
+++ b/slack_sdk/webhook/async_client.py
@@ -49,7 +49,7 @@ class AsyncWebhookClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[AsyncRetryHandler] = async_default_handlers,
+        retry_handlers: List[AsyncRetryHandler] = async_default_handlers(),
     ):
         """API client for Incoming Webhooks and `response_url`
 

--- a/slack_sdk/webhook/client.py
+++ b/slack_sdk/webhook/client.py
@@ -44,7 +44,7 @@ class WebhookClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[RetryHandler] = default_retry_handlers,
+        retry_handlers: List[RetryHandler] = default_retry_handlers(),
     ):
         """API client for Incoming Webhooks and `response_url`
 

--- a/tests/slack_sdk/http_retry/test_builtins.py
+++ b/tests/slack_sdk/http_retry/test_builtins.py
@@ -1,18 +1,27 @@
 import unittest
 
-from slack_sdk.http_retry import FixedValueRetryIntervalCalculator
-from tests.slack_sdk.audit_logs.mock_web_api_server import (
-    cleanup_mock_web_api_server,
-    setup_mock_web_api_server,
+from slack_sdk.http_retry import (
+    FixedValueRetryIntervalCalculator,
+    default_retry_handlers,
+    all_builtin_retry_handlers,
 )
 
 
 class TestBuiltins(unittest.TestCase):
-    def setUp(self):
-        setup_mock_web_api_server(self)
+    def test_default_ones(self):
+        list = default_retry_handlers()
+        self.assertEqual(1, len(list))
+        list.clear()
+        self.assertEqual(0, len(list))
+        list = default_retry_handlers()
+        self.assertEqual(1, len(list))
 
-    def tearDown(self):
-        cleanup_mock_web_api_server(self)
+        list = all_builtin_retry_handlers()
+        self.assertEqual(2, len(list))
+        list.clear()
+        self.assertEqual(0, len(list))
+        list = all_builtin_retry_handlers()
+        self.assertEqual(2, len(list))
 
     def test_fixed_value_retry_interval_calculator(self):
         for fixed_value in [0.1, 0.2]:

--- a/tests/slack_sdk_async/http_retry/test_builtins.py
+++ b/tests/slack_sdk_async/http_retry/test_builtins.py
@@ -1,0 +1,13 @@
+import unittest
+
+from slack_sdk.http_retry.builtin_async_handlers import async_default_handlers
+
+
+class TestBuiltins(unittest.TestCase):
+    def test_default_ones(self):
+        list = async_default_handlers()
+        self.assertEqual(1, len(list))
+        list.clear()
+        self.assertEqual(0, len(list))
+        list = async_default_handlers()
+        self.assertEqual(1, len(list))


### PR DESCRIPTION
## Summary

This pull request removes all the globally mutable list objects from the pull request #1084 changes. If we have those, mutating the list of retry handlers can cause side effects to other API client instances in the same app.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [x] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
