### PR TITLE
Add domain to team.info API parameters

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -3954,12 +3954,13 @@ class AsyncWebClient(AsyncBaseClient):
         self,
         *,
         team: Optional[str] = None,
+        domain: Optional[str] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets information about the current team.
         https://api.slack.com/methods/team.info
         """
-        kwargs.update({"team": team})
+        kwargs.update({"team": team, "domain": domain})
         return await self.api_call("team.info", http_verb="GET", params=kwargs)
 
     async def team_integrationLogs(

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -3893,12 +3893,13 @@ class WebClient(BaseClient):
         self,
         *,
         team: Optional[str] = None,
+        domain: Optional[str] = None,
         **kwargs,
     ) -> SlackResponse:
         """Gets information about the current team.
         https://api.slack.com/methods/team.info
         """
-        kwargs.update({"team": team})
+        kwargs.update({"team": team, "domain": domain})
         return self.api_call("team.info", http_verb="GET", params=kwargs)
 
     def team_integrationLogs(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3904,12 +3904,13 @@ class LegacyWebClient(LegacyBaseClient):
         self,
         *,
         team: Optional[str] = None,
+        domain: Optional[str] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets information about the current team.
         https://api.slack.com/methods/team.info
         """
-        kwargs.update({"team": team})
+        kwargs.update({"team": team, "domain": domain})
         return self.api_call("team.info", http_verb="GET", params=kwargs)
 
     def team_integrationLogs(


### PR DESCRIPTION
## Summary

This pull request adds `domain` parameter to the [team.info](https://api.slack.com/methods/team.info) API method.

>The [team.info](https://api.slack.com/methods/team.info) parameter [domain](https://api.slack.com/methods/team.info#arg_domain) is now public. Query for your team's information by domain only when team is null.
>https://api.slack.com/changelog

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
