### PR TITLE
Make the aiohttp-based SocketModeClient's debug logging more consistent with the built-in one (#1122)

### DIFF
--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -274,20 +274,18 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                                     f"session: {session_id})"
                                 )
 
-                            counter_for_logging += 1
-                            # The logging here is for detailed trouble shooting of potential issues in this client.
-                            # If you don't see this log for a while, it can mean that
-                            # this receive_messages execution is no longer working for some reason.
-                            if (
-                                self.trace_enabled
-                                and counter_for_logging >= logging_interval
-                            ):
-                                counter_for_logging = 0
-                                log_message = (
-                                    "#receive_messages method has been working without any issues "
-                                    f"(session: {session_id}, logging interval: {logging_interval})"
-                                )
-                                self.logger.debug(log_message)
+                            if self.trace_enabled:
+                                # The logging here is for detailed trouble shooting of potential issues in this client.
+                                # If you don't see this log for a while, it can mean that
+                                # this receive_messages execution is no longer working for some reason.
+                                counter_for_logging += 1
+                                if counter_for_logging >= logging_interval:
+                                    counter_for_logging = 0
+                                    log_message = (
+                                        "#receive_messages method has been working without any issues "
+                                        f"(session: {session_id}, logging interval: {logging_interval})"
+                                    )
+                                    self.logger.debug(log_message)
 
                         if message.type == WSMsgType.TEXT:
                             message_data = message.data

--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -164,16 +164,19 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                         )
                     break
                 try:
-                    # The logging here is for detailed trouble shooting of potential issues in this client.
-                    # If you don't see this log for a while, it means that
-                    # this receive_messages execution is no longer working for some reason.
-                    counter_for_logging = (counter_for_logging + 1) % logging_interval
-                    if counter_for_logging == 0:
-                        log_message = (
-                            f"{logging_interval} session verification executed after the previous same log"
-                            f" ({session_id})"
-                        )
-                        self.logger.debug(log_message)
+                    if self.trace_enabled and self.logger.level <= logging.DEBUG:
+                        # The logging here is for detailed investigation on potential issues in this client.
+                        # If you don't see this log for a while, it means that
+                        # this receive_messages execution is no longer working for some reason.
+                        counter_for_logging = (
+                            counter_for_logging + 1
+                        ) % logging_interval
+                        if counter_for_logging == 0:
+                            log_message = (
+                                f"{logging_interval} session verification executed after the previous same log"
+                                f" ({session_id})"
+                            )
+                            self.logger.debug(log_message)
 
                     await asyncio.sleep(self.ping_interval)
 
@@ -250,38 +253,41 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                     break
                 try:
                     message: WSMessage = await session.receive()
-                    if self.trace_enabled and self.logger.level <= logging.DEBUG:
-                        # The following logging prints every single received message except empty message data ones.
-                        type = WSMsgType(message.type)
-                        message_type = type.name if type is not None else message.type
-                        message_data = message.data
-                        if isinstance(message_data, bytes):
-                            message_data = message_data.decode("utf-8")
-                        if len(message_data) > 0:
-                            # To skip the empty message that Slack server-side often sends
-                            self.logger.debug(
-                                f"Received message "
-                                f"(type: {message_type}, "
-                                f"data: {message_data}, "
-                                f"extra: {message.extra}, "
-                                f"session: {session_id})"
-                            )
-
-                    # The logging here is for detailed trouble shooting of potential issues in this client.
-                    # If you don't see this log for a while, it means that
-                    # this receive_messages execution is no longer working for some reason.
-                    if self.logger.level <= logging.DEBUG:
-                        counter_for_logging = (
-                            counter_for_logging + 1
-                        ) % logging_interval
-                        if counter_for_logging == 0:
-                            log_message = (
-                                f"{logging_interval} WebSocket messages received "
-                                f"after the previous same log ({session_id})"
-                            )
-                            self.logger.debug(log_message)
-
+                    # just in case, checking if the value is not None
                     if message is not None:
