### PR TITLE
Fix #1305 by fixing pagination with async for syntax

### DIFF
--- a/integration_tests/web/test_issue_1305.py
+++ b/integration_tests/web/test_issue_1305.py
@@ -1,15 +1,9 @@
 import asyncio
-import logging
 import os
 import time
 import unittest
 
-from integration_tests.env_variable_names import (
-    SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN,
-    SLACK_SDK_TEST_GRID_IDP_USERGROUP_ID,
-    SLACK_SDK_TEST_GRID_TEAM_ID,
-    SLACK_SDK_TEST_GRID_USER_ID,
-)
+from integration_tests.env_variable_names import SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN
 from integration_tests.helpers import async_test
 from slack_sdk.web import WebClient
 from slack_sdk.web.async_client import AsyncWebClient

--- a/integration_tests/web/test_issue_1305.py
+++ b/integration_tests/web/test_issue_1305.py
@@ -1,0 +1,55 @@
+import asyncio
+import logging
+import os
+import time
+import unittest
+
+from integration_tests.env_variable_names import (
+    SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN,
+    SLACK_SDK_TEST_GRID_IDP_USERGROUP_ID,
+    SLACK_SDK_TEST_GRID_TEAM_ID,
+    SLACK_SDK_TEST_GRID_USER_ID,
+)
+from integration_tests.helpers import async_test
+from slack_sdk.web import WebClient
+from slack_sdk.web.async_client import AsyncWebClient
+
+
+class TestWebClient(unittest.TestCase):
+    """Runs integration tests with real Slack API
+
+    https://github.com/slackapi/python-slack-sdk/issues/1305
+    """
+
+    def setUp(self):
+        self.org_admin_token = os.environ[SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN]
+        self.sync_client: WebClient = WebClient(token=self.org_admin_token)
+        self.async_client: AsyncWebClient = AsyncWebClient(token=self.org_admin_token)
+
+    def tearDown(self):
+        pass
+
+    def test_sync(self):
+        client = self.sync_client
+        count = 0
+
+        for page in client.admin_conversations_search(limit=1):
+            count += len(page["conversations"])
+            if count > 1:
+                break
+            time.sleep(1)
+
+        self.assertGreater(count, 0)
+
+    @async_test
+    async def test_async(self):
+        client = self.async_client
+        count = 0
+
+        async for page in await client.admin_conversations_search(limit=1):
+            count += len(page["conversations"])
+            if count > 1:
+                break
+            await asyncio.sleep(1)
+
+        self.assertGreater(count, 0)

--- a/slack_sdk/web/async_slack_response.py
+++ b/slack_sdk/web/async_slack_response.py
@@ -145,7 +145,8 @@ class AsyncSlackResponse:
             params = self.req_args.get("params", {})
             if params is None:
                 params = {}
-            params.update({"cursor": self.data["response_metadata"]["next_cursor"]})
+            next_cursor = self.data.get("response_metadata", {}).get("next_cursor") or self.data.get("next_cursor")
+            params.update({"cursor": next_cursor})
             self.req_args.update({"params": params})
 
             response = await self._client._request(  # skipcq: PYL-W0212


### PR DESCRIPTION
## Summary

This pull request resolves #1305 

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
