### PR TITLE
Fix #1184 Add exception handling for socket mode - BlockingIOError: Resource temporarily unavailable

### DIFF
--- a/slack_sdk/socket_mode/builtin/client.py
+++ b/slack_sdk/socket_mode/builtin/client.py
@@ -247,10 +247,15 @@ class SocketModeClient(BaseSocketModeClient):
             listener(message)
 
     def _on_error(self, error: Exception):
-        self.logger.exception(
+        error_message = (
             f"on_error invoked (session id: {self.session_id()}, "
             f"error: {type(error).__name__}, message: {error})"
         )
+        if self.trace_enabled:
+            self.logger.exception(error_message)
+        else:
+            self.logger.error(error_message)
+
         for listener in self.on_error_listeners:
             listener(error)
 
@@ -281,10 +286,14 @@ class SocketModeClient(BaseSocketModeClient):
                     f" (session id: {session_id})"
                 )
             except Exception as e:
-                self.logger.exception(
+                error_message = (
                     "Failed to start or stop the current session"
                     f" (session id: {session_id}, error: {e})"
                 )
+                if self.trace_enabled:
+                    self.logger.exception(error_message)
+                else:
+                    self.logger.error(error_message)
 
     def _monitor_current_session(self):
         if self.current_app_monitor_started:


### PR DESCRIPTION
## Summary

This pull request fixes #1184 . Also, it changes other internal methods in the same way. As for the built-in internal modules, there is less benefit by displaying full stacktrace.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
