### PR TITLE
rtm_v2 api spins in infinite loop under gevent

### DIFF
--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -199,19 +199,12 @@ def _receive_messages(
     def receive(specific_buffer_size: Optional[int] = None):
         size = specific_buffer_size if specific_buffer_size is not None else receive_buffer_size
         with sock_receive_lock:
-            try:
-                received_bytes = sock.recv(size)
-                if all_message_trace_enabled:
-                    if len(received_bytes) > 0:
-                        logger.debug(f"Received bytes: {received_bytes}")
-                return received_bytes
-            except OSError as e:
-                # For Linux/macOS, errno.EBADF is the expected error for bad connections.
-                # The errno.ENOTSOCK can be sent when running on Windows OS.
-                if e.errno in (errno.EBADF, errno.ENOTSOCK):
-                    logger.debug("The connection seems to be already closed.")
-                    return bytes()
-                raise e
+            received_bytes = sock.recv(size)
+            if not received_bytes:
+                raise Exception('socket is dead')
+            if all_message_trace_enabled:
+                logger.debug(f"Received bytes: {received_bytes}")
+            return received_bytes
 
     return _fetch_messages(
         messages=[],

--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -1,4 +1,3 @@
-import errno
 import hashlib
 import itertools
 import os
@@ -25,7 +24,7 @@ def _parse_connect_response(sock: Socket) -> Tuple[Optional[int], str]:
         while True:
             c = sock.recv(1)
             if not c:
-                raise ConnectionError('Connection is closed')
+                raise ConnectionError("Connection is closed")
             line.append(c)
             if c == b"\n":
                 break
@@ -118,7 +117,7 @@ def _read_http_response_line(sock: ssl.SSLSocket) -> str:
     while True:
         b: bytes = sock.recv(1)
         if not b:
-            raise ConnectionError('Connection is closed')
+            raise ConnectionError("Connection is closed")
         c: str = b.decode("utf-8")
         if c == "\r":
             break
@@ -206,7 +205,7 @@ def _receive_messages(
         with sock_receive_lock:
             received_bytes = sock.recv(size)
             if not received_bytes:
-                raise ConnectionError('Connection is closed')
+                raise ConnectionError("Connection is closed")
             if all_message_trace_enabled:
                 logger.debug(f"Received bytes: {received_bytes}")
             return received_bytes

--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -24,6 +24,8 @@ def _parse_connect_response(sock: Socket) -> Tuple[Optional[int], str]:
         line = []
         while True:
             c = sock.recv(1)
+            if not c:
+                raise Exception('socket is dead')
             line.append(c)
             if c == b"\n":
                 break
@@ -114,7 +116,10 @@ def _establish_new_socket_connection(
 def _read_http_response_line(sock: ssl.SSLSocket) -> str:
     cs = []
     while True:
-        c: str = sock.recv(1).decode("utf-8")
+        b: bytes = sock.recv(1)
+        if not b:
+            raise Exception('socket is dead')
+        c: str = b.decode("utf-8")
         if c == "\r":
             break
         if c != "\n":

--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -25,7 +25,7 @@ def _parse_connect_response(sock: Socket) -> Tuple[Optional[int], str]:
         while True:
             c = sock.recv(1)
             if not c:
-                raise Exception('server closed connection')
+                raise ConnectionError('Connection is closed')
             line.append(c)
             if c == b"\n":
                 break
@@ -118,7 +118,7 @@ def _read_http_response_line(sock: ssl.SSLSocket) -> str:
     while True:
         b: bytes = sock.recv(1)
         if not b:
-            raise Exception('server closed connection')
+            raise ConnectionError('Connection is closed')
         c: str = b.decode("utf-8")
         if c == "\r":
             break
@@ -206,7 +206,7 @@ def _receive_messages(
         with sock_receive_lock:
             received_bytes = sock.recv(size)
             if not received_bytes:
-                raise Exception('server closed connection')
+                raise ConnectionError('Connection is closed')
             if all_message_trace_enabled:
                 logger.debug(f"Received bytes: {received_bytes}")
             return received_bytes

--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -25,7 +25,7 @@ def _parse_connect_response(sock: Socket) -> Tuple[Optional[int], str]:
         while True:
             c = sock.recv(1)
             if not c:
-                raise Exception('socket is dead')
+                raise Exception('server closed connection')
             line.append(c)
             if c == b"\n":
                 break
@@ -118,7 +118,7 @@ def _read_http_response_line(sock: ssl.SSLSocket) -> str:
     while True:
         b: bytes = sock.recv(1)
         if not b:
-            raise Exception('socket is dead')
+            raise Exception('server closed connection')
         c: str = b.decode("utf-8")
         if c == "\r":
             break
@@ -206,7 +206,7 @@ def _receive_messages(
         with sock_receive_lock:
             received_bytes = sock.recv(size)
             if not received_bytes:
-                raise Exception('socket is dead')
+                raise Exception('server closed connection')
             if all_message_trace_enabled:
                 logger.debug(f"Received bytes: {received_bytes}")
             return received_bytes


### PR DESCRIPTION
## Summary

Fix websocket handling code - test case at: https://github.com/mattbillenstein/slack-rtm_v2-recv-bug

From the README.txt there:

When listening on a websocket with the regular rtm_v2 lib using gevent, the
socket will after a time become unresponsive, and the cpu spin at 100%. This is
because the socket.recv() call doesn't return any data if the other end closed
the connection and the code gets into an infinite loop between _fetch and
receive because the error handling logic just returns an empty bytes object
- so the code whereever it is consuming data can't make progress.

Per the python3 sockets howto:

https://docs.python.org/3/howto/sockets.html:

    "When a recv returns 0 bytes, it means the other side has closed (or is in
    the process of closing) the connection. You will not receive any more data
    on this connection. Ever. You may be able to send data successfully..."

In this fix if we receive no data from sock.recv, just raise OSError so the
consuming code closes and establishes a new connecition.

You can run this code using the two requirements.txt - just connecting to slack
and waiting a time will cause this error to happen with the mainline lib.

  $ SLACK_BOT_TOKEN=... ./slack-bot.py

As to why this happens so quickly - I'm guessing there might be other errors in the fetch function that are causing protocol errors on the server and the server to prematurely close the connection - worth investigating further.

Tested on Python 3.10.4, Ubuntu 22.04 x86_64

Also, I might suggest replacing this code with the websocket-client lib (like
the async code uses the websockets lib) - it seems like a better implementation
of consuming data from websockets.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [x] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.

==== 752 passed, 1 skipped, 1144 warnings in 278.15s (0:04:38) ========
