### PR TITLE
Add full_file_info_required to files_upload_v2 method

### DIFF
--- a/integration_tests/web/test_files_upload_v2.py
+++ b/integration_tests/web/test_files_upload_v2.py
@@ -190,3 +190,50 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             file=upload["file"]["id"],
         )
         self.assertIsNotNone(deletion)
+
+    def test_full_file_info_required_false(self):
+        client = self.sync_client
+        upload = client.files_upload_v2(
+            channels=self.channel_id,
+            title="Foo",
+            filename="foo.txt",
+            content="foo",
+        )
+        self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("name"))
+
+        upload = client.files_upload_v2(
+            channels=self.channel_id,
+            title="Foo",
+            filename="foo.txt",
+            content="foo",
+            full_file_info_required=False,
+        )
+        self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNone(upload.get("files")[0].get("name"))
+
+    @async_test
+    async def test_full_file_info_required_false_async(self):
+        client = self.async_client
+        upload = await client.files_upload_v2(
+            channels=self.channel_id,
+            title="Foo",
+            filename="foo.txt",
+            content="foo",
+        )
+        self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("name"))
+
+        upload = await client.files_upload_v2(
+            channels=self.channel_id,
+            title="Foo",
+            filename="foo.txt",
+            content="foo",
+            full_file_info_required=False,
+        )
+        self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNone(upload.get("files")[0].get("name"))

--- a/integration_tests/web/test_files_upload_v2.py
+++ b/integration_tests/web/test_files_upload_v2.py
@@ -191,7 +191,7 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
         )
         self.assertIsNotNone(deletion)
 
-    def test_full_file_info_required_false(self):
+    def test_request_file_info_false(self):
         client = self.sync_client
         upload = client.files_upload_v2(
             channels=self.channel_id,
@@ -208,14 +208,14 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             title="Foo",
             filename="foo.txt",
             content="foo",
-            full_file_info_required=False,
+            request_file_info=False,
         )
         self.assertIsNotNone(upload)
         self.assertIsNotNone(upload.get("files")[0].get("id"))
         self.assertIsNone(upload.get("files")[0].get("name"))
 
     @async_test
-    async def test_full_file_info_required_false_async(self):
+    async def test_request_file_info_false_async(self):
         client = self.async_client
         upload = await client.files_upload_v2(
             channels=self.channel_id,
@@ -232,7 +232,7 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             title="Foo",
             filename="foo.txt",
             content="foo",
-            full_file_info_required=False,
+            request_file_info=False,
         )
         self.assertIsNotNone(upload)
         self.assertIsNotNone(upload.get("files")[0].get("id"))

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -3015,7 +3015,7 @@ class AsyncWebClient(AsyncBaseClient):
         channel: Optional[str] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
-        full_file_info_required: bool = True,
+        request_file_info: bool = True,
         **kwargs,
     ) -> AsyncSlackResponse:
         """This wrapper method provides an easy way to upload files using the following endpoints:
@@ -3114,7 +3114,7 @@ class AsyncWebClient(AsyncBaseClient):
             thread_ts=thread_ts,
             **kwargs,
         )
-        if full_file_info_required is True:
+        if request_file_info is True:
             await _attach_full_file_metadata_async(
                 client=self,
                 token_as_arg=kwargs.get("token"),

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -3015,6 +3015,7 @@ class AsyncWebClient(AsyncBaseClient):
         channel: Optional[str] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
+        full_file_info_required: bool = True,
         **kwargs,
     ) -> AsyncSlackResponse:
         """This wrapper method provides an easy way to upload files using the following endpoints:
@@ -3113,11 +3114,12 @@ class AsyncWebClient(AsyncBaseClient):
             thread_ts=thread_ts,
             **kwargs,
         )
-        await _attach_full_file_metadata_async(
-            client=self,
-            token_as_arg=kwargs.get("token"),
-            completion=completion,
-        )
+        if full_file_info_required is True:
+            await _attach_full_file_metadata_async(
+                client=self,
+                token_as_arg=kwargs.get("token"),
+                completion=completion,
+            )
         return completion
 
     async def files_getUploadURLExternal(

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -3006,7 +3006,7 @@ class WebClient(BaseClient):
         channel: Optional[str] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
-        full_file_info_required: bool = True,
+        request_file_info: bool = True,
         **kwargs,
     ) -> SlackResponse:
         """This wrapper method provides an easy way to upload files using the following endpoints:
@@ -3105,7 +3105,7 @@ class WebClient(BaseClient):
             thread_ts=thread_ts,
             **kwargs,
         )
-        if full_file_info_required is True:
+        if request_file_info is True:
             _attach_full_file_metadata(
                 client=self,
                 token_as_arg=kwargs.get("token"),

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -3006,6 +3006,7 @@ class WebClient(BaseClient):
         channel: Optional[str] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
+        full_file_info_required: bool = True,
         **kwargs,
     ) -> SlackResponse:
         """This wrapper method provides an easy way to upload files using the following endpoints:
@@ -3104,11 +3105,12 @@ class WebClient(BaseClient):
             thread_ts=thread_ts,
             **kwargs,
         )
-        _attach_full_file_metadata(
-            client=self,
-            token_as_arg=kwargs.get("token"),
-            completion=completion,
-        )
+        if full_file_info_required is True:
+            _attach_full_file_metadata(
+                client=self,
+                token_as_arg=kwargs.get("token"),
+                completion=completion,
+            )
         return completion
 
     def files_getUploadURLExternal(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3017,7 +3017,7 @@ class LegacyWebClient(LegacyBaseClient):
         channel: Optional[str] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
-        full_file_info_required: bool = True,
+        request_file_info: bool = True,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """This wrapper method provides an easy way to upload files using the following endpoints:
@@ -3116,7 +3116,7 @@ class LegacyWebClient(LegacyBaseClient):
             thread_ts=thread_ts,
             **kwargs,
         )
-        if full_file_info_required is True:
+        if request_file_info is True:
             _attach_full_file_metadata(
                 client=self,
                 token_as_arg=kwargs.get("token"),

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3017,6 +3017,7 @@ class LegacyWebClient(LegacyBaseClient):
         channel: Optional[str] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
+        full_file_info_required: bool = True,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """This wrapper method provides an easy way to upload files using the following endpoints:
@@ -3115,11 +3116,12 @@ class LegacyWebClient(LegacyBaseClient):
             thread_ts=thread_ts,
             **kwargs,
         )
-        _attach_full_file_metadata(
-            client=self,
-            token_as_arg=kwargs.get("token"),
-            completion=completion,
-        )
+        if full_file_info_required is True:
+            _attach_full_file_metadata(
+                client=self,
+                token_as_arg=kwargs.get("token"),
+                completion=completion,
+            )
         return completion
 
     def files_getUploadURLExternal(


### PR DESCRIPTION
## Summary

This pull request adds a new optional flag argument to files_upload_v2 method. When a developer passes full_file_info_required=False, the method skips fetching files.info response data for the uploaded files. Refer to https://github.com/slackapi/python-slack-sdk/issues/1277 for the context behind this change.

@srajiang I am thinking of adding the same flag to your Node SDK implementation. If you have any suggestions on better naming, I am happy to align for it.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
