### PR TITLE
fixed broken link related to documenation of modals.

### DIFF
--- a/docs/api-docs/slack_sdk/index.html
+++ b/docs/api-docs/slack_sdk/index.html
@@ -5208,7 +5208,7 @@ removed at anytime.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id})
         if isinstance(view, View):
@@ -5230,7 +5230,7 @@ removed at anytime.</p></div>
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         &#34;&#34;&#34;
@@ -5255,7 +5255,7 @@ removed at anytime.</p></div>
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         &#34;&#34;&#34;
@@ -13175,7 +13175,7 @@ multiparty direct message.</p></div>
 <dd>
 <div class="desc"><p>Open a view for a user.
 <a href="https://api.slack.com/methods/views.open">https://api.slack.com/methods/views.open</a>
-See <a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.com/block-kit/surfaces/modals</a> for details.</p></div>
+See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a> for details.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -13189,7 +13189,7 @@ See <a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Open a view for a user.
     https://api.slack.com/methods/views.open
-    See https://api.slack.com/block-kit/surfaces/modals for details.
+    See https://api.slack.com/surfaces/modals for details.
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id})
     if isinstance(view, View):
@@ -13244,7 +13244,7 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
 Push a new view onto the existing view stack by passing a view
 payload and a valid trigger_id generated from an interaction
 within the existing modal.
-Read the modals documentation (<a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.com/block-kit/surfaces/modals</a>)
+Read the modals documentation (<a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a>)
 to learn more about the lifecycle and intricacies of views.
 <a href="https://api.slack.com/methods/views.push">https://api.slack.com/methods/views.push</a></p></div>
 <details class="source">
@@ -13262,7 +13262,7 @@ to learn more about the lifecycle and intricacies of views.
     Push a new view onto the existing view stack by passing a view
     payload and a valid trigger_id generated from an interaction
     within the existing modal.
-    Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+    Read the modals documentation (https://api.slack.com/surfaces/modals)
     to learn more about the lifecycle and intricacies of views.
     https://api.slack.com/methods/views.push
     &#34;&#34;&#34;
@@ -13283,7 +13283,7 @@ to learn more about the lifecycle and intricacies of views.
 <div class="desc"><p>Update an existing view.
 Update a view by passing a new view definition along with the
 view_id returned in views.open or the external_id.
-See the modals documentation (<a href="https://api.slack.com/block-kit/surfaces/modals#updating_views">https://api.slack.com/block-kit/surfaces/modals#updating_views</a>)
+See the modals documentation (<a href="https://api.slack.com/surfaces/modals#updating_views">https://api.slack.com/surfaces/modals#updating_views</a>)
 to learn more about updating views and avoiding race conditions with the hash argument.
 <a href="https://api.slack.com/methods/views.update">https://api.slack.com/methods/views.update</a></p></div>
 <details class="source">
@@ -13302,7 +13302,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     &#34;&#34;&#34;Update an existing view.
     Update a view by passing a new view definition along with the
     view_id returned in views.open or the external_id.
-    See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+    See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
     to learn more about updating views and avoiding race conditions with the hash argument.
     https://api.slack.com/methods/views.update
     &#34;&#34;&#34;

--- a/docs/api-docs/slack_sdk/web/async_client.html
+++ b/docs/api-docs/slack_sdk/web/async_client.html
@@ -5007,7 +5007,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id})
         if isinstance(view, View):
@@ -5029,7 +5029,7 @@ class AsyncWebClient(AsyncBaseClient):
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         &#34;&#34;&#34;
@@ -5054,7 +5054,7 @@ class AsyncWebClient(AsyncBaseClient):
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         &#34;&#34;&#34;
@@ -10175,7 +10175,7 @@ removed at anytime.</p></div>
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id})
         if isinstance(view, View):
@@ -10197,7 +10197,7 @@ removed at anytime.</p></div>
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         &#34;&#34;&#34;
@@ -10222,7 +10222,7 @@ removed at anytime.</p></div>
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         &#34;&#34;&#34;
@@ -18142,7 +18142,7 @@ multiparty direct message.</p></div>
 <dd>
 <div class="desc"><p>Open a view for a user.
 <a href="https://api.slack.com/methods/views.open">https://api.slack.com/methods/views.open</a>
-See <a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.com/block-kit/surfaces/modals</a> for details.</p></div>
+See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a> for details.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -18156,7 +18156,7 @@ See <a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Open a view for a user.
     https://api.slack.com/methods/views.open
-    See https://api.slack.com/block-kit/surfaces/modals for details.
+    See https://api.slack.com/surfaces/modals for details.
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id})
     if isinstance(view, View):
