### PR TITLE
Fix #1218 - Reduce minimum number of overflow options

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -1490,7 +1490,7 @@ class RadioButtonsElement(InputInteractiveElement):
 
 class OverflowMenuElement(InteractiveElement):
     type = "overflow"
-    options_min_length = 2
+    options_min_length = 1
     options_max_length = 5
 
     @property
@@ -1501,7 +1501,7 @@ class OverflowMenuElement(InteractiveElement):
         self,
         *,
         action_id: Optional[str] = None,
-        options: Sequence[Union[Option]],
+        options: Sequence[Option],
         confirm: Optional[Union[dict, ConfirmObject]] = None,
         **others: dict,
     ):
@@ -1524,7 +1524,7 @@ class OverflowMenuElement(InteractiveElement):
                 Should be unique among all other action_ids in the containing block.
                 Maximum length for this field is 255 characters.
             options (required): An array of option objects to display in the menu.
-                Maximum number of options is 5, minimum is 2.
+                Maximum number of options is 5, minimum is 1.
             confirm: A confirm object that defines an optional confirmation dialog that appears
                 after a menu item is selected.
         """


### PR DESCRIPTION
## Summary

Fixes #1218. 

Though [API documentation](https://api.slack.com/reference/block-kit/block-elements#overflow) says a minimum of two options are required for the `overflow` menu, one is acceptable and works without issue. This PR updates the SDK's minimum number to match that.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
