### PR TITLE
Fix #1200 Model to_dict doesn't handle tuple sequences

### DIFF
--- a/slack_sdk/models/basic_objects.py
+++ b/slack_sdk/models/basic_objects.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from functools import wraps
-from typing import Callable, Iterable, Set, Union, Any
+from typing import Callable, Iterable, Set, Union, Any, Tuple
 
 from slack_sdk.errors import SlackObjectFormationError
 
@@ -38,9 +38,9 @@ class JsonObject(BaseObject, metaclass=ABCMeta):
         """
 
         def to_dict_compatible(
-            value: Union[dict, list, object]
+            value: Union[dict, list, object, Tuple]
         ) -> Union[dict, list, Any]:
-            if isinstance(value, list):  # skipcq: PYL-R1705
+            if isinstance(value, (list, Tuple)):  # skipcq: PYL-R1705
                 return [to_dict_compatible(v) for v in value]
             else:
                 to_dict = getattr(value, "to_dict", None)

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -641,7 +641,7 @@ class StaticSelectElementTests(unittest.TestCase):
         }
         self.assertDictEqual(input, StaticSelectElement(**input).to_dict())
 
-    def test_issue_1200(self):
+    def test_lists_and_tuples_serialize_to_dict_equally(self):
         expected = {
             "options": [
                 {

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -641,6 +641,28 @@ class StaticSelectElementTests(unittest.TestCase):
         }
         self.assertDictEqual(input, StaticSelectElement(**input).to_dict())
 
+    def test_issue_1200(self):
+        expected = {
+            "options": [
+                {
+                    "text": {"emoji": True, "text": "X", "type": "plain_text"},
+                    "value": "x",
+                }
+            ],
+            "type": "static_select",
+        }
+        option = Option(value="x", text="X")
+        # List
+        self.assertDictEqual(
+            expected,
+            StaticSelectElement(options=[option]).to_dict(),
+        )
+        # Tuple (this pattern used to be failing)
+        self.assertDictEqual(
+            expected,
+            StaticSelectElement(options=(option,)).to_dict(),
+        )
+
 
 # -------------------------------------------------
 # External Data Source Select


### PR DESCRIPTION
## Summary

This pull request resolves #1200

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
