### PR TITLE
Add cursor parameter to Audit Logs API method

### DIFF
--- a/integration_tests/audit_logs/test_pagination.py
+++ b/integration_tests/audit_logs/test_pagination.py
@@ -1,0 +1,29 @@
+import logging
+import os
+import unittest
+
+from integration_tests.env_variable_names import (
+    SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN,
+)
+from slack_sdk.audit_logs import AuditLogsClient
+
+
+class TestAuditLogsClient(unittest.TestCase):
+    def setUp(self):
+        self.client = AuditLogsClient(
+            token=os.environ[SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN]
+        )
+
+    def tearDown(self):
+        pass
+
+    def test_pagination(self):
+        call_count = 0
+        response = None
+        ids = []
+        while call_count < 10 and (response is None or response.status_code != 429):
+            cursor = response.body["response_metadata"]["next_cursor"] if response is not None else None
+            response = self.client.logs(action="user_login", limit=1, cursor=cursor)
+            ids += map(lambda v: v["id"], response.body.get("entries", []))
+            call_count += 1
+        self.assertGreaterEqual(len(set(ids)), 10)

--- a/slack_sdk/audit_logs/v1/async_client.py
+++ b/slack_sdk/audit_logs/v1/async_client.py
@@ -151,6 +151,7 @@ class AsyncAuditLogsClient:
         action: Optional[str] = None,
         actor: Optional[str] = None,
         entity: Optional[str] = None,
+        cursor: Optional[str] = None,
         additional_query_params: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> AuditLogsResponse:
@@ -171,6 +172,7 @@ class AsyncAuditLogsClient:
             action: Name of the action.
             actor: User ID who initiated the action.
             entity: ID of the target entity of the action (such as a channel, workspace, organization, file).
+            cursor: The next page cursor of pagination
             additional_query_params: Add anything else if you need to use the ones this library does not support
             headers: Additional request headers
 
@@ -184,6 +186,7 @@ class AsyncAuditLogsClient:
             "action": action,
             "actor": actor,
             "entity": entity,
+            "cursor": cursor,
         }
         if additional_query_params is not None:
             query_params.update(additional_query_params)

--- a/slack_sdk/audit_logs/v1/client.py
+++ b/slack_sdk/audit_logs/v1/client.py
@@ -140,6 +140,7 @@ class AuditLogsClient:
         action: Optional[str] = None,
         actor: Optional[str] = None,
         entity: Optional[str] = None,
+        cursor: Optional[str] = None,
         additional_query_params: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> AuditLogsResponse:
@@ -160,6 +161,7 @@ class AuditLogsClient:
             action: Name of the action.
             actor: User ID who initiated the action.
             entity: ID of the target entity of the action (such as a channel, workspace, organization, file).
+            cursor: The next page cursor of pagination
             additional_query_params: Add anything else if you need to use the ones this library does not support
             headers: Additional request headers
 
@@ -173,6 +175,7 @@ class AuditLogsClient:
             "action": action,
             "actor": actor,
             "entity": entity,
+            "cursor": cursor,
         }
         if additional_query_params is not None:
             query_params.update(additional_query_params)

--- a/slack_sdk/audit_logs/v1/response.py
+++ b/slack_sdk/audit_logs/v1/response.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, Optional
 
 from slack_sdk.audit_logs.v1.logs import LogsResponse
 
+
 # TODO: Unlike WebClient's responses, this class has not yet provided __iter__ method
 class AuditLogsResponse:
     url: str

--- a/slack_sdk/audit_logs/v1/response.py
+++ b/slack_sdk/audit_logs/v1/response.py
@@ -3,7 +3,7 @@ from typing import Dict, Any, Optional
 
 from slack_sdk.audit_logs.v1.logs import LogsResponse
 
-
+# TODO: Unlike WebClient's responses, this class has not yet provided __iter__ method
 class AuditLogsResponse:
     url: str
     status_code: int

--- a/tests/slack_sdk/audit_logs/mock_web_api_server.py
+++ b/tests/slack_sdk/audit_logs/mock_web_api_server.py
@@ -49,7 +49,7 @@ class MockHandler(SimpleHTTPRequestHandler):
                 return
             if "ratelimited" in pattern:
                 self.send_response(429)
-                self.send_header("Retry-After", 1)
+                self.send_header("retry-after", 1)
                 self.set_common_headers()
                 self.wfile.write(
                     """{"ok": false, "error": "ratelimited"}""".encode("utf-8")

--- a/tests/slack_sdk/audit_logs/test_client.py
+++ b/tests/slack_sdk/audit_logs/test_client.py
@@ -23,6 +23,15 @@ class TestAuditLogsClient(unittest.TestCase):
 
         self.assertEqual(resp.typed_body.entries[0].id, "xxx-yyy-zzz-111")
 
+    def test_logs_pagination(self):
+        resp: AuditLogsResponse = self.client.logs(
+            limit=1, action="user_login", cursor="xxxxxxx"
+        )
+        self.assertEqual(200, resp.status_code)
+        self.assertIsNotNone(resp.body.get("entries"))
+
+        self.assertEqual(resp.typed_body.entries[0].id, "xxx-yyy-zzz-111")
+
     def test_actions(self):
         resp: AuditLogsResponse = self.client.actions()
         self.assertEqual(200, resp.status_code)

--- a/tests/slack_sdk_async/audit_logs/test_async_client.py
+++ b/tests/slack_sdk_async/audit_logs/test_async_client.py
@@ -28,6 +28,16 @@ class TestAsyncAuditLogsClient(unittest.TestCase):
         self.assertEqual(resp.typed_body.entries[0].id, "xxx-yyy-zzz-111")
 
     @async_test
+    async def test_logs_pagination(self):
+        resp: AuditLogsResponse = await self.client.logs(
+            limit=1, action="user_login", cursor="XXXXXXXXXXX"
+        )
+        self.assertEqual(200, resp.status_code)
+        self.assertIsNotNone(resp.body.get("entries"))
+
+        self.assertEqual(resp.typed_body.entries[0].id, "xxx-yyy-zzz-111")
+
+    @async_test
     async def test_actions(self):
         resp: AuditLogsResponse = await self.client.actions()
         self.assertEqual(200, resp.status_code)


### PR DESCRIPTION
## Summary

The Audit Logs API's /logs endpoint supports pagination in requests. Although developers can use `additional_query_params` as workaround now, we should have the `cursor` parameter in the method arguments.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
