### PR TITLE
Fix #1178 text type hint in LinkButtonElement does not accept PlainTextObject/dict

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -325,7 +325,7 @@ class LinkButtonElement(ButtonElement):
     def __init__(
         self,
         *,
-        text: str,
+        text: Union[str, dict, PlainTextObject],
         url: str,
         action_id: Optional[str] = None,
         style: Optional[str] = None,

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -26,6 +26,7 @@ from slack_sdk.models.blocks import (
     Option,
     InputInteractiveElement,
     InteractiveElement,
+    PlainTextObject,
 )
 from . import STRING_3001_CHARS, STRING_301_CHARS
 
@@ -203,6 +204,23 @@ class LinkButtonElementTests(unittest.TestCase):
             {
                 "text": {"emoji": True, "text": "button text", "type": "plain_text"},
                 "url": "http://google.com",
+                "type": "button",
+                "action_id": button.action_id,
+            },
+            button.to_dict(),
+        )
+
+    # https://github.com/slackapi/python-slack-sdk/issues/1178
+    def test_text_patterns_issue_1178(self):
+        button = LinkButtonElement(
+            action_id="test",
+            text=PlainTextObject(text="button text"),
+            url="http://slack.com",
+        )
+        self.assertDictEqual(
+            {
+                "text": {"text": "button text", "type": "plain_text"},
+                "url": "http://slack.com",
                 "type": "button",
                 "action_id": button.action_id,
             },


### PR DESCRIPTION
## Summary

This pull request resolves #1178 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
