### PR TITLE
chore: align README pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 <p align="center">
     <a href="https://github.com/slackapi/python-slack-sdk/actions/workflows/ci-build.yml">
-        <img alt="CI Build" src="https://img.shields.io/github/actions/workflow/status/slackapi/python-slack-sdk/ci-build.yml?style=flat-square"></a>
+        <img alt="CI Build" src="https://img.shields.io/github/actions/workflow/status/slackapi/python-slack-sdk/ci-build.yml"></a>
     <a href="https://codecov.io/gh/slackapi/python-slack-sdk">
-        <img alt="Codecov" src="https://img.shields.io/codecov/c/gh/slackapi/python-slack-sdk?style=flat-square"></a>
+        <img alt="Codecov" src="https://img.shields.io/codecov/c/gh/slackapi/python-slack-sdk"></a>
     <a href="https://pepy.tech/project/slack-sdk">
-        <img alt="Pepy Total Downloads" src="https://img.shields.io/pepy/dt/slack-sdk?style=flat-square"></a>
+        <img alt="Pepy Total Downloads" src="https://img.shields.io/pepy/dt/slack-sdk"></a>
     <br>
     <a href="https://pypi.org/project/slack-sdk/">
-        <img alt="PyPI - Version" src="https://img.shields.io/pypi/v/slack-sdk?style=flat-square"></a>
+        <img alt="PyPI - Version" src="https://img.shields.io/pypi/v/slack-sdk"></a>
     <a href="https://pypi.org/project/slack-sdk/">
-        <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/slack-sdk.svg?style=flat-square"></a>
+        <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/slack-sdk.svg"></a>
     <a href="https://slack.dev/python-slack-sdk/">
-        <img alt="Documentation" src="https://img.shields.io/badge/dev-docs-yellow?style=flat-square"></a>
+        <img alt="Documentation" src="https://img.shields.io/badge/dev-docs-yellow"></a>
 </p>
 
 The Slack platform offers several APIs to build apps. Each Slack API delivers part of the capabilities from the platform, so that you can pick just those that fit for your needs. This SDK offers a corresponding package for each of Slack’s APIs. They are small and powerful when used independently, and work seamlessly when used together, too.


### PR DESCRIPTION
## Summary

This PR updates the readme to follow the same pattern found in `bolt`, the `sdk` and the `hooks` projects

[Preview](https://github.com/WilliamBergamin/python-slack-sdk/blob/update-readme/README.md)

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
