### PR TITLE
Fix #1342 files_upload_v2 fails to share files in a channel

### DIFF
--- a/integration_tests/samples/basic_usage/uploading_files.py
+++ b/integration_tests/samples/basic_usage/uploading_files.py
@@ -14,3 +14,4 @@ client = WebClient(token=os.environ["SLACK_API_TOKEN"])
 channels = ",".join(["#random"])
 filepath = "./tmp.txt"
 response = client.files_upload(channels=channels, file=filepath)
+response = client.files_upload_v2(channel=response.get("file").get("channels")[0], file=filepath)

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -3152,9 +3152,10 @@ class AsyncWebClient(AsyncBaseClient):
                 channel_to_share = channels[0]
         completion = await self.files_completeUploadExternal(
             files=[{"id": f["file_id"], "title": f["title"]} for f in files],
-            channel=channel_to_share,
+            channel_id=channel_to_share,
             initial_comment=initial_comment,
             thread_ts=thread_ts,
+            token=kwargs.get("token"),
             **kwargs,
         )
         if request_file_info is True:

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -3143,9 +3143,10 @@ class WebClient(BaseClient):
                 channel_to_share = channels[0]
         completion = self.files_completeUploadExternal(
             files=[{"id": f["file_id"], "title": f["title"]} for f in files],
-            channel=channel_to_share,
+            channel_id=channel_to_share,
             initial_comment=initial_comment,
             thread_ts=thread_ts,
+            token=kwargs.get("token"),
             **kwargs,
         )
         if request_file_info is True:

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3154,9 +3154,10 @@ class LegacyWebClient(LegacyBaseClient):
                 channel_to_share = channels[0]
         completion = self.files_completeUploadExternal(
             files=[{"id": f["file_id"], "title": f["title"]} for f in files],
-            channel=channel_to_share,
+            channel_id=channel_to_share,
             initial_comment=initial_comment,
             thread_ts=thread_ts,
+            token=kwargs.get("token"),
             **kwargs,
         )
         if request_file_info is True:


### PR DESCRIPTION
## Summary

This pull request resolves #1342 . The root cause of the issue is miscoding in this SDK. The current implemenation of the v2 method internally passes "channel" parameter instead of "channel_id" parameter in `files.completeUploadExternal` API calls. Although "channel_id" is the correct one, the API server-side had been accepting both "channel" and "channel_id" until today. In the initial development of this v2 wrapper method on the SDK side, we overlooked the invalid parameter name due to the server-side behavior.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
