### PR TITLE
Add functions.completeSuccess/Error APIs for remote functions

### DIFF
--- a/integration_tests/web/test_admin_conversations_restrictAccess.py
+++ b/integration_tests/web/test_admin_conversations_restrictAccess.py
@@ -40,10 +40,7 @@ class TestWebClient(unittest.TestCase):
             if self.channel_id is None:
                 millis = int(round(time.time() * 1000))
                 channel_name = f"private-test-channel-{millis}"
-                self.channel_id = client.conversations_create(
-                    name=channel_name,
-                    is_private=True,
-                )[
+                self.channel_id = client.conversations_create(name=channel_name, is_private=True,)[
                     "channel"
                 ]["id"]
 

--- a/integration_tests/web/test_calls.py
+++ b/integration_tests/web/test_calls.py
@@ -24,12 +24,7 @@ class TestWebClient(unittest.TestCase):
 
     def test_sync(self):
         client = self.sync_client
-        user_id = list(
-            filter(
-                lambda u: not u["deleted"] and "bot_id" not in u,
-                client.users_list(limit=50)["members"],
-            )
-        )[
+        user_id = list(filter(lambda u: not u["deleted"] and "bot_id" not in u, client.users_list(limit=50)["members"],))[
             0
         ]["id"]
 

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -3658,6 +3658,32 @@ class AsyncWebClient(AsyncBaseClient):
         )
         return await self.api_call("files.completeUploadExternal", params=kwargs)
 
+    async def functions_completeSuccess(
+        self,
+        *,
+        function_execution_id: str,
+        outputs: Dict[str, Any],
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """Signal the successful completion of a function
+        https://api.slack.com/methods/functions.completeSuccess
+        """
+        kwargs.update({"function_execution_id": function_execution_id, "outputs": outputs})
+        return await self.api_call("functions.completeSuccess", params=kwargs)
+
+    async def functions_completeError(
+        self,
+        *,
+        function_execution_id: str,
+        error: str,
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """Signal the failure to execute a function
+        https://api.slack.com/methods/functions.completeError
+        """
+        kwargs.update({"function_execution_id": function_execution_id, "error": error})
+        return await self.api_call("functions.completeError", params=kwargs)
+
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -3668,7 +3668,7 @@ class AsyncWebClient(AsyncBaseClient):
         """Signal the successful completion of a function
         https://api.slack.com/methods/functions.completeSuccess
         """
-        kwargs.update({"function_execution_id": function_execution_id, "outputs": outputs})
+        kwargs.update({"function_execution_id": function_execution_id, "outputs": json.dumps(outputs)})
         return await self.api_call("functions.completeSuccess", params=kwargs)
 
     async def functions_completeError(

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -3649,6 +3649,32 @@ class WebClient(BaseClient):
         )
         return self.api_call("files.completeUploadExternal", params=kwargs)
 
+    def functions_completeSuccess(
+        self,
+        *,
+        function_execution_id: str,
+        outputs: Dict[str, Any],
+        **kwargs,
+    ) -> SlackResponse:
+        """Signal the successful completion of a function
+        https://api.slack.com/methods/functions.completeSuccess
+        """
+        kwargs.update({"function_execution_id": function_execution_id, "outputs": outputs})
+        return self.api_call("functions.completeSuccess", params=kwargs)
+
+    def functions_completeError(
+        self,
+        *,
+        function_execution_id: str,
+        error: str,
+        **kwargs,
+    ) -> SlackResponse:
+        """Signal the failure to execute a function
+        https://api.slack.com/methods/functions.completeError
+        """
+        kwargs.update({"function_execution_id": function_execution_id, "error": error})
+        return self.api_call("functions.completeError", params=kwargs)
+
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -3659,7 +3659,7 @@ class WebClient(BaseClient):
         """Signal the successful completion of a function
         https://api.slack.com/methods/functions.completeSuccess
         """
-        kwargs.update({"function_execution_id": function_execution_id, "outputs": outputs})
+        kwargs.update({"function_execution_id": function_execution_id, "outputs": json.dumps(outputs)})
         return self.api_call("functions.completeSuccess", params=kwargs)
 
     def functions_completeError(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3670,7 +3670,7 @@ class LegacyWebClient(LegacyBaseClient):
         """Signal the successful completion of a function
         https://api.slack.com/methods/functions.completeSuccess
         """
-        kwargs.update({"function_execution_id": function_execution_id, "outputs": outputs})
+        kwargs.update({"function_execution_id": function_execution_id, "outputs": json.dumps(outputs)})
         return self.api_call("functions.completeSuccess", params=kwargs)
 
     def functions_completeError(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3660,6 +3660,32 @@ class LegacyWebClient(LegacyBaseClient):
         )
         return self.api_call("files.completeUploadExternal", params=kwargs)
 
+    def functions_completeSuccess(
+        self,
+        *,
+        function_execution_id: str,
+        outputs: Dict[str, Any],
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """Signal the successful completion of a function
+        https://api.slack.com/methods/functions.completeSuccess
+        """
+        kwargs.update({"function_execution_id": function_execution_id, "outputs": outputs})
+        return self.api_call("functions.completeSuccess", params=kwargs)
+
+    def functions_completeError(
+        self,
+        *,
+        function_execution_id: str,
+        error: str,
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """Signal the failure to execute a function
+        https://api.slack.com/methods/functions.completeError
+        """
+        kwargs.update({"function_execution_id": function_execution_id, "error": error})
+        return self.api_call("functions.completeError", params=kwargs)
+
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.

--- a/tests/slack_sdk_async/web/test_web_client_coverage.py
+++ b/tests/slack_sdk_async/web/test_web_client_coverage.py
@@ -640,6 +640,12 @@ class TestWebClientCoverage(unittest.TestCase):
             elif method_name == "files_completeUploadExternal":
                 self.api_methods_to_call.remove(method(files=[{"id": "F111"}])["method"])
                 await async_method(files=[{"id": "F111"}])
+            elif method_name == "functions_completeSuccess":
+                self.api_methods_to_call.remove(method(function_execution_id="Fn111", outputs={"num": 123}))
+                await async_method(function_execution_id="Fn111", outputs={"num": 123})
+            elif method_name == "functions_completeError":
+                self.api_methods_to_call.remove(method(function_execution_id="Fn111", error="something wrong"))
+                await async_method(function_execution_id="Fn111", error="something wrong")
             elif method_name == "migration_exchange":
                 self.api_methods_to_call.remove(method(users="U123,U234")["method"])
                 method(users="U123,U234")


### PR DESCRIPTION
## Summary

This pull request adds two endpoints, which will be coming soon, to WebClient family. Developers can use these APIs along with https://github.com/slackapi/bolt-python/pull/986

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
