### PR TITLE
Fix #1143 Keep Retry-After header compatibility wit 2.x series

### DIFF
--- a/integration_tests/web/test_issue_1143.py
+++ b/integration_tests/web/test_issue_1143.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+
+from integration_tests.env_variable_names import SLACK_SDK_TEST_BOT_TOKEN
+from integration_tests.helpers import async_test
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web import WebClient
+from slack_sdk.web.async_client import AsyncWebClient
+
+
+class TestWebClient(unittest.TestCase):
+    """Runs integration tests with real Slack API
+
+    export SLACK_SDK_TEST_BOT_TOKEN=xoxb-xxx
+    python setup.py run_integration_tests --test-target integration_tests/web/test_issue_1143.py
+
+    https://github.com/slackapi/python-slack-sdk/issues/1143
+    """
+
+    def setUp(self):
+        self.bot_token = os.environ[SLACK_SDK_TEST_BOT_TOKEN]
+
+    def tearDown(self):
+        pass
+
+    def test_backward_compatible_header(self):
+        client: WebClient = WebClient(token=self.bot_token)
+        try:
+            while True:
+                client.users_list()
+        except SlackApiError as e:
+            self.assertIsNotNone(e.response.headers["Retry-After"])
+
+    @async_test
+    async def test_backward_compatible_header_async(self):
+        client: AsyncWebClient = AsyncWebClient(token=self.bot_token)
+        try:
+            while True:
+                await client.users_list()
+        except SlackApiError as e:
+            self.assertIsNotNone(e.response.headers["Retry-After"])

--- a/slack_sdk/audit_logs/v1/client.py
+++ b/slack_sdk/audit_logs/v1/client.py
@@ -140,6 +140,7 @@ class AuditLogsClient:
         action: Optional[str] = None,
         actor: Optional[str] = None,
         entity: Optional[str] = None,
+        cursor: Optional[str] = None,
         additional_query_params: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> AuditLogsResponse:
@@ -160,6 +161,7 @@ class AuditLogsClient:
             action: Name of the action.
             actor: User ID who initiated the action.
             entity: ID of the target entity of the action (such as a channel, workspace, organization, file).
+            cursor: The next page cursor of pagination
             additional_query_params: Add anything else if you need to use the ones this library does not support
             headers: Additional request headers
 
@@ -173,6 +175,7 @@ class AuditLogsClient:
             "action": action,
             "actor": actor,
             "entity": entity,
+            "cursor": cursor,
         }
         if additional_query_params is not None:
             query_params.update(additional_query_params)
@@ -257,11 +260,13 @@ class AuditLogsClient:
                 # read the response body here
                 charset = e.headers.get_content_charset() or "utf-8"
                 response_body: str = e.read().decode(charset)
+                # As adding new values to HTTPError#headers can be ignored, building a new dict object here
+                response_headers = dict(e.headers.items())
                 resp = AuditLogsResponse(
                     url=url,
                     status_code=e.code,
                     raw_body=response_body,
-                    headers=dict(e.headers.items()),
+                    headers=response_headers,
                 )
                 if e.code == 429:
                     # for backward-compatibility with WebClient (v.2.5.0 or older)

--- a/slack_sdk/scim/v1/client.py
+++ b/slack_sdk/scim/v1/client.py
@@ -332,11 +332,13 @@ class SCIMClient:
                 # read the response body here
                 charset = e.headers.get_content_charset() or "utf-8"
                 response_body: str = e.read().decode(charset)
+                # As adding new values to HTTPError#headers can be ignored, building a new dict object here
+                response_headers = dict(e.headers.items())
                 resp = SCIMResponse(
                     url=url,
                     status_code=e.code,
                     raw_body=response_body,
-                    headers=dict(e.headers.items()),
+                    headers=response_headers,
                 )
                 if e.code == 429:
                     # for backward-compatibility with WebClient (v.2.5.0 or older)

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -508,19 +508,21 @@ class LegacyBaseClient:
                 return {"status": resp.code, "headers": resp.headers, "body": body}
             raise SlackRequestError(f"Invalid URL detected: {url}")
         except HTTPError as e:
-            resp = {"status": e.code, "headers": e.headers}
+            # As adding new values to HTTPError#headers can be ignored, building a new dict object here
+            response_headers = dict(e.headers.items())
+            resp = {"status": e.code, "headers": response_headers}
             if e.code == 429:
                 # for compatibility with aiohttp
                 if (
-                    "retry-after" not in resp["headers"]
-                    and "Retry-After" in resp["headers"]
+                    "retry-after" not in response_headers
+                    and "Retry-After" in response_headers
                 ):
-                    resp["headers"]["retry-after"] = resp["headers"]["Retry-After"]
+                    response_headers["retry-after"] = response_headers["Retry-After"]
                 if (
-                    "Retry-After" not in resp["headers"]
-                    and "retry-after" in resp["headers"]
+                    "Retry-After" not in response_headers
+                    and "retry-after" in response_headers
                 ):
-                    resp["headers"]["Retry-After"] = resp["headers"]["retry-after"]
+                    response_headers["Retry-After"] = response_headers["retry-after"]
 
             # read the response body here
             charset = e.headers.get_content_charset() or "utf-8"

--- a/slack_sdk/webhook/client.py
+++ b/slack_sdk/webhook/client.py
@@ -178,11 +178,13 @@ class WebhookClient:
                 # read the response body here
                 charset = e.headers.get_content_charset() or "utf-8"
                 response_body: str = e.read().decode(charset)
+                # As adding new values to HTTPError#headers can be ignored, building a new dict object here
+                response_headers = dict(e.headers.items())
                 resp = WebhookResponse(
                     url=url,
                     status_code=e.code,
                     body=response_body,
-                    headers=dict(e.headers.items()),
+                    headers=response_headers,
                 )
                 if e.code == 429:
                     # for backward-compatibility with WebClient (v.2.5.0 or older)

