### PR TITLE
Improve typing when using 'get' on an API response

### DIFF
--- a/slack_sdk/web/async_slack_response.py
+++ b/slack_sdk/web/async_slack_response.py
@@ -1,10 +1,12 @@
 """A Python module for interacting and consuming responses from Slack."""
 
 import logging
-from typing import Union
+from typing import Any, Optional, TypeVar, Union, overload
 
 import slack_sdk.errors as e
 from .internal_utils import _next_cursor_is_present
+
+T = TypeVar("T")
 
 
 class AsyncSlackResponse:
@@ -158,6 +160,14 @@ class AsyncSlackResponse:
             return self.validate()
         else:
             raise StopAsyncIteration
+
+    @overload
+    def get(self, key: str, default: None = None) -> Optional[Any]:
+        ...
+
+    @overload
+    def get(self, key: str, default: T) -> T:
+        ...
 
     def get(self, key, default=None):
         """Retrieves any key from the response data.

--- a/slack_sdk/web/slack_response.py
+++ b/slack_sdk/web/slack_response.py
@@ -1,10 +1,12 @@
 """A Python module for interacting and consuming responses from Slack."""
 
 import logging
-from typing import Union
+from typing import Any, Optional, TypeVar, Union, overload
 
 import slack_sdk.errors as e
 from .internal_utils import _next_cursor_is_present
+
+T = TypeVar("T")
 
 
 class SlackResponse:
@@ -155,6 +157,14 @@ class SlackResponse:
             return self.validate()
         else:
             raise StopIteration
+
+    @overload
+    def get(self, key: str, default: None = None) -> Optional[Any]:
+        ...
+
+    @overload
+    def get(self, key: str, default: T) -> T:
+        ...
 
     def get(self, key, default=None):
         """Retrieves any key from the response data.


### PR DESCRIPTION
## Summary

This is a ~~simple~~ somewhat complicated change that improves type handling when calling `.get()` on API responses.

For example, this line:

```python
    if api_response and api_response.get("ok") and len(api_response.get("messages", [])):
```

currently generates this warning in Pyright:

```
Argument of type "Unknown | None" cannot be assigned to parameter "__obj" of type "Sized" in function "len"
  Type "Unknown | None" cannot be assigned to type "Sized"
    "__len__" is not present
```

This ~~simple~~ typing change alleviates this issue.

This is the first use of `TypeVar` in **slack_sdk** that I see... are there compatibility issues with older Python versions, perhaps? Opening this PR so this fix can at least be considered.

### Category (place an `x` in each of the `[ ]`)

- [X] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [X] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
