### PR TITLE
Minor update: max elements in ActionsBlock to 25

### DIFF
--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -257,7 +257,7 @@ class ImageBlock(Block):
 
 class ActionsBlock(Block):
     type = "actions"
-    elements_max_length = 5
+    elements_max_length = 25
 
     @property
     def attributes(self) -> Set[str]:

--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -275,7 +275,7 @@ class ActionsBlock(Block):
 
         Args:
             elements (required): An array of interactive element objects - buttons, select menus, overflow menus,
-                or date pickers. There is a maximum of 5 elements in each action block.
+                or date pickers. There is a maximum of 25 elements in each action block.
             block_id: A string acting as a unique identifier for a block.
                 If not specified, a block_id will be generated.
                 You can use this block_id when you receive an interaction payload to identify the source of the action.


### PR DESCRIPTION
It seems from practical testing with the slack block kit builder that the (new?) max number of elements allowed in an ActionsBlock is 25, rather than 5 as previously enforced in the code.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [X] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).