### PR TITLE
Fix WebClient#files_upload does not send channels since v3.10.0

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2848,17 +2848,12 @@ class AsyncWebClient(AsyncBaseClient):
                 "You cannot specify both the file and the content argument."
             )
 
-        if file:
-            if "filename" not in kwargs and isinstance(file, str):
-                # use the local filename if filename is missing
-                kwargs["filename"] = file.split(os.path.sep)[-1]
-            return await self.api_call(
-                "files.upload", files={"file": file}, data=kwargs
-            )
-        data = kwargs.copy()
-        data.update(
+        if isinstance(channels, (list, Tuple)):
+            kwargs.update({"channels": ",".join(channels)})
+        else:
+            kwargs.update({"channels": channels})
+        kwargs.update(
             {
-                "content": content,
                 "filename": filename,
                 "filetype": filetype,
                 "initial_comment": initial_comment,
@@ -2866,11 +2861,17 @@ class AsyncWebClient(AsyncBaseClient):
                 "title": title,
             }
         )
-        if isinstance(channels, (list, Tuple)):
-            kwargs.update({"channels": ",".join(channels)})
+        if file:
+            if "filename" not in kwargs and isinstance(file, str):
+                # use the local filename if filename is missing
+                if kwargs.get("filename") is None:
+                    kwargs["filename"] = file.split(os.path.sep)[-1]
+            return await self.api_call(
+                "files.upload", files={"file": file}, data=kwargs
+            )
         else:
-            kwargs.update({"channels": channels})
-        return await self.api_call("files.upload", data=data)
+            kwargs["content"] = content
+            return await self.api_call("files.upload", data=kwargs)
 
     # --------------------------
     # Deprecated: groups.*

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2797,15 +2797,12 @@ class WebClient(BaseClient):
                 "You cannot specify both the file and the content argument."
             )
 
-        if file:
-            if "filename" not in kwargs and isinstance(file, str):
-                # use the local filename if filename is missing
-                kwargs["filename"] = file.split(os.path.sep)[-1]
-            return self.api_call("files.upload", files={"file": file}, data=kwargs)
-        data = kwargs.copy()
-        data.update(
+        if isinstance(channels, (list, Tuple)):
+            kwargs.update({"channels": ",".join(channels)})
+        else:
+            kwargs.update({"channels": channels})
+        kwargs.update(
             {
-                "content": content,
                 "filename": filename,
                 "filetype": filetype,
                 "initial_comment": initial_comment,
@@ -2813,11 +2810,15 @@ class WebClient(BaseClient):
                 "title": title,
             }
         )
-        if isinstance(channels, (list, Tuple)):
-            kwargs.update({"channels": ",".join(channels)})
+        if file:
+            if "filename" not in kwargs and isinstance(file, str):
+                # use the local filename if filename is missing
+                if kwargs.get("filename") is None:
+                    kwargs["filename"] = file.split(os.path.sep)[-1]
+            return self.api_call("files.upload", files={"file": file}, data=kwargs)
         else:
-            kwargs.update({"channels": channels})
-        return self.api_call("files.upload", data=data)
+            kwargs["content"] = content
+            return self.api_call("files.upload", data=kwargs)
 
     # --------------------------
     # Deprecated: groups.*

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2808,15 +2808,12 @@ class LegacyWebClient(LegacyBaseClient):
                 "You cannot specify both the file and the content argument."
             )
 
-        if file:
-            if "filename" not in kwargs and isinstance(file, str):
-                # use the local filename if filename is missing
-                kwargs["filename"] = file.split(os.path.sep)[-1]
-            return self.api_call("files.upload", files={"file": file}, data=kwargs)
-        data = kwargs.copy()
-        data.update(
+        if isinstance(channels, (list, Tuple)):
+            kwargs.update({"channels": ",".join(channels)})
+        else:
+            kwargs.update({"channels": channels})
+        kwargs.update(
             {
-                "content": content,
                 "filename": filename,
                 "filetype": filetype,
                 "initial_comment": initial_comment,
@@ -2824,11 +2821,15 @@ class LegacyWebClient(LegacyBaseClient):
                 "title": title,
             }
         )
-        if isinstance(channels, (list, Tuple)):
-            kwargs.update({"channels": ",".join(channels)})
+        if file:
+            if "filename" not in kwargs and isinstance(file, str):
+                # use the local filename if filename is missing
+                if kwargs.get("filename") is None:
+                    kwargs["filename"] = file.split(os.path.sep)[-1]
+            return self.api_call("files.upload", files={"file": file}, data=kwargs)
         else:
-            kwargs.update({"channels": channels})
-        return self.api_call("files.upload", data=data)
+            kwargs["content"] = content
+            return self.api_call("files.upload", data=kwargs)
 
     # --------------------------
     # Deprecated: groups.*


### PR DESCRIPTION
## Summary

This pull request fixes a regression bug by https://github.com/slackapi/python-slack-sdk/pull/1099 

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
