### PR TITLE
Add link to new file upload methods

### DIFF
--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -375,7 +375,7 @@ deletion of threaded replies works the same as regular messages.</p>
 <span class="p">)</span>
 </pre></div>
 </div>
-<p>See <a class="reference external" href="https://github.com/slackapi/python-slack-sdk/releases/tag/v3.19.0">files_upload_v2 method release notes</a> for more info.</p>
+<p>Files can still be uploaded via files.upload but it is less reliable than we'd like, especially for large files. We recommend that you retire any app functionality that relies on files.upload and use files.getUploadURLExternal and files.completeUploadExternal instead. See <a href="https://api.dev1247.slack.com/messaging/files#uploading_files">Uploading files</a> and <a class="reference external" href="https://github.com/slackapi/python-slack-sdk/releases/tag/v3.19.0">files_upload_v2 method release notes</a>for more details.</p>
 <p><strong>Adding a remote file</strong></p>
 <p>You can add a file information that is stored in an external storage, not in Slack.</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="n">response</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">files_remote_add</span><span class="p">(</span>

--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -375,7 +375,7 @@ deletion of threaded replies works the same as regular messages.</p>
 <span class="p">)</span>
 </pre></div>
 </div>
-<p>Files can still be uploaded via files.upload but it is less reliable than we'd like, especially for large files. We recommend that you retire any app functionality that relies on files.upload and use files.getUploadURLExternal and files.completeUploadExternal instead. See <a href="https://api.dev1247.slack.com/messaging/files#uploading_files">Uploading files</a> and <a class="reference external" href="https://github.com/slackapi/python-slack-sdk/releases/tag/v3.19.0">files_upload_v2 method release notes</a>for more details.</p>
+<p>Files can still be uploaded via files.upload but it is less reliable than we'd like, especially for large files. We recommend that you retire any app functionality that relies on files.upload and use files.getUploadURLExternal and files.completeUploadExternal instead. See <a href="https://api.slack.com/messaging/files#uploading_files">Uploading files</a> and <a class="reference external" href="https://github.com/slackapi/python-slack-sdk/releases/tag/v3.19.0">files_upload_v2 method release notes</a>for more details.</p>
 <p><strong>Adding a remote file</strong></p>
 <p>You can add a file information that is stored in an external storage, not in Slack.</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="n">response</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">files_remote_add</span><span class="p">(</span>


### PR DESCRIPTION
## Summary

Add links to files.upload v2 details.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
