### PR TITLE
Fix #1297 Building user_auth_blocks with slack_sdk.models class objects for chat.unfurl API call fails

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2131,7 +2131,7 @@ class AsyncWebClient(AsyncBaseClient):
         ts: Optional[str] = None,
         source: Optional[str] = None,
         unfurl_id: Optional[str] = None,
-        unfurls: Dict[str, Dict],
+        unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
         user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
         user_auth_message: Optional[str] = None,
         user_auth_required: Optional[bool] = None,
@@ -2154,6 +2154,7 @@ class AsyncWebClient(AsyncBaseClient):
                 "user_auth_url": user_auth_url,
             }
         )
+        _parse_web_class_objects(kwargs)  # for user_auth_blocks
         kwargs = _remove_none_values(kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return await self.api_call("chat.unfurl", json=kwargs)

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2122,7 +2122,7 @@ class WebClient(BaseClient):
         ts: Optional[str] = None,
         source: Optional[str] = None,
         unfurl_id: Optional[str] = None,
-        unfurls: Dict[str, Dict],
+        unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
         user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
         user_auth_message: Optional[str] = None,
         user_auth_required: Optional[bool] = None,
@@ -2145,6 +2145,7 @@ class WebClient(BaseClient):
                 "user_auth_url": user_auth_url,
             }
         )
+        _parse_web_class_objects(kwargs)  # for user_auth_blocks
         kwargs = _remove_none_values(kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return self.api_call("chat.unfurl", json=kwargs)

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -194,10 +194,11 @@ def _parse_web_class_objects(kwargs) -> None:
             return obj.to_dict()
         return obj
 
-    blocks = kwargs.get("blocks", None)
-    if blocks is not None and isinstance(blocks, Sequence) and (not isinstance(blocks, str)):
-        dict_blocks = [to_dict(b) for b in blocks]
-        kwargs.update({"blocks": dict_blocks})
+    for blocks_name in ["blocks", "user_auth_blocks"]:
+        blocks = kwargs.get(blocks_name, None)
+        if blocks is not None and isinstance(blocks, Sequence) and (not isinstance(blocks, str)):
+            dict_blocks = [to_dict(b) for b in blocks]
+            kwargs.update({blocks_name: dict_blocks})
 
     attachments = kwargs.get("attachments", None)
     if attachments is not None and isinstance(attachments, Sequence) and (not isinstance(attachments, str)):

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2133,7 +2133,7 @@ class LegacyWebClient(LegacyBaseClient):
         ts: Optional[str] = None,
         source: Optional[str] = None,
         unfurl_id: Optional[str] = None,
-        unfurls: Dict[str, Dict],
+        unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
         user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
         user_auth_message: Optional[str] = None,
         user_auth_required: Optional[bool] = None,
@@ -2156,6 +2156,7 @@ class LegacyWebClient(LegacyBaseClient):
                 "user_auth_url": user_auth_url,
             }
         )
+        _parse_web_class_objects(kwargs)  # for user_auth_blocks
         kwargs = _remove_none_values(kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return self.api_call("chat.unfurl", json=kwargs)

--- a/tests/slack_sdk/web/test_internal_utils.py
+++ b/tests/slack_sdk/web/test_internal_utils.py
@@ -5,7 +5,7 @@ from typing import Dict, Sequence, Union
 import pytest
 
 from slack_sdk.models.attachments import Attachment
-from slack_sdk.models.blocks import Block
+from slack_sdk.models.blocks import Block, DividerBlock
 from slack_sdk.web.internal_utils import _build_unexpected_body_error_message, _parse_web_class_objects
 
 
@@ -62,3 +62,13 @@ class TestInternalUtils(unittest.TestCase):
         _parse_web_class_objects(kwargs)
         assert isinstance(kwargs["attachments"], str)
         assert input == kwargs["attachments"]
+
+    def test_can_parse_user_auth_blocks(self):
+        kwargs = {
+            "channel": "C12345",
+            "ts": "1111.2222",
+            "unfurls": {},
+            "user_auth_blocks": [DividerBlock(), DividerBlock()],
+        }
+        _parse_web_class_objects(kwargs)
+        assert isinstance(kwargs["user_auth_blocks"][0], dict)

--- a/tests/slack_sdk/web/test_web_client.py
+++ b/tests/slack_sdk/web/test_web_client.py
@@ -5,6 +5,7 @@ import time
 
 import slack_sdk.errors as err
 from slack_sdk import WebClient
+from slack_sdk.models.blocks import DividerBlock
 from slack_sdk.models.metadata import Metadata
 from tests.slack_sdk.web.mock_web_api_server import (
     setup_mock_web_api_server,
@@ -218,3 +219,13 @@ class TestWebClient(unittest.TestCase):
             ),
         )
         self.assertIsNone(scheduled.get("error"))
+
+    def test_user_auth_blocks(self):
+        client = self.client
+        new_message = client.chat_unfurl(
+            channel="C12345",
+            ts="1111.2222",
+            unfurls={},
+            user_auth_blocks=[DividerBlock(), DividerBlock()],
+        )
+        self.assertIsNone(new_message.get("error"))

--- a/tests/slack_sdk_async/web/test_async_web_client.py
+++ b/tests/slack_sdk_async/web/test_async_web_client.py
@@ -1,9 +1,8 @@
 import re
 import unittest
 
-import aiohttp
-
 import slack_sdk.errors as err
+from slack_sdk.models.blocks import DividerBlock
 from slack_sdk.web.async_client import AsyncWebClient
 from tests.slack_sdk_async.helpers import async_test
 from tests.slack_sdk.web.mock_web_api_server import (
@@ -153,3 +152,15 @@ class TestAsyncWebClient(unittest.TestCase):
         client = AsyncWebClient(base_url="http://localhost:8888", team_id="T_DEFAULT")
         resp = await client.users_list(token="xoxb-users_list_pagination")
         self.assertIsNone(resp["error"])
+
+    @async_test
+    async def test_user_auth_blocks(self):
+        self.client.token = "xoxb-api_test"
+        client = self.client
+        new_message = await client.chat_unfurl(
+            channel="C12345",
+            ts="1111.2222",
+            unfurls={},
+            user_auth_blocks=[DividerBlock(), DividerBlock()],
+        )
+        self.assertIsNone(new_message.get("error"))


### PR DESCRIPTION
## Summary

This pull request resolves #1297 

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
