### PR TITLE
Tweaking warnings related to missing accessibility fields `text` and `fallback`

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -19,7 +19,7 @@ from .async_base_client import AsyncBaseClient, AsyncSlackResponse
 from .internal_utils import (
     _parse_web_class_objects,
     _update_call_participants,
-    _warn_if_text_is_missing,
+    _warn_if_text_or_attachment_fallback_is_missing,
     _remove_none_values,
 )
 from ..models.attachments import Attachment
@@ -2075,7 +2075,7 @@ class AsyncWebClient(AsyncBaseClient):
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.postEphemeral", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.postEphemeral", kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return await self.api_call("chat.postEphemeral", json=kwargs)
 
@@ -2129,7 +2129,7 @@ class AsyncWebClient(AsyncBaseClient):
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.postMessage", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.postMessage", kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return await self.api_call("chat.postMessage", json=kwargs)
 
@@ -2173,7 +2173,7 @@ class AsyncWebClient(AsyncBaseClient):
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.scheduleMessage", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.scheduleMessage", kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return await self.api_call("chat.scheduleMessage", json=kwargs)
 
@@ -2246,7 +2246,7 @@ class AsyncWebClient(AsyncBaseClient):
             kwargs.update({"file_ids": file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.update", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.update", kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return await self.api_call("chat.update", json=kwargs)
 

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -10,7 +10,7 @@ from .base_client import BaseClient, SlackResponse
 from .internal_utils import (
     _parse_web_class_objects,
     _update_call_participants,
-    _warn_if_text_is_missing,
+    _warn_if_text_or_attachment_fallback_is_missing,
     _remove_none_values,
 )
 from ..models.attachments import Attachment
@@ -2024,7 +2024,7 @@ class WebClient(BaseClient):
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.postEphemeral", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.postEphemeral", kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call("chat.postEphemeral", json=kwargs)
 
@@ -2078,7 +2078,7 @@ class WebClient(BaseClient):
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.postMessage", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.postMessage", kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call("chat.postMessage", json=kwargs)
 
@@ -2122,7 +2122,7 @@ class WebClient(BaseClient):
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.scheduleMessage", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.scheduleMessage", kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call("chat.scheduleMessage", json=kwargs)
 
@@ -2195,7 +2195,7 @@ class WebClient(BaseClient):
             kwargs.update({"file_ids": file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.update", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.update", kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return self.api_call("chat.update", json=kwargs)
 

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -21,7 +21,7 @@ from .legacy_base_client import LegacyBaseClient, SlackResponse
 from .internal_utils import (
     _parse_web_class_objects,
     _update_call_participants,
-    _warn_if_text_is_missing,
+    _warn_if_text_or_attachment_fallback_is_missing,
     _remove_none_values,
 )
 from ..models.attachments import Attachment
@@ -2035,7 +2035,7 @@ class LegacyWebClient(LegacyBaseClient):
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.postEphemeral", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.postEphemeral", kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call("chat.postEphemeral", json=kwargs)
 
@@ -2089,7 +2089,7 @@ class LegacyWebClient(LegacyBaseClient):
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.postMessage", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.postMessage", kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call("chat.postMessage", json=kwargs)
 
@@ -2133,7 +2133,7 @@ class LegacyWebClient(LegacyBaseClient):
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.scheduleMessage", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.scheduleMessage", kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call("chat.scheduleMessage", json=kwargs)
 
@@ -2206,7 +2206,7 @@ class LegacyWebClient(LegacyBaseClient):
             kwargs.update({"file_ids": file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_is_missing("chat.update", kwargs)
+        _warn_if_text_or_attachment_fallback_is_missing("chat.update", kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return self.api_call("chat.update", json=kwargs)
 

--- a/tests/slack_sdk/web/test_web_client_issue_891.py
+++ b/tests/slack_sdk/web/test_web_client_issue_891.py
@@ -14,24 +14,54 @@ class TestWebClient_Issue_891(unittest.TestCase):
     def tearDown(self):
         cleanup_mock_web_api_server(self)
 
-    def test_missing_text_warnings_chat_postMessage(self):
+    def test_missing_text_warning_chat_postMessage(self):
         client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = client.chat_postMessage(channel="C111", blocks=[])
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = client.chat_postMessage(channel="C111", blocks=[])
         self.assertIsNone(resp["error"])
 
-    def test_missing_text_warnings_chat_postEphemeral(self):
+    def test_missing_text_warning_chat_postEphemeral(self):
         client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = client.chat_postEphemeral(channel="C111", user="U111", blocks=[])
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = client.chat_postEphemeral(channel="C111", user="U111", blocks=[])
         self.assertIsNone(resp["error"])
 
-    def test_missing_text_warnings_chat_scheduleMessage(self):
+    def test_missing_text_warning_chat_scheduleMessage(self):
         client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = client.chat_scheduleMessage(
-            channel="C111", post_at="299876400", text="", blocks=[]
-        )
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = client.chat_scheduleMessage(
+                channel="C111", post_at="299876400", text="", blocks=[]
+            )
         self.assertIsNone(resp["error"])
 
-    def test_missing_text_warnings_chat_update(self):
+    def test_missing_text_warning_chat_update(self):
         client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = client.chat_update(channel="C111", ts="111.222", blocks=[])
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = client.chat_update(channel="C111", ts="111.222", blocks=[])
+        self.assertIsNone(resp["error"])
+
+    def test_missing_fallback_warning_chat_postMessage(self):
+        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`fallback` argument is missing"):
+            resp = client.chat_postMessage(channel="C111", blocks=[], attachments=[{"text": "hi"}])
+        self.assertIsNone(resp["error"])
+
+    def test_missing_fallback_warning_chat_postEphemeral(self):
+        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`fallback` argument is missing"):
+            resp = client.chat_postEphemeral(channel="C111", user="U111", blocks=[], attachments=[{"text": "hi"}])
+        self.assertIsNone(resp["error"])
+
+    def test_missing_fallback_warning_chat_scheduleMessage(self):
+        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`fallback` argument is missing"):
+            resp = client.chat_scheduleMessage(
+                channel="C111", post_at="299876400", text="", blocks=[], attachments=[{"text": "hi"}]
+            )
+        self.assertIsNone(resp["error"])
+
+    def test_missing_fallback_warning_chat_update(self):
+        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`fallback` argument is missing"):
+            resp = client.chat_update(channel="C111", ts="111.222", blocks=[], attachments=[{"text": "hi"}])
         self.assertIsNone(resp["error"])

--- a/tests/slack_sdk/web/test_web_client_issue_971.py
+++ b/tests/slack_sdk/web/test_web_client_issue_971.py
@@ -33,6 +33,7 @@ class TestWebClient_Issue_971(unittest.TestCase):
         client = WebClient(
             base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
         )
+        # this generates a warning because "text" is missing
         with self.assertWarns(UserWarning):
             resp = client.chat_postMessage(channel="C111", blocks=[])
         self.assertTrue(resp["ok"])
@@ -41,6 +42,7 @@ class TestWebClient_Issue_971(unittest.TestCase):
         client = WebClient(
             base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
         )
+        # this generates a warning because "text" is missing
         resp = client.chat_postMessage(
             channel="C111", attachments=[{"fallback": "test"}]
         )
@@ -50,6 +52,7 @@ class TestWebClient_Issue_971(unittest.TestCase):
         client = WebClient(
             base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
         )
+        # this generates two warnings: "text" is missing, and also one attachment with no fallback
         with self.assertWarns(UserWarning):
             resp = client.chat_postMessage(
                 channel="C111", attachments=[{"fallback": ""}]
@@ -60,25 +63,16 @@ class TestWebClient_Issue_971(unittest.TestCase):
         client = WebClient(
             base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
         )
+        # this generates two warnings: "text" is missing, and also one attachment with no fallback
         with self.assertWarns(UserWarning):
             resp = client.chat_postMessage(channel="C111", attachments=[{}])
-        self.assertTrue(resp["ok"])
-
-    def test_attachments_without_fallback_with_text_arg(self):
-        client = WebClient(
-            base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
-        )
-        # this warns because each attachment should have its own fallback, even with "text"
-        with self.assertWarns(UserWarning):
-            resp = client.chat_postMessage(
-                channel="C111", text="test", attachments=[{}]
-            )
         self.assertTrue(resp["ok"])
 
     def test_multiple_attachments_one_without_fallback(self):
         client = WebClient(
             base_url="http://localhost:8888", token="xoxb-api_test", team_id="T111"
         )
+        # this generates two warnings: "text" is missing, and also one attachment with no fallback
         with self.assertWarns(UserWarning):
             resp = client.chat_postMessage(
                 channel="C111", attachments=[{"fallback": "test"}, {}]

--- a/tests/slack_sdk_async/web/test_web_client_issue_891.py
+++ b/tests/slack_sdk_async/web/test_web_client_issue_891.py
@@ -16,27 +16,61 @@ class TestWebClient_Issue_829(unittest.TestCase):
         cleanup_mock_web_api_server(self)
 
     @async_test
-    async def test_missing_text_warnings_chat_postMessage(self):
+    async def test_missing_text_warning_chat_postMessage(self):
         client = AsyncWebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = await client.chat_postMessage(channel="C111", blocks=[])
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = await client.chat_postMessage(channel="C111", blocks=[])
         self.assertIsNone(resp["error"])
 
     @async_test
-    async def test_missing_text_warnings_chat_postEphemeral(self):
+    async def test_missing_text_warning_chat_postEphemeral(self):
         client = AsyncWebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = await client.chat_postEphemeral(channel="C111", user="U111", blocks=[])
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = await client.chat_postEphemeral(channel="C111", user="U111", blocks=[])
         self.assertIsNone(resp["error"])
 
     @async_test
-    async def test_missing_text_warnings_chat_scheduleMessage(self):
+    async def test_missing_text_warning_chat_scheduleMessage(self):
         client = AsyncWebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = await client.chat_scheduleMessage(
-            channel="C111", post_at="299876400", text="", blocks=[]
-        )
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = await client.chat_scheduleMessage(
+                channel="C111", post_at="299876400", text="", blocks=[]
+            )
         self.assertIsNone(resp["error"])
 
     @async_test
-    async def test_missing_text_warnings_chat_update(self):
+    async def test_missing_text_warning_chat_update(self):
         client = AsyncWebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = await client.chat_update(channel="C111", ts="111.222", blocks=[])
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = await client.chat_update(channel="C111", ts="111.222", blocks=[])
+        self.assertIsNone(resp["error"])
+
+    @async_test
+    async def test_missing_fallback_warning_chat_postMessage(self):
+        client = AsyncWebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`fallback` argument is missing"):
+            resp = await client.chat_postMessage(channel="C111", blocks=[], attachments=[{"text": "hi"}])
+        self.assertIsNone(resp["error"])
+
+    @async_test
+    async def test_missing_fallback_warning_chat_postEphemeral(self):
+        client = AsyncWebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`fallback` argument is missing"):
+            resp = await client.chat_postEphemeral(channel="C111", user="U111", blocks=[], attachments=[{"text": "hi"}])
+        self.assertIsNone(resp["error"])
+
+    @async_test
+    async def test_missing_fallback_warning_chat_scheduleMessage(self):
+        client = AsyncWebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = await client.chat_scheduleMessage(
+                channel="C111", post_at="299876400", text="", blocks=[], attachments=[{"text": "hi"}]
+            )
+        self.assertIsNone(resp["error"])
+
+    @async_test
+    async def test_missing_fallback_warning_chat_update(self):
+        client = AsyncWebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = await client.chat_update(channel="C111", ts="111.222", blocks=[], attachments=[{"text": "hi"}])
         self.assertIsNone(resp["error"])

--- a/tests/web/test_web_client_issue_891.py
+++ b/tests/web/test_web_client_issue_891.py
@@ -14,24 +14,54 @@ class TestWebClient_Issue_891(unittest.TestCase):
     def tearDown(self):
         cleanup_mock_web_api_server(self)
 
-    def test_missing_text_warnings_chat_postMessage(self):
+    def test_missing_text_warning_chat_postMessage(self):
         client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = client.chat_postMessage(channel="C111", blocks=[])
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = client.chat_postMessage(channel="C111", blocks=[])
         self.assertIsNone(resp["error"])
 
-    def test_missing_text_warnings_chat_postEphemeral(self):
+    def test_missing_text_warning_chat_postEphemeral(self):
         client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = client.chat_postEphemeral(channel="C111", user="U111", blocks=[])
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = client.chat_postEphemeral(channel="C111", user="U111", blocks=[])
         self.assertIsNone(resp["error"])
 
-    def test_missing_text_warnings_chat_scheduleMessage(self):
+    def test_missing_text_warning_chat_scheduleMessage(self):
         client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = client.chat_scheduleMessage(
-            channel="C111", post_at="299876400", text="", blocks=[]
-        )
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = client.chat_scheduleMessage(
+                channel="C111", post_at="299876400", text="", blocks=[]
+            )
         self.assertIsNone(resp["error"])
 
-    def test_missing_text_warnings_chat_update(self):
+    def test_missing_text_warning_chat_update(self):
         client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
-        resp = client.chat_update(channel="C111", ts="111.222", blocks=[])
+        with self.assertWarnsRegex(UserWarning, "`text` argument is missing"):
+            resp = client.chat_update(channel="C111", ts="111.222", blocks=[])
+        self.assertIsNone(resp["error"])
+
+    def test_missing_fallback_warning_chat_postMessage(self):
+        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`fallback` argument is missing"):
+            resp = client.chat_postMessage(channel="C111", blocks=[], attachments=[{"text": "hi"}])
+        self.assertIsNone(resp["error"])
+
+    def test_missing_fallback_warning_chat_postEphemeral(self):
+        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`fallback` argument is missing"):
+            resp = client.chat_postEphemeral(channel="C111", user="U111", blocks=[], attachments=[{"text": "hi"}])
+        self.assertIsNone(resp["error"])
+
+    def test_missing_fallback_warning_chat_scheduleMessage(self):
+        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`fallback` argument is missing"):
+            resp = client.chat_scheduleMessage(
+                channel="C111", post_at="299876400", text="", blocks=[], attachments=[{"text": "hi"}]
+            )
+        self.assertIsNone(resp["error"])
+
+    def test_missing_fallback_warning_chat_update(self):
+        client = WebClient(base_url="http://localhost:8888", token="xoxb-api_test")
+        with self.assertWarnsRegex(UserWarning, "`fallback` argument is missing"):
+            resp = client.chat_update(channel="C111", ts="111.222", blocks=[], attachments=[{"text": "hi"}])
         self.assertIsNone(resp["error"])


### PR DESCRIPTION
This follows the pattern in the solution converged on for https://github.com/slackapi/node-slack-sdk/issues/1476.

Wondering if there is an opportunity to DRY the tests up here, especially across the legacy vs. the regular synchronous client code. The tests seem to be a carbon copy. I don't really have a suggestion on how to improve that though, but maybe some more Python-y folks have ideas?