### PR TITLE
Add Python 3.10 to the supported versions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
     env:
       PYTHON_SLACK_SDK_MOCK_SERVER_MODE: 'threading'
       #CI_UNSTABLE_TESTS_SKIP_ENABLED: '1'

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as readme:
     long_description = readme.read()
 
 validate_dependencies = [
-    "pytest>=5.4,<6",
+    "pytest>=6.2.5,<7",
     "pytest-asyncio<1",  # for async
     "Flask-Sockets>=0.2,<1",
     "Flask>=1,<2",  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
@@ -277,6 +277,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     keywords="slack slack-api web-api slack-rtm websocket chat chatbot chatops",
     packages=find_packages(
@@ -310,7 +311,8 @@ setup(
             # InstallationStore/OAuthStateStore
             "SQLAlchemy>=1,<2",
             # Socket Mode
-            "websockets>=9.1,<10",
+            # websockets 9 is not compatible with Python 3.10
+            "websockets>=10,<11" if sys.version_info.minor > 6 else "websockets>=9.1,<10",
             "websocket-client>=1,<2",
         ],
     },


### PR DESCRIPTION
## Summary

This pull request adds Python 3.10 runtime to the supported ones since the next release.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
