### PR TITLE
Replace Flask-Sockets with aiohttp for testing

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       PYTHON_SLACK_SDK_MOCK_SERVER_MODE: 'threading'
       CI_LARGE_SOCKET_MODE_PAYLOAD_TESTING_DISABLED: '1'
+      FORCE_COLOR: '1'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -35,9 +36,12 @@ jobs:
         cache: pip
     - name: Install dependencies
       run: |
-        pip install -U pip wheel
+        pip install -U pip setuptools wheel
         pip install -r requirements/testing.txt
         pip install -r requirements/optional.txt
+    - name: Run codegen
+      run: |
+        python setup.py codegen
     - name: Run validation (black/flake8/pytest)
       run: |
         python setup.py validate

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,11 +1,7 @@
 # pip install -r requirements/testing.txt
+aiohttp<4  # used for a WebSocket server mock
 pytest>=7.0.1,<8
 pytest-asyncio<1  # for async
-Flask-Sockets>=0.2,<1
-Flask>=1,<2  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
-Werkzeug<2  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
-itsdangerous==1.1.0  # TODO: Flask-Sockets is not yet compatible with Flask 2.x
-Jinja2==3.0.3  # https://github.com/pallets/flask/issues/4494
 pytest-cov>=2,<3
 # while flake8 5.x have issues with Python 3.12, flake8 6.x requires Python >= 3.8.1,
 # so 5.x should be kept in order to stay compatible with Python 3.6/3.7

--- a/scripts/run_validation.sh
+++ b/scripts/run_validation.sh
@@ -5,13 +5,10 @@ set -e
 
 script_dir=`dirname $0`
 cd ${script_dir}/..
-pip install -U pip
+
+pip install -U pip setuptools wheel
 pip install -r requirements/testing.txt \
   -r requirements/optional.txt
-
-black --check tests/ integration_tests/
-# TODO: resolve linting errors for tests
-# flake8 tests/ integration_tests/
 
 python setup.py codegen
 python setup.py validate

--- a/tests/slack_sdk/socket_mode/test_interactions_websocket_client.py
+++ b/tests/slack_sdk/socket_mode/test_interactions_websocket_client.py
@@ -83,7 +83,9 @@ class TestInteractionsWebSocketClient(unittest.TestCase):
             expected.sort()
 
             count = 0
-            while count < 10 and len(received_messages) < len(expected):
+            while count < 10 and (
+                len(received_messages) < len(expected) or len(received_socket_mode_requests) < len(socket_mode_envelopes)
+            ):
                 time.sleep(0.2)
                 count += 0.2
 
@@ -93,8 +95,8 @@ class TestInteractionsWebSocketClient(unittest.TestCase):
             self.assertEqual(len(socket_mode_envelopes), len(received_socket_mode_requests))
         finally:
             client.close()
-            self.server.stop()
-            self.server.close()
+            self.loop.stop()
+            t.join(timeout=5)
 
     def test_send_message_while_disconnection(self):
         if is_ci_unstable_test_skip_enabled():
@@ -105,7 +107,6 @@ class TestInteractionsWebSocketClient(unittest.TestCase):
         time.sleep(2)  # wait for the server
 
         try:
-            self.reset_sever_state()
             client = SocketModeClient(
                 app_token="xapp-A111-222-xyz",
                 web_client=self.web_client,
@@ -131,5 +132,5 @@ class TestInteractionsWebSocketClient(unittest.TestCase):
             client.send_message("foo")
         finally:
             client.close()
-            self.server.stop()
-            self.server.close()
+            self.loop.stop()
+            t.join(timeout=5)


### PR DESCRIPTION
Hello @seratch,
I hope you may find this PR useful.

## Summary

`Flask-Sockets` [is deprecated](https://github.com/heroku-python/flask-sockets/issues/85) and it won't receive any fixes in the future, so it seems reasonable to replace it with some up-to-date library.
`aiohttp` has been chosen since it was already presented as an optional requirement.

These changes also:
  * move format checking for tests from `run_validation.sh` to `setup.py`
  * remove duplicated dependency installations from `setup.py`
  * add a `codegen` step on CI
  * force colors on CI

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.

Best regards!