### PR TITLE
Fix #1292 files_upload_v2 does not work with io.BytesIO file parameters

### DIFF
--- a/integration_tests/web/test_files_upload_v2.py
+++ b/integration_tests/web/test_files_upload_v2.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import unittest
+from io import BytesIO
 
 import pytest
 
@@ -44,12 +45,12 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
         )
         self.assertIsNotNone(upload)
 
-    def test_uploading_text_files_legacy(self):
-        client = self.legacy_client
-        file = __file__
+    def test_uploading_bytes_io(self):
+        client = self.sync_client
         upload = client.files_upload_v2(
             channels=self.channel_id,
-            file=file,
+            file=BytesIO(bytearray("This is a test!", "utf-8")),
+            filename="test.txt",
             title="Test code",
         )
         self.assertIsNotNone(upload)

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -7,6 +7,7 @@ import urllib
 import warnings
 from asyncio import Future
 from http.client import HTTPResponse
+from io import IOBase
 from ssl import SSLContext
 from typing import Any, Dict, Optional, Sequence, Union
 from urllib.parse import urljoin
@@ -314,8 +315,14 @@ def _to_v2_file_upload_item(upload_file: Dict[str, Any]) -> Dict[str, Optional[A
         if isinstance(file, str):  # filepath
             with open(file.encode("utf-8", "ignore"), "rb") as readable:
                 data = readable.read()
-        else:
+        elif isinstance(file, bytes):
             data = file
+        elif isinstance(file, IOBase):
+            data = file.read()
+            if isinstance(data, str):
+                data = data.encode()
+        else:
+            raise SlackRequestError("file parameter must be any of filepath, bytes, and io.IOBase")
     elif content is not None:
         if isinstance(content, str):
             data = content.encode("utf-8")


### PR DESCRIPTION
## Summary

This pull request resolves #1292 

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
