### PR TITLE
Change websockets imports to make it compatible with older versions

### DIFF
--- a/slack_sdk/socket_mode/websockets/__init__.py
+++ b/slack_sdk/socket_mode/websockets/__init__.py
@@ -14,7 +14,9 @@ from typing import Union, Optional, List, Callable, Awaitable
 
 import websockets
 from websockets.exceptions import WebSocketException
-from websockets.legacy.client import WebSocketClientProtocol
+
+# To keep compatibility with websockets 8.x, we use this import over .legacy.client
+from websockets import WebSocketClientProtocol
 
 from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
 from slack_sdk.socket_mode.async_listeners import (


### PR DESCRIPTION
## Summary

This pull request resolves the build error issue in bolt-python project with python-slack-sdk v3.11.1: https://github.com/slackapi/bolt-python/actions/runs/1255825291

The error is caused by this change: https://github.com/slackapi/python-slack-sdk/pull/1117 More specifically, the following import is only compatible with websockets 9.x (the latest major series) while it's not with v8 or older ones.

>from websockets.legacy.client import WebSocketClientProtocol

This pull request corrects the import to make it compatible with all the websockets versions. For reference, the reason why bolt-python project detected the error is that the project has some tests for Sanic apps and the Sanic framework still requires websockets v8, not v9.

To prevent similar errors in our code, we may want to run tests with older versions of external dependencies. But at this point, I am thinking that it's not so beneficial while the work like that requires a lot of efforts. I'd like to hold off taking such actions for this purpose.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
