### PR TITLE
Adjust the logic added by #1246

### DIFF
--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -204,8 +204,6 @@ def _receive_messages(
         size = specific_buffer_size if specific_buffer_size is not None else receive_buffer_size
         with sock_receive_lock:
             received_bytes = sock.recv(size)
-            if not received_bytes:
-                raise ConnectionError("Connection is closed")
             if all_message_trace_enabled:
                 logger.debug(f"Received bytes: {received_bytes}")
             return received_bytes


### PR DESCRIPTION
## Summary

This pull request tweaks an internal code in the built-in Socket Mode client. Since #1246 changes landed, we've received feedback from users that an active connection can be terminated unexpectedly.

```
Traceback (most recent call last):
 File "/usr/local/lib/python3.9/site-packages/slack_sdk/socket_mode/builtin/connection.py", line 305, in run_until_completion
   received_messages: List[Tuple[Optional[FrameHeader], bytes]] = _receive_messages(
 File "/usr/local/lib/python3.9/site-packages/slack_sdk/socket_mode/builtin/internals.py", line 213, in _receive_messages
   return _fetch_messages(
 File "/usr/local/lib/python3.9/site-packages/slack_sdk/socket_mode/builtin/internals.py", line 236, in _fetch_messages
   remaining_bytes = receive()  # type: ignore
 File "/usr/local/lib/python3.9/site-packages/slack_sdk/socket_mode/builtin/internals.py", line 208, in receive
   raise ConnectionError("Connection is closed")
ConnectionError: Connection is closed
```

I think that this specific change can be reverted for the sake of even more stable behavior.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
