### PR TITLE
Fix #1441 Built-in InstallationStores fail to resolve a valid bot token when both bot and user-only installations co-exist in database tables

### DIFF
--- a/slack_sdk/oauth/installation_store/file/__init__.py
+++ b/slack_sdk/oauth/installation_store/file/__init__.py
@@ -77,6 +77,10 @@ class FileInstallationStore(InstallationStore, AsyncInstallationStore):
                 f.write(entity)
 
     def save_bot(self, bot: Bot):
+        if bot.bot_token is None:
+            self.logger.debug("Skipped saving a new row because of the absense of bot token in it")
+            return
+
         none = "none"
         e_id = bot.enterprise_id or none
         t_id = bot.team_id or none
@@ -169,10 +173,13 @@ class FileInstallationStore(InstallationStore, AsyncInstallationStore):
                 data = json.loads(f.read())
                 installation = Installation(**data)
 
-            if installation is not None and user_id is not None:
+            has_user_installation = user_id is not None and installation is not None
+            no_bot_token_installation = installation is not None and installation.bot_token is None
+            should_find_bot_installation = has_user_installation or no_bot_token_installation
+            if should_find_bot_installation:
                 # Retrieve the latest bot token, just in case
                 # See also: https://github.com/slackapi/bolt-python/issues/664
