### PR TITLE
Add built in server error retry handlers (#1367)

### DIFF
--- a/slack_sdk/http_retry/builtin_async_handlers.py
+++ b/slack_sdk/http_retry/builtin_async_handlers.py
@@ -86,5 +86,26 @@ class AsyncRateLimitErrorRetryHandler(AsyncRetryHandler):
         state.increment_current_attempt()
 
 
+class AsyncServerErrorRetryHandler(AsyncRetryHandler):
+    """RetryHandler that does retries for server errors."""
+
+    def __init__(
+        self,
+        max_retry_count: int = 1,
+        interval_calculator: RetryIntervalCalculator = default_interval_calculator,
+    ):
+        super().__init__(max_retry_count, interval_calculator)
+
+    async def _can_retry_async(
+        self,
+        *,
+        state: RetryState,
+        request: HttpRequest,
+        response: Optional[HttpResponse],
+        error: Optional[Exception],
+    ) -> bool:
+        return response is not None and response.status_code in [500, 503]
+
+
 def async_default_handlers() -> List[AsyncRetryHandler]:
     return [AsyncConnectionErrorRetryHandler()]

--- a/slack_sdk/http_retry/builtin_handlers.py
+++ b/slack_sdk/http_retry/builtin_handlers.py
@@ -87,3 +87,24 @@ class RateLimitErrorRetryHandler(RetryHandler):
             duration = int(response.headers.get(retry_after_header_name)[0]) + random.random()
         time.sleep(duration)
         state.increment_current_attempt()
+
+
+class ServerErrorRetryHandler(RetryHandler):
+    """RetryHandler that does retries for server errors."""
+
+    def __init__(
+        self,
+        max_retry_count: int = 1,
+        interval_calculator: RetryIntervalCalculator = default_interval_calculator,
+    ):
+        super().__init__(max_retry_count, interval_calculator)
+
+    def _can_retry(
+        self,
+        *,
+        state: RetryState,
+        request: HttpRequest,
+        response: Optional[HttpResponse] = None,
+        error: Optional[Exception] = None,
+    ) -> bool:
+        return response is not None and response.status_code in [500, 503]


### PR DESCRIPTION
Co-authored-by: Kazuhiro Sera <seratch@gmail.com>

## Summary

(Describe the goal of this PR. Mention any related issue numbers)

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