--- a/tests/slack_sdk/scim/mock_web_api_server.py
+++ b/tests/slack_sdk/scim/mock_web_api_server.py
@@ -57,7 +57,7 @@ class MockHandler(SimpleHTTPRequestHandler):
                     return
                 if "ratelimited" in pattern:
                     self.send_response(429)
-                    self.send_header("Retry-After", 1)
+                    self.send_header("retry-after", 1)
                     self.set_common_headers()
                     self.wfile.write(
                         """{"ok": false, "error": "ratelimited"}""".encode("utf-8")

--- a/tests/slack_sdk/web/mock_web_api_server.py
+++ b/tests/slack_sdk/web/mock_web_api_server.py
@@ -115,7 +115,7 @@ class MockHandler(SimpleHTTPRequestHandler):
                     return
                 if "ratelimited" in pattern:
                     self.send_response(429)
-                    self.send_header("Retry-After", 1)
+                    self.send_header("retry-after", 1)
                     self.set_common_headers()
                     self.wfile.write(
                         """{"ok": false, "error": "ratelimited"}""".encode("utf-8")
@@ -160,7 +160,7 @@ class MockHandler(SimpleHTTPRequestHandler):
                 ):
                     self.state["rate_limited_count"] += 1
                     self.send_response(429)
-                    self.send_header("Retry-After", 1)
+                    self.send_header("retry-after", 1)
                     self.send_header("content-type", "application/json;charset=utf-8")
                     self.send_header("connection", "close")
                     self.end_headers()

--- a/tests/slack_sdk/web/mock_web_api_server_http_retry.py
+++ b/tests/slack_sdk/web/mock_web_api_server_http_retry.py
@@ -43,7 +43,7 @@ class MockHandler(SimpleHTTPRequestHandler):
                 return
             if pattern == "rate_limited":
                 self.send_response(429)
-                self.send_header("Retry-After", 1)
+                self.send_header("retry-after", 1)
                 self.set_common_headers()
                 self.wfile.write(
                     """{"ok":false,"error":"rate_limited"}""".encode("utf-8")

--- a/tests/slack_sdk/web/test_web_client.py
+++ b/tests/slack_sdk/web/test_web_client.py
@@ -91,6 +91,7 @@ class TestWebClient(unittest.TestCase):
         except err.SlackApiError as slack_api_error:
             self.assertFalse(slack_api_error.response["ok"])
             self.assertEqual(429, slack_api_error.response.status_code)
+            self.assertEqual(1, int(slack_api_error.response.headers["retry-after"]))
             self.assertEqual(1, int(slack_api_error.response.headers["Retry-After"]))
 
     def test_the_api_call_files_argument_creates_the_expected_data(self):

--- a/tests/slack_sdk/webhook/mock_web_api_server.py
+++ b/tests/slack_sdk/webhook/mock_web_api_server.py
@@ -52,7 +52,7 @@ class MockHandler(SimpleHTTPRequestHandler):
 
             if self.path == "/ratelimited":
                 self.send_response(429)
-                self.send_header("Retry-After", 1)
+                self.send_header("retry-after", 1)
                 self.set_common_headers()
                 self.wfile.write("".encode("utf-8"))
                 return

--- a/tests/slack_sdk_async/web/test_async_web_client.py
+++ b/tests/slack_sdk_async/web/test_async_web_client.py
@@ -71,6 +71,7 @@ class TestAsyncWebClient(unittest.TestCase):
         except err.SlackApiError as slack_api_error:
             self.assertFalse(slack_api_error.response["ok"])
             self.assertEqual(429, slack_api_error.response.status_code)
+            self.assertEqual(1, int(slack_api_error.response.headers["retry-after"]))
             self.assertEqual(1, int(slack_api_error.response.headers["Retry-After"]))
 
     @async_test

--- a/tests/web/mock_web_api_server.py
+++ b/tests/web/mock_web_api_server.py
@@ -111,7 +111,7 @@ class MockHandler(SimpleHTTPRequestHandler):
                     return
                 if pattern == "rate_limited":
                     self.send_response(429)
-                    self.send_header("Retry-After", 1)
+                    self.send_header("retry-after", 1)
                     self.set_common_headers()
                     self.wfile.write(
                         """{"ok":false,"error":"rate_limited"}""".encode("utf-8")

--- a/tests/web/test_async_web_client.py
+++ b/tests/web/test_async_web_client.py
@@ -70,6 +70,7 @@ class TestAsyncWebClient(unittest.TestCase):
         except err.SlackApiError as slack_api_error:
             self.assertFalse(slack_api_error.response["ok"])
             self.assertEqual(429, slack_api_error.response.status_code)
+            self.assertEqual(1, int(slack_api_error.response.headers["retry-after"]))
             self.assertEqual(1, int(slack_api_error.response.headers["Retry-After"]))
 
     @async_test

--- a/tests/web/test_web_client.py
+++ b/tests/web/test_web_client.py
@@ -133,6 +133,7 @@ class TestWebClient(unittest.TestCase):
         except err.SlackApiError as slack_api_error:
             self.assertFalse(slack_api_error.response["ok"])
             self.assertEqual(429, slack_api_error.response.status_code)
+            self.assertEqual(1, int(slack_api_error.response.headers["retry-after"]))
             self.assertEqual(1, int(slack_api_error.response.headers["Retry-After"]))
 
     def test_the_api_call_files_argument_creates_the_expected_data(self):


### PR DESCRIPTION
## Summary

This pull request fixes #1143, which is a regression bug since v3.12.0. For code consistency, I've updated all the clients but actually only `WebClient` had this issue.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [x] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
