### PR TITLE
Fix a bug where SQLAlchemy based InstallationStore is missing client_id in queries

### DIFF
--- a/slack_sdk/oauth/installation_store/sqlalchemy/__init__.py
+++ b/slack_sdk/oauth/installation_store/sqlalchemy/__init__.py
@@ -247,7 +247,11 @@ class SQLAlchemyInstallationStore(InstallationStore):
             team_id = None
 
         c = self.installations.c
-        where_clause = and_(c.enterprise_id == enterprise_id, c.team_id == team_id)
+        where_clause = and_(
+            c.client_id == self.client_id,
+            c.enterprise_id == enterprise_id,
+            c.team_id == team_id,
+        )
         if user_id is not None:
             where_clause = and_(
                 c.client_id == self.client_id,


### PR DESCRIPTION
## Summary

This pull reqeust resolves a bug where the SQLAlchemy based installation store does not work properly for multile apps sharing a single database.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
