### PR TITLE
Update the entity name to Slack Technologies, LLC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Slack Technologies, Inc
+Copyright (c) 2015- Slack Technologies, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs-src-v2/_themes/slack/conf.py
+++ b/docs-src-v2/_themes/slack/conf.py
@@ -52,8 +52,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'slackclient (Legacy Python Slack SDK)'
-copyright = u'2015–2016 Slack Technologies, Inc. and contributors'
-author = u'Slack Technologies, Inc. and contributors'
+copyright = u'2015– Slack Technologies, LLC and contributors'
+author = u'Slack Technologies, LLC and contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs-src-v2/_themes/slack/layout.html
+++ b/docs-src-v2/_themes/slack/layout.html
@@ -150,7 +150,7 @@
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-src/_themes/slack/conf.py
+++ b/docs-src/_themes/slack/conf.py
@@ -52,8 +52,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Python Slack SDK'
-copyright = u'2015– Slack Technologies, Inc. and contributors'
-author = u'Slack Technologies, Inc. and contributors'
+copyright = u'2015– Slack Technologies, LLC and contributors'
+author = u'Slack Technologies, LLC and contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs-src/_themes/slack/layout.html
+++ b/docs-src/_themes/slack/layout.html
@@ -146,7 +146,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs-v2/.buildinfo
+++ b/docs-v2/.buildinfo
@@ -1,4 +1,4 @@
 # Sphinx build info version 1
 # This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: 2cfca20515a7ec4c5dfdf57393105f87
+config: 5aeb40b1c45c7bb97acf441950bfceb8
 tags: 645f666f9bcd5a90fca523b33c5a78b7

--- a/docs-v2/about.html
+++ b/docs-v2/about.html
@@ -268,7 +268,7 @@
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-v2/auth.html
+++ b/docs-v2/auth.html
@@ -363,7 +363,7 @@ your workspace for changes to take effect.</p>
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-v2/basic_usage.html
+++ b/docs-v2/basic_usage.html
@@ -672,7 +672,7 @@ joined one by accident. This is how you leave a channel.</p>
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-v2/changelog.html
+++ b/docs-v2/changelog.html
@@ -735,7 +735,7 @@ This release would not have been possible without the support of our community. 
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-v2/conversations.html
+++ b/docs-v2/conversations.html
@@ -362,7 +362,7 @@
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-v2/faq.html
+++ b/docs-v2/faq.html
@@ -321,7 +321,7 @@ the changelog in <code class="docutils literal notranslate"><span class="pre">ch
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-v2/genindex.html
+++ b/docs-v2/genindex.html
@@ -260,7 +260,7 @@
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-v2/index.html
+++ b/docs-v2/index.html
@@ -313,7 +313,7 @@ consider using v1 of the SDK.</p>
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-v2/metadata.html
+++ b/docs-v2/metadata.html
@@ -254,7 +254,7 @@
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-v2/real_time_messaging.html
+++ b/docs-v2/real_time_messaging.html
@@ -341,7 +341,7 @@ and it supports most of the event types in the RTM API. If you’d like to use t
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs-v2/search.html
+++ b/docs-v2/search.html
@@ -274,7 +274,7 @@
 
     <footer>
       <p class="light tiny align_center">
-        © 2020 Slack Technologies, Inc. and contributors
+        © 2015- Slack Technologies, LLC and contributors
       </p>
     </footer>
 

--- a/docs/.buildinfo
+++ b/docs/.buildinfo
@@ -1,4 +1,4 @@
 # Sphinx build info version 1
 # This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: f47751de68c8ee3f7e02d24a875601e0
+config: ad89fb64a5900a5c9194f645c4af338b
 tags: 645f666f9bcd5a90fca523b33c5a78b7

--- a/docs/about.html
+++ b/docs/about.html
@@ -235,7 +235,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/audit-logs/index.html
+++ b/docs/audit-logs/index.html
@@ -309,7 +309,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -282,7 +282,7 @@ pip install <span class="s2">&quot;slack_sdk&gt;=3.0&quot;</span>
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/genindex.html
+++ b/docs/genindex.html
@@ -227,7 +227,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -320,7 +320,7 @@ pip install -e .  <span class="c1"># install the SDK project into the virtual en
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -331,7 +331,7 @@ your workspace for changes to take effect.</p>
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/metadata.html
+++ b/docs/metadata.html
@@ -221,7 +221,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/oauth/index.html
+++ b/docs/oauth/index.html
@@ -478,7 +478,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/real_time_messaging.html
+++ b/docs/real_time_messaging.html
@@ -325,7 +325,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/scim/index.html
+++ b/docs/scim/index.html
@@ -356,7 +356,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/search.html
+++ b/docs/search.html
@@ -241,7 +241,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/socket-mode/index.html
+++ b/docs/socket-mode/index.html
@@ -368,7 +368,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/v3-migration/index.html
+++ b/docs/v3-migration/index.html
@@ -259,7 +259,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -803,7 +803,7 @@ deletion of threaded replies works the same as regular messages.</p>
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/docs/webhook/index.html
+++ b/docs/webhook/index.html
@@ -367,7 +367,7 @@
 
         <footer>
             <p class="light tiny align_center">
-                © 2020 Slack Technologies, Inc. and contributors
+                © 2015- Slack Technologies, LLC and contributors
             </p>
         </footer>
 

--- a/setup.py
+++ b/setup.py
@@ -259,7 +259,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/slackapi/python-slack-sdk",
-    author="Slack Technologies, Inc.",
+    author="Slack Technologies, LLC",
     author_email="opensource@slack.com",
     python_requires=">=3.6.0",
     include_package_data=True,


### PR DESCRIPTION
## Summary

This pull request updates the entity name from "Slack Technologies, Inc." to "Slack Technologies, LLC"

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs-src` (Documents, have you run `./docs.sh`?)
- [x] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
