### PR TITLE
Mark stars.* API methods as deprecated

### DIFF
--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -100,6 +100,7 @@ class Block(JsonObject):
     def parse_all(cls, blocks: Optional[Sequence[Union[dict, "Block"]]]) -> List["Block"]:
         return [cls.parse(b) for b in blocks or []]  # type: ignore
 
+
 # -------------------------------------------------
 # Block Classes
 # -------------------------------------------------

--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -10,7 +10,7 @@ from .async_internal_utils import (
     _request_with_session,
 )  # type: ignore
 from .async_slack_response import AsyncSlackResponse
-from .deprecation import show_2020_01_deprecation
+from .deprecation import show_deprecation_warning_if_any
 from .internal_utils import (
     convert_bool_to_0_or_1,
     _build_req_args,
@@ -156,7 +156,7 @@ class AsyncBaseClient:
             proxy=self.proxy,
         )
 
-        show_2020_01_deprecation(api_method)
+        show_deprecation_warning_if_any(api_method)
 
         return await self._send(
             http_verb=http_verb,

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -21,7 +21,7 @@ from urllib.request import Request, urlopen, OpenerDirector, ProxyHandler, HTTPS
 
 import slack_sdk.errors as err
 from slack_sdk.errors import SlackRequestError
-from .deprecation import show_2020_01_deprecation
+from .deprecation import show_deprecation_warning_if_any
 from .internal_utils import (
     convert_bool_to_0_or_1,
     get_user_agent,
@@ -152,7 +152,7 @@ class BaseClient:
             proxy=self.proxy,
         )
 
-        show_2020_01_deprecation(api_method)
+        show_deprecation_warning_if_any(api_method)
         return self._sync_send(api_url=api_url, req_args=req_args)
 
     # =================================================================

--- a/slack_sdk/web/deprecation.py
+++ b/slack_sdk/web/deprecation.py
@@ -10,8 +10,10 @@ deprecated_method_prefixes_2020_01 = [
     "admin.conversations.whitelist.",
 ]
 
+deprecated_method_prefixes_2023_07 = ["stars."]
 
-def show_2020_01_deprecation(method_name: str):
+
+def show_deprecation_warning_if_any(method_name: str):
     """Prints a warning if the given method is deprecated"""
 
     skip_deprecation = os.environ.get("SLACKCLIENT_SKIP_DEPRECATION")  # for unit tests etc.
@@ -20,11 +22,21 @@ def show_2020_01_deprecation(method_name: str):
     if not method_name:
         return
 
+    # 2020/01 conversations API deprecation
     matched_prefixes = [prefix for prefix in deprecated_method_prefixes_2020_01 if method_name.startswith(prefix)]
     if len(matched_prefixes) > 0:
         message = (
             f"{method_name} is deprecated. Please use the Conversations API instead. "
             "For more info, go to "
             "https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api"
+        )
+        warnings.warn(message)
+
+    # 2023/07 stars API deprecation
+    matched_prefixes = [prefix for prefix in deprecated_method_prefixes_2023_07 if method_name.startswith(prefix)]
+    if len(matched_prefixes) > 0:
+        message = (
+            f"{method_name} is deprecated. For more info, go to "
+            "https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders"
         )
         warnings.warn(message)

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -25,7 +25,7 @@ from aiohttp import FormData, BasicAuth
 import slack_sdk.errors as err
 from slack_sdk.errors import SlackRequestError
 from .async_internal_utils import _files_to_data, _get_event_loop, _request_with_session
-from .deprecation import show_2020_01_deprecation
+from .deprecation import show_deprecation_warning_if_any
 from .internal_utils import (
     convert_bool_to_0_or_1,
     get_user_agent,
@@ -161,7 +161,7 @@ class LegacyBaseClient:
             proxy=self.proxy,
         )
 
-        show_2020_01_deprecation(api_method)
+        show_deprecation_warning_if_any(api_method)
 
         if self.run_async or self.use_sync_aiohttp:
             if self._event_loop is None:

--- a/tests/slack_sdk/web/test_web_client_stars_deprecation.py
+++ b/tests/slack_sdk/web/test_web_client_stars_deprecation.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+import pytest
+
+from slack_sdk.web import WebClient
+from tests.slack_sdk.web.mock_web_api_server import (
+    setup_mock_web_api_server,
+    cleanup_mock_web_api_server,
+)
+
+
+class TestWebClient(unittest.TestCase):
+    def setUp(self):
+        setup_mock_web_api_server(self)
+
+    def tearDown(self):
+        cleanup_mock_web_api_server(self)
+
+    # You can enable this test to verify if the warning can be printed as expected
+    @pytest.mark.skip()
+    def test_stars_deprecation(self):
+        env_value = os.environ.get("SLACKCLIENT_SKIP_DEPRECATION")
+        try:
+            os.environ.pop("SLACKCLIENT_SKIP_DEPRECATION")
+            client = WebClient(base_url="http://localhost:8888")
+            client.stars_list(token="xoxb-api_test")
+        finally:
+            os.environ.update({"SLACKCLIENT_SKIP_DEPRECATION": env_value})


### PR DESCRIPTION
see also: https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders

## Summary

(Describe the goal of this PR. Mention any related issue numbers)

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
