### PR TITLE
Improve the stability of SocketModeClient implementations

### DIFF
--- a/slack_sdk/socket_mode/builtin/connection.py
+++ b/slack_sdk/socket_mode/builtin/connection.py
@@ -244,7 +244,7 @@ class Connection:
             except Exception as e:
                 # In most cases, we want to retry this operation with a newly established connection.
                 # Getting this exception means that this connection has been replaced with a new one
-                # and it's no loner usable.
+                # and it's no longer usable.
                 # The SocketModeClient implementation can do one retry when it gets this exception.
                 raise SlackClientNotConnectedError(
                     f"Failed to send a message as the connection is no longer active "

--- a/slack_sdk/socket_mode/websocket_client/__init__.py
+++ b/slack_sdk/socket_mode/websocket_client/__init__.py
@@ -13,7 +13,7 @@ from threading import Lock
 from typing import Union, Optional, List, Callable, Tuple
 
 import websocket
-from websocket import WebSocketApp
+from websocket import WebSocketApp, WebSocketException
 
 from slack_sdk.socket_mode.client import BaseSocketModeClient
 from slack_sdk.socket_mode.interval_runner import IntervalRunner
@@ -212,7 +212,27 @@ class SocketModeClient(BaseSocketModeClient):
     def send_message(self, message: str) -> None:
         if self.logger.level <= logging.DEBUG:
             self.logger.debug(f"Sending a message: {message}")
-        self.current_session.send(message)
+        try:
+            self.current_session.send(message)
+        except WebSocketException as e:
+            # We rarely get this exception while replacing the underlying WebSocket connections.
+            # We can do one more try here as the self.current_session should be ready now.
+            if self.logger.level <= logging.DEBUG:
+                self.logger.debug(
+                    f"Failed to send a message (error: {e}, message: {message})"
+                    " as the underlying connection was replaced. Retrying the same request only one time..."
+                )
+            # Although acquiring self.connect_operation_lock also for the first method call is the safest way,
+            # we avoid synchronizing a lot for better performance. That's why we are doing a retry here.
+            with self.connect_operation_lock:
+                if self.is_connected():
+                    self.current_session.send(message)
+                else:
+                    self.logger.warning(
+                        f"The current session (session id: {self.session_id()}) is no longer active. "
+                        "Failed to send a message"
+                    )
+                    raise e
 
     def close(self):
         self.closed = True

--- a/tests/slack_sdk/socket_mode/test_interactions_builtin.py
+++ b/tests/slack_sdk/socket_mode/test_interactions_builtin.py
@@ -4,7 +4,7 @@ import unittest
 from random import randint
 from threading import Thread
 
-from slack_sdk.errors import SlackClientConfigurationError
+from slack_sdk.errors import SlackClientConfigurationError, SlackClientNotConnectedError
 from slack_sdk.socket_mode.request import SocketModeRequest
 
 from slack_sdk.socket_mode.client import BaseSocketModeClient
@@ -126,7 +126,44 @@ class TestInteractionsBuiltin(unittest.TestCase):
                 self.logger.info(f"Passed with buffer size: {buffer_size}")
 
         finally:
+            client.close()
             self.server.stop()
             self.server.close()
 
         self.logger.info(f"Passed with buffer size: {buffer_size_list}")
+
+    def test_sending_messages(self):
+        if is_ci_unstable_test_skip_enabled():
+            return
+        t = Thread(target=start_socket_mode_server(self, 3011))
+        t.daemon = True
+        t.start()
+        time.sleep(2)  # wait for the server
+
+        try:
+            self.reset_sever_state()
+            client = SocketModeClient(
+                app_token="xapp-A111-222-xyz",
+                web_client=self.web_client,
+                auto_reconnect_enabled=False,
+                trace_enabled=True,
+            )
+            client.wss_uri = "ws://0.0.0.0:3011/link"
+            client.connect()
+            time.sleep(1)  # wait for the connection
+            client.send_message("foo")
+
+            client.disconnect()
+            time.sleep(1)  # wait for the connection
+            try:
+                client.send_message("foo")
+            except SlackClientNotConnectedError as _:
+                pass
+
+            client.connect()
+            time.sleep(1)  # wait for the connection
+            client.send_message("foo")
+        finally:
+            client.close()
+            self.server.stop()
+            self.server.close()

--- a/tests/slack_sdk/socket_mode/test_interactions_builtin.py
+++ b/tests/slack_sdk/socket_mode/test_interactions_builtin.py
@@ -132,7 +132,7 @@ class TestInteractionsBuiltin(unittest.TestCase):
 
         self.logger.info(f"Passed with buffer size: {buffer_size_list}")
 
-    def test_sending_messages(self):
+    def test_send_message_while_disconnection(self):
         if is_ci_unstable_test_skip_enabled():
             return
         t = Thread(target=start_socket_mode_server(self, 3011))
@@ -157,6 +157,7 @@ class TestInteractionsBuiltin(unittest.TestCase):
             time.sleep(1)  # wait for the connection
             try:
                 client.send_message("foo")
+                self.fail("SlackClientNotConnectedError is expected here")
             except SlackClientNotConnectedError as _:
                 pass
 

--- a/tests/slack_sdk/socket_mode/test_interactions_websocket_client.py
+++ b/tests/slack_sdk/socket_mode/test_interactions_websocket_client.py
@@ -104,7 +104,7 @@ class TestInteractionsWebSocketClient(unittest.TestCase):
             self.server.stop()
             self.server.close()
 
-    def test_sending_messages(self):
+    def test_send_message_while_disconnection(self):
         if is_ci_unstable_test_skip_enabled():
             return
         t = Thread(target=start_socket_mode_server(self, 3012))
@@ -129,6 +129,7 @@ class TestInteractionsWebSocketClient(unittest.TestCase):
             time.sleep(1)  # wait for the connection
             try:
                 client.send_message("foo")
+                self.fail("WebSocketException is expected here")
             except WebSocketException as _:
                 pass
 

--- a/tests/slack_sdk_async/socket_mode/test_interactions_aiohttp.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_aiohttp.py
@@ -107,7 +107,7 @@ class TestInteractionsAiohttp(unittest.TestCase):
             self.server.close()
 
     @async_test
-    async def test_sending_messages(self):
+    async def test_send_message_while_disconnection(self):
         if is_ci_unstable_test_skip_enabled():
             return
         t = Thread(target=start_socket_mode_server(self, 3001))
@@ -132,6 +132,7 @@ class TestInteractionsAiohttp(unittest.TestCase):
             await asyncio.sleep(1)  # wait for the message receiver
             try:
                 await client.send_message("foo")
+                self.fail("ConnectionError is expected here")
             except ConnectionError as _:
                 pass
 

--- a/tests/slack_sdk_async/socket_mode/test_interactions_aiohttp.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_aiohttp.py
@@ -105,3 +105,40 @@ class TestInteractionsAiohttp(unittest.TestCase):
             await client.close()
             self.server.stop()
             self.server.close()
+
+    @async_test
+    async def test_sending_messages(self):
+        if is_ci_unstable_test_skip_enabled():
+            return
+        t = Thread(target=start_socket_mode_server(self, 3001))
+        t.daemon = True
+        t.start()
+
+        client = SocketModeClient(
+            app_token="xapp-A111-222-xyz",
+            web_client=self.web_client,
+            auto_reconnect_enabled=False,
+            trace_enabled=True,
+        )
+
+        try:
+            time.sleep(1)  # wait for the server
+            client.wss_uri = "ws://0.0.0.0:3001/link"
+            await client.connect()
+            await asyncio.sleep(1)  # wait for the message receiver
+            await client.send_message("foo")
+
+            await client.disconnect()
+            await asyncio.sleep(1)  # wait for the message receiver
+            try:
+                await client.send_message("foo")
+            except ConnectionError as _:
+                pass
+
+            await client.connect()
+            await asyncio.sleep(1)  # wait for the message receiver
+            await client.send_message("foo")
+        finally:
+            await client.close()
+            self.server.stop()
+            self.server.close()

--- a/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
@@ -110,7 +110,7 @@ class TestInteractionsWebsockets(unittest.TestCase):
             self.server.close()
 
     @async_test
-    async def test_sending_messages(self):
+    async def test_send_message_while_disconnection(self):
         if is_ci_unstable_test_skip_enabled():
             return
         t = Thread(target=start_socket_mode_server(self, 3001))
@@ -135,6 +135,7 @@ class TestInteractionsWebsockets(unittest.TestCase):
             await asyncio.sleep(1)  # wait for the message receiver
             try:
                 await client.send_message("foo")
+                self.fail("WebSocketException is expected here")
             except WebSocketException as _:
                 pass
 

--- a/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
@@ -6,6 +6,8 @@ from random import randint
 from threading import Thread
 from typing import Optional
 
+from websockets.exceptions import WebSocketException
+
 from slack_sdk.socket_mode.request import SocketModeRequest
 
 from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
@@ -102,6 +104,43 @@ class TestInteractionsWebsockets(unittest.TestCase):
             self.assertEqual(
                 len(socket_mode_envelopes), len(received_socket_mode_requests)
             )
+        finally:
+            await client.close()
+            self.server.stop()
+            self.server.close()
+
+    @async_test
+    async def test_sending_messages(self):
+        if is_ci_unstable_test_skip_enabled():
+            return
+        t = Thread(target=start_socket_mode_server(self, 3001))
+        t.daemon = True
+        t.start()
+
+        client = SocketModeClient(
+            app_token="xapp-A111-222-xyz",
+            web_client=self.web_client,
+            auto_reconnect_enabled=False,
+            trace_enabled=True,
+        )
+
+        try:
+            time.sleep(1)  # wait for the server
+            client.wss_uri = "ws://0.0.0.0:3001/link"
+            await client.connect()
+            await asyncio.sleep(1)  # wait for the message receiver
+            await client.send_message("foo")
+
+            await client.disconnect()
+            await asyncio.sleep(1)  # wait for the message receiver
+            try:
+                await client.send_message("foo")
+            except WebSocketException as _:
+                pass
+
+            await client.connect()
+            await asyncio.sleep(1)  # wait for the message receiver
+            await client.send_message("foo")
         finally:
             await client.close()
             self.server.stop()

--- a/tests/slack_sdk_async/socket_mode/test_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_websockets.py
@@ -34,8 +34,11 @@ class TestAiohttp(unittest.TestCase):
             app_token="xapp-A111-222-xyz",
             web_client=self.web_client,
         )
-        url = await client.issue_new_wss_url()
-        self.assertTrue(url.startswith("wss://"))
+        try:
+            url = await client.issue_new_wss_url()
+            self.assertTrue(url.startswith("wss://"))
+        finally:
+            await client.close()
 
     @async_test
     async def test_connect_to_new_endpoint(self):


### PR DESCRIPTION
## Summary

This pull request improves the internals of built-in SocketModeClient implementations to properly handle the situations like https://github.com/slackapi/bolt-python/issues/461 I will add a few comments for reviewers.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
