### PR TITLE
Fix #1169 by Proxy-Authorization header generation

### DIFF
--- a/integration_tests/samples/socket_mode/builtin_proxy_auth_example.py
+++ b/integration_tests/samples/socket_mode/builtin_proxy_auth_example.py
@@ -14,8 +14,8 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode import SocketModeClient
 
 # https://github.com/seratch/my-proxy-server
-# go build && ./my-proxy-sever -a
-proxy_url = "http://user:pass@localhost:9000"
+# go build && my-proxy-server -a -u user -p pass/word
+proxy_url = "http://user:pass%2Fword@localhost:9000"
 
 client = SocketModeClient(
     app_token=os.environ.get("SLACK_SDK_TEST_SOCKET_MODE_APP_TOKEN"),

--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -12,7 +12,7 @@ from hmac import compare_digest
 from logging import Logger
 from threading import Lock
 from typing import Tuple, Optional, Union, List, Callable, Dict
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 
 from .frame_header import FrameHeader
 
@@ -59,7 +59,9 @@ def _establish_new_socket_connection(
         message = [f"CONNECT {server_hostname}:{server_port} HTTP/1.0"]
         if parsed_proxy.username is not None and parsed_proxy.password is not None:
             # In the case where the proxy is "http://{username}:{password}@{hostname}:{port}"
-            raw_value = f"{parsed_proxy.username}:{parsed_proxy.password}"
+            raw_value = (
+                f"{unquote(parsed_proxy.username)}:{unquote(parsed_proxy.password)}"
+            )
             auth = b64encode(raw_value.encode("utf-8")).decode("ascii")
             message.append(f"Proxy-Authorization: Basic {auth}")
         if proxy_headers is not None:


### PR DESCRIPTION
## Summary

This pull request resolves #1169 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
