### PR TITLE
Fix #1450 slack_file in image block/element

### DIFF
--- a/slack_sdk/models/blocks/basic_components.py
+++ b/slack_sdk/models/blocks/basic_components.py
@@ -570,6 +570,13 @@ class SlackFile(JsonObject):
         id: Optional[str] = None,
         url: Optional[str] = None,
     ):
+        """An object containing Slack file information to be used in an image block or image element.
+        https://api.slack.com/reference/block-kit/composition-objects#slack_file
+
+        Args:
+            id: Slack ID of the file.
+            url: This URL can be the url_private or the permalink of the Slack file.
+        """
         self._id = id
         self._url = url
 

--- a/slack_sdk/models/blocks/basic_components.py
+++ b/slack_sdk/models/blocks/basic_components.py
@@ -559,3 +559,25 @@ class Workflow(JsonObject):
         else:
             json["trigger"] = self._trigger
         return json
+
+
+class SlackFile(JsonObject):
+    attributes = {"id", "url"}
+
+    def __init__(
+        self,
+        *,
+        id: Optional[str] = None,
+        url: Optional[str] = None,
+    ):
+        self._id = id
+        self._url = url
+
+    def to_dict(self) -> Dict[str, Any]:  # skipcq: PYL-W0221
+        self.validate_json()
+        json = {}
+        if self._id is not None:
+            json["id"] = self._id
+        if self._url is not None:
+            json["url"] = self._url
+        return json

--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -11,7 +11,7 @@ from slack_sdk.models.basic_objects import (
     JsonValidator,
     EnumValidator,
 )
-from .basic_components import ButtonStyles, Workflow
+from .basic_components import ButtonStyles, Workflow, SlackFile
 from .basic_components import ConfirmObject
 from .basic_components import DispatchActionConfig
 from .basic_components import MarkdownTextObject
@@ -551,13 +551,14 @@ class ImageElement(BlockElement):
 
     @property
     def attributes(self) -> Set[str]:
-        return super().attributes.union({"alt_text", "image_url"})
+        return super().attributes.union({"alt_text", "image_url", "slack_file"})
 
     def __init__(
         self,
         *,
-        image_url: Optional[str] = None,
         alt_text: Optional[str] = None,
+        image_url: Optional[str] = None,
+        slack_file: Optional[Union[Dict[str, Any], SlackFile]] = None,
         **others: dict,
     ):
         """An element to insert an image - this element can be used in section and
@@ -566,18 +567,20 @@ class ImageElement(BlockElement):
         https://api.slack.com/reference/block-kit/block-elements#image
 
         Args:
-            image_url (required): The URL of the image to be displayed.
             alt_text (required): A plain-text summary of the image. This should not contain any markup.
+            image_url: The URL of the image to be displayed.
+            slack_file: A Slack image file object that defines the source of the image.
         """
         super().__init__(type=self.type)
         show_unknown_key_warning(self, others)
 
         self.image_url = image_url
         self.alt_text = alt_text
+        self.slack_file = slack_file if slack_file is None or isinstance(slack_file, SlackFile) else SlackFile(**slack_file)
 
     @JsonValidator(f"image_url attribute cannot exceed {image_url_max_length} characters")
     def _validate_image_url_length(self) -> bool:
-        return len(self.image_url) <= self.image_url_max_length
+        return self.image_url is None or len(self.image_url) <= self.image_url_max_length
 
     @JsonValidator(f"alt_text attribute cannot exceed {alt_text_max_length} characters")
     def _validate_alt_text_length(self) -> bool:

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -334,11 +334,10 @@ class ImageBlockTests(unittest.TestCase):
         with self.assertRaises(SlackObjectFormationError):
             ImageBlock(image_url="https://example.com", alt_text="text", title=STRING_3001_CHARS).to_dict()
 
