### PR TITLE
Improve #1092 #1084 by removing mutable method default arguments

### DIFF
--- a/slack_sdk/audit_logs/v1/async_client.py
+++ b/slack_sdk/audit_logs/v1/async_client.py
@@ -55,7 +55,7 @@ class AsyncAuditLogsClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[AsyncRetryHandler] = async_default_handlers(),
+        retry_handlers: Optional[List[AsyncRetryHandler]] = None,
     ):
         """API client for Audit Logs API
         See https://api.slack.com/admins/audit-logs for more details
@@ -88,7 +88,9 @@ class AsyncAuditLogsClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
-        self.retry_handlers = retry_handlers
+        self.retry_handlers = (
+            retry_handlers if retry_handlers is not None else async_default_handlers()
+        )
 
         if self.proxy is None or len(self.proxy.strip()) == 0:
             env_variable = load_http_proxy_from_env(self.logger)

--- a/slack_sdk/audit_logs/v1/client.py
+++ b/slack_sdk/audit_logs/v1/client.py
@@ -50,7 +50,7 @@ class AuditLogsClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[RetryHandler] = default_retry_handlers(),
+        retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         """API client for Audit Logs API
         See https://api.slack.com/admins/audit-logs for more details
@@ -77,7 +77,9 @@ class AuditLogsClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
-        self.retry_handlers = retry_handlers
+        self.retry_handlers = (
+            retry_handlers if retry_handlers is not None else default_retry_handlers()
+        )
 
         if self.proxy is None or len(self.proxy.strip()) == 0:
             env_variable = load_http_proxy_from_env(self.logger)

--- a/slack_sdk/http_retry/builtin_handlers.py
+++ b/slack_sdk/http_retry/builtin_handlers.py
@@ -56,7 +56,7 @@ class RateLimitErrorRetryHandler(RetryHandler):
         response: Optional[HttpResponse] = None,
         error: Optional[Exception] = None,
     ) -> bool:
-        return response.status_code == 429
+        return response is not None and response.status_code == 429
 
     def prepare_for_next_attempt(
         self,

--- a/slack_sdk/scim/v1/async_client.py
+++ b/slack_sdk/scim/v1/async_client.py
@@ -70,7 +70,7 @@ class AsyncSCIMClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[AsyncRetryHandler] = async_default_handlers(),
+        retry_handlers: Optional[List[AsyncRetryHandler]] = None,
     ):
         """API client for SCIM API
         See https://api.slack.com/scim for more details
@@ -103,7 +103,9 @@ class AsyncSCIMClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
-        self.retry_handlers = retry_handlers
+        self.retry_handlers = (
+            retry_handlers if retry_handlers is not None else async_default_handlers()
+        )
 
         if self.proxy is None or len(self.proxy.strip()) == 0:
             env_variable = load_http_proxy_from_env(self.logger)

--- a/slack_sdk/scim/v1/client.py
+++ b/slack_sdk/scim/v1/client.py
@@ -72,7 +72,7 @@ class SCIMClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[RetryHandler] = default_retry_handlers(),
+        retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         """API client for SCIM API
         See https://api.slack.com/scim for more details
@@ -99,7 +99,9 @@ class SCIMClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
-        self.retry_handlers = retry_handlers
+        self.retry_handlers = (
+            retry_handlers if retry_handlers is not None else default_retry_handlers()
+        )
 
         if self.proxy is None or len(self.proxy.strip()) == 0:
             env_variable = load_http_proxy_from_env(self.logger)

--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -41,7 +41,7 @@ class AsyncBaseClient:
         # for Org-Wide App installation
         team_id: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[RetryHandler] = async_default_handlers(),
+        retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url
@@ -59,7 +59,9 @@ class AsyncBaseClient:
         if team_id is not None:
             self.default_params["team_id"] = team_id
         self._logger = logger if logger is not None else logging.getLogger(__name__)
-        self.retry_handlers = retry_handlers
+        self.retry_handlers = (
+            retry_handlers if retry_handlers is not None else async_default_handlers()
+        )
 
         if self.proxy is None or len(self.proxy.strip()) == 0:
             env_variable = load_http_proxy_from_env(self._logger)

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -54,7 +54,7 @@ class BaseClient:
         # for Org-Wide App installation
         team_id: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[RetryHandler] = default_retry_handlers(),
+        retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         self.token = None if token is None else token.strip()
         self.base_url = base_url
@@ -70,7 +70,9 @@ class BaseClient:
             self.default_params["team_id"] = team_id
         self._logger = logger if logger is not None else logging.getLogger(__name__)
 
-        self.retry_handlers = retry_handlers
+        self.retry_handlers = (
+            retry_handlers if retry_handlers is not None else default_retry_handlers()
+        )
 
         if self.proxy is None or len(self.proxy.strip()) == 0:
             env_variable = load_http_proxy_from_env(self._logger)

