### PR TITLE
Add missing properties in Audit Logs details data class

### DIFF
--- a/slack_sdk/audit_logs/v1/logs.py
+++ b/slack_sdk/audit_logs/v1/logs.py
@@ -86,6 +86,22 @@ class Context:
         self.unknown_fields = kwargs
 
 
+class RetentionPolicy:
+    type: Optional[str]
+    duration_days: Optional[int]
+
+    def __init__(
+        self,
+        *,
+        type: Optional[str] = None,
+        duration_days: Optional[int] = None,
+        **kwargs,
+    ) -> None:
+        self.type = type
+        self.duration_days = duration_days
+        self.unknown_fields = kwargs
+
+
 class Details:
     name: Optional[str]
     new_value: Optional[Union[str, List[str], Dict[str, Any]]]
@@ -140,6 +156,8 @@ class Details:
     added_team_id: Optional[str]
     unknown_fields: Dict[str, Any]
     is_token_rotation_enabled_app: Optional[bool]
+    old_retention_policy: Optional[RetentionPolicy]
+    new_retention_policy: Optional[RetentionPolicy]
 
     def __init__(
         self,
@@ -153,8 +171,8 @@ class Details:
         non_sso_only: Optional[bool] = None,
         type: Optional[str] = None,
         is_workflow: Optional[bool] = None,
-        inviter: Optional[User] = None,
-        kicker: Optional[User] = None,
+        inviter: Optional[Union[Dict[str, Any], User]] = None,
+        kicker: Optional[Union[Dict[str, Any], User]] = None,
         shared_to: Optional[str] = None,
         reason: Optional[str] = None,
         origin_team: Optional[str] = None,
@@ -196,6 +214,8 @@ class Details:
         channel_id: Optional[str] = None,
         added_team_id: Optional[str] = None,
         is_token_rotation_enabled_app: Optional[bool] = None,
+        old_retention_policy: Optional[Union[Dict[str, Any], RetentionPolicy]] = None,
+        new_retention_policy: Optional[Union[Dict[str, Any], RetentionPolicy]] = None,
         **kwargs,
     ) -> None:
         self.name = name
@@ -207,8 +227,8 @@ class Details:
         self.non_sso_only = non_sso_only
         self.type = type
         self.is_workflow = is_workflow
-        self.inviter = inviter
-        self.kicker = kicker
+        self.inviter = inviter if isinstance(inviter, User) else User(**inviter)
+        self.kicker = kicker if isinstance(kicker, User) else User(**kicker)
         self.shared_to = shared_to
         self.reason = reason
         self.origin_team = origin_team
@@ -251,6 +271,16 @@ class Details:
         self.channel_id = channel_id
         self.added_team_id = added_team_id
         self.is_token_rotation_enabled_app = is_token_rotation_enabled_app
+        self.old_retention_policy = (
+            old_retention_policy
+            if isinstance(old_retention_policy, RetentionPolicy)
+            else RetentionPolicy(**old_retention_policy)
+        )
+        self.new_retention_policy = (
+            new_retention_policy
+            if isinstance(new_retention_policy, RetentionPolicy)
+            else RetentionPolicy(**new_retention_policy)
+        )
 
 
 class App:

--- a/tests/slack_sdk/audit_logs/test_response.py
+++ b/tests/slack_sdk/audit_logs/test_response.py
@@ -126,6 +126,11 @@ class TestAuditLogsClient(unittest.TestCase):
             [],
             f"found: {entry.actor.unknown_fields.keys()}",
         )
+        self.assertEqual(entry.details.is_token_rotation_enabled_app, True)
+        self.assertEqual(entry.details.inviter.id, "inviter_id")
+        self.assertEqual(entry.details.kicker.id, "kicker_id")
+        self.assertEqual(entry.details.old_retention_policy.type, "old")
+        self.assertEqual(entry.details.new_retention_policy.type, "new")
 
 
 logs_response_data = """{
@@ -242,27 +247,13 @@ logs_response_data = """{
           ""
         ],
         "inviter": {
-          "type": "",
-          "user": {
-            "id": "",
-            "name": "",
-            "email": "",
-            "team": ""
-          },
-          "id": "",
+          "id": "inviter_id",
           "name": "",
           "email": "",
           "team": ""
         },
         "kicker": {
-          "type": "",
-          "user": {
-            "id": "",
-            "name": "",
-            "email": "",
-            "team": ""
-          },
-          "id": "",
+          "id": "kicker_id",
           "name": "",
           "email": "",
           "team": ""
@@ -331,7 +322,16 @@ logs_response_data = """{
         "external_user_id": "",
         "external_user_email": "",
         "channel_id": "",
-        "added_team_id": ""
+        "added_team_id": "",
+        "is_token_rotation_enabled_app": true,
+        "old_retention_policy": {
+          "type": "old",
+          "duration_days": 111
+        },
+        "new_retention_policy": {
+          "type": "new",
+          "duration_days": 222
+        }
       }
     }
   ]


### PR DESCRIPTION
## Summary

This pull request adds message retention policy related fields to the `entity[].details` data. Also, improved the `Details` class constructor to accept both class data and dict value.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
