### PR TITLE
Add new arguments to admin.users.list API method

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -1675,6 +1675,8 @@ class AsyncWebClient(AsyncBaseClient):
         self,
         *,
         team_id: str,
+        include_deactivated_user_workspaces: Optional[bool] = None,
+        is_active: Optional[bool] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         **kwargs,
@@ -1685,6 +1687,8 @@ class AsyncWebClient(AsyncBaseClient):
         kwargs.update(
             {
                 "team_id": team_id,
+                "include_deactivated_user_workspaces": include_deactivated_user_workspaces,
+                "is_active": is_active,
                 "cursor": cursor,
                 "limit": limit,
             }

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -1666,6 +1666,8 @@ class WebClient(BaseClient):
         self,
         *,
         team_id: str,
+        include_deactivated_user_workspaces: Optional[bool] = None,
+        is_active: Optional[bool] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         **kwargs,
@@ -1676,6 +1678,8 @@ class WebClient(BaseClient):
         kwargs.update(
             {
                 "team_id": team_id,
+                "include_deactivated_user_workspaces": include_deactivated_user_workspaces,
+                "is_active": is_active,
                 "cursor": cursor,
                 "limit": limit,
             }

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -1677,6 +1677,8 @@ class LegacyWebClient(LegacyBaseClient):
         self,
         *,
         team_id: str,
+        include_deactivated_user_workspaces: Optional[bool] = None,
+        is_active: Optional[bool] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         **kwargs,
@@ -1687,6 +1689,8 @@ class LegacyWebClient(LegacyBaseClient):
         kwargs.update(
             {
                 "team_id": team_id,
+                "include_deactivated_user_workspaces": include_deactivated_user_workspaces,
+                "is_active": is_active,
                 "cursor": cursor,
                 "limit": limit,
             }


### PR DESCRIPTION
## Summary

This pull request adds two newly added options to https://api.slack.com/methods/admin.users.list

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
