### PR TITLE
Add bookmarks.* API support

### DIFF
--- a/integration_tests/web/test_bookmarks.py
+++ b/integration_tests/web/test_bookmarks.py
@@ -1,0 +1,73 @@
+import logging
+import os
+import unittest
+
+from integration_tests.env_variable_names import (
+    SLACK_SDK_TEST_BOT_TOKEN,
+    SLACK_SDK_TEST_WEB_TEST_CHANNEL_ID,
+)
+from slack_sdk.web import WebClient
+from slack_sdk.web.async_client import AsyncWebClient
+
+
+class TestBookmarks(unittest.TestCase):
+    """Runs integration tests with real Slack API testing the bookmarks.* APIs"""
+
+    def setUp(self):
+        if not hasattr(self, "logger"):
+            self.logger = logging.getLogger(__name__)
+            self.bot_token = os.environ[SLACK_SDK_TEST_BOT_TOKEN]
+            self.async_client: AsyncWebClient = AsyncWebClient(token=self.bot_token)
+            self.sync_client: WebClient = WebClient(token=self.bot_token)
+            self.channel_id = os.environ[SLACK_SDK_TEST_WEB_TEST_CHANNEL_ID]
+
+    def tearDown(self):
+        pass
+
+    def test_adding_listing_editing_removing_bookmark(self):
+        client = self.sync_client
+        # create a new bookmark
+        bookmark = client.bookmarks_add(
+            channel_id=self.channel_id,
+            title="slack!",
+            type="link",
+            link="https://slack.com",
+        )
+        self.assertIsNotNone(bookmark)
+        bookmark_id = bookmark["bookmark"]["id"]
+        # make sure we find the bookmark we just added
+        all_bookmarks = client.bookmarks_list(channel_id=self.channel_id)
+        self.assertIsNotNone(all_bookmarks)
+        self.assertIsNotNone(
+            next(
+                (b for b in all_bookmarks["bookmarks"] if b["id"] == bookmark_id), None
+            )
+        )
+        # edit the bookmark
+        bookmark = client.bookmarks_edit(
+            bookmark_id=bookmark_id,
+            channel_id=self.channel_id,
+            title="slack api!",
+            type="link",
+            link="https://api.slack.com",
+        )
+        self.assertIsNotNone(bookmark)
+        # make sure we find the edited bookmark we just added
+        all_bookmarks = client.bookmarks_list(channel_id=self.channel_id)
+        self.assertIsNotNone(all_bookmarks)
+        edited_bookmark = next(
+            (b for b in all_bookmarks["bookmarks"] if b["id"] == bookmark_id), None
+        )
+        self.assertIsNotNone(edited_bookmark)
+        self.assertEqual(edited_bookmark["title"], "slack api!")
+        # remove the bookmark
+        removed_bookmark = client.bookmarks_remove(
+            bookmark_id=bookmark_id, channel_id=self.channel_id
+        )
+        self.assertIsNotNone(removed_bookmark)
+        # make sure we cannot find the bookmark we just removed
+        all_bookmarks = client.bookmarks_list(channel_id=self.channel_id)
+        self.assertIsNotNone(all_bookmarks)
+        self.assertIsNone(
+            next((b for b in all_bookmarks if b["id"] == bookmark_id), None)
+        )

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1601,6 +1601,83 @@ class AsyncWebClient(AsyncBaseClient):
         """
         return await self.api_call("auth.test", params=kwargs)
 
+    async def bookmarks_add(
+        self,
+        *,
+        channel_id: str,
+        title: str,
+        type: str,
+        emoji: Optional[str] = None,
+        entity_id: Optional[str] = None,
+        link: Optional[str] = None,  # include when type is 'link'
+        parent_id: Optional[str] = None,
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """Add bookmark to a channel.
+        https://api.slack.com/methods/bookmarks.add
+        """
+        kwargs.update(
+            {
+                "channel_id": channel_id,
+                "title": title,
+                "type": type,
+                "emoji": emoji,
+                "entity_id": entity_id,
+                "link": link,
+                "parent_id": parent_id,
+            }
+        )
+        return await self.api_call("bookmarks.add", http_verb="POST", params=kwargs)
+
+    async def bookmarks_edit(
+        self,
+        *,
+        bookmark_id: str,
+        channel_id: str,
+        emoji: Optional[str] = None,
+        link: Optional[str] = None,
+        title: Optional[str] = None,
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """Edit bookmark.
+        https://api.slack.com/methods/bookmarks.edit
+        """
+        kwargs.update(
+            {
+                "bookmark_id": bookmark_id,
+                "channel_id": channel_id,
+                "emoji": emoji,
+                "link": link,
+                "title": title,
+            }
+        )
+        return await self.api_call("bookmarks.edit", http_verb="POST", params=kwargs)
+
+    async def bookmarks_list(
+        self,
+        *,
+        channel_id: str,
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """List bookmark for the channel.
+        https://api.slack.com/methods/bookmarks.list
+        """
+        kwargs.update({"channel_id": channel_id})
+        return await self.api_call("bookmarks.list", http_verb="POST", params=kwargs)
+
+    async def bookmarks_remove(
+        self,
+        *,
+        bookmark_id: str,
+        channel_id: str,
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """Remove bookmark from the channel.
+        https://api.slack.com/methods/bookmarks.remove
+        """
+        kwargs.update({"bookmark_id": bookmark_id, "channel_id": channel_id})
+        return await self.api_call("bookmarks.remove", http_verb="POST", params=kwargs)
+
     async def bots_info(
         self,
         *,

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1560,7 +1560,7 @@ class WebClient(BaseClient):
         type: str,
         emoji: Optional[str] = None,
         entity_id: Optional[str] = None,
-        link: Optional[str] = None,
+        link: Optional[str] = None,  # include when type is 'link'
         parent_id: Optional[str] = None,
         **kwargs,
     ) -> SlackResponse:

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1552,6 +1552,83 @@ class WebClient(BaseClient):
         """
         return self.api_call("auth.test", params=kwargs)
 
