### PR TITLE
Fix #1379 websocket-client socket mode client doesn't handle reconnects properly

### DIFF
--- a/slack_sdk/socket_mode/websocket_client/__init__.py
+++ b/slack_sdk/socket_mode/websocket_client/__init__.py
@@ -136,7 +136,7 @@ class SocketModeClient(BaseSocketModeClient):
         self.on_close_listeners = on_close_listeners or []
 
     def is_connected(self) -> bool:
-        return self.current_session is not None
+        return self.current_session is not None and self.current_session.sock is not None
 
     def connect(self) -> None:
         def on_open(ws: WebSocketApp):

--- a/tests/slack_sdk/socket_mode/test_interactions_websocket_client.py
+++ b/tests/slack_sdk/socket_mode/test_interactions_websocket_client.py
@@ -70,8 +70,8 @@ class TestInteractionsWebSocketClient(unittest.TestCase):
             time.sleep(1)  # wait for the server
             client.wss_uri = "ws://0.0.0.0:3012/link"
             client.connect()
-            self.assertTrue(client.is_connected())
             time.sleep(1)  # wait for the message receiver
+            self.assertTrue(client.is_connected())
 
             for _ in range(10):
                 client.send_message("foo")


### PR DESCRIPTION
## Summary

This pull request resolves #1379 

The `_monitor_current_session` method in the same class already checks the existence of the `sock` property. So, having the same logic should be consistent and safe enough.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
