### PR TITLE
Add message metadata support

### DIFF
--- a/integration_tests/web/test_message_metadata.py
+++ b/integration_tests/web/test_message_metadata.py
@@ -1,0 +1,128 @@
+import logging
+import os
+import time
+import unittest
+
+from integration_tests.env_variable_names import SLACK_SDK_TEST_BOT_TOKEN
+from slack_sdk.models.metadata import Metadata
+from slack_sdk.web import WebClient
+
+
+class TestWebClient(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = logging.getLogger(__name__)
+        self.bot_token = os.environ[SLACK_SDK_TEST_BOT_TOKEN]
+
+    def tearDown(self):
+        pass
+
+    def test_publishing_message_metadata(self):
+        client: WebClient = WebClient(token=self.bot_token)
+        new_message = client.chat_postMessage(
+            channel='#random',
+            text="message with metadata",
+            metadata={
+                "event_type": "procurement-task",
+                "event_payload": {
+                    "id": "11111",
+                    "amount": 5000,
+                    "tags": ["foo", "bar", "baz"]
+                },
+            }
+        )
+        self.assertIsNone(new_message.get("error"))
+        self.assertIsNotNone(new_message.get("message").get("metadata"))
+
+        history = client.conversations_history(
+            channel=new_message.get("channel"),
+            limit=1,
+            include_all_metadata=True,
+        )
+        self.assertIsNone(history.get("error"))
+        self.assertIsNotNone(history.get("messages")[0].get("metadata"))
+
+        modification = client.chat_update(
+            channel=new_message.get("channel"),
+            ts=new_message.get("ts"),
+            text="message with metadata (modified)",
+            metadata={
+                "event_type": "procurement-task",
+                "event_payload": {
+                    "id": "11111",
+                    "amount": 6000,
+                },
+            }
+        )
+        self.assertIsNone(modification.get("error"))
+        self.assertIsNotNone(modification.get("message").get("metadata"))
+
+        scheduled = client.chat_scheduleMessage(
+            channel=new_message.get("channel"),
+            post_at=int(time.time()) + 30,
+            text="message with metadata (scheduled)",
+            metadata={
+                "event_type": "procurement-task",
+                "event_payload": {
+                    "id": "11111",
+                    "amount": 10,
+                },
+            }
+        )
+        self.assertIsNone(scheduled.get("error"))
+        self.assertIsNotNone(scheduled.get("message").get("metadata"))
+
+    def test_publishing_message_metadata_using_models(self):
+        client: WebClient = WebClient(token=self.bot_token)
+        new_message = client.chat_postMessage(
+            channel='#random',
+            text="message with metadata",
+            metadata=Metadata(
+                event_type="procurement-task",
+                event_payload={
+                    "id": "11111",
+                    "amount": 5000,
+                    "tags": ["foo", "bar", "baz"]
+                }
+            )
+        )
+        self.assertIsNone(new_message.get("error"))
+        self.assertIsNotNone(new_message.get("message").get("metadata"))
+
+        history = client.conversations_history(
+            channel=new_message.get("channel"),
+            limit=1,
+            include_all_metadata=True,
+        )
+        self.assertIsNone(history.get("error"))
+        self.assertIsNotNone(history.get("messages")[0].get("metadata"))
+
+        modification = client.chat_update(
+            channel=new_message.get("channel"),
+            ts=new_message.get("ts"),
+            text="message with metadata (modified)",
+            metadata=Metadata(
+                event_type="procurement-task",
+                event_payload={
+                    "id": "11111",
+                    "amount": 6000,
+                }
+            )
+        )
+        self.assertIsNone(modification.get("error"))
+        self.assertIsNotNone(modification.get("message").get("metadata"))
+
+        scheduled = client.chat_scheduleMessage(
+            channel=new_message.get("channel"),
+            post_at=int(time.time()) + 30,
+            text="message with metadata (scheduled)",
+            metadata=Metadata(
+                event_type="procurement-task",
+                event_payload={
+                    "id": "11111",
+                    "amount": 10,
+                }
+            )
+        )
+        self.assertIsNone(scheduled.get("error"))
+        self.assertIsNotNone(scheduled.get("message").get("metadata"))

--- a/slack_sdk/models/metadata/__init__.py
+++ b/slack_sdk/models/metadata/__init__.py
@@ -5,7 +5,7 @@ from slack_sdk.models.basic_objects import JsonObject
 class Metadata(JsonObject):
     """Message metadata
 
-    https://api.slack.com/metadta
+    https://api.slack.com/metadata
     """
 
     attributes = {

--- a/slack_sdk/models/metadata/__init__.py
+++ b/slack_sdk/models/metadata/__init__.py
@@ -1,0 +1,30 @@
+from typing import Dict, Any
+from slack_sdk.models.basic_objects import JsonObject
+
+
+class Metadata(JsonObject):
+    """Message metadata
+
+    https://api.slack.com/metadta
+    """
+
+    attributes = {
+        "event_type",
+        "event_payload",
+    }
+
+    def __init__(
+        self,
+        event_type: str,
+        event_payload: Dict[str, Any],
+        **kwargs,
+    ):
+        self.event_type = event_type
+        self.event_payload = event_payload
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -24,6 +24,7 @@ from .internal_utils import (
 )
 from ..models.attachments import Attachment
 from ..models.blocks import Block
+from ..models.metadata import Metadata
 
 
 class AsyncWebClient(AsyncBaseClient):
@@ -2098,6 +2099,7 @@ class AsyncWebClient(AsyncBaseClient):
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sends a message to a channel.
@@ -2122,6 +2124,7 @@ class AsyncWebClient(AsyncBaseClient):
                 "link_names": link_names,
                 "username": username,
                 "parse": parse,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)
@@ -2145,6 +2148,7 @@ class AsyncWebClient(AsyncBaseClient):
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
         link_names: Optional[bool] = None,
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Schedules a message.
@@ -2164,6 +2168,7 @@ class AsyncWebClient(AsyncBaseClient):
                 "unfurl_links": unfurl_links,
                 "unfurl_media": unfurl_media,
                 "link_names": link_names,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)
