### PR TITLE
Adding the auth_teams_list method

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1606,7 +1606,7 @@ class AsyncWebClient(AsyncBaseClient):
         self,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        include_icon: Optional[bool] = False,
+        include_icon: Optional[bool] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """List the workspaces a token can access.

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1602,6 +1602,19 @@ class AsyncWebClient(AsyncBaseClient):
         """
         return await self.api_call("auth.test", params=kwargs)
 
+    async def auth_teams_list(
+        self,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        include_icon: Optional[bool] = False,
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """List the workspaces a token can access.
+        https://api.slack.com/methods/auth.teams.list
+        """
+        kwargs.update({"cursor": cursor, "limit": limit, "include_icon": include_icon})
+        return await self.api_call("auth.teams.list", params=kwargs)
+
     async def bookmarks_add(
         self,
         *,

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1557,7 +1557,7 @@ class WebClient(BaseClient):
         self,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        include_icon: Optional[bool] = False,
+        include_icon: Optional[bool] = None,
         **kwargs,
     ) -> SlackResponse:
         """List the workspaces a token can access.

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1553,6 +1553,19 @@ class WebClient(BaseClient):
         """
         return self.api_call("auth.test", params=kwargs)
 
+    def auth_teams_list(
+        self,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        include_icon: Optional[bool] = False,
+        **kwargs,
+    ) -> SlackResponse:
+        """List the workspaces a token can access.
+        https://api.slack.com/methods/auth.teams.list
+        """
+        kwargs.update({"cursor": cursor, "limit": limit, "include_icon": include_icon})
+        return self.api_call("auth.teams.list", params=kwargs)
+
     def bookmarks_add(
         self,
         *,

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1564,6 +1564,19 @@ class LegacyWebClient(LegacyBaseClient):
         """
         return self.api_call("auth.test", params=kwargs)
 
+    def auth_teams_list(
+        self,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        include_icon: Optional[bool] = False,
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """List the workspaces a token can access.
+        https://api.slack.com/methods/auth.teams.list
+        """
+        kwargs.update({"cursor": cursor, "limit": limit, "include_icon": include_icon})
+        return self.api_call("auth.teams.list", params=kwargs)
+
     def bookmarks_add(
         self,
         *,

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1568,7 +1568,7 @@ class LegacyWebClient(LegacyBaseClient):
         self,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        include_icon: Optional[bool] = False,
+        include_icon: Optional[bool] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List the workspaces a token can access.

--- a/tests/slack_sdk_async/web/test_web_client_coverage.py
+++ b/tests/slack_sdk_async/web/test_web_client_coverage.py
@@ -40,7 +40,6 @@ class TestWebClientCoverage(unittest.TestCase):
         for api_method in self.all_api_methods:
             if api_method.startswith("apps.permissions.") or api_method in [
                 "apps.connections.open",  # app-level token
-                "auth.teams.list",  # app-level token
                 "oauth.access",
                 "oauth.v2.access",
                 "oauth.v2.exchange",


### PR DESCRIPTION
## Summary

This fixes #1212.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
