### PR TITLE
Add metadata support to Incoming Webhooks

### DIFF
--- a/integration_tests/webhook/test_async_webhook.py
+++ b/integration_tests/webhook/test_async_webhook.py
@@ -276,3 +276,17 @@ class TestAsyncWebhook(unittest.TestCase):
         )
         self.assertEqual(200, response.status_code)
         self.assertEqual("ok", response.body)
+
+    @async_test
+    async def test_metadata(self):
+        url = os.environ[SLACK_SDK_TEST_INCOMING_WEBHOOK_URL]
+        webhook = AsyncWebhookClient(url)
+        response = await webhook.send(
+            text="Hello with metadata",
+            metadata={
+                "event_type": "foo",
+                "event_payload": {"foo": "bar"},
+            },
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("ok", response.body)

--- a/integration_tests/webhook/test_webhook.py
+++ b/integration_tests/webhook/test_webhook.py
@@ -270,3 +270,16 @@ class TestWebhook(unittest.TestCase):
         )
         self.assertEqual(200, response.status_code)
         self.assertEqual("ok", response.body)
+
+    def test_metadata(self):
+        url = os.environ[SLACK_SDK_TEST_INCOMING_WEBHOOK_URL]
+        webhook = WebhookClient(url)
+        response = webhook.send(
+            text="Hello with metadata",
+            metadata={
+                "event_type": "foo",
+                "event_payload": {"foo": "bar"},
+            },
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("ok", response.body)

--- a/slack_sdk/webhook/async_client.py
+++ b/slack_sdk/webhook/async_client.py
@@ -96,6 +96,7 @@ class AsyncWebhookClient:
         delete_original: Optional[bool] = None,
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> WebhookResponse:
         """Performs a Slack API request and returns the result.
@@ -109,6 +110,7 @@ class AsyncWebhookClient:
             delete_original: True if you use this option for response_url requests
             unfurl_links: Option to indicate whether text url should unfurl
             unfurl_media: Option to indicate whether media url should unfurl
+            metadata: Metadata attached to the message
             headers: Request headers to append only for this request
 
         Returns:
@@ -126,6 +128,7 @@ class AsyncWebhookClient:
                 "delete_original": delete_original,
                 "unfurl_links": unfurl_links,
                 "unfurl_media": unfurl_media,
+                "metadata": metadata,
             },
             headers=headers,
         )

--- a/slack_sdk/webhook/client.py
+++ b/slack_sdk/webhook/client.py
@@ -86,6 +86,7 @@ class WebhookClient:
         delete_original: Optional[bool] = None,
         unfurl_links: Optional[bool] = None,
         unfurl_media: Optional[bool] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> WebhookResponse:
         """Performs a Slack API request and returns the result.
@@ -100,6 +101,7 @@ class WebhookClient:
             delete_original: True if you use this option for response_url requests
             unfurl_links: Option to indicate whether text url should unfurl
             unfurl_media: Option to indicate whether media url should unfurl
+            metadata: Metadata attached to the message
             headers: Request headers to append only for this request
 
         Returns:
@@ -117,6 +119,7 @@ class WebhookClient:
                 "delete_original": delete_original,
                 "unfurl_links": unfurl_links,
                 "unfurl_media": unfurl_media,
+                "metadata": metadata,
             },
             headers=headers,
         )


### PR DESCRIPTION
## Summary

As pointed out at https://github.com/slackapi/bolt-js/issues/1819, metadata argument must be supported when posting a message using response_url and incoming webhooks

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