@@ -2215,6 +2220,7 @@ class AsyncWebClient(AsyncBaseClient):
         link_names: Optional[bool] = None,
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Updates a message in a channel.
@@ -2231,6 +2237,7 @@ class AsyncWebClient(AsyncBaseClient):
                 "link_names": link_names,
                 "parse": parse,
                 "reply_broadcast": reply_broadcast,
+                "metadata": metadata,
             }
         )
         if isinstance(file_ids, (list, Tuple)):
@@ -2375,6 +2382,7 @@ class AsyncWebClient(AsyncBaseClient):
         channel: str,
         cursor: Optional[str] = None,
         inclusive: Optional[bool] = None,
+        include_all_metadata: Optional[bool] = None,
         latest: Optional[str] = None,
         limit: Optional[int] = None,
         oldest: Optional[str] = None,
@@ -2388,6 +2396,7 @@ class AsyncWebClient(AsyncBaseClient):
                 "channel": channel,
                 "cursor": cursor,
                 "inclusive": inclusive,
+                "include_all_metadata": include_all_metadata,
                 "limit": limit,
                 "latest": latest,
                 "oldest": oldest,

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -15,6 +15,7 @@ from .internal_utils import (
 )
 from ..models.attachments import Attachment
 from ..models.blocks import Block
+from ..models.metadata import Metadata
 
 
 class WebClient(BaseClient):
@@ -2047,6 +2048,7 @@ class WebClient(BaseClient):
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> SlackResponse:
         """Sends a message to a channel.
@@ -2071,6 +2073,7 @@ class WebClient(BaseClient):
                 "link_names": link_names,
                 "username": username,
                 "parse": parse,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)
@@ -2094,6 +2097,7 @@ class WebClient(BaseClient):
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
         link_names: Optional[bool] = None,
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> SlackResponse:
         """Schedules a message.
@@ -2113,6 +2117,7 @@ class WebClient(BaseClient):
                 "unfurl_links": unfurl_links,
                 "unfurl_media": unfurl_media,
                 "link_names": link_names,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)
