### PR TITLE
Fix 1086 add interactivity patterns in SocketModeClient docs

### DIFF
--- a/docs-src/socket-mode/index.rst
+++ b/docs-src/socket-mode/index.rst
@@ -63,7 +63,7 @@ You will be using the app-level token that starts with ``xapp-`` prefix. Note th
                     timestamp=req.payload["event"]["ts"],
                 )
         if req.type == "interactive" \
-                and req.payload["type"] == "shortcut":
+            and req.payload["type"] == "shortcut":
             if req.payload["callback_id"] == "hello-shortcut":
                 # Acknowledge the request
                 response = SocketModeResponse(envelope_id=req.envelope_id)
@@ -95,7 +95,7 @@ You will be using the app-level token that starts with ``xapp-`` prefix. Note th
                 )
 
         if req.type == "interactive" \
-                and req.payload["type"] == "view_submission":
+            and req.payload["type"] == "view_submission":
             if req.payload["view"]["callback_id"] == "hello-modal":
                 # Acknowledge the request and close the modal
                 response = SocketModeResponse(envelope_id=req.envelope_id)
@@ -183,14 +183,14 @@ To use the asyncio-based ones such as aiohttp, your app needs to be compatible w
 
                 # Add a reaction to the message if it's a new message
                 if req.payload["event"]["type"] == "message" \
-                        and req.payload["event"].get("subtype") is None:
+                    and req.payload["event"].get("subtype") is None:
                     await client.web_client.reactions_add(
                         name="eyes",
                         channel=req.payload["event"]["channel"],
                         timestamp=req.payload["event"]["ts"],
                     )
             if req.type == "interactive" \
-                    and req.payload["type"] == "shortcut":
+                and req.payload["type"] == "shortcut":
                 if req.payload["callback_id"] == "hello-shortcut":
                     # Acknowledge the request
                     response = SocketModeResponse(envelope_id=req.envelope_id)
@@ -222,7 +222,7 @@ To use the asyncio-based ones such as aiohttp, your app needs to be compatible w
                     )
 
             if req.type == "interactive" \
-                    and req.payload["type"] == "view_submission":
+                and req.payload["type"] == "view_submission":
                 if req.payload["view"]["callback_id"] == "hello-modal":
                     # Acknowledge the request and close the modal
                     response = SocketModeResponse(envelope_id=req.envelope_id)

--- a/docs-src/socket-mode/index.rst
+++ b/docs-src/socket-mode/index.rst
@@ -15,13 +15,17 @@ First off, let's start with enabling Socket Mode. Visit `the Slack App configura
 * Go to **Settings** > **Socket Mode**, then turn on **Enable Socket Mode**
 * Go to **Features** > **App Home**, look under **Show Tabs** > **Messages Tab** then turn on **Allow users to send Slash commands and messages from the messages tab**
 * Go to **Features** > **Event Subscriptions**, then turn on **Enable Events**
+
     * On the same page expand **Subscribe to bot events** click **Add Bot User Event** and select **message.im**
+
         * This will allow the bot to get events for messages that are sent in 1:1 direct messages with itself
 * Go to **Features** > **Interactivity and Shortcuts**, look under *Shortcuts** click **Create a New Shortcut** then create a new Global shortcut with the following details
+
     * **Name**: Hello
     * **Short Description**: Receive a Greeting
     * **Callback ID**: hello-shortcut
 * Go to **Features** > **OAuth & Permissions** under **Scopes** > **Bot Token Scopes** click **Add an OAuth Scope** and select **reactions:write**
+
     * This will allow the bot to add emoji reactions (Reacji's) to messages
 * Go to **Features** > **Oauth & Permissions** under **OAuth Tokens for Your Workspace** click **Install to Workspace**
 

--- a/docs-src/socket-mode/index.rst
+++ b/docs-src/socket-mode/index.rst
@@ -13,6 +13,17 @@ First off, let's start with enabling Socket Mode. Visit `the Slack App configura
 
 * Go to **Settings** > **Basic Information**, then add a new **App-Level Token** with the `connections:write` scope
 * Go to **Settings** > **Socket Mode**, then turn on **Enable Socket Mode**
+* Go to **Features** > **App Home**, look under **Show Tabs** > **Messages Tab** then turn on **Allow users to send Slash commands and messages from the messages tab**
+* Go to **Features** > **Event Subscriptions**, then turn on **Enable Events**
+    * On the same page expand **Subscribe to bot events** click **Add Bot User Event** and select **message.im**
+        * This will allow the bot to get events for messages that are sent in 1:1 direct messages with itself
+* Go to **Features** > **Interactivity and Shortcuts**, look under *Shortcuts** click **Create a New Shortcut** then create a new Global shortcut with the following details
+    * **Name**: Hello
+    * **Short Description**: Receive a Greeting
+    * **Callback ID**: hello-shortcut
+* Go to **Features** > **OAuth & Permissions** under **Scopes** > **Bot Token Scopes** click **Add an OAuth Scope** and select **reactions:write**
+    * This will allow the bot to add emoji reactions (Reacji's) to messages
+* Go to **Features** > **Oauth & Permissions** under **OAuth Tokens for Your Workspace** click **Install to Workspace**
 
 You will be using the app-level token that starts with ``xapp-`` prefix. Note that the token here is not the ones starting with either ``xoxb-`` or ``xoxp-``.
 
@@ -47,6 +58,44 @@ You will be using the app-level token that starts with ``xapp-`` prefix. Note th
                     channel=req.payload["event"]["channel"],
                     timestamp=req.payload["event"]["ts"],
                 )
+        if req.type == "interactive" \
+                and req.payload["type"] == "shortcut":
+            if req.payload["callback_id"] == "hello-shortcut":
+                # Acknowledge the request
+                response = SocketModeResponse(envelope_id=req.envelope_id)
+                client.send_socket_mode_response(response)
+                # Open a welcome modal
+                client.web_client.views_open(
+                    trigger_id=req.payload["trigger_id"],
+                    view={
+                        "type": "modal",
+                        "callback_id": "hello-modal",
+                        "title": {
+                            "type": "plain_text",
+                            "text": "Greetings!"
+                        },
+                        "submit": {
+                            "type": "plain_text",
+                            "text": "Good Bye"
+                        },
+                        "blocks": [
+                            {
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": "Hello!"
+                                }
+                            }
+                        ]
+                    }
+                )
+
+        if req.type == "interactive" \
+                and req.payload["type"] == "view_submission":
+            if req.payload["view"]["callback_id"] == "hello-modal":
+                # Acknowledge the request and close the modal
+                response = SocketModeResponse(envelope_id=req.envelope_id)
+                client.send_socket_mode_response(response)
 
     # Add a new listener to receive messages from Slack
     # You can add more listeners like this
