### PR TITLE
Update files.upload v2 method in correspondence with server-side changes

### DIFF
--- a/integration_tests/web/test_files_upload_v2.py
+++ b/integration_tests/web/test_files_upload_v2.py
@@ -44,6 +44,8 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             title="Test code",
         )
         self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("title"))
 
     def test_uploading_bytes_io(self):
         client = self.sync_client
@@ -54,6 +56,8 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             title="Test code",
         )
         self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("title"))
 
     def test_uploading_multiple_files(self):
         client = self.sync_client
@@ -74,6 +78,8 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             initial_comment="Here are files :wave:",
         )
         self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("title"))
 
     @async_test
     async def test_uploading_text_files_async(self):
@@ -86,6 +92,8 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             file=file,
         )
         self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("title"))
 
         deletion = await client.files_delete(file=upload["file"]["id"])
         self.assertIsNotNone(deletion)
@@ -116,6 +124,8 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             file=file,
         )
         self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("title"))
 
         deletion = client.files_delete(file=upload["file"]["id"])
         self.assertIsNotNone(deletion)
@@ -133,6 +143,8 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
                 content=content,
             )
             self.assertIsNotNone(upload)
+            self.assertIsNotNone(upload.get("files")[0].get("id"))
+            self.assertIsNotNone(upload.get("files")[0].get("title"))
 
             deletion = client.files_delete(file=upload["file"]["id"])
             self.assertIsNotNone(deletion)
@@ -149,6 +161,8 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             file=file,
         )
         self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("title"))
 
         deletion = await client.files_delete(file=upload["file"]["id"])
         self.assertIsNotNone(deletion)
@@ -165,6 +179,8 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             file=file,
         )
         self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("title"))
 
         deletion = client.files_delete(
             token=self.bot_token,
@@ -185,56 +201,11 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             file=file,
         )
         self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("title"))
 
         deletion = await client.files_delete(
             token=self.bot_token,
             file=upload["file"]["id"],
         )
         self.assertIsNotNone(deletion)
-
-    def test_request_file_info_false(self):
-        client = self.sync_client
-        upload = client.files_upload_v2(
-            channels=self.channel_id,
-            title="Foo",
-            filename="foo.txt",
-            content="foo",
-        )
-        self.assertIsNotNone(upload)
-        self.assertIsNotNone(upload.get("files")[0].get("id"))
-        self.assertIsNotNone(upload.get("files")[0].get("name"))
-
-        upload = client.files_upload_v2(
-            channels=self.channel_id,
-            title="Foo",
-            filename="foo.txt",
-            content="foo",
-            request_file_info=False,
-        )
-        self.assertIsNotNone(upload)
-        self.assertIsNotNone(upload.get("files")[0].get("id"))
-        self.assertIsNone(upload.get("files")[0].get("name"))
-
-    @async_test
-    async def test_request_file_info_false_async(self):
-        client = self.async_client
-        upload = await client.files_upload_v2(
-            channels=self.channel_id,
-            title="Foo",
-            filename="foo.txt",
-            content="foo",
-        )
-        self.assertIsNotNone(upload)
-        self.assertIsNotNone(upload.get("files")[0].get("id"))
-        self.assertIsNotNone(upload.get("files")[0].get("name"))
-
-        upload = await client.files_upload_v2(
-            channels=self.channel_id,
-            title="Foo",
-            filename="foo.txt",
-            content="foo",
-            request_file_info=False,
-        )
-        self.assertIsNotNone(upload)
-        self.assertIsNotNone(upload.get("files")[0].get("id"))
-        self.assertIsNone(upload.get("files")[0].get("name"))

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -3520,8 +3520,8 @@ class AsyncWebClient(AsyncBaseClient):
             thread_ts=thread_ts,
             **kwargs,
         )
-        if len(completion.get("files")) == 1:
-            completion.data["file"] = completion.get("files")[0]
+        if len(completion.get("files")) == 1:  # type: ignore
+            completion.data["file"] = completion.get("files")[0]  # type: ignore
         return completion
 
     async def files_getUploadURLExternal(

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -24,7 +24,6 @@ from .internal_utils import (
     _remove_none_values,
     _to_v2_file_upload_item,
     _upload_file_via_v2_url,
-    _attach_full_file_metadata_async,
     _validate_for_legacy_client,
     _print_files_upload_v2_suggestion,
 )
@@ -3422,7 +3421,7 @@ class AsyncWebClient(AsyncBaseClient):
         channel: Optional[str] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
-        request_file_info: bool = True,
+        request_file_info: bool = True,  # since v3.23, this flag is no longer necessary
         **kwargs,
     ) -> AsyncSlackResponse:
         """This wrapper method provides an easy way to upload files using the following endpoints:
@@ -3519,15 +3518,10 @@ class AsyncWebClient(AsyncBaseClient):
             channel_id=channel_to_share,
             initial_comment=initial_comment,
             thread_ts=thread_ts,
-            token=kwargs.get("token"),
             **kwargs,
         )
-        if request_file_info is True:
-            await _attach_full_file_metadata_async(
-                client=self,
-                token_as_arg=kwargs.get("token"),
-                completion=completion,
-            )
+        if len(completion.get("files")) == 1:
+            completion.data["file"] = completion.get("files")[0]
         return completion
 
     async def files_getUploadURLExternal(

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -3511,8 +3511,8 @@ class WebClient(BaseClient):
             thread_ts=thread_ts,
             **kwargs,
         )
-        if len(completion.get("files")) == 1:
-            completion.data["file"] = completion.get("files")[0]
+        if len(completion.get("files")) == 1:  # type: ignore
+            completion.data["file"] = completion.get("files")[0]  # type: ignore
         return completion
 
     def files_getUploadURLExternal(

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -15,7 +15,6 @@ from .internal_utils import (
     _remove_none_values,
     _to_v2_file_upload_item,
     _upload_file_via_v2_url,
-    _attach_full_file_metadata,
     _validate_for_legacy_client,
     _print_files_upload_v2_suggestion,
 )
@@ -3413,7 +3412,7 @@ class WebClient(BaseClient):
         channel: Optional[str] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
-        request_file_info: bool = True,
+        request_file_info: bool = True,  # since v3.23, this flag is no longer necessary
         **kwargs,
     ) -> SlackResponse:
         """This wrapper method provides an easy way to upload files using the following endpoints:
@@ -3510,15 +3509,10 @@ class WebClient(BaseClient):
             channel_id=channel_to_share,
             initial_comment=initial_comment,
             thread_ts=thread_ts,
-            token=kwargs.get("token"),
             **kwargs,
         )
-        if request_file_info is True:
-            _attach_full_file_metadata(
-                client=self,
-                token_as_arg=kwargs.get("token"),
-                completion=completion,
-            )
+        if len(completion.get("files")) == 1:
+            completion.data["file"] = completion.get("files")[0]
         return completion
 
     def files_getUploadURLExternal(

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -407,40 +407,6 @@ def _validate_for_legacy_client(
         raise SlackRequestError(message)
 
 
-def _attach_full_file_metadata(
-    client,  # type: ignore
-    token_as_arg: Optional[str],
-    completion: Union["SlackResponse", Future],  # noqa: F821
-) -> None:
-    _validate_for_legacy_client(completion)
-    _completion: Any = completion  # just for satisfying pytype
-    # fetch all the file metadata for backward-compatibility
-    for f in _completion.get("files"):
-        full_info = client.files_info(
-            file=f.get("id"),
-            token=token_as_arg,
-        )
-        f.update(full_info["file"])
-    if len(_completion.get("files")) == 1:
-        _completion.data["file"] = _completion.get("files")[0]
-
-
-async def _attach_full_file_metadata_async(
-    client,  # type: ignore
-    token_as_arg: Optional[str],
-    completion: "SlackResponse",  # noqa: F821
-) -> None:
-    # fetch all the file metadata for backward-compatibility
-    for f in completion.get("files"):
-        full_info = await client.files_info(
-            file=f.get("id"),
-            token=token_as_arg,
-        )
-        f.update(full_info["file"])
-    if len(completion.get("files")) == 1:
-        completion.data["file"] = completion.get("files")[0]
-
-
 def _print_files_upload_v2_suggestion():
     message = (
         "client.files_upload() may cause some issues like timeouts for relatively large files. "

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -26,7 +26,6 @@ from .internal_utils import (
     _remove_none_values,
     _to_v2_file_upload_item,
     _upload_file_via_v2_url,
-    _attach_full_file_metadata,
     _validate_for_legacy_client,
     _print_files_upload_v2_suggestion,
 )
@@ -3424,7 +3423,7 @@ class LegacyWebClient(LegacyBaseClient):
         channel: Optional[str] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
-        request_file_info: bool = True,
+        request_file_info: bool = True,  # since v3.23, this flag is no longer necessary
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """This wrapper method provides an easy way to upload files using the following endpoints:
@@ -3521,15 +3520,10 @@ class LegacyWebClient(LegacyBaseClient):
             channel_id=channel_to_share,
             initial_comment=initial_comment,
             thread_ts=thread_ts,
-            token=kwargs.get("token"),
             **kwargs,
         )
-        if request_file_info is True:
-            _attach_full_file_metadata(
-                client=self,
-                token_as_arg=kwargs.get("token"),
-                completion=completion,
-            )
+        if len(completion.get("files")) == 1:
+            completion.data["file"] = completion.get("files")[0]
         return completion
 
     def files_getUploadURLExternal(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3522,8 +3522,8 @@ class LegacyWebClient(LegacyBaseClient):
             thread_ts=thread_ts,
             **kwargs,
         )
-        if len(completion.get("files")) == 1:
-            completion.data["file"] = completion.get("files")[0]
+        if len(completion.get("files")) == 1:  # type: ignore
+            completion.data["file"] = completion.get("files")[0]  # type: ignore
         return completion
 
     def files_getUploadURLExternal(


### PR DESCRIPTION
## Summary

This pull request updates the internals of `files_upload_v2` method to eliminate files.info API calls, which are no longer necessary because the server-side now returns the same metadata as part of `files.completeUploadExternal` API responses.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