@@ -18211,7 +18211,7 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
 Push a new view onto the existing view stack by passing a view
 payload and a valid trigger_id generated from an interaction
 within the existing modal.
-Read the modals documentation (<a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.com/block-kit/surfaces/modals</a>)
+Read the modals documentation (<a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a>)
 to learn more about the lifecycle and intricacies of views.
 <a href="https://api.slack.com/methods/views.push">https://api.slack.com/methods/views.push</a></p></div>
 <details class="source">
@@ -18229,7 +18229,7 @@ to learn more about the lifecycle and intricacies of views.
     Push a new view onto the existing view stack by passing a view
     payload and a valid trigger_id generated from an interaction
     within the existing modal.
-    Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+    Read the modals documentation (https://api.slack.com/surfaces/modals)
     to learn more about the lifecycle and intricacies of views.
     https://api.slack.com/methods/views.push
     &#34;&#34;&#34;
@@ -18250,7 +18250,7 @@ to learn more about the lifecycle and intricacies of views.
 <div class="desc"><p>Update an existing view.
 Update a view by passing a new view definition along with the
 view_id returned in views.open or the external_id.
-See the modals documentation (<a href="https://api.slack.com/block-kit/surfaces/modals#updating_views">https://api.slack.com/block-kit/surfaces/modals#updating_views</a>)
+See the modals documentation (<a href="https://api.slack.com/surfaces/modals#updating_views">https://api.slack.com/surfaces/modals#updating_views</a>)
 to learn more about updating views and avoiding race conditions with the hash argument.
 <a href="https://api.slack.com/methods/views.update">https://api.slack.com/methods/views.update</a></p></div>
 <details class="source">
@@ -18269,7 +18269,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     &#34;&#34;&#34;Update an existing view.
     Update a view by passing a new view definition along with the
     view_id returned in views.open or the external_id.
-    See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+    See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
     to learn more about updating views and avoiding race conditions with the hash argument.
     https://api.slack.com/methods/views.update
     &#34;&#34;&#34;

--- a/docs/api-docs/slack_sdk/web/client.html
+++ b/docs/api-docs/slack_sdk/web/client.html
@@ -4998,7 +4998,7 @@ class WebClient(BaseClient):
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id})
         if isinstance(view, View):
@@ -5020,7 +5020,7 @@ class WebClient(BaseClient):
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         &#34;&#34;&#34;
@@ -5045,7 +5045,7 @@ class WebClient(BaseClient):
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         &#34;&#34;&#34;
@@ -10166,7 +10166,7 @@ removed at anytime.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id})
         if isinstance(view, View):
@@ -10188,7 +10188,7 @@ removed at anytime.</p></div>
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         &#34;&#34;&#34;
@@ -10213,7 +10213,7 @@ removed at anytime.</p></div>
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         &#34;&#34;&#34;
@@ -18133,7 +18133,7 @@ multiparty direct message.</p></div>
 <dd>
 <div class="desc"><p>Open a view for a user.
 <a href="https://api.slack.com/methods/views.open">https://api.slack.com/methods/views.open</a>
-See <a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.com/block-kit/surfaces/modals</a> for details.</p></div>
+See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a> for details.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -18147,7 +18147,7 @@ See <a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Open a view for a user.
     https://api.slack.com/methods/views.open
-    See https://api.slack.com/block-kit/surfaces/modals for details.
+    See https://api.slack.com/surfaces/modals for details.
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id})
     if isinstance(view, View):
@@ -18202,7 +18202,7 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
 Push a new view onto the existing view stack by passing a view
 payload and a valid trigger_id generated from an interaction
 within the existing modal.
-Read the modals documentation (<a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.com/block-kit/surfaces/modals</a>)
+Read the modals documentation (<a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a>)
 to learn more about the lifecycle and intricacies of views.
 <a href="https://api.slack.com/methods/views.push">https://api.slack.com/methods/views.push</a></p></div>
 <details class="source">
@@ -18220,7 +18220,7 @@ to learn more about the lifecycle and intricacies of views.
     Push a new view onto the existing view stack by passing a view
     payload and a valid trigger_id generated from an interaction
     within the existing modal.
