### PR TITLE
asyncio-based Socket Mode client improvements

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9']
     env:
       PYTHON_SLACK_SDK_MOCK_SERVER_MODE: 'threading'
-      CI_UNSTABLE_TESTS_SKIP_ENABLED: '1'
+      #CI_UNSTABLE_TESTS_SKIP_ENABLED: '1'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -318,7 +318,7 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                 except Exception as e:
                     consecutive_error_count += 1
                     self.logger.error(
-                        f"Failed to receive or enqueue a message: {type(e).__name__}, {e} ({session_id}"
+                        f"Failed to receive or enqueue a message: {type(e).__name__}, {e} ({session_id})"
                     )
                     if isinstance(e, ClientConnectionError):
                         await asyncio.sleep(self.ping_interval)
@@ -347,13 +347,15 @@ class SocketModeClient(AsyncBaseSocketModeClient):
         )
         if connected is False and self.logger.level <= logging.DEBUG:
             is_ping_pong_failing = await self.is_ping_pong_failing()
+            session_id = await self.session_id()
             self.logger.debug(
-                "Inactive connection detected "
-                f"(session_id: {await self.session_id()}, "
+                "Inactive connection detected ("
+                f"session_id: {session_id}, "
                 f"closed: {self.closed}, "
                 f"stale: {self.stale}, "
                 f"current_session.closed: {self.current_session.closed}, "
-                f"is_ping_pong_failing: {is_ping_pong_failing})"
+                f"is_ping_pong_failing: {is_ping_pong_failing}"
+                ")"
             )
         return connected
 
@@ -411,8 +413,9 @@ class SocketModeClient(AsyncBaseSocketModeClient):
     async def disconnect(self):
         if self.current_session is not None:
             await self.current_session.close()
+        session_id = await self.session_id()
         self.logger.info(
-            f"The current session ({await self.session_id()}) has been abandoned by disconnect() method call"
+            f"The current session ({session_id}) has been abandoned by disconnect() method call"
         )
 
     async def send_message(self, message: str):

--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -275,6 +275,10 @@ class SocketModeClient(AsyncBaseSocketModeClient):
         self.stale = False
         self.logger.info("A new session has been established")
 
+        # The first ping from the new connection
+        t = time.time()
+        await self.current_session.ping(f"sdk-ping-pong:{t}")
+
         if self.current_session_monitor is not None:
             self.current_session_monitor.cancel()
 


### PR DESCRIPTION
## Summary

This pull request applies a few improvements to asyncio-based Socket Mode clients.


1. Add initial ping request to `connect()` method in AIOHTTP based client

This pull request adds a missing change in the pull request https://github.com/slackapi/python-slack-sdk/pull/1112

Like [the built-in client implementation does](https://github.com/slackapi/python-slack-sdk/blob/v3.11.0/slack_sdk/socket_mode/builtin/connection.py#L153), sending our own ping message to check if the connection is healthy can make the session check logic more accurate. If the connection is working, the client instance receives a new PONG message immediately and update the `self.last_ping_pong_time` with the timestamp of the latest trial.

This change can improve the situation described in this comment: https://github.com/slackapi/python-slack-sdk/issues/1110#issuecomment-921682995 (= the situation where the current connection is determined as stale 10 seconds after the last reconnection).

2. Improve the monitoring task not to access `self.current_session` directly

For both AIOHTTP and websockets implementations, this pull request improves the internals of `monitor_current_session` and `receive_messages` not to access the instance field `self.current_session`. Instead of that, now these methods accesses only the local variable set when the method execution starts. While doing more tests with these clients, I found that accessing shared objects from tasks can cause unexpected race conditions and invalid data reference. The changes in this PR will make the executions of these methods much safer.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
