### PR TITLE
Unpin moto, and support moto 5.0 changes

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -14,4 +14,7 @@ click==8.0.4  # black is affected by https://github.com/pallets/click/issues/222
 psutil>=5,<6
 #  used only under slack_sdk/*_store
 boto3<=2
-moto>=3,<4  # For AWS tests
+# For AWS tests
+moto==4.0.13; python_version=="3.6"
+moto<5; python_version=="3.7"
+moto<6

--- a/tests/slack_sdk/oauth/installation_store/test_amazon_s3.py
+++ b/tests/slack_sdk/oauth/installation_store/test_amazon_s3.py
@@ -1,23 +1,27 @@
 import unittest
 
 import boto3
-from moto import mock_s3
+
+try:
+    from moto import mock_aws
+except ImportError:
+    from moto import mock_s3 as mock_aws
 from slack_sdk.oauth.installation_store import Installation
 from slack_sdk.oauth.installation_store.amazon_s3 import AmazonS3InstallationStore
 
 
 class TestAmazonS3(unittest.TestCase):
-    mock_s3 = mock_s3()
+    mock_aws = mock_aws()
     bucket_name = "test-bucket"
 
     def setUp(self):
-        self.mock_s3.start()
+        self.mock_aws.start()
         s3 = boto3.resource("s3")
         bucket = s3.Bucket(self.bucket_name)
         bucket.create(CreateBucketConfiguration={"LocationConstraint": "af-south-1"})
 
     def tearDown(self):
-        self.mock_s3.stop()
+        self.mock_aws.stop()
 
     def build_store(self) -> AmazonS3InstallationStore:
         return AmazonS3InstallationStore(

--- a/tests/slack_sdk/oauth/state_store/test_amazon_s3.py
+++ b/tests/slack_sdk/oauth/state_store/test_amazon_s3.py
@@ -1,22 +1,26 @@
 import unittest
 
 import boto3
-from moto import mock_s3
+
+try:
+    from moto import mock_aws
+except ImportError:
+    from moto import mock_s3 as mock_aws
 from slack_sdk.oauth.state_store.amazon_s3 import AmazonS3OAuthStateStore
 
 
 class TestAmazonS3(unittest.TestCase):
-    mock_s3 = mock_s3()
+    mock_aws = mock_aws()
     bucket_name = "test-bucket"
 
     def setUp(self):
-        self.mock_s3.start()
+        self.mock_aws.start()
         s3 = boto3.resource("s3")
         bucket = s3.Bucket(self.bucket_name)
         bucket.create(CreateBucketConfiguration={"LocationConstraint": "af-south-1"})
 
     def tearDown(self):
-        self.mock_s3.stop()
+        self.mock_aws.stop()
 
     def test_instance(self):
         store = AmazonS3OAuthStateStore(


### PR DESCRIPTION
To stop testing with old versions of moto, unpin it from version 3, to the latest, and also change the test cases to cope with the new changes.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
