### PR TITLE
Fix #1496 Async client uses blocking call when uploading file with v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,11 @@ class CodegenCommand(BaseCommand):
                 async_source,
             )
             async_source = re.sub(
+                r" self._upload_file\(",
+                " await self._upload_file(",
+                async_source,
+            )
+            async_source = re.sub(
                 r" self.files_completeUploadExternal\(",
                 " await self.files_completeUploadExternal(",
                 async_source,

--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -11,6 +11,7 @@ from .async_internal_utils import (
 )  # type: ignore
 from .async_slack_response import AsyncSlackResponse
 from .deprecation import show_deprecation_warning_if_any
+from .file_upload_v2_result import FileUploadV2Result
 from .internal_utils import (
     convert_bool_to_0_or_1,
     _build_req_args,
@@ -213,4 +214,29 @@ class AsyncBaseClient:
             api_url=api_url,
             req_args=req_args,
             retry_handlers=self.retry_handlers,
+        )
+
+    async def _upload_file(
+        self,
+        *,
+        url: str,
+        data: bytes,
+        logger: logging.Logger,
+        timeout: int,
+        proxy: Optional[str],
+        ssl: Optional[SSLContext],
+    ) -> FileUploadV2Result:
+        """Upload a file using the issued upload URL"""
+        result = await _request_with_session(
+            current_session=self.session,
+            timeout=timeout,
+            logger=logger,
+            http_verb="POST",
+            api_url=url,
+            req_args={"data": data, "proxy": proxy, "ssl": ssl},
+            retry_handlers=self.retry_handlers,
+        )
+        return FileUploadV2Result(
+            status=result.get("status_code"),
+            body=result.get("body"),
         )

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -23,7 +23,6 @@ from .internal_utils import (
     _warn_if_text_or_attachment_fallback_is_missing,
     _remove_none_values,
     _to_v2_file_upload_item,
-    _upload_file_via_v2_url,
     _validate_for_legacy_client,
     _print_files_upload_v2_suggestion,
 )
@@ -3584,7 +3583,7 @@ class AsyncWebClient(AsyncBaseClient):
 
         # step2: "https://files.slack.com/upload/v1/..." per file
         for f in files:
-            upload_result = _upload_file_via_v2_url(
+            upload_result = await self._upload_file(
                 url=f["upload_url"],
                 data=f["data"],
                 logger=self._logger,
@@ -3592,9 +3591,9 @@ class AsyncWebClient(AsyncBaseClient):
                 proxy=self.proxy,
                 ssl=self.ssl,
             )
-            if upload_result.get("status") != 200:
-                status = upload_result.get("status")
-                body = upload_result.get("body")
+            if upload_result.status != 200:
+                status = upload_result.status
+                body = upload_result.body
                 message = (
                     "Failed to upload a file "
                     f"(status: {status}, body: {body}, filename: {f.get('filename')}, title: {f.get('title')})"

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -14,7 +14,6 @@ from .internal_utils import (
     _warn_if_text_or_attachment_fallback_is_missing,
     _remove_none_values,
     _to_v2_file_upload_item,
-    _upload_file_via_v2_url,
     _validate_for_legacy_client,
     _print_files_upload_v2_suggestion,
 )
@@ -3575,7 +3574,7 @@ class WebClient(BaseClient):
 
         # step2: "https://files.slack.com/upload/v1/..." per file
         for f in files:
-            upload_result = _upload_file_via_v2_url(
+            upload_result = self._upload_file(
                 url=f["upload_url"],
                 data=f["data"],
                 logger=self._logger,
@@ -3583,9 +3582,9 @@ class WebClient(BaseClient):
                 proxy=self.proxy,
                 ssl=self.ssl,
             )
-            if upload_result.get("status") != 200:
-                status = upload_result.get("status")
-                body = upload_result.get("body")
+            if upload_result.status != 200:
+                status = upload_result.status
+                body = upload_result.body
                 message = (
                     "Failed to upload a file "
                     f"(status: {status}, body: {body}, filename: {f.get('filename')}, title: {f.get('title')})"

--- a/slack_sdk/web/file_upload_v2_result.py
+++ b/slack_sdk/web/file_upload_v2_result.py
@@ -1,0 +1,7 @@
+class FileUploadV2Result:
+    status: int
+    body: str
+
+    def __init__(self, status: int, body: str):
+        self.status = status
+        self.body = body

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -377,6 +377,9 @@ def _upload_file_via_v2_url(
         else:
             raise SlackRequestError(f"Invalid proxy detected: {proxy} must be a str value")
 
+    if logger.level <= logging.DEBUG:
+        logger.debug(f"Sending a request: POST {url}")
+
     resp: Optional[HTTPResponse] = None
     req: Request = Request(method="POST", url=url, data=data, headers={})
     if opener:
@@ -388,8 +391,10 @@ def _upload_file_via_v2_url(
     body: str = resp.read().decode(charset)  # read the response body here
     if logger.level <= logging.DEBUG:
         message = (
-            "Received the following response - ",
-            f"status: {resp.status}, " f"headers: {dict(resp.headers)}, " f"body: {body}",
+            "Received the following response - "
+            f"status: {resp.status}, "
+            f"headers: {dict(resp.headers)}, "
+            f"body: {body}"
         )
         logger.debug(message)
 

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -25,7 +25,6 @@ from .internal_utils import (
     _warn_if_text_or_attachment_fallback_is_missing,
     _remove_none_values,
     _to_v2_file_upload_item,
-    _upload_file_via_v2_url,
     _validate_for_legacy_client,
     _print_files_upload_v2_suggestion,
 )
@@ -3586,7 +3585,7 @@ class LegacyWebClient(LegacyBaseClient):
 
         # step2: "https://files.slack.com/upload/v1/..." per file
         for f in files:
-            upload_result = _upload_file_via_v2_url(
+            upload_result = self._upload_file(
                 url=f["upload_url"],
                 data=f["data"],
                 logger=self._logger,
@@ -3594,9 +3593,9 @@ class LegacyWebClient(LegacyBaseClient):
                 proxy=self.proxy,
                 ssl=self.ssl,
             )
-            if upload_result.get("status") != 200:
-                status = upload_result.get("status")
-                body = upload_result.get("body")
+            if upload_result.status != 200:
+                status = upload_result.status
+                body = upload_result.body
                 message = (
                     "Failed to upload a file "
                     f"(status: {status}, body: {body}, filename: {f.get('filename')}, title: {f.get('title')})"


### PR DESCRIPTION
## Summary

This pull request resolves #1496 

### Category (place an `x` in each of the `[ ]`)

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
