### PR TITLE
Upgrade pytype to 2021.11.18

### DIFF
--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -24,7 +24,7 @@ jobs:
         pip install -e ".[testing]"
         pip install -e ".[optional]"
         # As pytype can change its behavior in newer versions, we manually upgrade it
-        pip install "pytype==2021.10.11"
+        pip install "pytype==2021.11.18"
     - name: Run pytype
       run: |
         pytype slack_sdk/

--- a/slack_sdk/models/messages/__init__.py
+++ b/slack_sdk/models/messages/__init__.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime  # type: ignore
 from typing import Optional, Union
 
 from slack_sdk.models.basic_objects import BaseObject
@@ -33,7 +33,7 @@ class DateLink(Link):
         https://api.slack.com/reference/surfaces/formatting#date-formatting
         """
         if isinstance(date, datetime):
-            epoch = int(date.timestamp())
+            epoch = int(date.timestamp())  # type: ignore
         else:
             epoch = date
         if link is not None:

--- a/slack_sdk/oauth/installation_store/models/bot.py
+++ b/slack_sdk/oauth/installation_store/models/bot.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import datetime  # type: ignore
 from time import time
 from typing import Optional, Union, Dict, Any, Sequence
 

--- a/slack_sdk/oauth/installation_store/models/installation.py
+++ b/slack_sdk/oauth/installation_store/models/installation.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import datetime  # type: ignore
 from time import time
 from typing import Optional, Union, Dict, Any, Sequence
 

--- a/slack_sdk/oauth/state_store/sqlalchemy/__init__.py
+++ b/slack_sdk/oauth/state_store/sqlalchemy/__init__.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import datetime
+from datetime import datetime  # type: ignore
 from logging import Logger
 from uuid import uuid4
 


### PR DESCRIPTION
## Summary

This pull request upgrades pytype version to the latest.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
