### PR TITLE
Fix #1056 by changing the default type for Option values

### DIFF
--- a/slack_sdk/models/blocks/basic_components.py
+++ b/slack_sdk/models/blocks/basic_components.py
@@ -193,7 +193,12 @@ class Option(JsonObject):
                 dialogs.
         """
         if text:
-            self._text: Optional[TextObject] = TextObject.parse(text)
+            # For better compatibility with Block Kit ("mrkdwn" does not work for it),
+            # we've changed the default text object type to plain_text since version 3.10.0
+            self._text: Optional[TextObject] = TextObject.parse(
+                text=text,  # "text" here can be either a str or a TextObject
+                default_type=PlainTextObject.type,
+            )
             self._label: Optional[str] = None
         else:
             self._text: Optional[TextObject] = None

--- a/tests/slack_sdk/models/test_options.py
+++ b/tests/slack_sdk/models/test_options.py
@@ -1,0 +1,44 @@
+import unittest
+
+from slack_sdk.models.blocks import (
+    StaticSelectElement,
+    Option,
+)
+
+
+class TestOptions(unittest.TestCase):
+    def test_with_static_select_element(self):
+        self.maxDiff = None
+
+        elem = StaticSelectElement(
+            action_id="action-id",
+            initial_option=Option(value="option-1", text="Option 1"),
+            options=[
+                Option(value="option-1", text="Option 1"),
+                Option(value="option-2", text="Option 2"),
+                Option(value="option-3", text="Option 3"),
+            ],
+        )
+        expected = {
+            "action_id": "action-id",
+            "initial_option": {
+                "text": {"emoji": True, "text": "Option 1", "type": "plain_text"},
+                "value": "option-1",
+            },
+            "options": [
+                {
+                    "text": {"emoji": True, "text": "Option 1", "type": "plain_text"},
+                    "value": "option-1",
+                },
+                {
+                    "text": {"emoji": True, "text": "Option 2", "type": "plain_text"},
+                    "value": "option-2",
+                },
+                {
+                    "text": {"emoji": True, "text": "Option 3", "type": "plain_text"},
+                    "value": "option-3",
+                },
+            ],
+            "type": "static_select",
+        }
+        self.assertDictEqual(expected, elem.to_dict())


### PR DESCRIPTION
## Summary

This pull request fixes #1056 by changing the default type when a developer passes a str value for `text` when constructing `Option` values in a Block Kit select menu. As the current behavior using the constructor just does not work, I call this change a bug fix, not a breaking change.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
