### PR TITLE
Remove confusing warning from FileInstallationStore

### DIFF
--- a/slack_sdk/oauth/installation_store/file/__init__.py
+++ b/slack_sdk/oauth/installation_store/file/__init__.py
@@ -129,8 +129,8 @@ class FileInstallationStore(InstallationStore, AsyncInstallationStore):
                 data = json.loads(f.read())
                 return Bot(**data)
         except FileNotFoundError as e:
-            message = f"Failed to find bot installation data for enterprise: {e_id}, team: {t_id}: {e}"
-            self.logger.warning(message)
+            message = f"Installation data missing for enterprise: {e_id}, team: {t_id}: {e}"
+            self.logger.debug(message)
             return None
 
     async def async_find_installation(
@@ -172,8 +172,8 @@ class FileInstallationStore(InstallationStore, AsyncInstallationStore):
                 data = json.loads(f.read())
                 return Installation(**data)
         except FileNotFoundError as e:
-            message = f"Failed to find an installation data for enterprise: {e_id}, team: {t_id}: {e}"
-            self.logger.warning(message)
+            message = f"Installation data missing for enterprise: {e_id}, team: {t_id}: {e}"
+            self.logger.debug(message)
             return None
 
     async def async_delete_bot(


### PR DESCRIPTION
## Summary

We've got a question about the warning at https://github.com/slackapi/bolt-python/issues/464 and I found that we should not have the logs in warning level. It's just confusing and also we don't have the same log in warning level in other built-in implementations.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
