### PR TITLE
fix `RichTextElement.elements` items are never promoted to a proper Python object type

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -1868,7 +1868,7 @@ class RichTextListElement(RichTextElement):
     ):
         super().__init__(type=self.type)
         show_unknown_key_warning(self, others)
-        self.elements = elements
+        self.elements = BlockElement.parse_all(elements)
         self.style = style
         self.indent = indent
         self.offset = offset
@@ -1891,7 +1891,7 @@ class RichTextPreformattedElement(RichTextElement):
     ):
         super().__init__(type=self.type)
         show_unknown_key_warning(self, others)
-        self.elements = elements
+        self.elements = BlockElement.parse_all(elements)
         self.border = border
 
 
@@ -1910,7 +1910,7 @@ class RichTextQuoteElement(RichTextElement):
     ):
         super().__init__(type=self.type)
         show_unknown_key_warning(self, others)
-        self.elements = elements
+        self.elements = BlockElement.parse_all(elements)
 
 
 class RichTextSectionElement(RichTextElement):
@@ -1928,7 +1928,7 @@ class RichTextSectionElement(RichTextElement):
     ):
         super().__init__(type=self.type)
         show_unknown_key_warning(self, others)
-        self.elements = elements
+        self.elements = BlockElement.parse_all(elements)
 
 
 class RichTextElementParts:

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -1083,3 +1083,38 @@ class RichTextBlockTests(unittest.TestCase):
             ],
         )
         self.assertDictEqual(dict_block, class_block.to_dict())
+
+    def test_elements_are_parsed(self):
+        dict_block = {
+            "type": "rich_text",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [{"type": "text", "text": "Hello there, I am a basic rich text block!"}],
+                },
+                {
+                    "type": "rich_text_quote",
+                    "elements": [{"type": "text", "text": "this is very important"}],
+                },
+                {
+                    "type": "rich_text_preformatted",
+                    "elements": [{"type": "text", "text": 'print("Hello world")'}],
+                },
+                {
+                    "type": "rich_text_list",
+                    "elements": [
+                        {"type": "rich_text_section", "elements": [{"type": "text", "text": "a"}]},
+                    ],
+                }
+            ],
+        }
+        block = RichTextBlock(**dict_block)
+        self.assertIsInstance(block.elements[0], RichTextSectionElement)
+        self.assertIsInstance(block.elements[0].elements[0], RichTextElementParts.Text)
+        self.assertIsInstance(block.elements[1], RichTextQuoteElement)
+        self.assertIsInstance(block.elements[1].elements[0], RichTextElementParts.Text)
+        self.assertIsInstance(block.elements[2], RichTextPreformattedElement)
+        self.assertIsInstance(block.elements[2].elements[0], RichTextElementParts.Text)
+        self.assertIsInstance(block.elements[3], RichTextListElement)
+        self.assertIsInstance(block.elements[3].elements[0], RichTextSectionElement)
+        self.assertIsInstance(block.elements[3].elements[0].elements[0], RichTextElementParts.Text)

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -1105,7 +1105,7 @@ class RichTextBlockTests(unittest.TestCase):
                     "elements": [
                         {"type": "rich_text_section", "elements": [{"type": "text", "text": "a"}]},
                     ],
-                }
+                },
             ],
         }
         block = RichTextBlock(**dict_block)


### PR DESCRIPTION
## Summary

This pull request resolves #1468 

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
