### PR TITLE
Omit two websocket_client/websockets tests due to their instability on GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       PYTHON_SLACK_SDK_MOCK_SERVER_MODE: 'threading'
       CI_LARGE_SOCKET_MODE_PAYLOAD_TESTING_DISABLED: '1'
+      CI_UNSTABLE_TESTS_SKIP_ENABLED: '1'
       FORCE_COLOR: '1'
     steps:
     - uses: actions/checkout@v4

--- a/tests/slack_sdk/socket_mode/test_interactions_builtin.py
+++ b/tests/slack_sdk/socket_mode/test_interactions_builtin.py
@@ -13,7 +13,6 @@ from slack_sdk.socket_mode.client import BaseSocketModeClient
 
 from slack_sdk import WebClient
 from slack_sdk.socket_mode import SocketModeClient
-from tests.helpers import is_ci_unstable_test_skip_enabled
 from tests.slack_sdk.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
     socket_mode_envelopes,
@@ -48,9 +47,6 @@ class TestInteractionsBuiltin(unittest.TestCase):
             pass
 
     def test_interactions(self):
-        if is_ci_unstable_test_skip_enabled():
-            return
-
         default_recursion_limit = sys.getrecursionlimit()  # will restore later
         # This built-in WebSocket client internally has recursive method calls of _fetch_messages method.
         # In this test, the method calls can result in the following error when giving a quite small buffer size.
@@ -135,8 +131,6 @@ class TestInteractionsBuiltin(unittest.TestCase):
         self.logger.info(f"Passed with buffer size: {buffer_size_list}")
 
     def test_send_message_while_disconnection(self):
-        if is_ci_unstable_test_skip_enabled():
-            return
         t = Thread(target=start_socket_mode_server(self, 3011))
         t.daemon = True
         t.start()

--- a/tests/slack_sdk/socket_mode/test_interactions_websocket_client.py
+++ b/tests/slack_sdk/socket_mode/test_interactions_websocket_client.py
@@ -38,8 +38,6 @@ class TestInteractionsWebSocketClient(unittest.TestCase):
         cleanup_mock_web_api_server(self)
 
     def test_interactions(self):
-        if is_ci_unstable_test_skip_enabled():
-            return
         t = Thread(target=start_socket_mode_server(self, 3012))
         t.daemon = True
         t.start()
@@ -100,6 +98,7 @@ class TestInteractionsWebSocketClient(unittest.TestCase):
 
     def test_send_message_while_disconnection(self):
         if is_ci_unstable_test_skip_enabled():
+            # this test tends to fail on the GitHub Actions platform
             return
         t = Thread(target=start_socket_mode_server(self, 3012))
         t.daemon = True

--- a/tests/slack_sdk_async/socket_mode/test_interactions_aiohttp.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_aiohttp.py
@@ -14,7 +14,6 @@ from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
 
 from slack_sdk.socket_mode.aiohttp import SocketModeClient
 from slack_sdk.web.async_client import AsyncWebClient
-from tests.helpers import is_ci_unstable_test_skip_enabled
 from tests.slack_sdk.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
     start_socket_mode_server_with_disconnection,
@@ -44,8 +43,6 @@ class TestInteractionsAiohttp(unittest.TestCase):
 
     @async_test
     async def test_interactions(self):
-        if is_ci_unstable_test_skip_enabled():
-            return
         t = Thread(target=start_socket_mode_server(self, 3001))
         t.daemon = True
         t.start()
@@ -108,8 +105,6 @@ class TestInteractionsAiohttp(unittest.TestCase):
 
     @async_test
     async def test_interactions_with_disconnection(self):
-        if is_ci_unstable_test_skip_enabled():
-            return
         t = Thread(target=start_socket_mode_server_with_disconnection(self, 3001))
         t.daemon = True
         t.start()
@@ -196,8 +191,6 @@ class TestInteractionsAiohttp(unittest.TestCase):
 
     @async_test
     async def test_send_message_while_disconnection(self):
-        if is_ci_unstable_test_skip_enabled():
-            return
         t = Thread(target=start_socket_mode_server(self, 3001))
         t.daemon = True
         t.start()

--- a/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
@@ -42,8 +42,6 @@ class TestInteractionsWebsockets(unittest.TestCase):
 
     @async_test
     async def test_interactions(self):
-        if is_ci_unstable_test_skip_enabled():
-            return
         t = Thread(target=start_socket_mode_server(self, 3002))
         t.daemon = True
         t.start()
@@ -109,6 +107,7 @@ class TestInteractionsWebsockets(unittest.TestCase):
     @async_test
     async def test_send_message_while_disconnection(self):
         if is_ci_unstable_test_skip_enabled():
+            # this test tends to fail on the GitHub Actions platform
             return
         t = Thread(target=start_socket_mode_server(self, 3001))
         t.daemon = True


### PR DESCRIPTION
## Summary

The latest minor version of pytest (8.2), which was released a few days ago, affects some of the tests that this project has. So, this pull request locks the version to its previous for now.

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
