### PR TITLE
Add include_categories to emoji.list args

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2734,11 +2734,13 @@ class AsyncWebClient(AsyncBaseClient):
 
     async def emoji_list(
         self,
+        include_categories: Optional[bool] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists custom emoji for a team.
         https://api.slack.com/methods/emoji.list
         """
+        kwargs.update({"include_categories": include_categories})
         return await self.api_call("emoji.list", http_verb="GET", params=kwargs)
 
     async def files_comments_delete(

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2725,11 +2725,13 @@ class WebClient(BaseClient):
 
     def emoji_list(
         self,
+        include_categories: Optional[bool] = None,
         **kwargs,
     ) -> SlackResponse:
         """Lists custom emoji for a team.
         https://api.slack.com/methods/emoji.list
         """
+        kwargs.update({"include_categories": include_categories})
         return self.api_call("emoji.list", http_verb="GET", params=kwargs)
 
     def files_comments_delete(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2736,11 +2736,13 @@ class LegacyWebClient(LegacyBaseClient):
 
     def emoji_list(
         self,
+        include_categories: Optional[bool] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists custom emoji for a team.
         https://api.slack.com/methods/emoji.list
         """
+        kwargs.update({"include_categories": include_categories})
         return self.api_call("emoji.list", http_verb="GET", params=kwargs)
 
     def files_comments_delete(


### PR DESCRIPTION
## Summary

This pull request adds a new argument to emoji.list API. Refer to https://github.com/slackapi/java-slack-sdk/issues/821#issuecomment-1378235761 for its context.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