-
     def test_slack_file(self):
         self.assertDictEqual(
             {
-                "slack_file": {"url": "https://example.com" },
+                "slack_file": {"url": "https://example.com"},
                 "alt_text": "not really an image",
                 "type": "image",
             },
@@ -346,7 +345,7 @@ class ImageBlockTests(unittest.TestCase):
         )
         self.assertDictEqual(
             {
-                "slack_file": {"id": "F11111" },
+                "slack_file": {"id": "F11111"},
                 "alt_text": "not really an image",
                 "type": "image",
             },
@@ -354,20 +353,21 @@ class ImageBlockTests(unittest.TestCase):
         )
         self.assertDictEqual(
             {
-                "slack_file": {"url": "https://example.com" },
+                "slack_file": {"url": "https://example.com"},
                 "alt_text": "not really an image",
                 "type": "image",
             },
-            ImageBlock(slack_file= {"url": "https://example.com" }, alt_text="not really an image").to_dict(),
+            ImageBlock(slack_file={"url": "https://example.com"}, alt_text="not really an image").to_dict(),
         )
         self.assertDictEqual(
             {
-                "slack_file": {"id": "F11111" },
+                "slack_file": {"id": "F11111"},
                 "alt_text": "not really an image",
                 "type": "image",
             },
-            ImageBlock(slack_file={"id": "F11111" }, alt_text="not really an image").to_dict(),
+            ImageBlock(slack_file={"id": "F11111"}, alt_text="not really an image").to_dict(),
         )
+
 
 # ----------------------------------------------
 # Actions

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -29,6 +29,7 @@ from slack_sdk.models.blocks import (
     RichTextPreformattedElement,
     RichTextElementParts,
 )
+from slack_sdk.models.blocks.basic_components import SlackFile
 from . import STRING_3001_CHARS
 
 
@@ -151,7 +152,7 @@ class SectionBlockTests(unittest.TestCase):
             SectionBlock(text="some text", fields=[f"field{i}" for i in range(5)]).to_dict(),
         )
 
-        button = LinkButtonElement(text="Click me!", url="http://google.com")
+        button = LinkButtonElement(text="Click me!", url="https://example.com")
         self.assertDictEqual(
             {
                 "type": "section",
@@ -314,11 +315,11 @@ class ImageBlockTests(unittest.TestCase):
     def test_json(self):
         self.assertDictEqual(
             {
-                "image_url": "http://google.com",
+                "image_url": "https://example.com",
                 "alt_text": "not really an image",
                 "type": "image",
             },
-            ImageBlock(image_url="http://google.com", alt_text="not really an image").to_dict(),
+            ImageBlock(image_url="https://example.com", alt_text="not really an image").to_dict(),
         )
 
     def test_image_url_length(self):
@@ -327,12 +328,46 @@ class ImageBlockTests(unittest.TestCase):
 
     def test_alt_text_length(self):
         with self.assertRaises(SlackObjectFormationError):
-            ImageBlock(image_url="http://google.com", alt_text=STRING_3001_CHARS).to_dict()
+            ImageBlock(image_url="https://example.com", alt_text=STRING_3001_CHARS).to_dict()
 
     def test_title_length(self):
         with self.assertRaises(SlackObjectFormationError):
-            ImageBlock(image_url="http://google.com", alt_text="text", title=STRING_3001_CHARS).to_dict()
+            ImageBlock(image_url="https://example.com", alt_text="text", title=STRING_3001_CHARS).to_dict()
 
+
+    def test_slack_file(self):
+        self.assertDictEqual(
+            {
+                "slack_file": {"url": "https://example.com" },
+                "alt_text": "not really an image",
+                "type": "image",
+            },
+            ImageBlock(slack_file=SlackFile(url="https://example.com"), alt_text="not really an image").to_dict(),
+        )
+        self.assertDictEqual(
+            {
+                "slack_file": {"id": "F11111" },
+                "alt_text": "not really an image",
+                "type": "image",
+            },
+            ImageBlock(slack_file=SlackFile(id="F11111"), alt_text="not really an image").to_dict(),
+        )
+        self.assertDictEqual(
+            {
+                "slack_file": {"url": "https://example.com" },
+                "alt_text": "not really an image",
+                "type": "image",
+            },
+            ImageBlock(slack_file= {"url": "https://example.com" }, alt_text="not really an image").to_dict(),
+        )
+        self.assertDictEqual(
+            {
+                "slack_file": {"id": "F11111" },
+                "alt_text": "not really an image",
+                "type": "image",
+            },
+            ImageBlock(slack_file={"id": "F11111" }, alt_text="not really an image").to_dict(),
+        )
 
 # ----------------------------------------------
 # Actions
@@ -446,7 +481,7 @@ class ActionsBlockTests(unittest.TestCase):
     def test_json(self):
         self.elements = [
             ButtonElement(text="Click me", action_id="reg_button", value="1"),
-            LinkButtonElement(text="URL Button", url="http://google.com"),
+            LinkButtonElement(text="URL Button", url="https://example.com"),
         ]
         self.dict_elements = []
         for e in self.elements:

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -503,7 +503,7 @@ class ImageElementTests(unittest.TestCase):
                 "alt_text": "not really an image",
                 "type": "image",
             },
-            ImageElement(slack_file= {"url": "https://example.com"}, alt_text="not really an image").to_dict(),
+            ImageElement(slack_file={"url": "https://example.com"}, alt_text="not really an image").to_dict(),
         )
 
 

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -28,6 +28,7 @@ from slack_sdk.models.blocks import (
     InteractiveElement,
     PlainTextObject,
 )
