### PR TITLE
Stop from re-declaring 'type' keyword

### DIFF
--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -233,8 +233,8 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                         if self.logger.level <= logging.DEBUG:
                             # The following logging prints every single received message
                             # except empty message data ones.
-                            type = WSMsgType(message.type)
-                            message_type = type.name if type is not None else message.type
+                            m_type = WSMsgType(message.type)
+                            message_type = m_type.name if m_type is not None else message.type
                             message_data = message.data
                             if isinstance(message_data, bytes):
                                 message_data = message_data.decode("utf-8")


### PR DESCRIPTION
## Summary

`__init__.py` redeclared type before using it, leading to an error when the exception in receive_messages was reached.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
