### PR TITLE
fix #1446: monitor dies when exceptions raised before monitor created.

### DIFF
--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -402,7 +402,7 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                     self.logger.debug(f"A new receive_messages() executor has been recreated for {session_id}")
                 break
             except Exception as e:
-                self.logger.exception(f"Failed to connect : {e}. Retrying...")
+                self.logger.exception(f"Failed to connect (error: {e}); Retrying...")
                 await asyncio.sleep(self.ping_interval)
 
     async def disconnect(self):

--- a/tests/slack_sdk/socket_mode/mock_web_api_server.py
+++ b/tests/slack_sdk/socket_mode/mock_web_api_server.py
@@ -89,7 +89,7 @@ class MockHandler(SimpleHTTPRequestHandler):
                 if self.path == "/apps.connections.open":
                     body = {
                         "ok": True,
-                        "url": "wss://test-server/link/?ticket=xxx&app_id=yyy",
+                        "url": "ws://0.0.0.0:3001/link",
                     }
                 if self.path == "/api.test" and request_body:
                     body = {"ok": True, "args": request_body}

--- a/tests/slack_sdk/socket_mode/test_builtin.py
+++ b/tests/slack_sdk/socket_mode/test_builtin.py
@@ -56,7 +56,7 @@ class TestBuiltin(unittest.TestCase):
             web_client=self.web_client,
         )
         url = client.issue_new_wss_url()
-        self.assertTrue(url.startswith("wss://"))
+        self.assertTrue(url.startswith("ws://"))
 
         legacy_client = LegacyWebClient(token="xoxb-api_test", base_url="http://localhost:8888")
         response = legacy_client.apps_connections_open(app_token="xapp-A111-222-xyz")

--- a/tests/slack_sdk_async/socket_mode/test_aiohttp.py
+++ b/tests/slack_sdk_async/socket_mode/test_aiohttp.py
@@ -42,7 +42,7 @@ class TestAiohttp(unittest.TestCase):
         )
         try:
             url = await client.issue_new_wss_url()
-            self.assertTrue(url.startswith("wss://"))
+            self.assertTrue(url.startswith("ws://"))
         finally:
             await client.close()
 

--- a/tests/slack_sdk_async/socket_mode/test_interactions_aiohttp.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_aiohttp.py
@@ -17,8 +17,10 @@ from slack_sdk.web.async_client import AsyncWebClient
 from tests.helpers import is_ci_unstable_test_skip_enabled
 from tests.slack_sdk.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
+    start_socket_mode_server_with_disconnection,
     socket_mode_envelopes,
     socket_mode_hello_message,
+    socket_mode_disconnect_message,
 )
 from tests.slack_sdk.socket_mode.mock_web_api_server import (
     setup_mock_web_api_server,
@@ -96,6 +98,94 @@ class TestInteractionsAiohttp(unittest.TestCase):
                 count += 0.2
 
             received_messages.sort()
+            self.assertEqual(received_messages, expected)
+
+            self.assertEqual(len(socket_mode_envelopes), len(received_socket_mode_requests))
+        finally:
+            await client.close()
+            self.loop.stop()
+            t.join(timeout=5)
+
+    @async_test
+    async def test_interactions_with_disconnection(self):
+        if is_ci_unstable_test_skip_enabled():
+            return
+        t = Thread(target=start_socket_mode_server_with_disconnection(self, 3001))
+        t.daemon = True
+        t.start()
+
+        self.disconnected = False
+        received_messages = []
+        received_socket_mode_requests = []
+
+        async def message_handler(message: WSMessage):
+            session_id = client.build_session_id(client.current_session)
+            if "wait_for_disconnect" in message.data:
+                return
+            self.logger.info(f"Raw Message: {message}")
+            await asyncio.sleep(randint(50, 200) / 1000)
+            self.disconnected = "disconnect" in message.data
+            received_messages.append(message.data + "_" + session_id)
+
+        async def socket_mode_listener(
+            self: AsyncBaseSocketModeClient,
+            request: SocketModeRequest,
+        ):
+            self.logger.info(f"Socket Mode Request: {request.payload}")
+            await asyncio.sleep(randint(50, 200) / 1000)
+            received_socket_mode_requests.append(request.payload)
+
+        client = SocketModeClient(
+            app_token="xapp-A111-222-xyz",
+            web_client=self.web_client,
+            on_message_listeners=[message_handler],
+            auto_reconnect_enabled=True,
+            trace_enabled=True,
+        )
+        client.socket_mode_request_listeners.append(socket_mode_listener)
+
+        try:
+            time.sleep(1)  # wait for the server
+            client.wss_uri = "ws://0.0.0.0:3001/link"
+            await client.connect()
+            await asyncio.sleep(1)  # wait for the message receiver
+
+            # Because we want to check the expected messages of new session,
+            # we need to ensure we send messaged after disconnected.
+            count = 0
+            while not self.disconnected and count < 10:
+                try:
+                    await client.send_message("wait_for_disconnect")
+                except Exception as e:
+                    self.logger.exception(e)
+                finally:
+                    await asyncio.sleep(1)
+                    count += 1
+            await asyncio.sleep(10)
+            expected_session_id = client.build_session_id(client.current_session)
+
+            for _ in range(10):
+                await client.send_message("foo")
+                await client.send_message("bar")
+                await client.send_message("baz")
+
+            expected = socket_mode_envelopes + [socket_mode_hello_message] + ["foo", "bar", "baz"] * 10
+            expected.sort()
+
+            count = 0
+            while count < 10 and (
+                len([msg for msg in received_messages if expected_session_id in msg]) < len(expected)
+                or len(received_socket_mode_requests) < len(socket_mode_envelopes)
+            ):
+                await asyncio.sleep(0.2)
+                count += 0.2
+
+            received_messages.sort()
+
+            # Only check messages of current alive session. Ignore the disconnected session.
+            received_messages = [msg for msg in received_messages if expected_session_id in msg]
+            expected = [msg + "_" + expected_session_id for msg in expected]
+
             self.assertEqual(received_messages, expected)
 
             self.assertEqual(len(socket_mode_envelopes), len(received_socket_mode_requests))

--- a/tests/slack_sdk_async/socket_mode/test_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_websockets.py
@@ -36,7 +36,7 @@ class TestAiohttp(unittest.TestCase):
         )
         try:
             url = await client.issue_new_wss_url()
-            self.assertTrue(url.startswith("wss://"))
+            self.assertTrue(url.startswith("ws://"))
         finally:
             await client.close()
 


### PR DESCRIPTION
## Summary

- Fix the problem of monitor dies if an exception raised during reconnect before monitor created.
- Add a unit test `test_interactions_with_disconnection` for Slack server side request to disconnect.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
