### PR TITLE
Fix #1421 Update SlackApiError exception handling for web client

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ except SlackApiError as e:
     assert e.response["ok"] is False
     assert e.response["error"]  # str like 'invalid_auth', 'channel_not_found'
     print(f"Got an error: {e.response['error']}")
+    # Also receive a corresponding status_code
+    assert isinstance(e.response.status_code, int)
+    print(f"Received a response status_code: {e.response.status_code}")
 ```
 
 Here we also ensure that the response back from Slack is a successful one and that the message is the one we sent by using the `assert` statement.

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -299,7 +299,8 @@ class BaseClient:
                     response_body_data = json.loads(response["body"])
                 except json.decoder.JSONDecodeError:
                     message = _build_unexpected_body_error_message(response.get("body", ""))
-                    raise err.SlackApiError(message, response)
+                    self._logger.error(f"Failed to decode Slack API response: {message}")
+                    response_body_data = {"ok": False, "error": message}
 
             all_params: Dict[str, Any] = copy.copy(body_params) if body_params is not None else {}
             if query_params:

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -19,7 +19,6 @@ from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen, OpenerDirector, ProxyHandler, HTTPSHandler
 
-import slack_sdk.errors as err
 from slack_sdk.errors import SlackRequestError
 from .deprecation import show_deprecation_warning_if_any
 from .internal_utils import (

--- a/tests/slack_sdk/web/test_web_client.py
+++ b/tests/slack_sdk/web/test_web_client.py
@@ -150,7 +150,7 @@ class TestWebClient(unittest.TestCase):
             self.fail("SlackApiError expected here")
         except err.SlackApiError as e:
             self.assertTrue(
-                str(e).startswith("Received a response in a non-JSON format: <!DOCTYPE HTML PUBLIC"),
+                str(e).startswith("The request to the Slack API failed. (url: http://"),
                 e,
             )
 

--- a/tests/slack_sdk/web/test_web_client_http_retry_server_error.py
+++ b/tests/slack_sdk/web/test_web_client_http_retry_server_error.py
@@ -51,7 +51,16 @@ class TestWebClient_HttpRetry_ServerError(unittest.TestCase):
             client.users_list(token="xoxb-error_html_response")
             self.fail("SlackApiError expected here")
         except err.SlackApiError as e:
-            self.assertTrue(str(e).startswith("Received a response in a non-JSON format: "), e)
+            self.assertTrue(
+                str(e).startswith("The request to the Slack API failed. (url: http://"),
+                e,
+            )
+            self.assertIsInstance(e.response.status_code, int)
+            self.assertFalse(e.response["ok"])
+            self.assertTrue(
+                e.response["error"].startswith("Received a response in a non-JSON format: <!DOCTYPE "),
+                e.response["error"],
+            )
 
         self.assertEqual(2, retry_handlers[0].call_count)
 

--- a/tests/slack_sdk/web/test_web_client_issue_829.py
+++ b/tests/slack_sdk/web/test_web_client_issue_829.py
@@ -21,4 +21,13 @@ class TestWebClient_Issue_829(unittest.TestCase):
             client.users_list(token="xoxb-error_html_response")
             self.fail("SlackApiError expected here")
         except err.SlackApiError as e:
-            self.assertTrue(str(e).startswith("Received a response in a non-JSON format: "), e)
+            self.assertTrue(
+                str(e).startswith("The request to the Slack API failed. (url: http://"),
+                e,
+            )
+            self.assertIsInstance(e.response.status_code, int)
+            self.assertFalse(e.response["ok"])
+            self.assertTrue(
+                e.response["error"].startswith("Received a response in a non-JSON format: <!DOCTYPE "),
+                e.response["error"],
+            )


### PR DESCRIPTION
## Summary

This pull request resolves #1421, also updated unit tests and README.

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