-    Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+    Read the modals documentation (https://api.slack.com/surfaces/modals)
     to learn more about the lifecycle and intricacies of views.
     https://api.slack.com/methods/views.push
     &#34;&#34;&#34;
@@ -18241,7 +18241,7 @@ to learn more about the lifecycle and intricacies of views.
 <div class="desc"><p>Update an existing view.
 Update a view by passing a new view definition along with the
 view_id returned in views.open or the external_id.
-See the modals documentation (<a href="https://api.slack.com/block-kit/surfaces/modals#updating_views">https://api.slack.com/block-kit/surfaces/modals#updating_views</a>)
+See the modals documentation (<a href="https://api.slack.com/surfaces/modals#updating_views">https://api.slack.com/surfaces/modals#updating_views</a>)
 to learn more about updating views and avoiding race conditions with the hash argument.
 <a href="https://api.slack.com/methods/views.update">https://api.slack.com/methods/views.update</a></p></div>
 <details class="source">
@@ -18260,7 +18260,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     &#34;&#34;&#34;Update an existing view.
     Update a view by passing a new view definition along with the
     view_id returned in views.open or the external_id.
-    See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+    See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
     to learn more about updating views and avoiding race conditions with the hash argument.
     https://api.slack.com/methods/views.update
     &#34;&#34;&#34;

--- a/docs/api-docs/slack_sdk/web/index.html
+++ b/docs/api-docs/slack_sdk/web/index.html
@@ -5419,7 +5419,7 @@ removed at anytime.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id})
         if isinstance(view, View):
@@ -5441,7 +5441,7 @@ removed at anytime.</p></div>
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         &#34;&#34;&#34;
@@ -5466,7 +5466,7 @@ removed at anytime.</p></div>
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         &#34;&#34;&#34;
@@ -13386,7 +13386,7 @@ multiparty direct message.</p></div>
 <dd>
 <div class="desc"><p>Open a view for a user.
 <a href="https://api.slack.com/methods/views.open">https://api.slack.com/methods/views.open</a>
-See <a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.com/block-kit/surfaces/modals</a> for details.</p></div>
+See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a> for details.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -13400,7 +13400,7 @@ See <a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Open a view for a user.
     https://api.slack.com/methods/views.open
-    See https://api.slack.com/block-kit/surfaces/modals for details.
+    See https://api.slack.com/surfaces/modals for details.
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id})
     if isinstance(view, View):
@@ -13455,7 +13455,7 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
 Push a new view onto the existing view stack by passing a view
 payload and a valid trigger_id generated from an interaction
 within the existing modal.
-Read the modals documentation (<a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.com/block-kit/surfaces/modals</a>)
+Read the modals documentation (<a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a>)
 to learn more about the lifecycle and intricacies of views.
 <a href="https://api.slack.com/methods/views.push">https://api.slack.com/methods/views.push</a></p></div>
 <details class="source">
@@ -13473,7 +13473,7 @@ to learn more about the lifecycle and intricacies of views.
     Push a new view onto the existing view stack by passing a view
     payload and a valid trigger_id generated from an interaction
     within the existing modal.
-    Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+    Read the modals documentation (https://api.slack.com/surfaces/modals)
     to learn more about the lifecycle and intricacies of views.
     https://api.slack.com/methods/views.push
     &#34;&#34;&#34;
@@ -13494,7 +13494,7 @@ to learn more about the lifecycle and intricacies of views.
 <div class="desc"><p>Update an existing view.
 Update a view by passing a new view definition along with the
 view_id returned in views.open or the external_id.
-See the modals documentation (<a href="https://api.slack.com/block-kit/surfaces/modals#updating_views">https://api.slack.com/block-kit/surfaces/modals#updating_views</a>)
+See the modals documentation (<a href="https://api.slack.com/surfaces/modals#updating_views">https://api.slack.com/surfaces/modals#updating_views</a>)
 to learn more about updating views and avoiding race conditions with the hash argument.
 <a href="https://api.slack.com/methods/views.update">https://api.slack.com/methods/views.update</a></p></div>
 <details class="source">
@@ -13513,7 +13513,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     &#34;&#34;&#34;Update an existing view.
     Update a view by passing a new view definition along with the
     view_id returned in views.open or the external_id.
-    See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+    See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
     to learn more about updating views and avoiding race conditions with the hash argument.
     https://api.slack.com/methods/views.update
     &#34;&#34;&#34;

--- a/docs/api-docs/slack_sdk/web/legacy_client.html
+++ b/docs/api-docs/slack_sdk/web/legacy_client.html
@@ -5008,7 +5008,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id})
         if isinstance(view, View):
@@ -5030,7 +5030,7 @@ class LegacyWebClient(LegacyBaseClient):
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         &#34;&#34;&#34;
@@ -5055,7 +5055,7 @@ class LegacyWebClient(LegacyBaseClient):
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         &#34;&#34;&#34;
@@ -10176,7 +10176,7 @@ removed at anytime.</p></div>
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id})
         if isinstance(view, View):
