### PR TITLE
Add file_ids to chat.update parameters

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2211,6 +2211,7 @@ class AsyncWebClient(AsyncBaseClient):
         attachments: Optional[Sequence[Union[Dict, Attachment]]] = None,
         blocks: Optional[Sequence[Union[Dict, Block]]] = None,
         as_user: Optional[bool] = None,
+        file_ids: Optional[Union[str, Sequence[str]]] = None,
         link_names: Optional[bool] = None,
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
@@ -2232,6 +2233,10 @@ class AsyncWebClient(AsyncBaseClient):
                 "reply_broadcast": reply_broadcast,
             }
         )
+        if isinstance(file_ids, (list, Tuple)):
+            kwargs.update({"file_ids": ",".join(file_ids)})
+        else:
+            kwargs.update({"file_ids": file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
         _warn_if_text_is_missing("chat.update", kwargs)
@@ -2448,7 +2453,7 @@ class AsyncWebClient(AsyncBaseClient):
         else:
             kwargs.update({"emails": emails})
         if isinstance(user_ids, (list, Tuple)):
-            kwargs.update({"emails": ",".join(user_ids)})
+            kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
         return await self.api_call(

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2160,6 +2160,7 @@ class WebClient(BaseClient):
         attachments: Optional[Sequence[Union[Dict, Attachment]]] = None,
         blocks: Optional[Sequence[Union[Dict, Block]]] = None,
         as_user: Optional[bool] = None,
+        file_ids: Optional[Union[str, Sequence[str]]] = None,
         link_names: Optional[bool] = None,
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
@@ -2181,6 +2182,10 @@ class WebClient(BaseClient):
                 "reply_broadcast": reply_broadcast,
             }
         )
+        if isinstance(file_ids, (list, Tuple)):
+            kwargs.update({"file_ids": ",".join(file_ids)})
+        else:
+            kwargs.update({"file_ids": file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
         _warn_if_text_is_missing("chat.update", kwargs)
@@ -2395,7 +2400,7 @@ class WebClient(BaseClient):
         else:
             kwargs.update({"emails": emails})
         if isinstance(user_ids, (list, Tuple)):
-            kwargs.update({"emails": ",".join(user_ids)})
+            kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
         return self.api_call(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2171,6 +2171,7 @@ class LegacyWebClient(LegacyBaseClient):
         attachments: Optional[Sequence[Union[Dict, Attachment]]] = None,
         blocks: Optional[Sequence[Union[Dict, Block]]] = None,
         as_user: Optional[bool] = None,
+        file_ids: Optional[Union[str, Sequence[str]]] = None,
         link_names: Optional[bool] = None,
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
@@ -2192,6 +2193,10 @@ class LegacyWebClient(LegacyBaseClient):
                 "reply_broadcast": reply_broadcast,
             }
         )
+        if isinstance(file_ids, (list, Tuple)):
+            kwargs.update({"file_ids": ",".join(file_ids)})
+        else:
+            kwargs.update({"file_ids": file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
         _warn_if_text_is_missing("chat.update", kwargs)
@@ -2406,7 +2411,7 @@ class LegacyWebClient(LegacyBaseClient):
         else:
             kwargs.update({"emails": emails})
         if isinstance(user_ids, (list, Tuple)):
-            kwargs.update({"emails": ",".join(user_ids)})
+            kwargs.update({"user_ids": ",".join(user_ids)})
         else:
             kwargs.update({"user_ids": user_ids})
         return self.api_call(


### PR DESCRIPTION
## Summary

This pull request adds file_ids to chat.update parameters. Also, it fixes an existing bug in conversations_inviteShared method.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
