### PR TITLE
Upgrade black, flake8, and pytype

### DIFF
--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -24,7 +24,7 @@ jobs:
         pip install -e ".[testing]"
         pip install -e ".[optional]"
         # As pytype can change its behavior in newer versions, we manually upgrade it
-        pip install "pytype==2021.11.18"
+        pip install "pytype==2021.12.8"
     - name: Run pytype
       run: |
         pytype slack_sdk/

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ validate_dependencies = [
     "Werkzeug<2",  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
     "pytest-cov>=2,<3",
     "codecov>=2,<3",
-    "flake8>=3,<4",
-    "black==21.9b0",
+    "flake8>=4,<5",
+    "black==21.12b0",
     "psutil>=5,<6",
     "databases>=0.3",
     # used only under slack_sdk/*_store
@@ -34,7 +34,7 @@ validate_dependencies = [
     "moto<2",  # For AWS tests
 ]
 codegen_dependencies = [
-    "black==21.11b1",
+    "black==21.12b0",
 ]
 
 needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)


### PR DESCRIPTION
## Summary

This pull request upgrades the development tools -- code formatter and static code analyzer. No impact to the runtime behavior.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
