### PR TITLE
Fix #1100 by improving the get/__getitem__ method behavior when response body is empty

### DIFF
--- a/slack/web/async_slack_response.py
+++ b/slack/web/async_slack_response.py
@@ -74,6 +74,10 @@ class AsyncSlackResponse:
 
     def __str__(self):
         """Return the Response data if object is converted to a string."""
+        if isinstance(self.data, bytes):
+            raise ValueError(
+                "As the response.data is binary data, this operation is unsupported"
+            )
         return f"{self.data}"
 
     def __getitem__(self, key):
@@ -87,6 +91,14 @@ class AsyncSlackResponse:
         Returns:
             The value from data or None.
         """
+        if isinstance(self.data, bytes):
+            raise ValueError(
+                "As the response.data is binary data, this operation is unsupported"
+            )
+        if self.data is None:
+            raise ValueError(
+                "As the response.data is empty, this operation is unsupported"
+            )
         return self.data.get(key, None)
 
     def __aiter__(self):
@@ -156,6 +168,12 @@ class AsyncSlackResponse:
         Returns:
             The value from data or the specified default.
         """
+        if isinstance(self.data, bytes):
+            raise ValueError(
+                "As the response.data is binary data, this operation is unsupported"
+            )
+        if self.data is None:
+            return None
         return self.data.get(key, default)
 
     def validate(self):
@@ -168,13 +186,6 @@ class AsyncSlackResponse:
         Raises:
             SlackApiError: The request to the Slack API failed.
         """
-        if self._logger.level <= logging.DEBUG:
-            self._logger.debug(
-                "Received the following response - "
-                f"status: {self.status_code}, "
-                f"headers: {dict(self.headers)}, "
-                f"body: {self.data}"
-            )
         if self.status_code == 200 and self.data and self.data.get("ok", False):
             return self
         msg = "The request to the Slack API failed."

--- a/slack_sdk/web/async_slack_response.py
+++ b/slack_sdk/web/async_slack_response.py
@@ -96,6 +96,10 @@ class AsyncSlackResponse:
             raise ValueError(
                 "As the response.data is binary data, this operation is unsupported"
             )
+        if self.data is None:
+            raise ValueError(
+                "As the response.data is empty, this operation is unsupported"
+            )
         return self.data.get(key, None)
 
     def __aiter__(self):
@@ -177,6 +181,8 @@ class AsyncSlackResponse:
             raise ValueError(
                 "As the response.data is binary data, this operation is unsupported"
             )
+        if self.data is None:
+            return None
         return self.data.get(key, default)
 
     def validate(self):
@@ -189,14 +195,6 @@ class AsyncSlackResponse:
         Raises:
             SlackApiError: The request to the Slack API failed.
         """
-        if self._logger.level <= logging.DEBUG:
-            body = self.data if isinstance(self.data, dict) else "(binary)"
-            self._logger.debug(
-                "Received the following response - "
-                f"status: {self.status_code}, "
-                f"headers: {dict(self.headers)}, "
-                f"body: {body}"
-            )
         if (
             self.status_code == 200
             and self.data

--- a/slack_sdk/web/slack_response.py
+++ b/slack_sdk/web/slack_response.py
@@ -96,6 +96,10 @@ class SlackResponse:
             raise ValueError(
                 "As the response.data is binary data, this operation is unsupported"
             )
+        if self.data is None:
+            raise ValueError(
+                "As the response.data is empty, this operation is unsupported"
+            )
         return self.data.get(key, None)
 
     def __iter__(self):
@@ -174,6 +178,8 @@ class SlackResponse:
             raise ValueError(
                 "As the response.data is binary data, this operation is unsupported"
             )
+        if self.data is None:
+            return None
         return self.data.get(key, default)
 
     def validate(self):

--- a/tests/slack_sdk/web/test_slack_response.py
+++ b/tests/slack_sdk/web/test_slack_response.py
@@ -26,3 +26,20 @@ class TestSlackResponse(unittest.TestCase):
         self.assertTrue("ok" in response.data)
         self.assertTrue("args" in response.data)
         self.assertFalse("error" in response.data)
+
+    # https://github.com/slackapi/python-slack-sdk/issues/1100
+    def test_issue_1100(self):
+        response = SlackResponse(
+            client=WebClient(token="xoxb-dummy"),
+            http_verb="POST",
+            api_url="http://localhost:3000/api.test",
+            req_args={},
+            data=None,
+            headers={},
+            status_code=200,
+        )
+        with self.assertRaises(ValueError):
+            response["foo"]
+
+        foo = response.get("foo")
+        self.assertIsNone(foo)

--- a/tests/slack_sdk_async/web/test_async_slack_response.py
+++ b/tests/slack_sdk_async/web/test_async_slack_response.py
@@ -1,0 +1,29 @@
+import unittest
+
+from slack.web.async_slack_response import AsyncSlackResponse
+from slack_sdk.web.async_client import AsyncWebClient
+
+
+class TestAsyncSlackResponse(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    # https://github.com/slackapi/python-slack-sdk/issues/1100
+    def test_issue_1100(self):
+        response = AsyncSlackResponse(
+            client=AsyncWebClient(token="xoxb-dummy"),
+            http_verb="POST",
+            api_url="http://localhost:3000/api.test",
+            req_args={},
+            data=None,
+            headers={},
+            status_code=200,
+        )
+        with self.assertRaises(ValueError):
+            response["foo"]
+
+        foo = response.get("foo")
+        self.assertIsNone(foo)


### PR DESCRIPTION
## Summary

This pull request fixes #1100 by improving `SlackResponse` and `AsyncSlackResponse`.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