+                        if self.logger.level <= logging.DEBUG:
+                            # The following logging prints every single received message
+                            # except empty message data ones.
+                            type = WSMsgType(message.type)
+                            message_type = (
+                                type.name if type is not None else message.type
+                            )
+                            message_data = message.data
+                            if isinstance(message_data, bytes):
+                                message_data = message_data.decode("utf-8")
+                            if len(message_data) > 0:
+                                # To skip the empty message that Slack server-side often sends
+                                self.logger.debug(
+                                    f"Received message "
+                                    f"(type: {message_type}, "
+                                    f"data: {message_data}, "
+                                    f"extra: {message.extra}, "
+                                    f"session: {session_id})"
+                                )
+
+                            counter_for_logging = (
+                                counter_for_logging + 1
+                            ) % logging_interval
+                            # The logging here is for detailed trouble shooting of potential issues in this client.
+                            # If you don't see this log for a while, it can mean that
+                            # this receive_messages execution is no longer working for some reason.
+                            if self.trace_enabled and counter_for_logging == 0:
+                                log_message = (
+                                    f"{logging_interval} WebSocket messages received "
+                                    f"after the previous same log ({session_id})"
+                                )
+                                self.logger.debug(log_message)
+
                         if message.type == WSMsgType.TEXT:
                             message_data = message.data
                             await self.enqueue_message(message_data)
@@ -320,7 +326,9 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                                             f" - error : {e}, session: {session_id}"
                                         )
                             continue
+
                     consecutive_error_count = 0
+
                 except Exception as e:
                     consecutive_error_count += 1
                     self.logger.error(
@@ -351,7 +359,8 @@ class SocketModeClient(AsyncBaseSocketModeClient):
             and not self.current_session.closed
             and not await self.is_ping_pong_failing()
         )
-        if connected is False and self.logger.level <= logging.DEBUG:
+        if self.logger.level <= logging.DEBUG and connected is False:
+            # Prints more detailed information about the inactive connection
             is_ping_pong_failing = await self.is_ping_pong_failing()
             session_id = await self.session_id()
             self.logger.debug(
@@ -369,9 +378,14 @@ class SocketModeClient(AsyncBaseSocketModeClient):
         return self.build_session_id(self.current_session)
 
     async def connect(self):
-        old_session = None if self.current_session is None else self.current_session
+        old_session: Optional[ClientWebSocketResponse] = (
+            None if self.current_session is None else self.current_session
+        )
         if self.wss_uri is None:
+            # If the underlying WSS URL does not exist,
+            # acquiring a new active WSS URL from the server-side first
             self.wss_uri = await self.issue_new_wss_url()
+
         self.current_session = await self.aiohttp_client_session.ws_connect(
             self.wss_uri,
             autoping=False,

--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -168,13 +168,12 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                         # The logging here is for detailed investigation on potential issues in this client.
                         # If you don't see this log for a while, it means that
                         # this receive_messages execution is no longer working for some reason.
-                        counter_for_logging = (
-                            counter_for_logging + 1
-                        ) % logging_interval
-                        if counter_for_logging == 0:
+                        counter_for_logging += 1
+                        if counter_for_logging >= logging_interval:
+                            counter_for_logging = 0
                             log_message = (
-                                f"{logging_interval} session verification executed after the previous same log"
-                                f" ({session_id})"
+                                "#monitor_current_session method has been verifying if this session is active "
+                                f"(session: {session_id}, logging interval: {logging_interval})"
                             )
                             self.logger.debug(log_message)
 
@@ -275,16 +274,18 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                                     f"session: {session_id})"
                                 )
 
-                            counter_for_logging = (
-                                counter_for_logging + 1
-                            ) % logging_interval
+                            counter_for_logging += 1
                             # The logging here is for detailed trouble shooting of potential issues in this client.
                             # If you don't see this log for a while, it can mean that
                             # this receive_messages execution is no longer working for some reason.
-                            if self.trace_enabled and counter_for_logging == 0:
+                            if (
+                                self.trace_enabled
+                                and counter_for_logging >= logging_interval
+                            ):
+                                counter_for_logging = 0
                                 log_message = (
-                                    f"{logging_interval} WebSocket messages received "
-                                    f"after the previous same log ({session_id})"
+                                    "#receive_messages method has been working without any issues "
+                                    f"(session: {session_id}, logging interval: {logging_interval})"
                                 )
                                 self.logger.debug(log_message)
 


### PR DESCRIPTION
## Summary

This pull request fixes #1122 by improving the internals of the AIOHTTP-based Socket Mode client to be more consistent with the built-in client. Will add some context in line comments.

cc @eddyg 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
