### PR TITLE
Fix #1424 Add file input block element support

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -1625,6 +1625,55 @@ class NumberInputElement(InputInteractiveElement):
 
 
 # -------------------------------------------------
+# File Input Element
+# -------------------------------------------------
+
+
+class FileInputElement(InputInteractiveElement):
+    type = "file_input"
+
+    @property
+    def attributes(self) -> Set[str]:
+        return super().attributes.union(
+            {
+                "filetypes",
+                "max_files",
+            }
+        )
+
+    def __init__(
+        self,
+        *,
+        action_id: Optional[str] = None,
+        filetypes: Optional[List[str]] = False,
+        max_files: Optional[int] = None,
+        **others: dict,
+    ):
+        """
+        https://api.slack.com/reference/block-kit/block-elements#file_input
+
+        Args:
+            action_id (required): An identifier for the input value when the parent modal is submitted.
+                You can use this when you receive a view_submission payload to identify the value of the input element.
+                Should be unique among all other action_ids in the containing block. Maximum length is 255 characters.
+            filetypes: An array of valid file extensions that will be accepted for this element.
+                All file extensions will be accepted if filetypes is not specified.
+                This validation is provided for convenience only,
+                and you should perform your own file type validation based on what you expect to receive.
+            max_files: Maximum number of files that can be uploaded for this file_input element.
+                Minimum of 1, maximum of 10. Defaults to 10 if not specified.
+        """
+        super().__init__(
+            type=self.type,
+            action_id=action_id,
+        )
+        show_unknown_key_warning(self, others)
+
+        self.filetypes = filetypes
+        self.max_files = max_files
+
+
+# -------------------------------------------------
 # Radio Buttons Select
 # -------------------------------------------------
 

--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -1645,7 +1645,7 @@ class FileInputElement(InputInteractiveElement):
         self,
         *,
         action_id: Optional[str] = None,
-        filetypes: Optional[List[str]] = False,
+        filetypes: Optional[List[str]] = None,
         max_files: Optional[int] = None,
         **others: dict,
     ):

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -35,6 +35,7 @@ from slack_sdk.models.blocks.block_elements import (
     UrlInputElement,
     WorkflowButtonElement,
     RichTextInputElement,
+    FileInputElement,
 )
 from . import STRING_3001_CHARS, STRING_301_CHARS
 
@@ -1197,6 +1198,22 @@ class NumberInputElementTests(unittest.TestCase):
             "focus_on_load": True,
         }
         self.assertDictEqual(input, NumberInputElement(**input).to_dict())
+
+
+# -------------------------------------------------
+# File Input Element
+# -------------------------------------------------
+
+
+class FileInputElementTests(unittest.TestCase):
+    def test_element(self):
+        input = {
+            "type": "file_input",
+            "action_id": "file_input-action",
+            "filetypes": ["pdf", "txt"],
+            "max_files": 3,
+        }
+        self.assertDictEqual(input, FileInputElement(**input).to_dict())
 
 
 # -------------------------------------------------


### PR DESCRIPTION
## Summary

This pull request resolves #1424 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
