### PR TITLE
Fix #1236 Add video block to Block Kit model classes

### DIFF
--- a/slack_sdk/models/blocks/__init__.py
+++ b/slack_sdk/models/blocks/__init__.py
@@ -48,6 +48,7 @@ from .blocks import HeaderBlock
 from .blocks import ImageBlock
 from .blocks import InputBlock
 from .blocks import SectionBlock
+from .blocks import VideoBlock
 
 __all__ = [
     "ButtonStyles",
@@ -92,4 +93,5 @@ __all__ = [
     "ImageBlock",
     "InputBlock",
     "SectionBlock",
+    "VideoBlock",
 ]

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -20,6 +20,7 @@ from slack_sdk.models.blocks import (
     PlainTextObject,
     MarkdownTextObject,
     HeaderBlock,
+    VideoBlock,
     Option,
 )
 from . import STRING_3001_CHARS
@@ -694,3 +695,79 @@ class HeaderBlockTests(unittest.TestCase):
         }
         with self.assertRaises(SlackObjectFormationError):
             HeaderBlock(**input).validate_json()
+
+
+# ----------------------------------------------
+# Video
+# ----------------------------------------------
+
+
+class VideoBlockTests(unittest.TestCase):
+    def test_document(self):
+        input = {
+            "type": "video",
+            "title": {"type": "plain_text", "text": "How to use Slack.", "emoji": True},
+            "title_url": "https://www.youtube.com/watch?v=RRxQQxiM7AA",
+            "description": {
+                "type": "plain_text",
+                "text": "Slack is a new way to communicate with your team. "
+                "It's faster, better organized and more secure than email.",
+                "emoji": True,
+            },
+            "video_url": "https://www.youtube.com/embed/RRxQQxiM7AA?feature=oembed&autoplay=1",
+            "alt_text": "How to use Slack?",
+            "thumbnail_url": "https://i.ytimg.com/vi/RRxQQxiM7AA/hqdefault.jpg",
+            "author_name": "Arcado Buendia",
+            "provider_name": "YouTube",
+            "provider_icon_url": "https://a.slack-edge.com/80588/img/unfurl_icons/youtube.png",
+        }
+        self.assertDictEqual(input, VideoBlock(**input).to_dict())
+        self.assertDictEqual(input, Block.parse(input).to_dict())
+
+    def test_required(self):
+        input = {
+            "type": "video",
+            "title": {"type": "plain_text", "text": "How to use Slack.", "emoji": True},
+            "video_url": "https://www.youtube.com/embed/RRxQQxiM7AA?feature=oembed&autoplay=1",
+            "alt_text": "How to use Slack?",
+            "thumbnail_url": "https://i.ytimg.com/vi/RRxQQxiM7AA/hqdefault.jpg",
+        }
+        VideoBlock(**input).validate_json()
+
+    def test_required_error(self):
+        # title is missing
+        input = {
+            "type": "video",
+            "video_url": "https://www.youtube.com/embed/RRxQQxiM7AA?feature=oembed&autoplay=1",
+            "alt_text": "How to use Slack?",
+            "thumbnail_url": "https://i.ytimg.com/vi/RRxQQxiM7AA/hqdefault.jpg",
+        }
+        with self.assertRaises(SlackObjectFormationError):
+            VideoBlock(**input).validate_json()
+
+    def test_title_length_199(self):
+        input = {
+            "type": "video",
+            "title": {
+                "type": "plain_text",
+                "text": "1234567890" * 19 + "123456789",
+            },
+            "video_url": "https://www.youtube.com/embed/RRxQQxiM7AA?feature=oembed&autoplay=1",
+            "alt_text": "How to use Slack?",
+            "thumbnail_url": "https://i.ytimg.com/vi/RRxQQxiM7AA/hqdefault.jpg",
+        }
+        VideoBlock(**input).validate_json()
+
+    def test_title_length_200(self):
+        input = {
+            "type": "video",
+            "title": {
+                "type": "plain_text",
+                "text": "1234567890" * 20,
+            },
+            "video_url": "https://www.youtube.com/embed/RRxQQxiM7AA?feature=oembed&autoplay=1",
+            "alt_text": "How to use Slack?",
+            "thumbnail_url": "https://i.ytimg.com/vi/RRxQQxiM7AA/hqdefault.jpg",
+        }
+        with self.assertRaises(SlackObjectFormationError):
+            VideoBlock(**input).validate_json()


### PR DESCRIPTION
## Summary

This pull request resolves #1236 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
