### PR TITLE
Fix #1327 OAuth module: SQLAlchemy v2 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -337,7 +337,7 @@ setup(
             # used only under slack_sdk/*_store
             "boto3<=2",
             # InstallationStore/OAuthStateStore
-            "SQLAlchemy>=1,<2",
+            "SQLAlchemy>=1,<3",
             # Socket Mode
             # websockets 9 is not compatible with Python 3.10
             "websockets>=10,<11" if sys.version_info.minor > 6 else "websockets>=9.1,<10",

--- a/slack_sdk/oauth/installation_store/sqlalchemy/__init__.py
+++ b/slack_sdk/oauth/installation_store/sqlalchemy/__init__.py
@@ -140,7 +140,7 @@ class SQLAlchemyInstallationStore(InstallationStore):
 
             i_column = self.installations.c
             installations_rows = conn.execute(
-                sqlalchemy.select([i_column.id])
+                sqlalchemy.select(i_column.id)
                 .where(
                     and_(
                         i_column.client_id == self.client_id,
@@ -152,7 +152,7 @@ class SQLAlchemyInstallationStore(InstallationStore):
                 .limit(1)
             )
             installations_row_id: Optional[str] = None
-            for row in installations_rows:
+            for row in installations_rows.mappings():
                 installations_row_id = row["id"]
             if installations_row_id is None:
                 conn.execute(self.installations.insert(), i)
@@ -171,7 +171,7 @@ class SQLAlchemyInstallationStore(InstallationStore):
 
             b_column = self.bots.c
             bots_rows = conn.execute(
-                sqlalchemy.select([b_column.id])
+                sqlalchemy.select(b_column.id)
                 .where(
                     and_(
                         b_column.client_id == self.client_id,
@@ -183,7 +183,7 @@ class SQLAlchemyInstallationStore(InstallationStore):
                 .limit(1)
             )
             bots_row_id: Optional[str] = None
-            for row in bots_rows:
+            for row in bots_rows.mappings():
                 bots_row_id = row["id"]
             if bots_row_id is None:
                 conn.execute(self.bots.insert(), b)
@@ -217,7 +217,7 @@ class SQLAlchemyInstallationStore(InstallationStore):
 
         with self.engine.connect() as conn:
             result: object = conn.execute(query)
-            for row in result:  # type: ignore
+            for row in result.mappings():  # type: ignore
                 return Bot(
                     app_id=row["app_id"],
                     enterprise_id=row["enterprise_id"],
@@ -261,7 +261,7 @@ class SQLAlchemyInstallationStore(InstallationStore):
         installation: Optional[Installation] = None
         with self.engine.connect() as conn:
             result: object = conn.execute(query)
-            for row in result:  # type: ignore
+            for row in result.mappings():  # type: ignore
                 installation = Installation(
                     app_id=row["app_id"],
                     enterprise_id=row["enterprise_id"],
@@ -302,7 +302,7 @@ class SQLAlchemyInstallationStore(InstallationStore):
             query = self.installations.select().where(where_clause).order_by(desc(c.installed_at)).limit(1)
             with self.engine.connect() as conn:
                 result: object = conn.execute(query)
-                for row in result:  # type: ignore
+                for row in result.mappings():  # type: ignore
                     installation.bot_token = row["bot_token"]
                     installation.bot_id = row["bot_id"]
                     installation.bot_user_id = row["bot_user_id"]

--- a/slack_sdk/oauth/state_store/sqlalchemy/__init__.py
+++ b/slack_sdk/oauth/state_store/sqlalchemy/__init__.py
@@ -64,7 +64,7 @@ class SQLAlchemyOAuthStateStore(OAuthStateStore):
                 c = self.oauth_states.c
                 query = self.oauth_states.select().where(and_(c.state == state, c.expire_at > datetime.utcnow()))
                 result = conn.execute(query)
-                for row in result:
+                for row in result.mappings():
                     self.logger.debug(f"consume's query result: {row}")
                     conn.execute(self.oauth_states.delete().where(c.id == row["id"]))
                     return True


### PR DESCRIPTION
## Summary

This pull request resolves #1327. I've confirmed that the code works with both v1.4 and v2.0.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