@@ -10198,7 +10198,7 @@ removed at anytime.</p></div>
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         &#34;&#34;&#34;
@@ -10223,7 +10223,7 @@ removed at anytime.</p></div>
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         &#34;&#34;&#34;
@@ -18143,7 +18143,7 @@ multiparty direct message.</p></div>
 <dd>
 <div class="desc"><p>Open a view for a user.
 <a href="https://api.slack.com/methods/views.open">https://api.slack.com/methods/views.open</a>
-See <a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.com/block-kit/surfaces/modals</a> for details.</p></div>
+See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a> for details.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -18157,7 +18157,7 @@ See <a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Open a view for a user.
     https://api.slack.com/methods/views.open
-    See https://api.slack.com/block-kit/surfaces/modals for details.
+    See https://api.slack.com/surfaces/modals for details.
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id})
     if isinstance(view, View):
@@ -18212,7 +18212,7 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
 Push a new view onto the existing view stack by passing a view
 payload and a valid trigger_id generated from an interaction
 within the existing modal.
-Read the modals documentation (<a href="https://api.slack.com/block-kit/surfaces/modals">https://api.slack.com/block-kit/surfaces/modals</a>)
+Read the modals documentation (<a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a>)
 to learn more about the lifecycle and intricacies of views.
 <a href="https://api.slack.com/methods/views.push">https://api.slack.com/methods/views.push</a></p></div>
 <details class="source">
@@ -18230,7 +18230,7 @@ to learn more about the lifecycle and intricacies of views.
     Push a new view onto the existing view stack by passing a view
     payload and a valid trigger_id generated from an interaction
     within the existing modal.
-    Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+    Read the modals documentation (https://api.slack.com/surfaces/modals)
     to learn more about the lifecycle and intricacies of views.
     https://api.slack.com/methods/views.push
     &#34;&#34;&#34;
@@ -18251,7 +18251,7 @@ to learn more about the lifecycle and intricacies of views.
 <div class="desc"><p>Update an existing view.
 Update a view by passing a new view definition along with the
 view_id returned in views.open or the external_id.
-See the modals documentation (<a href="https://api.slack.com/block-kit/surfaces/modals#updating_views">https://api.slack.com/block-kit/surfaces/modals#updating_views</a>)
+See the modals documentation (<a href="https://api.slack.com/surfaces/modals#updating_views">https://api.slack.com/surfaces/modals#updating_views</a>)
 to learn more about updating views and avoiding race conditions with the hash argument.
 <a href="https://api.slack.com/methods/views.update">https://api.slack.com/methods/views.update</a></p></div>
 <details class="source">
@@ -18270,7 +18270,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     &#34;&#34;&#34;Update an existing view.
     Update a view by passing a new view definition along with the
     view_id returned in views.open or the external_id.
-    See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+    See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
     to learn more about updating views and avoiding race conditions with the hash argument.
     https://api.slack.com/methods/views.update
     &#34;&#34;&#34;

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -4978,7 +4978,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         """
         kwargs.update({"trigger_id": trigger_id})
         if isinstance(view, View):
@@ -5000,7 +5000,7 @@ class AsyncWebClient(AsyncBaseClient):
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         """
@@ -5025,7 +5025,7 @@ class AsyncWebClient(AsyncBaseClient):
         """Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         """

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -4969,7 +4969,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         """
         kwargs.update({"trigger_id": trigger_id})
         if isinstance(view, View):
@@ -4991,7 +4991,7 @@ class WebClient(BaseClient):
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         """
@@ -5016,7 +5016,7 @@ class WebClient(BaseClient):
         """Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         """

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -4980,7 +4980,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Open a view for a user.
         https://api.slack.com/methods/views.open
-        See https://api.slack.com/block-kit/surfaces/modals for details.
+        See https://api.slack.com/surfaces/modals for details.
         """
         kwargs.update({"trigger_id": trigger_id})
         if isinstance(view, View):
@@ -5002,7 +5002,7 @@ class LegacyWebClient(LegacyBaseClient):
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/block-kit/surfaces/modals)
+        Read the modals documentation (https://api.slack.com/surfaces/modals)
         to learn more about the lifecycle and intricacies of views.
         https://api.slack.com/methods/views.push
         """
@@ -5027,7 +5027,7 @@ class LegacyWebClient(LegacyBaseClient):
         """Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/block-kit/surfaces/modals#updating_views)
+        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
         https://api.slack.com/methods/views.update
         """


### PR DESCRIPTION
## Summary

Fix a broken link related to the documentation of modals.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
