### PR TITLE
Migrate deprecated codecov to the latest recommended way

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,7 +39,9 @@ jobs:
         python setup.py unit_tests --test-target tests/slack_sdk/oauth/state_store/test_sqlalchemy.py
     - name: Run codecov (only 3.9)
       run: |
-        python_version=`python -V`
         if [ ${python_version:7:3} == "3.9" ]; then
-          codecov -e ${python_version:7}
+          pytest --cov .
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -t ${CODECOV_TOKEN}
         fi

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,6 +39,7 @@ jobs:
         python setup.py unit_tests --test-target tests/slack_sdk/oauth/state_store/test_sqlalchemy.py
     - name: Run codecov (only 3.9)
       run: |
+        python_version=`python -V`
         if [ ${python_version:7:3} == "3.9" ]; then
           pytest --cov .
           curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         python_version=`python -V`
         if [ ${python_version:7:3} == "3.9" ]; then
-          pytest --cov .
+          # python setup.py validate generates the coverage file
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
           ./codecov -t ${CODECOV_TOKEN}

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ validate_dependencies = [
     "itsdangerous==1.1.0",  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
     "Jinja2==3.0.3",  # https://github.com/pallets/flask/issues/4494
     "pytest-cov>=2,<3",
-    "codecov>=2,<3",
     "flake8>=5,<6",
     "black==22.8.0",
     "click==8.0.4",  # black is affected by https://github.com/pallets/click/issues/2225


### PR DESCRIPTION
## Summary

About 12 hours ago, codecov package was deleted from the PyPI registry as it's no longer supported. This pull request migrates the way to upload the coverage data to the service. In addition to the CI job setting change, I've added a new secret named CODECOV_TOKEN to this repository.

References:
* https://github.com/codecov/codecov-python
* https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