+    def bookmarks_add(
+        self,
+        *,
+        channel_id: str,
+        title: str,
+        type: str,
+        emoji: Optional[str] = None,
+        entity_id: Optional[str] = None,
+        link: Optional[str] = None,
+        parent_id: Optional[str] = None,
+        **kwargs,
+    ) -> SlackResponse:
+        """Add bookmark to a channel.
+        https://api.slack.com/methods/bookmarks.add
+        """
+        kwargs.update(
+            {
+                "channel_id": channel_id,
+                "title": title,
+                "type": type,
+                "emoji": emoji,
+                "entity_id": entity_id,
+                "link": link,
+                "parent_id": parent_id,
+            }
+        )
+        return self.api_call("bookmarks.add", http_verb="POST", params=kwargs)
+
+    def bookmarks_edit(
+        self,
+        *,
+        bookmark_id: str,
+        channel_id: str,
+        emoji: Optional[str] = None,
+        link: Optional[str] = None,
+        title: Optional[str] = None,
+        **kwargs,
+    ) -> SlackResponse:
+        """Edit bookmark.
+        https://api.slack.com/methods/bookmarks.edit
+        """
+        kwargs.update(
+            {
+                "bookmark_id": bookmark_id,
+                "channel_id": channel_id,
+                "emoji": emoji,
+                "link": link,
+                "title": title,
+            }
+        )
+        return self.api_call("bookmarks.edit", http_verb="POST", params=kwargs)
+
+    def bookmarks_list(
+        self,
+        *,
+        channel_id: str,
+        **kwargs,
+    ) -> SlackResponse:
+        """List bookmark for the channel.
+        https://api.slack.com/methods/bookmarks.list
+        """
+        kwargs.update({"channel_id": channel_id})
+        return self.api_call("bookmarks.list", http_verb="POST", params=kwargs)
+
+    def bookmarks_remove(
+        self,
+        *,
+        bookmark_id: str,
+        channel_id: str,
+        **kwargs,
+    ) -> SlackResponse:
+        """Remove bookmark from the channel.
+        https://api.slack.com/methods/bookmarks.remove
+        """
+        kwargs.update({"bookmark_id": bookmark_id, "channel_id": channel_id})
+        return self.api_call("bookmarks.remove", http_verb="POST", params=kwargs)
+
     def bots_info(
         self,
         *,

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1571,7 +1571,7 @@ class LegacyWebClient(LegacyBaseClient):
         type: str,
         emoji: Optional[str] = None,
         entity_id: Optional[str] = None,
-        link: Optional[str] = None,
+        link: Optional[str] = None,  # include when type is 'link'
         parent_id: Optional[str] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1563,6 +1563,83 @@ class LegacyWebClient(LegacyBaseClient):
         """
         return self.api_call("auth.test", params=kwargs)
 
+    def bookmarks_add(
+        self,
+        *,
+        channel_id: str,
+        title: str,
+        type: str,
+        emoji: Optional[str] = None,
+        entity_id: Optional[str] = None,
+        link: Optional[str] = None,
+        parent_id: Optional[str] = None,
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """Add bookmark to a channel.
+        https://api.slack.com/methods/bookmarks.add
+        """
+        kwargs.update(
+            {
+                "channel_id": channel_id,
+                "title": title,
+                "type": type,
+                "emoji": emoji,
+                "entity_id": entity_id,
+                "link": link,
+                "parent_id": parent_id,
+            }
+        )
+        return self.api_call("bookmarks.add", http_verb="POST", params=kwargs)
+
+    def bookmarks_edit(
+        self,
+        *,
+        bookmark_id: str,
+        channel_id: str,
+        emoji: Optional[str] = None,
+        link: Optional[str] = None,
+        title: Optional[str] = None,
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """Edit bookmark.
+        https://api.slack.com/methods/bookmarks.edit
+        """
+        kwargs.update(
+            {
+                "bookmark_id": bookmark_id,
+                "channel_id": channel_id,
+                "emoji": emoji,
+                "link": link,
+                "title": title,
+            }
+        )
+        return self.api_call("bookmarks.edit", http_verb="POST", params=kwargs)
+
+    def bookmarks_list(
+        self,
+        *,
+        channel_id: str,
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """List bookmark for the channel.
+        https://api.slack.com/methods/bookmarks.list
+        """
+        kwargs.update({"channel_id": channel_id})
+        return self.api_call("bookmarks.list", http_verb="POST", params=kwargs)
+
+    def bookmarks_remove(
+        self,
+        *,
+        bookmark_id: str,
+        channel_id: str,
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """Remove bookmark from the channel.
+        https://api.slack.com/methods/bookmarks.remove
+        """
+        kwargs.update({"bookmark_id": bookmark_id, "channel_id": channel_id})
+        return self.api_call("bookmarks.remove", http_verb="POST", params=kwargs)
+
     def bots_info(
         self,
         *,

--- a/tests/slack_sdk_async/web/test_web_client_coverage.py
+++ b/tests/slack_sdk_async/web/test_web_client_coverage.py
@@ -15,7 +15,7 @@ from tests.slack_sdk.web.mock_web_api_server import (
 
 
 class TestWebClientCoverage(unittest.TestCase):
-    # 222 endpoints as of Jan 11, 2022
+    # 227 endpoints as of Feb 16, 2022
     # Can be fetched by running `var methodNames = [].slice.call(document.getElementsByClassName('apiReferenceFilterableList__listItemLink')).map(e => e.href.replace("https://api.slack.com/methods/", ""));console.log(methodNames.toString());console.log(methodNames.length);` on https://api.slack.com/methods
     all_api_methods = "admin.analytics.getFile,admin.apps.approve,admin.apps.clearResolution,admin.apps.restrict,admin.apps.uninstall,admin.apps.approved.list,admin.apps.requests.cancel,admin.apps.requests.list,admin.apps.restricted.list,admin.auth.policy.assignEntities,admin.auth.policy.getEntities,admin.auth.policy.removeEntities,admin.barriers.create,admin.barriers.delete,admin.barriers.list,admin.barriers.update,admin.conversations.archive,admin.conversations.convertToPrivate,admin.conversations.create,admin.conversations.delete,admin.conversations.disconnectShared,admin.conversations.getConversationPrefs,admin.conversations.getCustomRetention,admin.conversations.getTeams,admin.conversations.invite,admin.conversations.removeCustomRetention,admin.conversations.rename,admin.conversations.search,admin.conversations.setConversationPrefs,admin.conversations.setCustomRetention,admin.conversations.setTeams,admin.conversations.unarchive,admin.conversations.ekm.listOriginalConnectedChannelInfo,admin.conversations.restrictAccess.addGroup,admin.conversations.restrictAccess.listGroups,admin.conversations.restrictAccess.removeGroup,admin.emoji.add,admin.emoji.addAlias,admin.emoji.list,admin.emoji.remove,admin.emoji.rename,admin.inviteRequests.approve,admin.inviteRequests.deny,admin.inviteRequests.list,admin.inviteRequests.approved.list,admin.inviteRequests.denied.list,admin.teams.admins.list,admin.teams.create,admin.teams.list,admin.teams.owners.list,admin.teams.settings.info,admin.teams.settings.setDefaultChannels,admin.teams.settings.setDescription,admin.teams.settings.setDiscoverability,admin.teams.settings.setIcon,admin.teams.settings.setName,admin.usergroups.addChannels,admin.usergroups.addTeams,admin.usergroups.listChannels,admin.usergroups.removeChannels,admin.users.assign,admin.users.invite,admin.users.list,admin.users.remove,admin.users.setAdmin,admin.users.setExpiration,admin.users.setOwner,admin.users.setRegular,admin.users.session.clearSettings,admin.users.session.getSettings,admin.users.session.invalidate,admin.users.session.list,admin.users.session.reset,admin.users.session.resetBulk,admin.users.session.setSettings,admin.users.unsupportedVersions.export,api.test,apps.connections.open,apps.event.authorizations.list,apps.manifest.create,apps.manifest.delete,apps.manifest.export,apps.manifest.update,apps.manifest.validate,apps.uninstall,auth.revoke,auth.test,auth.teams.list,bookmarks.add,bookmarks.edit,bookmarks.list,bookmarks.remove,bots.info,calls.add,calls.end,calls.info,calls.update,calls.participants.add,calls.participants.remove,chat.delete,chat.deleteScheduledMessage,chat.getPermalink,chat.meMessage,chat.postEphemeral,chat.postMessage,chat.scheduleMessage,chat.unfurl,chat.update,chat.scheduledMessages.list,conversations.acceptSharedInvite,conversations.approveSharedInvite,conversations.archive,conversations.close,conversations.create,conversations.declineSharedInvite,conversations.history,conversations.info,conversations.invite,conversations.inviteShared,conversations.join,conversations.kick,conversations.leave,conversations.list,conversations.listConnectInvites,conversations.mark,conversations.members,conversations.open,conversations.rename,conversations.replies,conversations.setPurpose,conversations.setTopic,conversations.unarchive,dialog.open,dnd.endDnd,dnd.endSnooze,dnd.info,dnd.setSnooze,dnd.teamInfo,emoji.list,files.comments.delete,files.delete,files.info,files.list,files.revokePublicURL,files.sharedPublicURL,files.upload,files.remote.add,files.remote.info,files.remote.list,files.remote.remove,files.remote.share,files.remote.update,migration.exchange,oauth.access,oauth.v2.access,oauth.v2.exchange,openid.connect.token,openid.connect.userInfo,pins.add,pins.list,pins.remove,reactions.add,reactions.get,reactions.list,reactions.remove,reminders.add,reminders.complete,reminders.delete,reminders.info,reminders.list,rtm.connect,rtm.start,search.all,search.files,search.messages,stars.add,stars.list,stars.remove,team.accessLogs,team.billableInfo,team.info,team.integrationLogs,team.billing.info,team.preferences.list,team.profile.get,tooling.tokens.rotate,usergroups.create,usergroups.disable,usergroups.enable,usergroups.list,usergroups.update,usergroups.users.list,usergroups.users.update,users.conversations,users.deletePhoto,users.getPresence,users.identity,users.info,users.list,users.lookupByEmail,users.setActive,users.setPhoto,users.setPresence,users.profile.get,users.profile.set,views.open,views.publish,views.push,views.update,workflows.stepCompleted,workflows.stepFailed,workflows.updateStep,channels.create,channels.info,channels.invite,channels.mark,groups.create,groups.info,groups.invite,groups.mark,groups.open,im.list,im.mark,im.open,mpim.list,mpim.mark,mpim.open".split(
         ","
@@ -55,11 +55,6 @@ class TestWebClientCoverage(unittest.TestCase):
                 "apps.manifest.update",
                 "apps.manifest.validate",
                 "tooling.tokens.rotate",
-                # TODO: bookmarks.*
-                "bookmarks.add",
-                "bookmarks.edit",
-                "bookmarks.list",
-                "bookmarks.remove",
             ]:
                 continue
             self.api_methods_to_call.append(api_method)
@@ -392,6 +387,28 @@ class TestWebClientCoverage(unittest.TestCase):
                     method(client_id="111.222", client_secret="xxx")["method"]
                 )
                 await async_method(client_id="111.222", client_secret="xxx")
+            elif method_name == "bookmarks_add":
+                self.api_methods_to_call.remove(
+                    method(channel_id="C1234", title="bedtime story", type="article")[
+                        "method"
+                    ]
+                )
+                await async_method(
+                    channel_id="C1234", title="bedtime story", type="article"
+                )
+            elif method_name == "bookmarks_edit":
+                self.api_methods_to_call.remove(
+                    method(bookmark_id="B1234", channel_id="C1234")["method"]
+                )
+                await async_method(bookmark_id="B1234", channel_id="C1234")
+            elif method_name == "bookmarks_list":
+                self.api_methods_to_call.remove(method(channel_id="C1234")["method"])
+                await async_method(channel_id="C1234")
+            elif method_name == "bookmarks_remove":
+                self.api_methods_to_call.remove(
+                    method(bookmark_id="B1234", channel_id="C1234")["method"]
+                )
+                await async_method(bookmark_id="B1234", channel_id="C1234")
             elif method_name == "calls_add":
                 self.api_methods_to_call.remove(
                     method(


### PR DESCRIPTION
## Summary

This PR adds support for the [add/edit/list/remove bookmark APIs](https://api.slack.com/methods?query=bookmarks).

This is my first PR adding support for new APIs, so reviews are appreciated. Maybe I missed some stuff? I.e. maybe integration tests? Not sure, would very much appreciate your guidance @seratch 🙇 

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.