### PR TITLE
fix: optional dependency install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack_sdk"
-dynamic = ["version", "readme", "authors"]
+dynamic = ["version", "readme", "authors", "optional-dependencies"]
 description = "The Slack API Platform SDK for Python"
 license = { text = "MIT" }
 requires-python = ">=3.6"
@@ -48,6 +48,7 @@ include = ["slack*", "slack_sdk*"]
 [tool.setuptools.dynamic]
 version = { attr = "slack_sdk.version.__version__" }
 readme = { file = ["README.md"], content-type = "text/markdown" }
+optional-dependencies.optional = { file = ["requirements/optional.txt"] }
 
 [tool.distutils.bdist_wheel]
 universal = true


### PR DESCRIPTION
## Summary

This PR aims to fix #1455 by exposing the dependencies  found in `requirements/optional.txt`

I've deployed these changes to https://test.pypi.org/project/slack-sdk/3.26.3a0/

You can test them out by executing `pip3 install -i https://test.pypi.org/simple/ 'slack-sdk[optional]==3.26.3a0'` 
NOTE: the install will fail since not all of the dependencies in `requirements/optional.txt` are in test.pypi.org


### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
