### PR TITLE
Fix return type annotation

### DIFF
--- a/slack_sdk/oauth/token_rotation/async_rotator.py
+++ b/slack_sdk/oauth/token_rotation/async_rotator.py
@@ -107,7 +107,7 @@ class AsyncTokenRotator:
         *,
         installation: Installation,
         minutes_before_expiration: int = 120,  # 2 hours by default
-    ) -> Optional[Bot]:  # type: ignore
+    ) -> Optional[Installation]:
         """Performs user token rotation if the underlying user token is expired / expiring.
 
         Args:
@@ -136,7 +136,7 @@ class AsyncTokenRotator:
             refreshed_installation.user_token = refresh_response.get("access_token")
             refreshed_installation.user_refresh_token = refresh_response.get("refresh_token")
             refreshed_installation.user_token_expires_at = int(time()) + int(refresh_response.get("expires_in"))
-            return refreshed_installation  # type: ignore
+            return refreshed_installation
 
         except SlackApiError as e:
             raise SlackTokenRotationError(e)


### PR DESCRIPTION
## Summary

Fix wrong return type annotation

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