@@ -2164,6 +2169,7 @@ class WebClient(BaseClient):
         link_names: Optional[bool] = None,
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> SlackResponse:
         """Updates a message in a channel.
@@ -2180,6 +2186,7 @@ class WebClient(BaseClient):
                 "link_names": link_names,
                 "parse": parse,
                 "reply_broadcast": reply_broadcast,
+                "metadata": metadata,
             }
         )
         if isinstance(file_ids, (list, Tuple)):
@@ -2324,6 +2331,7 @@ class WebClient(BaseClient):
         channel: str,
         cursor: Optional[str] = None,
         inclusive: Optional[bool] = None,
+        include_all_metadata: Optional[bool] = None,
         latest: Optional[str] = None,
         limit: Optional[int] = None,
         oldest: Optional[str] = None,
@@ -2337,6 +2345,7 @@ class WebClient(BaseClient):
                 "channel": channel,
                 "cursor": cursor,
                 "inclusive": inclusive,
+                "include_all_metadata": include_all_metadata,
                 "limit": limit,
                 "latest": latest,
                 "oldest": oldest,

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -11,6 +11,7 @@ from slack_sdk import version
 from slack_sdk.errors import SlackRequestError
 from slack_sdk.models.attachments import Attachment
 from slack_sdk.models.blocks import Block
+from slack_sdk.models.metadata import Metadata
 
 
 def convert_bool_to_0_or_1(
@@ -180,10 +181,12 @@ def _build_req_args(
 
 
 def _parse_web_class_objects(kwargs) -> None:
-    def to_dict(obj: Union[Dict, Block, Attachment]):
+    def to_dict(obj: Union[Dict, Block, Attachment, Metadata]):
         if isinstance(obj, Block):
             return obj.to_dict()
         if isinstance(obj, Attachment):
+            return obj.to_dict()
+        if isinstance(obj, Metadata):
             return obj.to_dict()
         return obj
 
@@ -196,6 +199,10 @@ def _parse_web_class_objects(kwargs) -> None:
     if attachments is not None and isinstance(attachments, list):
         dict_attachments = [to_dict(a) for a in attachments]
         kwargs.update({"attachments": dict_attachments})
+
+    metadata = kwargs.get("metadata", None)
+    if metadata is not None and isinstance(metadata, Metadata):
+        kwargs.update({"metadata": to_dict(metadata)})
 
 
 def _update_call_participants(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -26,6 +26,7 @@ from .internal_utils import (
 )
 from ..models.attachments import Attachment
 from ..models.blocks import Block
+from ..models.metadata import Metadata
 
 
 class LegacyWebClient(LegacyBaseClient):
@@ -2058,6 +2059,7 @@ class LegacyWebClient(LegacyBaseClient):
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sends a message to a channel.
@@ -2082,6 +2084,7 @@ class LegacyWebClient(LegacyBaseClient):
                 "link_names": link_names,
                 "username": username,
                 "parse": parse,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)
@@ -2105,6 +2108,7 @@ class LegacyWebClient(LegacyBaseClient):
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
         link_names: Optional[bool] = None,
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Schedules a message.
@@ -2124,6 +2128,7 @@ class LegacyWebClient(LegacyBaseClient):
                 "unfurl_links": unfurl_links,
                 "unfurl_media": unfurl_media,
                 "link_names": link_names,
+                "metadata": metadata,
             }
         )
         _parse_web_class_objects(kwargs)
@@ -2175,6 +2180,7 @@ class LegacyWebClient(LegacyBaseClient):
         link_names: Optional[bool] = None,
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
+        metadata: Optional[Union[Dict, Metadata]] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Updates a message in a channel.
@@ -2191,6 +2197,7 @@ class LegacyWebClient(LegacyBaseClient):
                 "link_names": link_names,
                 "parse": parse,
                 "reply_broadcast": reply_broadcast,
+                "metadata": metadata,
             }
         )
         if isinstance(file_ids, (list, Tuple)):
@@ -2335,6 +2342,7 @@ class LegacyWebClient(LegacyBaseClient):
         channel: str,
         cursor: Optional[str] = None,
         inclusive: Optional[bool] = None,
+        include_all_metadata: Optional[bool] = None,
         latest: Optional[str] = None,
         limit: Optional[int] = None,
         oldest: Optional[str] = None,
@@ -2348,6 +2356,7 @@ class LegacyWebClient(LegacyBaseClient):
                 "channel": channel,
                 "cursor": cursor,
                 "inclusive": inclusive,
+                "include_all_metadata": include_all_metadata,
                 "limit": limit,
                 "latest": latest,
                 "oldest": oldest,


### PR DESCRIPTION
## Summary

This pull request adds message metadata support: https://api.slack.com/metadata

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
