### PR TITLE
Update run_*.sh scripts

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -3,22 +3,16 @@
 # all: ./scripts/run_integration_tests.sh
 # single: ./scripts/run_integration_tests.sh integration_tests/web/test_async_web_client.py
 
+set -e
+
 script_dir=`dirname $0`
 cd ${script_dir}/..
 
-test_target="$1"
-python_version=`python --version | awk '{print $2}'`
-pip install -U pip && \
-  pip install -r requirements/testing.txt && \
-  pip install -r requirements/optional.txt && \
+pip install -U pip
+pip install -r requirements/testing.txt \
+  -r requirements/optional.txt
 
-if [[ $test_target != "" ]]
-then
-  black slack_sdk/ slack/ tests/ && \
-    python setup.py codegen && \
-    python setup.py integration_tests --test-target $1
-else
-  black slack_sdk/ slack/ tests/ && \
-    python setup.py codegen && \
-    python setup.py integration_tests
-fi
+python setup.py codegen
+
+test_target="${1:-integration_tests/}"
+python setup.py integration_tests --test-target $test_target

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -3,22 +3,16 @@
 # all: ./scripts/run_unit_tests.sh
 # single: ./scripts/run_unit_tests.sh tests/slack_sdk_async/web/test_web_client_coverage.py
 
+set -e
+
 script_dir=`dirname $0`
 cd ${script_dir}/..
 
-test_target="$1"
-python_version=`python --version | awk '{print $2}'`
-pip install -U pip && \
-  pip install -r requirements/testing.txt && \
-  pip install -r requirements/optional.txt && \
+pip install -U pip
+pip install -r requirements/testing.txt \
+  -r requirements/optional.txt
 
-if [[ $test_target != "" ]]
-then
-  black slack_sdk/ slack/ tests/ && \
-    python setup.py codegen && \
-    python setup.py unit_tests --test-target $1
-else
-  black slack_sdk/ slack/ tests/ && \
-    python setup.py codegen && \
-    python setup.py unit_tests
-fi
+python setup.py codegen
+
+test_target="${1:-tests/}"
+python setup.py unit_tests --test-target $test_target

--- a/scripts/run_validation.sh
+++ b/scripts/run_validation.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 # ./scripts/run_validation.sh
 
+set -e
+
 script_dir=`dirname $0`
 cd ${script_dir}/..
-pip install -U pip && \
-  pip install -r requirements/testing.txt && \
-  pip install -r requirements/optional.txt && \
-  black slack_sdk/ slack/ tests/ integration_tests/ && \
-  python setup.py codegen && \
-  python setup.py validate
+pip install -U pip
+pip install -r requirements/testing.txt \
+  -r requirements/optional.txt
+
+black --check tests/ integration_tests/
+# TODO: resolve linting errors for tests
+# flake8 tests/ integration_tests/
+
+python setup.py codegen
+python setup.py validate


### PR DESCRIPTION
## Summary

Hello,

The _Maintainers Guide_ [says that](https://github.com/slackapi/python-slack-sdk/blob/main/.github/maintainers_guide.md?plain=1#L78-L82) no formatter nor code analyzer is involved when you run unit tests, so I suppose `black` was added by mistake and should be removed.
Also, using [set -e](https://git.savannah.gnu.org/cgit/bash.git/tree/builtins/set.def#n64) allows you to avoid chaining of commands.

I'd like to suggest changes that:
  * remove `black` from `run_*_tests.sh` scripts
  * add `set -e` to unchain commands in scripts
  * simplify handling of a test target

Best regards!

### Category (place an `x` in each of the `[ ]`)

- [x] `/scripts`
- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
