### PR TITLE
Fix #1160 Links in README don't render properly on PyPi project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ $ pip install slack_sdk
 
 ---
 
-We've created this [tutorial](/tutorial) to build a basic Slack app in less than 10 minutes. It requires some general programming knowledge, and Python basics. It focuses on the interacting with Slack's Web and RTM API. Use it to give you an idea of how to use this SDK.
+We've created this [tutorial](https://github.com/slackapi/python-slack-sdk/tree/main/tutorial) to build a basic Slack app in less than 10 minutes. It requires some general programming knowledge, and Python basics. It focuses on the interacting with Slack's Web and RTM API. Use it to give you an idea of how to use this SDK.
 
-**[Read the tutorial to get started!](/tutorial)**
+**[Read the tutorial to get started!](https://github.com/slackapi/python-slack-sdk/tree/main/tutorial)**
 
 ### Basic Usage of the Web Client
 
@@ -291,7 +291,7 @@ helpful and collaborative way.
 [bolt-python]: https://github.com/slackapi/bolt-python
 [pypi]: https://pypi.org/
 [gh-issues]: https://github.com/slackapi/python-slack-sdk/issues
-[slack-community]: http://slackcommunity.com/
+[slack-community]: https://slackcommunity.com/
 [files.upload]: https://api.slack.com/methods/files.upload
 [aiohttp]: https://aiohttp.readthedocs.io/
 [urllib]: https://docs.python.org/3/library/urllib.request.html


### PR DESCRIPTION
## Summary

This pull request resolves #1160. You can check the current state here: https://pypi.org/project/slack-sdk/ ("Getting started tutorial" section)

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
