### PR TITLE
Pass ssl_context from the web_client to the websocket

### DIFF
--- a/slack_sdk/socket_mode/builtin/client.py
+++ b/slack_sdk/socket_mode/builtin/client.py
@@ -177,6 +177,7 @@ class SocketModeClient(BaseSocketModeClient):
             on_message_listener=self._on_message,
             on_error_listener=self._on_error,
             on_close_listener=self._on_close,
+            ssl_context=self.web_client.ssl,
         )
         current_session.connect()
 

--- a/slack_sdk/socket_mode/builtin/connection.py
+++ b/slack_sdk/socket_mode/builtin/connection.py
@@ -64,6 +64,7 @@ class Connection:
         on_error_listener: Optional[Callable[[Exception], None]] = None,
         on_close_listener: Optional[Callable[[int, Optional[str]], None]] = None,
         connection_type_name: str = "Socket Mode",
+        ssl_context: Optional[ssl.SSLContext] = None,
     ):
         self.url = url
         self.logger = logger
@@ -94,6 +95,8 @@ class Connection:
         self.on_close_listener = on_close_listener
         self.connection_type_name = connection_type_name
 
+        self.ssl_context = ssl_context
+
     def connect(self) -> None:
         try:
             parsed_url = urlparse(self.url.strip())
@@ -114,6 +117,7 @@ class Connection:
                 proxy=self.proxy,
                 proxy_headers=self.proxy_headers,
                 trace_enabled=self.trace_enabled,
+                ssl_context=self.ssl_context,
             )
 
             # WebSocket handshake


### PR DESCRIPTION
## Summary

This PR should fix this bug: https://github.com/slackapi/python-slack-sdk/issues/1175


### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