--- a/slack_sdk/webhook/async_client.py
+++ b/slack_sdk/webhook/async_client.py
@@ -49,7 +49,7 @@ class AsyncWebhookClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[AsyncRetryHandler] = async_default_handlers(),
+        retry_handlers: Optional[List[AsyncRetryHandler]] = None,
     ):
         """API client for Incoming Webhooks and `response_url`
 
@@ -80,7 +80,9 @@ class AsyncWebhookClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
-        self.retry_handlers = retry_handlers
+        self.retry_handlers = (
+            retry_handlers if retry_handlers is not None else async_default_handlers()
+        )
 
         if self.proxy is None or len(self.proxy.strip()) == 0:
             env_variable = load_http_proxy_from_env(self.logger)

--- a/slack_sdk/webhook/client.py
+++ b/slack_sdk/webhook/client.py
@@ -44,7 +44,7 @@ class WebhookClient:
         user_agent_prefix: Optional[str] = None,
         user_agent_suffix: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-        retry_handlers: List[RetryHandler] = default_retry_handlers(),
+        retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         """API client for Incoming Webhooks and `response_url`
 
@@ -70,7 +70,9 @@ class WebhookClient:
             user_agent_prefix, user_agent_suffix
         )
         self.logger = logger if logger is not None else logging.getLogger(__name__)
-        self.retry_handlers = retry_handlers
+        self.retry_handlers = (
+            retry_handlers if retry_handlers is not None else default_retry_handlers()
+        )
 
         if self.proxy is None or len(self.proxy.strip()) == 0:
             env_variable = load_http_proxy_from_env(self.logger)

--- a/tests/slack_sdk/audit_logs/test_client_http_retry.py
+++ b/tests/slack_sdk/audit_logs/test_client_http_retry.py
@@ -35,8 +35,8 @@ class TestAuditLogsClient_HttpRetries(unittest.TestCase):
         client = AuditLogsClient(
             token="xoxp-ratelimited",
             base_url="http://localhost:8888/",
-            retry_handlers=[RateLimitErrorRetryHandler()],
         )
+        client.retry_handlers.append(RateLimitErrorRetryHandler())
 
         response = client.actions()
         # Just running retries; no assertions for call count so far

--- a/tests/slack_sdk/scim/test_client_http_retry.py
+++ b/tests/slack_sdk/scim/test_client_http_retry.py
@@ -36,8 +36,8 @@ class TestSCIMClient(unittest.TestCase):
         client = SCIMClient(
             base_url="http://localhost:8888/",
             token="xoxp-ratelimited",
-            retry_handlers=[RateLimitErrorRetryHandler()],
         )
+        client.retry_handlers.append(RateLimitErrorRetryHandler())
 
         response = client.search_users(start_index=0, count=1)
         # Just running retries; no assertions for call count so far

--- a/tests/slack_sdk/web/test_web_client_http_retry.py
+++ b/tests/slack_sdk/web/test_web_client_http_retry.py
@@ -38,8 +38,8 @@ class TestWebClient_HttpRetry(unittest.TestCase):
             base_url="http://localhost:8888",
             token="xoxp-ratelimited",
             team_id="T111",
-            retry_handlers=[RateLimitErrorRetryHandler()],
         )
+        client.retry_handlers.append(RateLimitErrorRetryHandler())
         try:
             client.auth_test()
             self.fail("An exception is expected")

--- a/tests/slack_sdk/web/test_web_client_http_retry_ratelimited.py
+++ b/tests/slack_sdk/web/test_web_client_http_retry_ratelimited.py
@@ -20,6 +20,6 @@ class TestWebClient_HttpRetry_RateLimited(unittest.TestCase):
             base_url="http://localhost:8888",
             token="xoxb-rate_limited_only_once",
             team_id="T111",
-            retry_handlers=[rate_limit_error_retry_handler],
         )
+        client.retry_handlers.append(rate_limit_error_retry_handler)
         client.auth_test()

--- a/tests/slack_sdk/webhook/test_webhook_http_retry.py
+++ b/tests/slack_sdk/webhook/test_webhook_http_retry.py
@@ -31,10 +31,8 @@ class TestWebhook_HttpRetries(unittest.TestCase):
         self.assertEqual(2, retry_handler.call_count)
 
     def test_ratelimited(self):
-        client = WebhookClient(
-            "http://localhost:8888/ratelimited",
-            retry_handlers=[RateLimitErrorRetryHandler()],
-        )
+        client = WebhookClient("http://localhost:8888/ratelimited")
+        client.retry_handlers.append(RateLimitErrorRetryHandler())
         response = client.send(text="hello!")
         # Just running retries; no assertions for call count so far
         self.assertEqual(429, response.status_code)


### PR DESCRIPTION
## Summary

This pull request corrects a classic Python coding error 🤦 in #1084 #1092 . Passing mutable objects as default value for method arguments is a bad practice. The default value can be cached and can be shared among multiple instances. This pull request eliminates it by setting `None` to the arguments if nothing is passed.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [x] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
