### PR TITLE
Audit Logs API: Add new details properties for channel_posting_permissions_updated action

### DIFF
--- a/slack_sdk/audit_logs/v1/logs.py
+++ b/slack_sdk/audit_logs/v1/logs.py
@@ -102,6 +102,22 @@ class RetentionPolicy:
         self.unknown_fields = kwargs
 
 
+class ConversationPref:
+    type: Optional[List[str]]
+    user: Optional[List[str]]
+
+    def __init__(
+        self,
+        *,
+        type: Optional[List[str]] = None,
+        user: Optional[List[str]] = None,
+        **kwargs,
+    ) -> None:
+        self.type = type
+        self.user = user
+        self.unknown_fields = kwargs
+
+
 class Details:
     name: Optional[str]
     new_value: Optional[Union[str, List[str], Dict[str, Any]]]
@@ -159,6 +175,8 @@ class Details:
     is_token_rotation_enabled_app: Optional[bool]
     old_retention_policy: Optional[RetentionPolicy]
     new_retention_policy: Optional[RetentionPolicy]
+    who_can_post: Optional[ConversationPref]
+    can_thread: Optional[ConversationPref]
 
     def __init__(
         self,
@@ -218,6 +236,8 @@ class Details:
         is_token_rotation_enabled_app: Optional[bool] = None,
         old_retention_policy: Optional[Union[Dict[str, Any], RetentionPolicy]] = None,
         new_retention_policy: Optional[Union[Dict[str, Any], RetentionPolicy]] = None,
+        who_can_post: Optional[Union[Dict[str, List[str]], ConversationPref]] = None,
+        can_thread: Optional[Union[Dict[str, List[str]], ConversationPref]] = None,
         **kwargs,
     ) -> None:
         self.name = name
@@ -283,6 +303,16 @@ class Details:
             new_retention_policy
             if isinstance(new_retention_policy, RetentionPolicy)
             else RetentionPolicy(**new_retention_policy)
+        )
+        self.who_can_post = (
+            who_can_post
+            if isinstance(who_can_post, ConversationPref)
+            else ConversationPref(**who_can_post)
+        )
+        self.can_thread = (
+            can_thread
+            if isinstance(can_thread, ConversationPref)
+            else ConversationPref(**can_thread)
         )
 
 

--- a/tests/slack_sdk/audit_logs/test_response.py
+++ b/tests/slack_sdk/audit_logs/test_response.py
@@ -133,6 +133,10 @@ class TestAuditLogsClient(unittest.TestCase):
         self.assertEqual(entry.details.new_retention_policy.type, "new")
         self.assertEqual(entry.details.is_internal_integration, True)
         self.assertEqual(entry.details.cleared_resolution, "approved")
+        self.assertEqual(entry.details.who_can_post.type, ["owner", "admin"])
+        self.assertEqual(entry.details.who_can_post.user, ["W111"])
+        self.assertEqual(entry.details.can_thread.type, ["admin", "org_admin"])
+        self.assertEqual(entry.details.can_thread.user, ["W222"])
 
 
 logs_response_data = """{
@@ -335,7 +339,25 @@ logs_response_data = """{
           "duration_days": 222
         },
         "is_internal_integration": true,
-        "cleared_resolution": "approved"
+        "cleared_resolution": "approved",
+        "who_can_post": {
+          "type": [
+            "owner",
+            "admin"
+          ],
+          "user": [
+            "W111"
+          ]
+        },
+        "can_thread": {
+          "type": [
+            "admin",
+            "org_admin"
+          ],
+          "user": [
+            "W222"
+          ]
+        }
       }
     }
   ]


### PR DESCRIPTION
## Summary

This pull request adds two new properties to the Audit Logs API response data class. "who_can_post" and "can_thread" can be included in "channel_posting_permissions_updated" action response starting today. See also: https://github.com/slackapi/java-slack-sdk/commit/62f93c768d3bd3348dd1f4567dad86b660527fd4

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
