### PR TITLE
chore(release): 3.30.0

### DIFF
--- a/docs/api-docs/slack_sdk/index.html
+++ b/docs/api-docs/slack_sdk/index.html
@@ -4926,6 +4926,42 @@ removed at anytime.</p></div>
         &#34;&#34;&#34;
         return self.api_call(&#34;team.billing.info&#34;, params=kwargs)
 
+    def team_externalTeams_list(
+        self,
+        *,
+        connection_status_filter: Optional[str] = None,
+        slack_connect_pref_filter: Optional[Sequence[str]] = None,
+        sort_direction: Optional[str] = None,
+        sort_field: Optional[str] = None,
+        workspace_filter: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+        https://api.slack.com/methods/team.externalTeams.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;connection_status_filter&#34;: connection_status_filter,
+                &#34;sort_direction&#34;: sort_direction,
+                &#34;sort_field&#34;: sort_field,
+                &#34;cursor&#34;: cursor,
+                &#34;limit&#34;: limit,
+            }
+        )
+        if slack_connect_pref_filter is not None:
+            if isinstance(slack_connect_pref_filter, (list, Tuple)):
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+            else:
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+        if workspace_filter is not None:
+            if isinstance(workspace_filter, (list, Tuple)):
+                kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+            else:
+                kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+        return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
     def team_info(
         self,
         *,
@@ -12833,6 +12869,53 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.billing.info&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
+<dt id="slack_sdk.WebClient.team_externalTeams_list"><code class="name flex">
+<span>def <span class="ident">team_externalTeams_list</span></span>(<span>self, *, connection_status_filter: Optional[str] = None, slack_connect_pref_filter: Optional[Sequence[str]] = None, sort_direction: Optional[str] = None, sort_field: Optional[str] = None, workspace_filter: Optional[Sequence[str]] = None, cursor: Optional[str] = None, limit: Optional[int] = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a list of all the external teams connected and details about the connection.
+<a href="https://api.slack.com/methods/team.externalTeams.list">https://api.slack.com/methods/team.externalTeams.list</a></p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def team_externalTeams_list(
+    self,
+    *,
+    connection_status_filter: Optional[str] = None,
+    slack_connect_pref_filter: Optional[Sequence[str]] = None,
+    sort_direction: Optional[str] = None,
+    sort_field: Optional[str] = None,
+    workspace_filter: Optional[Sequence[str]] = None,
+    cursor: Optional[str] = None,
+    limit: Optional[int] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+    https://api.slack.com/methods/team.externalTeams.list
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;connection_status_filter&#34;: connection_status_filter,
+            &#34;sort_direction&#34;: sort_direction,
+            &#34;sort_field&#34;: sort_field,
+            &#34;cursor&#34;: cursor,
+            &#34;limit&#34;: limit,
+        }
+    )
+    if slack_connect_pref_filter is not None:
+        if isinstance(slack_connect_pref_filter, (list, Tuple)):
+            kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+        else:
+            kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+    if workspace_filter is not None:
+        if isinstance(workspace_filter, (list, Tuple)):
+            kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+        else:
+            kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+    return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
+</details>
+</dd>
 <dt id="slack_sdk.WebClient.team_info"><code class="name flex">
 <span>def <span class="ident">team_info</span></span>(<span>self, *, team: Optional[str] = None, domain: Optional[str] = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
@@ -14503,6 +14586,7 @@ if you give this argument, body_params and files will be skipped</dd>
 <li><code><a title="slack_sdk.WebClient.team_accessLogs" href="#slack_sdk.WebClient.team_accessLogs">team_accessLogs</a></code></li>
 <li><code><a title="slack_sdk.WebClient.team_billableInfo" href="#slack_sdk.WebClient.team_billableInfo">team_billableInfo</a></code></li>
 <li><code><a title="slack_sdk.WebClient.team_billing_info" href="#slack_sdk.WebClient.team_billing_info">team_billing_info</a></code></li>
+<li><code><a title="slack_sdk.WebClient.team_externalTeams_list" href="#slack_sdk.WebClient.team_externalTeams_list">team_externalTeams_list</a></code></li>
 <li><code><a title="slack_sdk.WebClient.team_info" href="#slack_sdk.WebClient.team_info">team_info</a></code></li>
 <li><code><a title="slack_sdk.WebClient.team_integrationLogs" href="#slack_sdk.WebClient.team_integrationLogs">team_integrationLogs</a></code></li>
 <li><code><a title="slack_sdk.WebClient.team_preferences_list" href="#slack_sdk.WebClient.team_preferences_list">team_preferences_list</a></code></li>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/file/index.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/file/index.html
@@ -291,7 +291,7 @@ class FileInstallationStore(InstallationStore, AsyncInstallationStore):
 <dl>
 <dt id="slack_sdk.oauth.installation_store.file.FileInstallationStore"><code class="flex name class">
 <span>class <span class="ident">FileInstallationStore</span></span>
-<span>(</span><span>*, base_dir: str = '/Users/kazuhiro.sera/.bolt-app-installation', historical_data_enabled: bool = True, client_id: Optional[str] = None, logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*, base_dir: str = '/Users/wbergamin/.bolt-app-installation', historical_data_enabled: bool = True, client_id: Optional[str] = None, logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>The installation store interface.</p>

--- a/docs/api-docs/slack_sdk/oauth/installation_store/index.html
+++ b/docs/api-docs/slack_sdk/oauth/installation_store/index.html
@@ -327,7 +327,7 @@ __all__ = [
 </dd>
 <dt id="slack_sdk.oauth.installation_store.FileInstallationStore"><code class="flex name class">
 <span>class <span class="ident">FileInstallationStore</span></span>
-<span>(</span><span>*, base_dir: str = '/Users/kazuhiro.sera/.bolt-app-installation', historical_data_enabled: bool = True, client_id: Optional[str] = None, logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*, base_dir: str = '/Users/wbergamin/.bolt-app-installation', historical_data_enabled: bool = True, client_id: Optional[str] = None, logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>The installation store interface.</p>

--- a/docs/api-docs/slack_sdk/oauth/state_store/file/index.html
+++ b/docs/api-docs/slack_sdk/oauth/state_store/file/index.html
@@ -110,7 +110,7 @@ class FileOAuthStateStore(OAuthStateStore, AsyncOAuthStateStore):
 <dl>
 <dt id="slack_sdk.oauth.state_store.file.FileOAuthStateStore"><code class="flex name class">
 <span>class <span class="ident">FileOAuthStateStore</span></span>
-<span>(</span><span>*, expiration_seconds: int, base_dir: str = '/Users/kazuhiro.sera/.bolt-app-oauth-state', client_id: Optional[str] = None, logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*, expiration_seconds: int, base_dir: str = '/Users/wbergamin/.bolt-app-oauth-state', client_id: Optional[str] = None, logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>

--- a/docs/api-docs/slack_sdk/oauth/state_store/index.html
+++ b/docs/api-docs/slack_sdk/oauth/state_store/index.html
@@ -80,7 +80,7 @@ __all__ = [
 <dl>
 <dt id="slack_sdk.oauth.state_store.FileOAuthStateStore"><code class="flex name class">
 <span>class <span class="ident">FileOAuthStateStore</span></span>
-<span>(</span><span>*, expiration_seconds: int, base_dir: str = '/Users/kazuhiro.sera/.bolt-app-oauth-state', client_id: Optional[str] = None, logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*, expiration_seconds: int, base_dir: str = '/Users/wbergamin/.bolt-app-oauth-state', client_id: Optional[str] = None, logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>

--- a/docs/api-docs/slack_sdk/web/async_client.html
+++ b/docs/api-docs/slack_sdk/web/async_client.html
@@ -4724,6 +4724,42 @@ class AsyncWebClient(AsyncBaseClient):
         &#34;&#34;&#34;
         return await self.api_call(&#34;team.billing.info&#34;, params=kwargs)
 
+    async def team_externalTeams_list(
+        self,
+        *,
+        connection_status_filter: Optional[str] = None,
+        slack_connect_pref_filter: Optional[Sequence[str]] = None,
+        sort_direction: Optional[str] = None,
+        sort_field: Optional[str] = None,
+        workspace_filter: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+        https://api.slack.com/methods/team.externalTeams.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;connection_status_filter&#34;: connection_status_filter,
+                &#34;sort_direction&#34;: sort_direction,
+                &#34;sort_field&#34;: sort_field,
+                &#34;cursor&#34;: cursor,
+                &#34;limit&#34;: limit,
+            }
+        )
+        if slack_connect_pref_filter is not None:
+            if isinstance(slack_connect_pref_filter, (list, Tuple)):
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+            else:
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+        if workspace_filter is not None:
+            if isinstance(workspace_filter, (list, Tuple)):
+                kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+            else:
+                kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+        return await self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
     async def team_info(
         self,
         *,
@@ -10016,6 +10052,42 @@ removed at anytime.</p></div>
         https://api.slack.com/methods/team.billing.info
         &#34;&#34;&#34;
         return await self.api_call(&#34;team.billing.info&#34;, params=kwargs)
+
+    async def team_externalTeams_list(
+        self,
+        *,
+        connection_status_filter: Optional[str] = None,
+        slack_connect_pref_filter: Optional[Sequence[str]] = None,
+        sort_direction: Optional[str] = None,
+        sort_field: Optional[str] = None,
+        workspace_filter: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+        https://api.slack.com/methods/team.externalTeams.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;connection_status_filter&#34;: connection_status_filter,
+                &#34;sort_direction&#34;: sort_direction,
+                &#34;sort_field&#34;: sort_field,
+                &#34;cursor&#34;: cursor,
+                &#34;limit&#34;: limit,
+            }
+        )
+        if slack_connect_pref_filter is not None:
+            if isinstance(slack_connect_pref_filter, (list, Tuple)):
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+            else:
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+        if workspace_filter is not None:
+            if isinstance(workspace_filter, (list, Tuple)):
+                kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+            else:
+                kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+        return await self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
     async def team_info(
         self,
@@ -17924,6 +17996,53 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;team.billing.info&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.team_externalTeams_list"><code class="name flex">
+<span>async def <span class="ident">team_externalTeams_list</span></span>(<span>self, *, connection_status_filter: Optional[str] = None, slack_connect_pref_filter: Optional[Sequence[str]] = None, sort_direction: Optional[str] = None, sort_field: Optional[str] = None, workspace_filter: Optional[Sequence[str]] = None, cursor: Optional[str] = None, limit: Optional[int] = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a list of all the external teams connected and details about the connection.
+<a href="https://api.slack.com/methods/team.externalTeams.list">https://api.slack.com/methods/team.externalTeams.list</a></p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def team_externalTeams_list(
+    self,
+    *,
+    connection_status_filter: Optional[str] = None,
+    slack_connect_pref_filter: Optional[Sequence[str]] = None,
+    sort_direction: Optional[str] = None,
+    sort_field: Optional[str] = None,
+    workspace_filter: Optional[Sequence[str]] = None,
+    cursor: Optional[str] = None,
+    limit: Optional[int] = None,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+    https://api.slack.com/methods/team.externalTeams.list
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;connection_status_filter&#34;: connection_status_filter,
+            &#34;sort_direction&#34;: sort_direction,
+            &#34;sort_field&#34;: sort_field,
+            &#34;cursor&#34;: cursor,
+            &#34;limit&#34;: limit,
+        }
+    )
+    if slack_connect_pref_filter is not None:
+        if isinstance(slack_connect_pref_filter, (list, Tuple)):
+            kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+        else:
+            kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+    if workspace_filter is not None:
+        if isinstance(workspace_filter, (list, Tuple)):
+            kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+        else:
+            kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+    return await self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
+</details>
+</dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.team_info"><code class="name flex">
 <span>async def <span class="ident">team_info</span></span>(<span>self, *, team: Optional[str] = None, domain: Optional[str] = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
@@ -19133,6 +19252,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.team_accessLogs" href="#slack_sdk.web.async_client.AsyncWebClient.team_accessLogs">team_accessLogs</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.team_billableInfo" href="#slack_sdk.web.async_client.AsyncWebClient.team_billableInfo">team_billableInfo</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.team_billing_info" href="#slack_sdk.web.async_client.AsyncWebClient.team_billing_info">team_billing_info</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.team_externalTeams_list" href="#slack_sdk.web.async_client.AsyncWebClient.team_externalTeams_list">team_externalTeams_list</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.team_info" href="#slack_sdk.web.async_client.AsyncWebClient.team_info">team_info</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.team_integrationLogs" href="#slack_sdk.web.async_client.AsyncWebClient.team_integrationLogs">team_integrationLogs</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.team_preferences_list" href="#slack_sdk.web.async_client.AsyncWebClient.team_preferences_list">team_preferences_list</a></code></li>

--- a/docs/api-docs/slack_sdk/web/client.html
+++ b/docs/api-docs/slack_sdk/web/client.html
@@ -4715,6 +4715,42 @@ class WebClient(BaseClient):
         &#34;&#34;&#34;
         return self.api_call(&#34;team.billing.info&#34;, params=kwargs)
 
+    def team_externalTeams_list(
+        self,
+        *,
+        connection_status_filter: Optional[str] = None,
+        slack_connect_pref_filter: Optional[Sequence[str]] = None,
+        sort_direction: Optional[str] = None,
+        sort_field: Optional[str] = None,
+        workspace_filter: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+        https://api.slack.com/methods/team.externalTeams.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;connection_status_filter&#34;: connection_status_filter,
+                &#34;sort_direction&#34;: sort_direction,
+                &#34;sort_field&#34;: sort_field,
+                &#34;cursor&#34;: cursor,
+                &#34;limit&#34;: limit,
+            }
+        )
+        if slack_connect_pref_filter is not None:
+            if isinstance(slack_connect_pref_filter, (list, Tuple)):
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+            else:
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+        if workspace_filter is not None:
+            if isinstance(workspace_filter, (list, Tuple)):
+                kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+            else:
+                kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+        return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
     def team_info(
         self,
         *,
@@ -10007,6 +10043,42 @@ removed at anytime.</p></div>
         https://api.slack.com/methods/team.billing.info
         &#34;&#34;&#34;
         return self.api_call(&#34;team.billing.info&#34;, params=kwargs)
+
+    def team_externalTeams_list(
+        self,
+        *,
+        connection_status_filter: Optional[str] = None,
+        slack_connect_pref_filter: Optional[Sequence[str]] = None,
+        sort_direction: Optional[str] = None,
+        sort_field: Optional[str] = None,
+        workspace_filter: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+        https://api.slack.com/methods/team.externalTeams.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;connection_status_filter&#34;: connection_status_filter,
+                &#34;sort_direction&#34;: sort_direction,
+                &#34;sort_field&#34;: sort_field,
+                &#34;cursor&#34;: cursor,
+                &#34;limit&#34;: limit,
+            }
+        )
+        if slack_connect_pref_filter is not None:
+            if isinstance(slack_connect_pref_filter, (list, Tuple)):
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+            else:
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+        if workspace_filter is not None:
+            if isinstance(workspace_filter, (list, Tuple)):
+                kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+            else:
+                kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+        return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
     def team_info(
         self,
@@ -17915,6 +17987,53 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.billing.info&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
+<dt id="slack_sdk.web.client.WebClient.team_externalTeams_list"><code class="name flex">
+<span>def <span class="ident">team_externalTeams_list</span></span>(<span>self, *, connection_status_filter: Optional[str] = None, slack_connect_pref_filter: Optional[Sequence[str]] = None, sort_direction: Optional[str] = None, sort_field: Optional[str] = None, workspace_filter: Optional[Sequence[str]] = None, cursor: Optional[str] = None, limit: Optional[int] = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a list of all the external teams connected and details about the connection.
+<a href="https://api.slack.com/methods/team.externalTeams.list">https://api.slack.com/methods/team.externalTeams.list</a></p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def team_externalTeams_list(
+    self,
+    *,
+    connection_status_filter: Optional[str] = None,
+    slack_connect_pref_filter: Optional[Sequence[str]] = None,
+    sort_direction: Optional[str] = None,
+    sort_field: Optional[str] = None,
+    workspace_filter: Optional[Sequence[str]] = None,
+    cursor: Optional[str] = None,
+    limit: Optional[int] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+    https://api.slack.com/methods/team.externalTeams.list
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;connection_status_filter&#34;: connection_status_filter,
+            &#34;sort_direction&#34;: sort_direction,
+            &#34;sort_field&#34;: sort_field,
+            &#34;cursor&#34;: cursor,
+            &#34;limit&#34;: limit,
+        }
+    )
+    if slack_connect_pref_filter is not None:
+        if isinstance(slack_connect_pref_filter, (list, Tuple)):
+            kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+        else:
+            kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+    if workspace_filter is not None:
+        if isinstance(workspace_filter, (list, Tuple)):
+            kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+        else:
+            kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+    return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
+</details>
+</dd>
 <dt id="slack_sdk.web.client.WebClient.team_info"><code class="name flex">
 <span>def <span class="ident">team_info</span></span>(<span>self, *, team: Optional[str] = None, domain: Optional[str] = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
@@ -19123,6 +19242,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.client.WebClient.team_accessLogs" href="#slack_sdk.web.client.WebClient.team_accessLogs">team_accessLogs</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.team_billableInfo" href="#slack_sdk.web.client.WebClient.team_billableInfo">team_billableInfo</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.team_billing_info" href="#slack_sdk.web.client.WebClient.team_billing_info">team_billing_info</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.team_externalTeams_list" href="#slack_sdk.web.client.WebClient.team_externalTeams_list">team_externalTeams_list</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.team_info" href="#slack_sdk.web.client.WebClient.team_info">team_info</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.team_integrationLogs" href="#slack_sdk.web.client.WebClient.team_integrationLogs">team_integrationLogs</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.team_preferences_list" href="#slack_sdk.web.client.WebClient.team_preferences_list">team_preferences_list</a></code></li>

--- a/docs/api-docs/slack_sdk/web/index.html
+++ b/docs/api-docs/slack_sdk/web/index.html
@@ -5141,6 +5141,42 @@ removed at anytime.</p></div>
         &#34;&#34;&#34;
         return self.api_call(&#34;team.billing.info&#34;, params=kwargs)
 
+    def team_externalTeams_list(
+        self,
+        *,
+        connection_status_filter: Optional[str] = None,
+        slack_connect_pref_filter: Optional[Sequence[str]] = None,
+        sort_direction: Optional[str] = None,
+        sort_field: Optional[str] = None,
+        workspace_filter: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+        https://api.slack.com/methods/team.externalTeams.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;connection_status_filter&#34;: connection_status_filter,
+                &#34;sort_direction&#34;: sort_direction,
+                &#34;sort_field&#34;: sort_field,
+                &#34;cursor&#34;: cursor,
+                &#34;limit&#34;: limit,
+            }
+        )
+        if slack_connect_pref_filter is not None:
+            if isinstance(slack_connect_pref_filter, (list, Tuple)):
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+            else:
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+        if workspace_filter is not None:
+            if isinstance(workspace_filter, (list, Tuple)):
+                kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+            else:
+                kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+        return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
     def team_info(
         self,
         *,
@@ -13048,6 +13084,53 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.billing.info&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
+<dt id="slack_sdk.web.WebClient.team_externalTeams_list"><code class="name flex">
+<span>def <span class="ident">team_externalTeams_list</span></span>(<span>self, *, connection_status_filter: Optional[str] = None, slack_connect_pref_filter: Optional[Sequence[str]] = None, sort_direction: Optional[str] = None, sort_field: Optional[str] = None, workspace_filter: Optional[Sequence[str]] = None, cursor: Optional[str] = None, limit: Optional[int] = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a list of all the external teams connected and details about the connection.
+<a href="https://api.slack.com/methods/team.externalTeams.list">https://api.slack.com/methods/team.externalTeams.list</a></p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def team_externalTeams_list(
+    self,
+    *,
+    connection_status_filter: Optional[str] = None,
+    slack_connect_pref_filter: Optional[Sequence[str]] = None,
+    sort_direction: Optional[str] = None,
+    sort_field: Optional[str] = None,
+    workspace_filter: Optional[Sequence[str]] = None,
+    cursor: Optional[str] = None,
+    limit: Optional[int] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+    https://api.slack.com/methods/team.externalTeams.list
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;connection_status_filter&#34;: connection_status_filter,
+            &#34;sort_direction&#34;: sort_direction,
+            &#34;sort_field&#34;: sort_field,
+            &#34;cursor&#34;: cursor,
+            &#34;limit&#34;: limit,
+        }
+    )
+    if slack_connect_pref_filter is not None:
+        if isinstance(slack_connect_pref_filter, (list, Tuple)):
+            kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+        else:
+            kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+    if workspace_filter is not None:
+        if isinstance(workspace_filter, (list, Tuple)):
+            kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+        else:
+            kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+    return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
+</details>
+</dd>
 <dt id="slack_sdk.web.WebClient.team_info"><code class="name flex">
 <span>def <span class="ident">team_info</span></span>(<span>self, *, team: Optional[str] = None, domain: Optional[str] = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
@@ -14280,6 +14363,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.WebClient.team_accessLogs" href="#slack_sdk.web.WebClient.team_accessLogs">team_accessLogs</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.team_billableInfo" href="#slack_sdk.web.WebClient.team_billableInfo">team_billableInfo</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.team_billing_info" href="#slack_sdk.web.WebClient.team_billing_info">team_billing_info</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.team_externalTeams_list" href="#slack_sdk.web.WebClient.team_externalTeams_list">team_externalTeams_list</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.team_info" href="#slack_sdk.web.WebClient.team_info">team_info</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.team_integrationLogs" href="#slack_sdk.web.WebClient.team_integrationLogs">team_integrationLogs</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.team_preferences_list" href="#slack_sdk.web.WebClient.team_preferences_list">team_preferences_list</a></code></li>

--- a/docs/api-docs/slack_sdk/web/legacy_client.html
+++ b/docs/api-docs/slack_sdk/web/legacy_client.html
@@ -4725,6 +4725,42 @@ class LegacyWebClient(LegacyBaseClient):
         &#34;&#34;&#34;
         return self.api_call(&#34;team.billing.info&#34;, params=kwargs)
 
+    def team_externalTeams_list(
+        self,
+        *,
+        connection_status_filter: Optional[str] = None,
+        slack_connect_pref_filter: Optional[Sequence[str]] = None,
+        sort_direction: Optional[str] = None,
+        sort_field: Optional[str] = None,
+        workspace_filter: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+        https://api.slack.com/methods/team.externalTeams.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;connection_status_filter&#34;: connection_status_filter,
+                &#34;sort_direction&#34;: sort_direction,
+                &#34;sort_field&#34;: sort_field,
+                &#34;cursor&#34;: cursor,
+                &#34;limit&#34;: limit,
+            }
+        )
+        if slack_connect_pref_filter is not None:
+            if isinstance(slack_connect_pref_filter, (list, Tuple)):
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+            else:
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+        if workspace_filter is not None:
+            if isinstance(workspace_filter, (list, Tuple)):
+                kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+            else:
+                kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+        return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
     def team_info(
         self,
         *,
@@ -10017,6 +10053,42 @@ removed at anytime.</p></div>
         https://api.slack.com/methods/team.billing.info
         &#34;&#34;&#34;
         return self.api_call(&#34;team.billing.info&#34;, params=kwargs)
+
+    def team_externalTeams_list(
+        self,
+        *,
+        connection_status_filter: Optional[str] = None,
+        slack_connect_pref_filter: Optional[Sequence[str]] = None,
+        sort_direction: Optional[str] = None,
+        sort_field: Optional[str] = None,
+        workspace_filter: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+        https://api.slack.com/methods/team.externalTeams.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;connection_status_filter&#34;: connection_status_filter,
+                &#34;sort_direction&#34;: sort_direction,
+                &#34;sort_field&#34;: sort_field,
+                &#34;cursor&#34;: cursor,
+                &#34;limit&#34;: limit,
+            }
+        )
+        if slack_connect_pref_filter is not None:
+            if isinstance(slack_connect_pref_filter, (list, Tuple)):
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+            else:
+                kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+        if workspace_filter is not None:
+            if isinstance(workspace_filter, (list, Tuple)):
+                kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+            else:
+                kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+        return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
     def team_info(
         self,
@@ -17925,6 +17997,53 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.billing.info&#34;, params=kwargs)</code></pre>
 </details>
 </dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_externalTeams_list"><code class="name flex">
+<span>def <span class="ident">team_externalTeams_list</span></span>(<span>self, *, connection_status_filter: Optional[str] = None, slack_connect_pref_filter: Optional[Sequence[str]] = None, sort_direction: Optional[str] = None, sort_field: Optional[str] = None, workspace_filter: Optional[Sequence[str]] = None, cursor: Optional[str] = None, limit: Optional[int] = None, **kwargs) ‑> Union[_asyncio.Future, <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a>]</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a list of all the external teams connected and details about the connection.
+<a href="https://api.slack.com/methods/team.externalTeams.list">https://api.slack.com/methods/team.externalTeams.list</a></p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def team_externalTeams_list(
+    self,
+    *,
+    connection_status_filter: Optional[str] = None,
+    slack_connect_pref_filter: Optional[Sequence[str]] = None,
+    sort_direction: Optional[str] = None,
+    sort_field: Optional[str] = None,
+    workspace_filter: Optional[Sequence[str]] = None,
+    cursor: Optional[str] = None,
+    limit: Optional[int] = None,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
+    https://api.slack.com/methods/team.externalTeams.list
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;connection_status_filter&#34;: connection_status_filter,
+            &#34;sort_direction&#34;: sort_direction,
+            &#34;sort_field&#34;: sort_field,
+            &#34;cursor&#34;: cursor,
+            &#34;limit&#34;: limit,
+        }
+    )
+    if slack_connect_pref_filter is not None:
+        if isinstance(slack_connect_pref_filter, (list, Tuple)):
+            kwargs.update({&#34;slack_connect_pref_filter&#34;: &#34;,&#34;.join(slack_connect_pref_filter)})
+        else:
+            kwargs.update({&#34;slack_connect_pref_filter&#34;: slack_connect_pref_filter})
+    if workspace_filter is not None:
+        if isinstance(workspace_filter, (list, Tuple)):
+            kwargs.update({&#34;workspace_filter&#34;: &#34;,&#34;.join(workspace_filter)})
+        else:
+            kwargs.update({&#34;workspace_filter&#34;: workspace_filter})
+    return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
+</details>
+</dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_info"><code class="name flex">
 <span>def <span class="ident">team_info</span></span>(<span>self, *, team: Optional[str] = None, domain: Optional[str] = None, **kwargs) ‑> Union[_asyncio.Future, <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a>]</span>
 </code></dt>
@@ -19133,6 +19252,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.team_accessLogs" href="#slack_sdk.web.legacy_client.LegacyWebClient.team_accessLogs">team_accessLogs</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.team_billableInfo" href="#slack_sdk.web.legacy_client.LegacyWebClient.team_billableInfo">team_billableInfo</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.team_billing_info" href="#slack_sdk.web.legacy_client.LegacyWebClient.team_billing_info">team_billing_info</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.team_externalTeams_list" href="#slack_sdk.web.legacy_client.LegacyWebClient.team_externalTeams_list">team_externalTeams_list</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.team_info" href="#slack_sdk.web.legacy_client.LegacyWebClient.team_info">team_info</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.team_integrationLogs" href="#slack_sdk.web.legacy_client.LegacyWebClient.team_integrationLogs">team_integrationLogs</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.team_preferences_list" href="#slack_sdk.web.legacy_client.LegacyWebClient.team_preferences_list">team_preferences_list</a></code></li>

--- a/slack_sdk/version.py
+++ b/slack_sdk/version.py
@@ -1,2 +1,2 @@
 """Check the latest version at https://pypi.org/project/slack-sdk/"""
-__version__ = "3.29.0"
+__version__ = "3.30.0"


### PR DESCRIPTION
## Summary

Bump version for release

### Category (place an `x` in each of the `[ ]`)

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs-src` (Documents, have you run `./scripts/docs.sh`?)
- [ ] `/docs-src-v2` (Documents, have you run `./scripts/docs-v2.sh`?)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements (place an `x` in each `[ ]`)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
