### PR TITLE
fix: simplify dependency specifiers for dependabot

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -12,6 +12,5 @@ boto3<=2
 SQLAlchemy>=1.4,<3
 # Socket Mode
 # websockets 9 is not compatible with Python 3.10
-websockets>=9.1,<10; python_version=="3.6"
-websockets>=10,<13; python_version>"3.6"
+websockets>=9.1,<13
 websocket-client>=1,<2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -15,6 +15,4 @@ psutil>=5,<6
 #  used only under slack_sdk/*_store
 boto3<=2
 # For AWS tests
-moto==4.0.13; python_version=="3.6"
-moto<5; python_version=="3.7"
-moto<6
+moto>=4.0.13,<6


### PR DESCRIPTION
## Summary

Dependabot does not seem to honor the python version specifier https://github.com/dependabot/dependabot-core/issues/8346

In bolt for python we specify a version range instead of assigning a specific dependency version for each python version, this PR aims to do this

Reference: [bolt-python/adapter_testing.txt](https://github.com/slackapi/bolt-python/blob/main/requirements/adapter_testing.txt)

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
