### PR TITLE
Add more revert to #1269

### DIFF
--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -1,3 +1,4 @@
+import errno
 import hashlib
 import itertools
 import os
@@ -203,10 +204,21 @@ def _receive_messages(
     def receive(specific_buffer_size: Optional[int] = None):
         size = specific_buffer_size if specific_buffer_size is not None else receive_buffer_size
         with sock_receive_lock:
-            received_bytes = sock.recv(size)
-            if all_message_trace_enabled:
-                logger.debug(f"Received bytes: {received_bytes}")
-            return received_bytes
+            try:
+                received_bytes = sock.recv(size)
+                if all_message_trace_enabled:
+                    if len(received_bytes) > 0:
+                        logger.debug(f"Received bytes: {received_bytes}")
+                return received_bytes
+            except OSError as e:
+                # For Linux/macOS, errno.EBADF is the expected error for bad connections.
+                # The errno.ENOTSOCK can be sent when running on Windows OS.
+                if e.errno in (errno.EBADF, errno.ENOTSOCK):
+                    # Note that bad connections can be detected by monitoring threads
+                    # the Socket Mode client automatically reconnects to a new endpoint later.
+                    logger.debug("The connection seems to be already closed.")
+                    return bytes()
+                raise e
 
     return _fetch_messages(
         messages=[],


### PR DESCRIPTION
## Summary

This pull request applies one more revert change to #1269 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