+from slack_sdk.models.blocks.basic_components import SlackFile
 from slack_sdk.models.blocks.block_elements import (
     DateTimePickerElement,
     EmailInputElement,
@@ -186,11 +187,11 @@ class ButtonElementTests(unittest.TestCase):
 
 class LinkButtonElementTests(unittest.TestCase):
     def test_json(self):
-        button = LinkButtonElement(action_id="test", text="button text", url="http://google.com")
+        button = LinkButtonElement(action_id="test", text="button text", url="https://example.com")
         self.assertDictEqual(
             {
                 "text": {"emoji": True, "text": "button text", "type": "plain_text"},
-                "url": "http://google.com",
+                "url": "https://example.com",
                 "type": "button",
                 "action_id": button.action_id,
             },
@@ -456,11 +457,11 @@ class ImageElementTests(unittest.TestCase):
     def test_json(self):
         self.assertDictEqual(
             {
-                "image_url": "http://google.com",
+                "image_url": "https://example.com",
                 "alt_text": "not really an image",
                 "type": "image",
             },
-            ImageElement(image_url="http://google.com", alt_text="not really an image").to_dict(),
+            ImageElement(image_url="https://example.com", alt_text="not really an image").to_dict(),
         )
 
     def test_image_url_length(self):
@@ -469,7 +470,41 @@ class ImageElementTests(unittest.TestCase):
 
     def test_alt_text_length(self):
         with self.assertRaises(SlackObjectFormationError):
-            ImageElement(image_url="http://google.com", alt_text=STRING_3001_CHARS).to_dict()
+            ImageElement(image_url="https://example.com", alt_text=STRING_3001_CHARS).to_dict()
+
+    def test_slack_file(self):
+        self.assertDictEqual(
+            {
+                "slack_file": {"id": "F11111"},
+                "alt_text": "not really an image",
+                "type": "image",
+            },
+            ImageElement(slack_file=SlackFile(id="F11111"), alt_text="not really an image").to_dict(),
+        )
+        self.assertDictEqual(
+            {
+                "slack_file": {"url": "https://example.com"},
+                "alt_text": "not really an image",
+                "type": "image",
+            },
+            ImageElement(slack_file=SlackFile(url="https://example.com"), alt_text="not really an image").to_dict(),
+        )
+        self.assertDictEqual(
+            {
+                "slack_file": {"id": "F11111"},
+                "alt_text": "not really an image",
+                "type": "image",
+            },
+            ImageElement(slack_file={"id": "F11111"}, alt_text="not really an image").to_dict(),
+        )
+        self.assertDictEqual(
+            {
+                "slack_file": {"url": "https://example.com"},
+                "alt_text": "not really an image",
+                "type": "image",
+            },
+            ImageElement(slack_file= {"url": "https://example.com"}, alt_text="not really an image").to_dict(),
+        )
 
 
 # -------------------------------------------------


### PR DESCRIPTION
## Summary

This pull request resolves #1450 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
