### PR TITLE
Fix #1102 Add __contains__ method in slack_sdk.web.SlackResponse / AsyncSlackResponse

### DIFF
--- a/slack/web/async_slack_response.py
+++ b/slack/web/async_slack_response.py
@@ -80,6 +80,9 @@ class AsyncSlackResponse:
             )
         return f"{self.data}"
 
+    def __contains__(self, key: str) -> bool:
+        return self.get(key) is not None
+
     def __getitem__(self, key):
         """Retrieves any key from the data store.
 

--- a/slack_sdk/web/async_slack_response.py
+++ b/slack_sdk/web/async_slack_response.py
@@ -81,6 +81,9 @@ class AsyncSlackResponse:
             )
         return f"{self.data}"
 
+    def __contains__(self, key: str) -> bool:
+        return self.get(key) is not None
+
     def __getitem__(self, key):
         """Retrieves any key from the data store.
 

--- a/slack_sdk/web/slack_response.py
+++ b/slack_sdk/web/slack_response.py
@@ -81,6 +81,9 @@ class SlackResponse:
             )
         return f"{self.data}"
 
+    def __contains__(self, key: str) -> bool:
+        return self.get(key) is not None
+
     def __getitem__(self, key):
         """Retrieves any key from the data store.
 

--- a/tests/slack_sdk/web/test_slack_response.py
+++ b/tests/slack_sdk/web/test_slack_response.py
@@ -43,3 +43,17 @@ class TestSlackResponse(unittest.TestCase):
 
         foo = response.get("foo")
         self.assertIsNone(foo)
+
+    # https://github.com/slackapi/python-slack-sdk/issues/1102
+    def test_issue_1102(self):
+        response = SlackResponse(
+            client=WebClient(token="xoxb-dummy"),
+            http_verb="POST",
+            api_url="http://localhost:3000/api.test",
+            req_args={},
+            data={"ok": True, "args": {"hello": "world"}},
+            headers={},
+            status_code=200,
+        )
+        self.assertTrue("ok" in response)
+        self.assertTrue("foo" not in response)

--- a/tests/slack_sdk_async/web/test_async_slack_response.py
+++ b/tests/slack_sdk_async/web/test_async_slack_response.py
@@ -1,6 +1,6 @@
 import unittest
 
-from slack.web.async_slack_response import AsyncSlackResponse
+from slack_sdk.web.async_slack_response import AsyncSlackResponse
 from slack_sdk.web.async_client import AsyncWebClient
 
 
@@ -27,3 +27,17 @@ class TestAsyncSlackResponse(unittest.TestCase):
 
         foo = response.get("foo")
         self.assertIsNone(foo)
+
+    # https://github.com/slackapi/python-slack-sdk/issues/1102
+    def test_issue_1102(self):
+        response = AsyncSlackResponse(
+            client=AsyncWebClient(token="xoxb-dummy"),
+            http_verb="POST",
+            api_url="http://localhost:3000/api.test",
+            req_args={},
+            data={"ok": True, "args": {"hello": "world"}},
+            headers={},
+            status_code=200,
+        )
+        self.assertTrue("ok" in response)
+        self.assertTrue("foo" not in response)


### PR DESCRIPTION
## Summary

This pull request resolves #1102. Refer to the issue for details.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
