### PR TITLE
Updated maintainer_guide

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -60,17 +60,25 @@ $ ./scripts/run_validation.sh
 
 Also check out [how
 we configure GitHub Actions to install dependencies for this project for use in
-our continuous integration](https://github.com/slackapi/python-slack-sdk/blob/main/.github/workflows/ci-build.yml#L26-L30).
+our continuous integration](https://github.com/slackapi/python-slack-sdk/blob/v3.17.0/.github/workflows/ci-build.yml#L28-L32).
 ## Tasks
 
 ### Testing (Unit Tests)
 
-When you make changes to this SDK, please write unit tests verifying if the changes work as you expected. You can easily run all the tests by running the command. The `validate` command runs Flake8 (static code analyzer), Black (code formatter), and unit tests in the `tests` directory for you.
+When you make changes to this SDK, please write unit tests verifying if the changes work as you expected. You can easily run all the tests and formatting/linter with the below scripts.
 
+Run all the unit tests, code formatter, and code analyzer:
 ```bash
-$ ./scripts/run_unit_tests.sh # run all
+$ ./scripts/run_validation.sh 
+```
 
-# run a single test
+Run all the unit tests (no formatter nor code analyzer):
+```bash
+$ ./scripts/run_unit_tests.sh
+```
+
+Run a specific unit test:
+```bash
 $ ./scripts/run_unit_tests.sh tests/web/test_web_client.py
 ```
 
@@ -80,10 +88,13 @@ You can rely on GitHub Actions builds for running the tests on a variety of Pyth
 
 This project also has integration tests that verify the SDK works with the Slack API platform. As a preparation, you need to set [the required env variables](https://github.com/slackapi/python-slack-sdk/blob/main/integration_tests/env_variable_names.py) properly. You don't need to setup all of them if you just want to run some of the tests. Commonly, `SLACK_SDK_TEST_BOT_TOKEN` and `SLACK_SDK_TEST_USER_TOKEN` are used for running `WebClient` tests.
 
+Run all integration tests:
 ```bash
-$ ./scripts/run_integration_tests.sh # run all
+$ ./scripts/run_integration_tests.sh
+```
 
-# run a single test
+Run a specific integration test:
+```bash
 $ ./scripts/run_integration_tests.sh integration_tests/web/test_async_web_client.py
 ```
 
@@ -92,16 +103,15 @@ $ ./scripts/run_integration_tests.sh integration_tests/web/test_async_web_client
 The documentation is generated from the source and templates in the `docs-src` directory. The generated documentation
 gets committed to the repo in `docs` and also published to a GitHub Pages website.
 
-You can generate and preview the **slack api documentation** by running
+You can generate and preview the **SDK document pages** by running
 ```bash
 $ ./scripts/docs.sh
 $ open docs/index.html
 ```
 
-Similarly you can generate and preview the **Package slack_sdk documentation** by running
+Similarly you can generate and preview the **API documents for `slack_sdk` package modules** by running
 ```bash
 $ ./scripts/generate_api_docs.sh
-$ open docs/api-docs/slack_sdk/index.html
 ```
 
 ### Releasing

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -40,7 +40,7 @@ $ pyenv rehash
 
 Then, you can create a new [Virtual Environment](https://docs.python.org/3/tutorial/venv.html) specific to the Python version you just installed by running:
 
-```
+```bash
 $ python -m venv env_3.9.6
 $ source env_3.9.6/bin/activate
 ```
@@ -53,10 +53,14 @@ do so after you are done working in this project. To come back to development
 work for this project again in the future, `cd` into this project directory and
 run `source env_3.9.6/bin/activate` again.
 
-The last step is to install this project's dependencies; to do so, check out [how
-we configure GitHub Actions to install dependencies for this project for use in
-our continuous integration](https://github.com/slackapi/python-slack-sdk/blob/main/.github/workflows/ci-build.yml#L26-L30). You can also run `./scripts/run_validation.sh` to install the dependencies and run the unit tests in one command!
+The last step is to install this project's dependencies and run all unit tests; to do so, you can run
+```bash
+$ ./scripts/run_validation.sh 
+```
 
+Also check out [how
+we configure GitHub Actions to install dependencies for this project for use in
+our continuous integration](https://github.com/slackapi/python-slack-sdk/blob/main/.github/workflows/ci-build.yml#L26-L30).
 ## Tasks
 
 ### Testing (Unit Tests)
@@ -64,11 +68,10 @@ our continuous integration](https://github.com/slackapi/python-slack-sdk/blob/ma
 When you make changes to this SDK, please write unit tests verifying if the changes work as you expected. You can easily run all the tests by running the command. The `validate` command runs Flake8 (static code analyzer), Black (code formatter), and unit tests in the `tests` directory for you.
 
 ```bash
-python setup.py validate # run all
+$ ./scripts/run_unit_tests.sh # run all
 
 # run a single test
-python setup.py validate \
-  --test-target tests/web/test_web_client.py
+$ ./scripts/run_unit_tests.sh tests/web/test_web_client.py
 ```
 
 You can rely on GitHub Actions builds for running the tests on a variety of Python runtimes.
@@ -78,11 +81,10 @@ You can rely on GitHub Actions builds for running the tests on a variety of Pyth
 This project also has integration tests that verify the SDK works with the Slack API platform. As a preparation, you need to set [the required env variables](https://github.com/slackapi/python-slack-sdk/blob/main/integration_tests/env_variable_names.py) properly. You don't need to setup all of them if you just want to run some of the tests. Commonly, `SLACK_SDK_TEST_BOT_TOKEN` and `SLACK_SDK_TEST_USER_TOKEN` are used for running `WebClient` tests.
 
 ```bash
-python setup.py integration_tests # run all
+$ ./scripts/run_integration_tests.sh # run all
 
 # run a single test
-python setup.py integration_tests \
-  --test-target integration_tests/web/test_web_client.py
+$ ./scripts/run_integration_tests.sh integration_tests/web/test_async_web_client.py
 ```
 
 ### Generating Documentation
@@ -90,7 +92,17 @@ python setup.py integration_tests \
 The documentation is generated from the source and templates in the `docs-src` directory. The generated documentation
 gets committed to the repo in `docs` and also published to a GitHub Pages website.
 
-You can generate the documentation by running `./scripts/docs.sh`.
+You can generate and preview the **slack api documentation** by running
+```bash
+$ ./scripts/docs.sh
+$ open docs/index.html
+```
+
+Similarly you can generate and preview the **Package slack_sdk documentation** by running
+```bash
+$ ./scripts/generate_api_docs.sh
+$ open docs/api-docs/slack_sdk/index.html
+```
 
 ### Releasing
 


### PR DESCRIPTION
## Summary

Updated the maintainers guide, this should help developer more clearly understand how to build the project and run the tests. This should also help push the project towards using a bash approach to building and running the test as implemented in the [bolt python project](https://github.com/slackapi/bolt-python).

What was done:
- Clarified how to initially install the dependencies and run all the unit tests
- Replaced the `python setup.py` commands with their corresponding bash script commands
- Added distinction between the 2 different types of documentation that can be generated

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)
- [x] miscellaneous documentation

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
