### PR TITLE
Fix #1369 ImageBlock title parsing defaults to incorrect behaviour when given a string

### DIFF
--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -251,6 +251,60 @@ class ImageBlockTests(unittest.TestCase):
         }
         self.assertDictEqual(input, ImageBlock(**input).to_dict())
 
+    def test_issue_1369_title_type(self):
+        self.assertEqual(
+            "plain_text",
+            ImageBlock(
+                image_url="https://example.com/",
+                alt_text="example",
+                title="example",
+            ).title.type,
+        )
+
+        self.assertEqual(
+            "plain_text",
+            ImageBlock(
+                image_url="https://example.com/",
+                alt_text="example",
+                title={
+                    "type": "plain_text",
+                    "text": "Please enjoy this photo of a kitten",
+                },
+            ).title.type,
+        )
+
+        self.assertEqual(
+            "plain_text",
+            ImageBlock(
+                image_url="https://example.com/",
+                alt_text="example",
+                title=PlainTextObject(text="example"),
+            ).title.type,
+        )
+
+        with self.assertRaises(SlackObjectFormationError):
+            self.assertEqual(
+                "plain_text",
+                ImageBlock(
+                    image_url="https://example.com/",
+                    alt_text="example",
+                    title={
+                        "type": "mrkdwn",
+                        "text": "Please enjoy this photo of a kitten",
+                    },
+                ).title.type,
+            )
+
+            with self.assertRaises(SlackObjectFormationError):
+                self.assertEqual(
+                    "plain_text",
+                    ImageBlock(
+                        image_url="https://example.com/",
+                        alt_text="example",
+                        title=MarkdownTextObject(text="example"),
+                    ).title.type,
+                )
+
     def test_json(self):
         self.assertDictEqual(
             {


### PR DESCRIPTION
## Summary

This pull request resolves #1369 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
