### PR TITLE
Add new `force` argument to `conversations.invite` API method.

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2865,12 +2865,18 @@ class AsyncWebClient(AsyncBaseClient):
         *,
         channel: str,
         users: Union[str, Sequence[str]],
+        force: Optional[bool] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Invites users to a channel.
         https://api.slack.com/methods/conversations.invite
         """
-        kwargs.update({"channel": channel})
+        kwargs.update(
+            {
+                "channel": channel,
+                "force": force,
+            }
+        )
         if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2856,12 +2856,18 @@ class WebClient(BaseClient):
         *,
         channel: str,
         users: Union[str, Sequence[str]],
+        force: Optional[bool] = None,
         **kwargs,
     ) -> SlackResponse:
         """Invites users to a channel.
         https://api.slack.com/methods/conversations.invite
         """
-        kwargs.update({"channel": channel})
+        kwargs.update(
+            {
+                "channel": channel,
+                "force": force,
+            }
+        )
         if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2867,12 +2867,18 @@ class LegacyWebClient(LegacyBaseClient):
         *,
         channel: str,
         users: Union[str, Sequence[str]],
+        force: Optional[bool] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Invites users to a channel.
         https://api.slack.com/methods/conversations.invite
         """
-        kwargs.update({"channel": channel})
+        kwargs.update(
+            {
+                "channel": channel,
+                "force": force,
+            }
+        )
         if isinstance(users, (list, Tuple)):
             kwargs.update({"users": ",".join(users)})
         else:


### PR DESCRIPTION
## Summary

Not released yet, but soon!

Adds a new `force` parameter that will be imminently available in the `conversations.invite` API method. 