-                latest_bot_installation = self.find_installation(
+                latest_bot_installation = self.find_bot(
                     enterprise_id=enterprise_id,
                     team_id=team_id,
                     is_enterprise_install=is_enterprise_install,

--- a/slack_sdk/oauth/installation_store/sqlite3/__init__.py
+++ b/slack_sdk/oauth/installation_store/sqlite3/__init__.py
@@ -59,9 +59,9 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 enterprise_url text,
                 team_id text not null default '',
                 team_name text,
-                bot_token text not null,
-                bot_id text not null,
-                bot_user_id text not null,
+                bot_token text,
+                bot_id text,
+                bot_user_id text,
                 bot_scopes text,
                 bot_refresh_token text,  -- since v3.8
                 bot_token_expires_at datetime,  -- since v3.8
@@ -224,6 +224,10 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
         self.save_bot(installation.to_bot())
 
     def save_bot(self, bot: Bot):
+        if bot.bot_token is None:
+            self.logger.debug("Skipped saving a new row because of the absense of bot token in it")
+            return
+
         with self.connect() as conn:
             conn.execute(
                 """

--- a/tests/slack_sdk/oauth/installation_store/test_amazon_s3.py
+++ b/tests/slack_sdk/oauth/installation_store/test_amazon_s3.py
@@ -242,3 +242,58 @@ class TestAmazonS3(unittest.TestCase):
         self.assertIsNone(i)
         bot = store.find_bot(enterprise_id="E111", team_id="T222")
         self.assertIsNone(bot)
+
+    def test_issue_1441_mixing_user_and_bot_installations(self):
+        store = self.build_store()
+
+        bot_installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_id="B111",
+            bot_token="xoxb-111",
+            bot_scopes=["chat:write"],
+            bot_user_id="U222",
+        )
+        store.save(bot_installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="T111")
+        self.assertIsNone(bot)
+
+        installation = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(installation.bot_token)
+        installation = store.find_installation(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(installation)
+        installation = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(installation)
+
+        user_installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_scopes=["openid"],
+            user_token="xoxp-111",
+        )
+        store.save(user_installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot.bot_token)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="T111")
+        self.assertIsNone(bot)
+
+        installation = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(installation.bot_token)
+        installation = store.find_installation(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(installation)
+        installation = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(installation)

--- a/tests/slack_sdk/oauth/installation_store/test_file.py
+++ b/tests/slack_sdk/oauth/installation_store/test_file.py
@@ -148,3 +148,58 @@ class TestFile(unittest.TestCase):
         self.assertIsNone(i)
         bot = store.find_bot(enterprise_id=None, team_id="T222")
         self.assertIsNone(bot)
+
+    def test_issue_1441_mixing_user_and_bot_installations(self):
+        store = FileInstallationStore(client_id="111.222")
+
+        bot_installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_id="B111",
+            bot_token="xoxb-111",
+            bot_scopes=["chat:write"],
+            bot_user_id="U222",
+        )
+        store.save(bot_installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="T111")
+        self.assertIsNone(bot)
+
+        installation = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(installation.bot_token)
+        installation = store.find_installation(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(installation)
+        installation = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(installation)
+
+        user_installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_scopes=["openid"],
+            user_token="xoxp-111",
+        )
+        store.save(user_installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot.bot_token)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="T111")
+        self.assertIsNone(bot)
+
+        installation = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(installation.bot_token)
+        installation = store.find_installation(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(installation)
+        installation = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(installation)

--- a/tests/slack_sdk/oauth/installation_store/test_sqlalchemy.py
+++ b/tests/slack_sdk/oauth/installation_store/test_sqlalchemy.py
@@ -7,7 +7,7 @@ from slack_sdk.oauth.installation_store import Installation
 from slack_sdk.oauth.installation_store.sqlalchemy import SQLAlchemyInstallationStore
 
 
-class TestSQLite3(unittest.TestCase):
+class TestSQLAlchemy(unittest.TestCase):
     engine: Engine
 
     def setUp(self):
@@ -234,3 +234,58 @@ class TestSQLite3(unittest.TestCase):
         self.assertIsNone(i)
         bot = store.find_bot(enterprise_id="E111", team_id="T222")
         self.assertIsNone(bot)
+
+    def test_issue_1441_mixing_user_and_bot_installations(self):
+        store = self.store
+
+        bot_installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_id="B111",
+            bot_token="xoxb-111",
+            bot_scopes=["chat:write"],
+            bot_user_id="U222",
+        )
+        store.save(bot_installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="T111")
+        self.assertIsNone(bot)
+
+        installation = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(installation.bot_token)
+        installation = store.find_installation(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(installation)
+        installation = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(installation)
+
+        user_installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_scopes=["openid"],
+            user_token="xoxp-111",
+        )
+        store.save(user_installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot.bot_token)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="T111")
+        self.assertIsNone(bot)
+
+        installation = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(installation.bot_token)
+        installation = store.find_installation(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(installation)
+        installation = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(installation)

--- a/tests/slack_sdk/oauth/installation_store/test_sqlite3.py
+++ b/tests/slack_sdk/oauth/installation_store/test_sqlite3.py
@@ -235,3 +235,58 @@ class TestSQLite3(unittest.TestCase):
         self.assertIsNone(i)
         bot = store.find_bot(enterprise_id="E111", team_id="T222")
         self.assertIsNone(bot)
+
+    def test_issue_1441_mixing_user_and_bot_installations(self):
+        store = SQLite3InstallationStore(database="logs/test.db", client_id="111.222")
+
+        bot_installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_id="B111",
+            bot_token="xoxb-111",
+            bot_scopes=["chat:write"],
+            bot_user_id="U222",
+        )
+        store.save(bot_installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="T111")
+        self.assertIsNone(bot)
+
+        installation = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(installation.bot_token)
+        installation = store.find_installation(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(installation)
+        installation = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(installation)
+
+        user_installation = Installation(
+            app_id="A111",
+            enterprise_id="E111",
+            team_id="T111",
+            user_id="U111",
+            bot_scopes=["openid"],
+            user_token="xoxp-111",
+        )
+        store.save(user_installation)
+
+        # find bots
+        bot = store.find_bot(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(bot.bot_token)
+        bot = store.find_bot(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(bot)
+        bot = store.find_bot(enterprise_id=None, team_id="T111")
+        self.assertIsNone(bot)
+
+        installation = store.find_installation(enterprise_id="E111", team_id="T111")
+        self.assertIsNotNone(installation.bot_token)
+        installation = store.find_installation(enterprise_id="E111", team_id="T222")
+        self.assertIsNone(installation)
+        installation = store.find_installation(enterprise_id=None, team_id="T111")
+        self.assertIsNone(installation)


### PR DESCRIPTION
## Summary

This pull request resolves #1441 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
