### PR TITLE
Fix a bug where some of the files.remote API parameters do not work since v3.10

### DIFF
--- a/integration_tests/web/test_remote_file_replacement.py
+++ b/integration_tests/web/test_remote_file_replacement.py
@@ -32,6 +32,7 @@ class TestWebClient(unittest.TestCase):
             external_id=external_id,
             external_url=url,
             title="Slack Logo",
+            indexable_file_contents="so many keywords!".encode("utf-8"),
             preview_image=f"{current_dir}/../../tests/data/slack_logo.png",
         )
         self.assertIsNotNone(remote_file_creation)
@@ -61,6 +62,7 @@ class TestWebClient(unittest.TestCase):
             external_id=external_id,
             external_url=url,
             title="Slack Logo",
+            indexable_file_contents="more and more keywords!".encode("utf-8"),
             preview_image=f"{current_dir}/../../tests/data/slack_logo_new.png",
         )
         self.assertIsNotNone(new_version)

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2794,14 +2794,10 @@ class AsyncWebClient(AsyncBaseClient):
         )
         files = None
         # preview_image (file): Preview of the document via multipart/form-data.
-        if "preview_image" in kwargs or "indexable_file_contents" in kwargs:
+        if preview_image is not None or indexable_file_contents is not None:
             files = {
-                "preview_image": preview_image
-                if preview_image is not None
-                else kwargs.pop("preview_image"),
-                "indexable_file_contents": indexable_file_contents
-                if indexable_file_contents is not None
-                else kwargs.pop("indexable_file_contents"),
+                "preview_image": preview_image,
+                "indexable_file_contents": indexable_file_contents,
             }
 
         return await self.api_call(
@@ -2834,16 +2830,14 @@ class AsyncWebClient(AsyncBaseClient):
                 "file": file,
                 "title": title,
                 "filetype": filetype,
-                "indexable_file_contents": indexable_file_contents,
             }
         )
         files = None
         # preview_image (file): Preview of the document via multipart/form-data.
-        if "preview_image" in kwargs:
+        if preview_image is not None or indexable_file_contents is not None:
             files = {
-                "preview_image": preview_image
-                if preview_image is not None
-                else kwargs.pop("preview_image")
+                "preview_image": preview_image,
+                "indexable_file_contents": indexable_file_contents,
             }
 
         return await self.api_call(

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2739,14 +2739,10 @@ class WebClient(BaseClient):
         )
         files = None
         # preview_image (file): Preview of the document via multipart/form-data.
-        if "preview_image" in kwargs or "indexable_file_contents" in kwargs:
+        if preview_image is not None or indexable_file_contents is not None:
             files = {
-                "preview_image": preview_image
-                if preview_image is not None
-                else kwargs.pop("preview_image"),
-                "indexable_file_contents": indexable_file_contents
-                if indexable_file_contents is not None
-                else kwargs.pop("indexable_file_contents"),
+                "preview_image": preview_image,
+                "indexable_file_contents": indexable_file_contents,
             }
 
         return self.api_call(
@@ -2779,16 +2775,14 @@ class WebClient(BaseClient):
                 "file": file,
                 "title": title,
                 "filetype": filetype,
-                "indexable_file_contents": indexable_file_contents,
             }
         )
         files = None
         # preview_image (file): Preview of the document via multipart/form-data.
-        if "preview_image" in kwargs:
+        if preview_image is not None or indexable_file_contents is not None:
             files = {
-                "preview_image": preview_image
-                if preview_image is not None
-                else kwargs.pop("preview_image")
+                "preview_image": preview_image,
+                "indexable_file_contents": indexable_file_contents,
             }
 
         return self.api_call(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2750,14 +2750,10 @@ class LegacyWebClient(LegacyBaseClient):
         )
         files = None
         # preview_image (file): Preview of the document via multipart/form-data.
-        if "preview_image" in kwargs or "indexable_file_contents" in kwargs:
+        if preview_image is not None or indexable_file_contents is not None:
             files = {
-                "preview_image": preview_image
-                if preview_image is not None
-                else kwargs.pop("preview_image"),
-                "indexable_file_contents": indexable_file_contents
-                if indexable_file_contents is not None
-                else kwargs.pop("indexable_file_contents"),
+                "preview_image": preview_image,
+                "indexable_file_contents": indexable_file_contents,
             }
 
         return self.api_call(
@@ -2790,16 +2786,14 @@ class LegacyWebClient(LegacyBaseClient):
                 "file": file,
                 "title": title,
                 "filetype": filetype,
-                "indexable_file_contents": indexable_file_contents,
             }
         )
         files = None
         # preview_image (file): Preview of the document via multipart/form-data.
-        if "preview_image" in kwargs:
+        if preview_image is not None or indexable_file_contents is not None:
             files = {
-                "preview_image": preview_image
-                if preview_image is not None
-                else kwargs.pop("preview_image")
+                "preview_image": preview_image,
+                "indexable_file_contents": indexable_file_contents,
             }
 
         return self.api_call(


### PR DESCRIPTION
## Summary

This pull request resolves a bug on files.remote.* API support that affects v3.10, 3.11, 3.12, 3.13, 3.14 users. When we added all the optional parameter support in v3.10, the changes caused a regression bug on those API methods: https://github.com/slackapi/python-slack-sdk/pull/1099
### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
