### PR TITLE
Improve clarity of 'content' error message for files_upload_v2

### DIFF
--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -317,12 +317,12 @@ def _to_v2_file_upload_item(upload_file: Dict[str, Any]) -> Dict[str, Optional[A
         else:
             data = file
     elif content is not None:
-        if isinstance(content, str):  # filepath
+        if isinstance(content, str):
             data = content.encode("utf-8")
         elif isinstance(content, bytes):
             data = content
         else:
-            raise SlackRequestError("The given content must be either filepath as str or data as bytes")
+            raise SlackRequestError("content for file upload must be 'str' (UTF-8 encoded) or 'bytes' (for data)")
 
     filename = upload_file.get("filename")
     if upload_file.get("filename") is None and isinstance(file, str):


### PR DESCRIPTION
## Summary

Very simple PR to improve the clarity of the error message raised when 'content' is specified and it's not the correct type. (Feel free to edit as you see fit, or simply disregard if it's too minor.)

It is worth noting that the `else` case of this comparison (where neither `content` nor `file_uploads` is specified) is already handled [here](https://github.com/slackapi/python-slack-sdk/blob/main/slack_sdk/web/async_client.py#L3030-L3031) (for the async client) and [here](https://github.com/slackapi/python-slack-sdk/blob/main/slack_sdk/web/client.py#L3021-L3022) (regular).

### Category (place an `x` in each of the `[ ]`)

- [X] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [X] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
