### PR TITLE
Enable testing for Python 3.12 and PyPy 3.10 on CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,10 +10,19 @@ jobs:
   build:
     # Avoiding -latest due to https://github.com/actions/setup-python/issues/162
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version:
+          - '3.12'
+          - '3.11'
+          - '3.10'
+          - '3.9'
+          - '3.8'
+          - '3.7'
+          - '3.6'
+          - 'pypy3.10'
     env:
       PYTHON_SLACK_SDK_MOCK_SERVER_MODE: 'threading'
       CI_LARGE_SOCKET_MODE_PAYLOAD_TESTING_DISABLED: '1'
@@ -23,12 +32,13 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
     - name: Install dependencies
       run: |
         pip install -U pip wheel
         pip install -e ".[testing]"
         pip install -e ".[optional]"
-    - name: Run validation
+    - name: Run validation (black/flake8/pytest)
       run: |
         python setup.py validate
     - name: Run tests for SQLAlchemy v1.4 (backward-compatibility)

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,5 @@ log_date_format = %Y-%m-%d %H:%M:%S
 filterwarnings =
     ignore:"@coroutine" decorator is deprecated since Python 3.8, use "async def" instead:DeprecationWarning
     ignore:The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.:DeprecationWarning
+    ignore:slack.* package is deprecated. Please use slack_sdk.* package instead.*:UserWarning
 asyncio_mode = auto

--- a/slack_sdk/oauth/installation_store/models/bot.py
+++ b/slack_sdk/oauth/installation_store/models/bot.py
@@ -1,11 +1,8 @@
-import re
 from datetime import datetime  # type: ignore
 from time import time
 from typing import Optional, Union, Dict, Any, Sequence
 
-from slack_sdk.oauth.installation_store.internals import (
-    _from_iso_format_to_unix_timestamp,
-)
+from slack_sdk.oauth.installation_store.internals import _timestamp_to_type
 
 
 class Bot:
@@ -70,30 +67,17 @@ class Bot:
         else:
             self.bot_scopes = bot_scopes
         self.bot_refresh_token = bot_refresh_token
+
         if bot_token_expires_at is not None:
-            if type(bot_token_expires_at) == datetime:
-                self.bot_token_expires_at = int(bot_token_expires_at.timestamp())  # type: ignore
-            elif type(bot_token_expires_at) == str and not re.match("^\\d+$", bot_token_expires_at):
-                self.bot_token_expires_at = int(_from_iso_format_to_unix_timestamp(bot_token_expires_at))
-            else:
-                self.bot_token_expires_at = int(bot_token_expires_at)
+            self.bot_token_expires_at = _timestamp_to_type(bot_token_expires_at, int)
         elif bot_token_expires_in is not None:
             self.bot_token_expires_at = int(time()) + bot_token_expires_in
         else:
             self.bot_token_expires_at = None
+
         self.is_enterprise_install = is_enterprise_install or False
 
-        if type(installed_at) == float:
-            self.installed_at = installed_at  # type: ignore
-        elif type(installed_at) == datetime:
-            self.installed_at = installed_at.timestamp()  # type: ignore
-        elif type(installed_at) == str:
-            if re.match("^\\d+.\\d+$", installed_at):
-                self.installed_at = float(installed_at)
-            else:
-                self.installed_at = _from_iso_format_to_unix_timestamp(installed_at)
-        else:
-            raise ValueError(f"Unsupported data format for installed_at {installed_at}")
+        self.installed_at = _timestamp_to_type(installed_at, float)
 
         self.custom_values = custom_values if custom_values is not None else {}
 

--- a/slack_sdk/oauth/installation_store/models/installation.py
+++ b/slack_sdk/oauth/installation_store/models/installation.py
@@ -1,11 +1,8 @@
-import re
 from datetime import datetime  # type: ignore
 from time import time
 from typing import Optional, Union, Dict, Any, Sequence
 
-from slack_sdk.oauth.installation_store.internals import (
-    _from_iso_format_to_unix_timestamp,
-)
+from slack_sdk.oauth.installation_store.internals import _timestamp_to_type
 from slack_sdk.oauth.installation_store.models.bot import Bot
 
 
@@ -100,14 +97,9 @@ class Installation:
         else:
             self.bot_scopes = bot_scopes
         self.bot_refresh_token = bot_refresh_token
+
         if bot_token_expires_at is not None:
-            if type(bot_token_expires_at) == datetime:
-                ts: float = bot_token_expires_at.timestamp()  # type: ignore
-                self.bot_token_expires_at = int(ts)
-            elif type(bot_token_expires_at) == str and not re.match("^\\d+$", bot_token_expires_at):
-                self.bot_token_expires_at = int(_from_iso_format_to_unix_timestamp(bot_token_expires_at))
-            else:
-                self.bot_token_expires_at = bot_token_expires_at  # type: ignore
+            self.bot_token_expires_at = _timestamp_to_type(bot_token_expires_at, int)
         elif bot_token_expires_in is not None:
             self.bot_token_expires_at = int(time()) + bot_token_expires_in
         else:
@@ -120,14 +112,9 @@ class Installation:
         else:
             self.user_scopes = user_scopes
         self.user_refresh_token = user_refresh_token
+
         if user_token_expires_at is not None:
-            if type(user_token_expires_at) == datetime:
-                ts: float = user_token_expires_at.timestamp()  # type: ignore
-                self.user_token_expires_at = int(ts)
-            elif type(user_token_expires_at) == str and not re.match("^\\d+$", user_token_expires_at):
-                self.user_token_expires_at = int(_from_iso_format_to_unix_timestamp(user_token_expires_at))
-            else:
-                self.user_token_expires_at = user_token_expires_at  # type: ignore
+            self.user_token_expires_at = _timestamp_to_type(user_token_expires_at, int)
         elif user_token_expires_in is not None:
             self.user_token_expires_at = int(time()) + user_token_expires_in
         else:
@@ -143,17 +130,8 @@ class Installation:
 
         if installed_at is None:
             self.installed_at = datetime.now().timestamp()
-        elif type(installed_at) == float:
-            self.installed_at = installed_at  # type: ignore
-        elif type(installed_at) == datetime:
-            self.installed_at = installed_at.timestamp()  # type: ignore
-        elif type(installed_at) == str:
-            if re.match("^\\d+.\\d+$", installed_at):
-                self.installed_at = float(installed_at)
-            else:
-                self.installed_at = _from_iso_format_to_unix_timestamp(installed_at)
         else:
-            raise ValueError(f"Unsupported data format for installed_at {installed_at}")
+            self.installed_at = _timestamp_to_type(installed_at, float)
 
         self.custom_values = custom_values if custom_values is not None else {}
 

--- a/tests/slack_sdk/oauth/installation_store/test_internals.py
+++ b/tests/slack_sdk/oauth/installation_store/test_internals.py
@@ -1,7 +1,11 @@
+import sys
 import unittest
+from datetime import datetime, timezone
+
+import pytest
 
 from slack_sdk.oauth.installation_store import Installation, FileInstallationStore
-from slack_sdk.oauth.installation_store.internals import _from_iso_format_to_datetime
+from slack_sdk.oauth.installation_store.internals import _from_iso_format_to_datetime, _timestamp_to_type
 
 
 class TestFile(unittest.TestCase):
@@ -14,3 +18,29 @@ class TestFile(unittest.TestCase):
     def test_iso_format(self):
         dt = _from_iso_format_to_datetime("2021-07-14 08:00:17")
         self.assertEqual(dt.timestamp(), 1626249617.0)
+
+
+@pytest.mark.parametrize('ts,target_type,expected_result', [
+    (1701209097, int, 1701209097),
+    (datetime(2023, 11, 28, 22, 9, 7, tzinfo=timezone.utc), int, 1701209347),
+    ("1701209605", int, 1701209605),
+    ("2023-11-28 22:11:19", int, 1701209479),
+    (1701209998.3429494, float, 1701209998.3429494),
+    (datetime(2023, 11, 28, 22, 20, 25, 262571, tzinfo=timezone.utc), float, 1701210025.262571),
+    ("1701210054.4672053", float, 1701210054.4672053),
+    ("2023-11-28 22:21:14.745556", float, 1701210074.745556),
+])
+def test_timestamp_to_type(ts, target_type, expected_result):
+    result = _timestamp_to_type(ts, target_type)
+    assert result == expected_result
+
+
+def test_timestamp_to_type_invalid_str():
+    match = "Invalid isoformat string" if sys.version_info[:2] > (3, 6) else "time data .* does not match format"
+    with pytest.raises(ValueError, match=match):
+        _timestamp_to_type('not-a-timestamp', int)
+
+
+def test_timestamp_to_type_unsupported_format():
+    with pytest.raises(ValueError, match="Unsupported data format"):
+        _timestamp_to_type({}, int)

--- a/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
@@ -90,7 +90,9 @@ class TestInteractionsWebsockets(unittest.TestCase):
             expected.sort()
 
             count = 0
-            while count < 10 and len(received_messages) < len(expected):
+            while count < 10 and (
+                len(received_messages) < len(expected) or len(received_socket_mode_requests) < len(socket_mode_envelopes)
+            ):
                 await asyncio.sleep(0.2)
                 count += 0.2
 


### PR DESCRIPTION
## Summary

Hello,

I believe it would be nice to ensure support for Python 3.12 and PyPy,
so I'd like to suggest changes that:
  * enable testing for Python 3.12 and PyPy 3.10 on CI
  * resolve/suppress some warnings
  * update [classifiers](https://pypi.org/classifiers/) at `setup.py`
  * bump `pytest` to 7.x
  * update constraints for `flake8` to allow `pip` do its job and resolve [compatibility issues](https://github.com/Jamim/python-slack-sdk/actions/runs/7023401877/job/19109825126#step:5:87)
  * refactor timestamp conversion logic in order to resolve a bunch of [E721](https://www.flake8rules.com/rules/E721.html) `flake8` errors
  * fix some regexps with [invalid escaping](https://github.com/Jamim/python-slack-sdk/actions/runs/7023401877/job/19109825126#step:5:14) at `setup.py`
  * fix spontaneous failures of `TestInteractionsWebsockets.test_interactions`

Best regards!

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've ~~run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh`~~ [debbuged everything on CI](https://github.com/Jamim/python-slack-sdk/actions) after making the changes.
