### PR TITLE
Add team parameter support to the authorize URL generators

### DIFF
--- a/integration_tests/web/test_issue_594.py
+++ b/integration_tests/web/test_issue_594.py
@@ -76,7 +76,9 @@ class TestWebClient(unittest.TestCase):
             external_id=external_id,
             external_url=external_url,
             title="Slack (Wikipedia)",
-            indexable_file_contents="Slack is a proprietary business communication platform developed by Slack Technologies.".encode("utf-8"),
+            indexable_file_contents="Slack is a proprietary business communication platform developed by Slack Technologies.".encode(
+                "utf-8"
+            ),
         )
         self.assertIsNotNone(creation)
 

--- a/slack_sdk/oauth/authorize_url_generator/__init__.py
+++ b/slack_sdk/oauth/authorize_url_generator/__init__.py
@@ -17,7 +17,7 @@ class AuthorizeUrlGenerator:
         self.user_scopes = user_scopes
         self.authorization_url = authorization_url
 
-    def generate(self, state: str) -> str:
+    def generate(self, state: str, team: Optional[str] = None) -> str:
         scopes = ",".join(self.scopes) if self.scopes else ""
         user_scopes = ",".join(self.user_scopes) if self.user_scopes else ""
         url = (
@@ -29,6 +29,8 @@ class AuthorizeUrlGenerator:
         )
         if self.redirect_uri is not None:
             url += f"&redirect_uri={self.redirect_uri}"
+        if team is not None:
+            url += f"&team={team}"
         return url
 
 
@@ -48,7 +50,7 @@ class OpenIDConnectAuthorizeUrlGenerator:
         self.scopes = scopes
         self.authorization_url = authorization_url
 
-    def generate(self, state: str, nonce: Optional[str] = None) -> str:
+    def generate(self, state: str, nonce: Optional[str] = None, team: Optional[str] = None) -> str:
         scopes = ",".join(self.scopes) if self.scopes else ""
         url = (
             f"{self.authorization_url}?"
@@ -58,6 +60,8 @@ class OpenIDConnectAuthorizeUrlGenerator:
             f"scope={scopes}&"
             f"redirect_uri={self.redirect_uri}"
         )
+        if team is not None:
+            url += f"&team={team}"
         if nonce is not None:
             url += f"&nonce={nonce}"
         return url

--- a/tests/slack_sdk/oauth/authorize_url_generator/test_generator.py
+++ b/tests/slack_sdk/oauth/authorize_url_generator/test_generator.py
@@ -1,6 +1,6 @@
 import unittest
 
-from slack_sdk.oauth import AuthorizeUrlGenerator
+from slack_sdk.oauth import AuthorizeUrlGenerator, OpenIDConnectAuthorizeUrlGenerator
 
 
 class TestGenerator(unittest.TestCase):
@@ -28,5 +28,45 @@ class TestGenerator(unittest.TestCase):
             authorization_url="https://www.example.com/authorize",
         )
         url = generator.generate("state-value")
-        expected = "https://www.example.com/authorize?state=state-value&client_id=111.222&scope=chat:write,commands&user_scope=search:read"
+        expected = (
+            "https://www.example.com/authorize"
+            "?state=state-value"
+            "&client_id=111.222"
+            "&scope=chat:write,commands"
+            "&user_scope=search:read"
+        )
+        self.assertEqual(expected, url)
+
+    def test_team(self):
+        generator = AuthorizeUrlGenerator(
+            client_id="111.222",
+            scopes=["chat:write", "commands"],
+            user_scopes=["search:read"],
+        )
+        url = generator.generate(state="state-value", team="T12345")
+        expected = (
+            "https://slack.com/oauth/v2/authorize"
+            "?state=state-value"
+            "&client_id=111.222"
+            "&scope=chat:write,commands&user_scope=search:read"
+            "&team=T12345"
+        )
+        self.assertEqual(expected, url)
+
+    def test_openid_connect(self):
+        generator = OpenIDConnectAuthorizeUrlGenerator(
+            client_id="111.222",
+            redirect_uri="https://www.example.com/oidc/callback",
+            scopes=["openid"],
+        )
+        url = generator.generate(state="state-value", nonce="nnn", team="T12345")
+        expected = (
+            "https://slack.com/openid/connect/authorize"
+            "?response_type=code&state=state-value"
+            "&client_id=111.222"
+            "&scope=openid"
+            "&redirect_uri=https://www.example.com/oidc/callback"
+            "&team=T12345"
+            "&nonce=nnn"
+        )
         self.assertEqual(expected, url)


### PR DESCRIPTION
## Summary

This pull request adds `team` parameter support to the authorize URL generators. Refer to the documents for details:
* https://api.slack.com/legacy/oauth#team_parameter
* https://api.slack.com/authentication/sign-in-with-slack#request

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