@@ -130,12 +179,50 @@ To use the asyncio-based ones such as aiohttp, your app needs to be compatible w
 
                 # Add a reaction to the message if it's a new message
                 if req.payload["event"]["type"] == "message" \
-                    and req.payload["event"].get("subtype") is None:
+                        and req.payload["event"].get("subtype") is None:
                     await client.web_client.reactions_add(
                         name="eyes",
                         channel=req.payload["event"]["channel"],
                         timestamp=req.payload["event"]["ts"],
                     )
+            if req.type == "interactive" \
+                    and req.payload["type"] == "shortcut":
+                if req.payload["callback_id"] == "hello-shortcut":
+                    # Acknowledge the request
+                    response = SocketModeResponse(envelope_id=req.envelope_id)
+                    await client.send_socket_mode_response(response)
+                    # Open a welcome modal
+                    await client.web_client.views_open(
+                        trigger_id=req.payload["trigger_id"],
+                        view={
+                            "type": "modal",
+                            "callback_id": "hello-modal",
+                            "title": {
+                                "type": "plain_text",
+                                "text": "Greetings!"
+                            },
+                            "submit": {
+                                "type": "plain_text",
+                                "text": "Good Bye"
+                            },
+                            "blocks": [
+                                {
+                                    "type": "section",
+                                    "text": {
+                                        "type": "mrkdwn",
+                                        "text": "Hello!"
+                                    }
+                                }
+                            ]
+                        }
+                    )
+
+            if req.type == "interactive" \
+                    and req.payload["type"] == "view_submission":
+                if req.payload["view"]["callback_id"] == "hello-modal":
+                    # Acknowledge the request and close the modal
+                    response = SocketModeResponse(envelope_id=req.envelope_id)
+                    await client.send_socket_mode_response(response)
 
         # Add a new listener to receive messages from Slack
         # You can add more listeners like this

--- a/docs-src/socket-mode/index.rst
+++ b/docs-src/socket-mode/index.rst
@@ -63,7 +63,7 @@ You will be using the app-level token that starts with ``xapp-`` prefix. Note th
                     timestamp=req.payload["event"]["ts"],
                 )
         if req.type == "interactive" \
-            and req.payload["type"] == "shortcut":
+            and req.payload.get("type") == "shortcut":
             if req.payload["callback_id"] == "hello-shortcut":
                 # Acknowledge the request
                 response = SocketModeResponse(envelope_id=req.envelope_id)
@@ -95,7 +95,7 @@ You will be using the app-level token that starts with ``xapp-`` prefix. Note th
                 )
 
         if req.type == "interactive" \
-            and req.payload["type"] == "view_submission":
+            and req.payload.get("type") == "view_submission":
             if req.payload["view"]["callback_id"] == "hello-modal":
                 # Acknowledge the request and close the modal
                 response = SocketModeResponse(envelope_id=req.envelope_id)
@@ -190,7 +190,7 @@ To use the asyncio-based ones such as aiohttp, your app needs to be compatible w
                         timestamp=req.payload["event"]["ts"],
                     )
             if req.type == "interactive" \
-                and req.payload["type"] == "shortcut":
+                and req.payload.get("type") == "shortcut":
                 if req.payload["callback_id"] == "hello-shortcut":
                     # Acknowledge the request
                     response = SocketModeResponse(envelope_id=req.envelope_id)
@@ -222,7 +222,7 @@ To use the asyncio-based ones such as aiohttp, your app needs to be compatible w
                     )
 
             if req.type == "interactive" \
-                and req.payload["type"] == "view_submission":
+                and req.payload.get("type") == "view_submission":
                 if req.payload["view"]["callback_id"] == "hello-modal":
                     # Acknowledge the request and close the modal
                     response = SocketModeResponse(envelope_id=req.envelope_id)


### PR DESCRIPTION
## Summary

Fixes #1086 

Adds examples for Shortcuts and Modal submissions to the Socket Mode documentation.

I've run the synchronous version of the code and tested. For some reason the async code was failing with 
```
sys:1: RuntimeWarning: coroutine 'AsyncBaseSocketModeClient.process_messages' was never awaited
```
on
```python
asyncio.run(main())
```

I'm not to familiar with Python's aysnc, I also get this error with the version on `main` as well. It could also be an issue with me writing this on Windows. 

Let me know if you'd like any changes to the non code documentation, I made it a bit verbose so that a first time user should be able to follow the guide but I'm unsure if that's the target audience. 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [X] `/docs-src` (Documents, have you run `./scripts/docs.sh`?) 👍 
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [X] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.

I've also run `./scripts/docs.sh` and confirmed the webpage matched what I expected