### PR TITLE
Docs: remove line breaks in md intros for unfurls

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
 - [ ] **slack_sdk.scim** (SCIM API client)
 - [ ] **slack_sdk.audit_logs** (Audit Logs API client)
 - [ ] **slack_sdk.rtm_v2** (RTM client)
-- [ ] `/docs-src` (Documents)
+- [ ] `/docs` (Documents)
 - [ ] `/tutorial` (PythOnBoardingBot tutorial)
 - [ ] `tests`/`integration_tests` (Automated tests for this library)
 

--- a/docs/content/audit-logs.md
+++ b/docs/content/audit-logs.md
@@ -1,20 +1,10 @@
 # Audit Logs API Client
 
-[Audit Logs API](https://api.slack.com/admins/audit-logs) is a set of
-APIs for monitoring what's happening in your [Enterprise
-Grid](https://api.slack.com/enterprise/grid) organization.
+[Audit Logs API](https://api.slack.com/admins/audit-logs) is a set of APIs for monitoring what's happening in your [Enterprise Grid](https://api.slack.com/enterprise/grid) organization.
 
-The Audit Logs API can be used by security information and event
-management (SIEM) tools to provide an analysis of how your Slack
-organization is being accessed. You can also use this API to write your
-own applications to see how members of your organization are using
-Slack.
+The Audit Logs API can be used by security information and event management (SIEM) tools to provide an analysis of how your Slack organization is being accessed. You can also use this API to write your own applications to see how members of your organization are using Slack.
 
-Follow the instructions in [the API
-document](https://api.slack.com/admins/audit-logs) to get a valid token
-for using Audit Logs API. The Slack app using the Audit Logs API needs
-to be installed in the Enterprise Grid Organization, not an individual
-workspace within the organization.
+Follow the instructions in [the API document](https://api.slack.com/admins/audit-logs) to get a valid token for using Audit Logs API. The Slack app using the Audit Logs API needs to be installed in the Enterprise Grid Organization, not an individual workspace within the organization.
 
 ---
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,12 +1,8 @@
 # Python Slack SDK
 
-The Slack Python SDK has corresponding
-package for Slack APIs. They are small and powerful when used
-independently, and work seamlessly when used together, too.
+The Slack Python SDK has corresponding package for Slack APIs. They are small and powerful when used independently, and work seamlessly when used together, too.
 
-The Slack platform offers several APIs to build apps. Each Slack API
-delivers part of the capabilities from the platform, so that you can
-pick just those that fit for your needs.
+The Slack platform offers several APIs to build apps. Each Slack API delivers part of the capabilities from the platform, so that you can pick just those that fit for your needs.
 
 ## Features
 
@@ -37,5 +33,4 @@ If you otherwise get stuck, we're here to help. The following are the best ways 
 
 These docs live within the [Python Slack SDK](https://github.com/slackapi/python-slack-sdk) repository and are open source.
 
-We welcome contributions from everyone! Please check out our
-[Contributor's Guide](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) for how to contribute in a helpful and collaborative way.
+We welcome contributions from everyone! Please check out our [Contributor's Guide](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) for how to contribute in a helpful and collaborative way.

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -1,7 +1,6 @@
 # Installation
 
-This package supports Python 3.6 and higher. We recommend using
-[PyPI](https://pypi.python.org/pypi) to install. Run the following command:
+This package supports Python 3.6 and higher. We recommend using [PyPI](https://pypi.python.org/pypi) to install. Run the following command:
 
 ``` bash
 pip install slack_sdk

--- a/docs/content/legacy/auth.md
+++ b/docs/content/legacy/auth.md
@@ -2,12 +2,7 @@
 
 :::danger
 
-The [slackclient](https://pypi.org/project/slackclient/) PyPI project is
-in maintenance mode now and
-[slack-sdk](https://pypi.org/project/slack-sdk/) project is the
-successor. The v3 SDK provides more functionalities such as Socket Mode,
-OAuth flow module, SCIM API, Audit Logs API, better asyncio support,
-retry handlers, and many more.
+The [slackclient](https://pypi.org/project/slackclient/) PyPI project is in maintenance mode now and [slack-sdk](https://pypi.org/project/slack-sdk/) project is the successor. The v3 SDK provides more functionalities such as Socket Mode, OAuth flow module, SCIM API, Audit Logs API, better asyncio support, retry handlers, and many more.
 
 :::
 

--- a/docs/content/legacy/basic_usage.md
+++ b/docs/content/legacy/basic_usage.md
@@ -2,18 +2,11 @@
 
 :::danger
 
-The [slackclient](https://pypi.org/project/slackclient/) PyPI project is
-in maintenance mode now and
-[slack-sdk](https://pypi.org/project/slack-sdk/) project is the
-successor. The v3 SDK provides more functionalities such as Socket Mode,
-OAuth flow module, SCIM API, Audit Logs API, better asyncio support,
-retry handlers, and many more.
+The [slackclient](https://pypi.org/project/slackclient/) PyPI project is in maintenance mode now and [slack-sdk](https://pypi.org/project/slack-sdk/) project is the successor. The v3 SDK provides more functionalities such as Socket Mode, OAuth flow module, SCIM API, Audit Logs API, better asyncio support, retry handlers, and many more.
 
 :::
 
-The Slack Web API allows you to build applications that interact with
-Slack in more complex ways than the integrations we provide out of the
-box.
+The Slack Web API allows you to build applications that interact with Slack in more complex ways than the integrations we provide out of the box.
 
 Accessing Slack API methods requires an OAuth token — see the [Tokens
 & Authentication](auth) section for more on how Slack uses OAuth tokens

--- a/docs/content/legacy/changelog.md
+++ b/docs/content/legacy/changelog.md
@@ -2,21 +2,15 @@
 
 ## v3.0.0 (2020-11-09)
 
-This is the first stable version of
-[slack_sdk](https://pypi.org/project/slack-sdk/) v3. The remarkable
-updates in this major version are:
+This is the first stable version of [slack_sdk](https://pypi.org/project/slack-sdk/) v3. The remarkable updates in this major version are:
 
 -   Newly added OAuth flow support
 -   Better Async/sync separation for `WebClient` and `WebhookClient`
 -   Renamed packages (from `slack` to `slack_sdk`) with deprecation
     warnings
 
-Refer to [v3.0.0
-milestone](https://github.com/slackapi/python-slack-sdk/milestone/10?closed=1)
-and [the website](https://slack.dev/python-slack-sdk/) for details. If
-you\'re a slackclient user, the migration guide for
-`slackclient` v2.x users is available at
-https://slack.dev/python-slack-sdk/v3-migration/
+Refer to [v3.0.0 milestone](https://github.com/slackapi/python-slack-sdk/milestone/10?closed=1)
+and [the website](https://slack.dev/python-slack-sdk/) for details. If you're a `slackclient` user, the migration guide for `slackclient` v2.x users is available at https://slack.dev/python-slack-sdk/v3-migration/
 
 ## v2.9.3 (2020-10-20)
 

--- a/docs/content/legacy/conversations.md
+++ b/docs/content/legacy/conversations.md
@@ -2,22 +2,13 @@
 
 :::danger
 
-The [slackclient](https://pypi.org/project/slackclient/) PyPI project is
-in maintenance mode now and
-[slack-sdk](https://pypi.org/project/slack-sdk/) project is the
-successor. The v3 SDK provides more functionalities such as Socket Mode,
-OAuth flow module, SCIM API, Audit Logs API, better asyncio support,
-retry handlers, and many more.
+The [slackclient](https://pypi.org/project/slackclient/) PyPI project is in maintenance mode now and [slack-sdk](https://pypi.org/project/slack-sdk/) project is the successor. The v3 SDK provides more functionalities such as Socket Mode, OAuth flow module, SCIM API, Audit Logs API, better asyncio support, retry handlers, and many more.
 
 :::
 
-The Slack Conversations API provides your app with a unified interface
-to work with all the channel-like things encountered in Slack; public
-channels, private channels, direct messages, group direct messages, and
-our newest channel type, Shared Channels.
+The Slack Conversations API provides your app with a unified interface to work with all the channel-like things encountered in Slack; public channels, private channels, direct messages, group direct messages, and our newest channel type, Shared Channels.
 
-See [Conversations API](https://api.slack.com/docs/conversations-api)
-docs for more info.
+See [Conversations API](https://api.slack.com/docs/conversations-api) docs for more info.
 
 ------------------------------------------------------------------------
 

--- a/docs/content/legacy/faq.md
+++ b/docs/content/legacy/faq.md
@@ -2,19 +2,13 @@
 
 :::danger
 
-The [slackclient](https://pypi.org/project/slackclient/) PyPI project is
-in maintenance mode now and
-[slack-sdk](https://pypi.org/project/slack-sdk/) project is the
-successor. The v3 SDK provides more functionalities such as Socket Mode,
-OAuth flow module, SCIM API, Audit Logs API, better asyncio support,
-retry handlers, and many more.
+The [slackclient](https://pypi.org/project/slackclient/) PyPI project is in maintenance mode now and [slack-sdk](https://pypi.org/project/slack-sdk/) project is the successor. The v3 SDK provides more functionalities such as Socket Mode, OAuth flow module, SCIM API, Audit Logs API, better asyncio support, retry handlers, and many more.
 
 :::
 
 ## I cannot install `slackclient`
 
-We recommend using [virtualenv
-(venv)](https://docs.python.org/3/tutorial/venv.html) to set up your
+We recommend using [virtualenv (venv)](https://docs.python.org/3/tutorial/venv.html) to set up your
 Python runtime.
 
 ``` bash

--- a/docs/content/legacy/index.md
+++ b/docs/content/legacy/index.md
@@ -2,30 +2,15 @@
 
 :::danger
 
-The [slackclient](https://pypi.org/project/slackclient/) PyPI project is
-in maintenance mode now and
-[slack-sdk](https://pypi.org/project/slack-sdk/) project is the
-successor. The v3 SDK provides more functionalities such as Socket Mode,
-OAuth flow module, SCIM API, Audit Logs API, better asyncio support, and
-retry handlers.
+The [slackclient](https://pypi.org/project/slackclient/) PyPI project is in maintenance mode now and [slack-sdk](https://pypi.org/project/slack-sdk/) project is the successor. The v3 SDK provides more functionalities such as Socket Mode, OAuth flow module, SCIM API, Audit Logs API, better asyncio support, and retry handlers.
 
 :::
 
-Refer to [the migration
-guide](https://slack.dev/python-slack-sdk/v3-migration/index.html#from-slackclient-2-x)
-to learn how to smoothly migrate your existing code.
+Refer to [the migration guide](https://slack.dev/python-slack-sdk/v3-migration/index.html#from-slackclient-2-x) to learn how to smoothly migrate your existing code.
 
-Slack APIs allow anyone to build full featured integrations that
-extend and expand the capabilities of your Slack workspace. These APIs
-allow you to build applications that interact with Slack just like the
-people on your team — they can post messages, respond to events that
-happen — as well as build complex UIs for getting work done.
+Slack APIs allow anyone to build full featured integrations that extend and expand the capabilities of your Slack workspace. These APIs allow you to build applications that interact with Slack just like the people on your team — they can post messages, respond to events that happen — as well as build complex UIs for getting work done.
 
-To make it easier for Python programmers to build Slack applications,
-we've provided this open source SDK. will let you get started building
-Python apps as quickly as possible. The current version is built for
-Python 3.6 and higher — if you need to target Python 2.x, you might
-consider using v1 of the SDK.
+To make it easier for Python programmers to build Slack applications, we've provided this open source SDK. will let you get started building Python apps as quickly as possible. The current version is built for Python 3.6 and higher — if you need to target Python 2.x, you might consider using v1 of the SDK.
 
 ## Slack Platform Basics
 

--- a/docs/content/legacy/real_time_messaging.md
+++ b/docs/content/legacy/real_time_messaging.md
@@ -2,42 +2,19 @@
 
 :::danger
 
-The [slackclient](https://pypi.org/project/slackclient/) PyPI project is
-in maintenance mode now and
-[slack-sdk](https://pypi.org/project/slack-sdk/) project is the
-successor. The v3 SDK provides more functionalities such as Socket Mode,
-OAuth flow module, SCIM API, Audit Logs API, better asyncio support,
-retry handlers, and many more.
+The [slackclient](https://pypi.org/project/slackclient/) PyPI project is in maintenance mode now and [slack-sdk](https://pypi.org/project/slack-sdk/) project is the successor. The v3 SDK provides more functionalities such as Socket Mode, OAuth flow module, SCIM API, Audit Logs API, better asyncio support, retry handlers, and many more.
 
 :::
 
-The [Real Time Messaging (RTM) API](https://api.slack.com/rtm) is a WebSocket-based API that
-allows you to receive events from Slack in real time and send messages
-as users.
+The [Real Time Messaging (RTM) API](https://api.slack.com/rtm) is a WebSocket-based API that allows you to receive events from Slack in real time and send messages as users.
 
-If you prefer events to be pushed to your app, we recommend using the
-HTTP-based [Events API](https://api.slack.com/events-api) instead. The
-Events API contains some events that aren't supported in the RTM API
-(like [app_home_opened
-event](https://api.slack.com/events/app_home_opened)), and it supports
-most of the event types in the RTM API. If you'd like to use the Events
-API, you can use the [Python Slack Events
-Adaptor](https://github.com/slackapi/python-slack-events-api).
+If you prefer events to be pushed to your app, we recommend using the HTTP-based [Events API](https://api.slack.com/events-api) instead. The Events API contains some events that aren't supported in the RTM API (like [app_home_opened event](https://api.slack.com/events/app_home_opened)), and it supports most of the event types in the RTM API. If you'd like to use the Events API, you can use the [Python Slack Events Adaptor](https://github.com/slackapi/python-slack-events-api).
 
-The RTMClient allows apps to communicate with the Slack RTM
-API.
+The RTMClient allows apps to communicate with the Slack RTM API.
 
-The event-driven architecture of this client allows you to simply link
-callbacks to their corresponding events. When an event occurs this
-client executes your callback while passing along any information it
-receives. We also give you the ability to call our web client from
-inside your callbacks.
+The event-driven architecture of this client allows you to simply link callbacks to their corresponding events. When an event occurs this client executes your callback while passing along any information it receives. We also give you the ability to call our web client from inside your callbacks.
 
-In our example below, we watch for a [message
-event](https://api.slack.com/events/message) that contains \"Hello\" and
-if its received, we call the `say_hello()` function. We then issue a
-call to the web client to post back to the channel saying \"Hi\" to the
-user.
+In our example below, we watch for a [message event](https://api.slack.com/events/message) that contains \"Hello\" and if its received, we call the `say_hello()` function. We then issue a call to the web client to post back to the channel saying \"Hi\" to the user.
 
 ## Configuring the RTM API
 

--- a/docs/content/oauth.md
+++ b/docs/content/oauth.md
@@ -1,30 +1,21 @@
 # OAuth Modules
 
-This section explains the details about how to handle the Slack OAuth
-flow.
+This section explains the details about how to handle the Slack OAuth flow.
 
-If you're looking for a much easier way to do the same, check [Bolt for
-Python](https://github.com/slackapi/bolt-python), which is a full-stack
-Slack App framework. With Bolt, you don't need to implement most of the
-following code on your own.
+If you're looking for a much easier way to do the same, check [Bolt for Python](https://github.com/slackapi/bolt-python), which is a full-stack Slack App framework. With Bolt, you don't need to implement most of the following code on your own.
 
 View the [Python document for this module](https://slack.dev/python-slack-sdk/api-docs/slack_sdk/)
 
 
 ## App Installation Flow
 
-OAuth lets a user in any Slack workspace install your app. At the end of
-OAuth, your app gains an access token. Refer to [Installing with
-OAuth](https://api.slack.com/authentication/oauth-v2) for details.
+OAuth lets a user in any Slack workspace install your app. At the end of OAuth, your app gains an access token. Refer to [Installing with OAuth](https://api.slack.com/authentication/oauth-v2) for details.
 
-Python Slack SDK provides the necessary modules for building the OAuth
-flow.
+Python Slack SDK provides the necessary modules for building the OAuth flow.
 
 ### Starting an OAuth flow
 
-The first step of Slack OAuth flow is to redirect a Slack user to
-[authorize](https://slack.com/oauth/v2/authorize) with a valid `state` parameter.
-To implement this process, you can use the following modules.
+The first step of Slack OAuth flow is to redirect a Slack user to [authorize](https://slack.com/oauth/v2/authorize) with a valid `state` parameter. To implement this process, you can use the following modules.
 
 Module                |    What its for                           |   Default Implementation
 ----------------------|-----------------------------------------|-------------------------

--- a/docs/content/rtm.md
+++ b/docs/content/rtm.md
@@ -1,32 +1,14 @@
 # RTM API Client {#real-time-messaging}
 
-The [Real Time Messaging (RTM) API](https://api.slack.com/rtm) is a WebSocket-based API that
-allows you to receive events from Slack in real time and send messages
-as users.
+The [Real Time Messaging (RTM) API](https://api.slack.com/rtm) is a WebSocket-based API that allows you to receive events from Slack in real time and send messages as users.
 
-If you prefer events to be pushed to your app, we recommend using the
-HTTP-based [Events API](https://api.slack.com/events-api) along with
-[Socket Mode](https://api.slack.com/socket-mode) instead. The Events API
-contains some events that aren't supported in the RTM API (like
-[app_home_opened event](https://api.slack.com/events/app_home_opened)),
-and it supports most of the event types in the RTM API. If you'd like
-to use the Events API, you can use the [Python Slack Events
-Adaptor](https://github.com/slackapi/python-slack-events-api).
+If you prefer events to be pushed to your app, we recommend using the HTTP-based [Events API](https://api.slack.com/events-api) along with [Socket Mode](https://api.slack.com/socket-mode) instead. The Events API contains some events that aren't supported in the RTM API (like [app_home_opened event](https://api.slack.com/events/app_home_opened)), and it supports most of the event types in the RTM API. If you'd like to use the Events API, you can use the [Python Slack Events Adaptor](https://github.com/slackapi/python-slack-events-api).
 
-The RTMClient allows apps to communicate with the Slack Platform's RTM
-API.
+The RTMClient allows apps to communicate with the Slack Platform's RTM API.
 
-The event-driven architecture of this client allows you to simply link
-callbacks to their corresponding events. When an event occurs this
-client executes your callback while passing along any information it
-receives. We also give you the ability to call our web client from
-inside your callbacks.
+The event-driven architecture of this client allows you to simply link callbacks to their corresponding events. When an event occurs this client executes your callback while passing along any information it receives. We also give you the ability to call our web client from inside your callbacks.
 
-In our example below, we watch for a [message
-event](https://api.slack.com/events/message) that contains \"Hello\" and
-if its received, we call the `say_hello()` function. We then issue a
-call to the web client to post back to the channel saying \"Hi\" to the
-user.
+In our example below, we watch for a [message event](https://api.slack.com/events/message) that contains \"Hello\" and if its received, we call the `say_hello()` function. We then issue a call to the web client to post back to the channel saying \"Hi\" to the user.
 
 ## Configuring the RTM API
 

--- a/docs/content/scim.md
+++ b/docs/content/scim.md
@@ -1,27 +1,18 @@
 # SCIM API Client
 
-[SCIM API](https://api.slack.com/scim) is a set of APIs for provisioning
-and managing user accounts and groups. SCIM is used by Single Sign-On
-(SSO) services and identity providers to manage people across a variety
-of tools, including Slack.
+[SCIM API](https://api.slack.com/scim) is a set of APIs for provisioning and managing user accounts and groups. SCIM is used by Single Sign-On (SSO) services and identity providers to manage people across a variety of tools, including Slack.
 
-[SCIM (System for Cross-domain Identity
-Management)](http://www.simplecloud.info/) is supported by a myriad of
-services. It behaves slightly differently from other Slack APIs.
+[SCIM (System for Cross-domain Identity Management)](http://www.simplecloud.info/) is supported by a myriad of services. It behaves slightly differently from other Slack APIs.
 
-Refer to [the API document](https://api.slack.com/scim) for more
-details.
+Refer to [the API document](https://api.slack.com/scim) for more details.
 
 View the [Python document for this module](https://slack.dev/python-slack-sdk/api-docs/slack_sdk/)
 
 ## SCIMClient
 
-An OAuth token with [the admin
-scope](https://api.slack.com/scopes/admin) is required to access the
-SCIM API.
+An OAuth token with [the admin scope](https://api.slack.com/scopes/admin) is required to access the SCIM API.
 
-To fetch provisioned user data, you can use the `search_users` method in
-the client.
+To fetch provisioned user data, you can use the `search_users` method in the client.
 
 ``` python
 import os
@@ -37,9 +28,7 @@ response = client.search_users(
 response.users  # List[User]
 ```
 
-Check out [the class source
-code](https://github.com/slackapi/python-slack-sdk/blob/main/slack_sdk/scim/v1/user.py)
-to learn more about the structure of the `user` in `response.users`.
+Check out [the class source code](https://github.com/slackapi/python-slack-sdk/blob/main/slack_sdk/scim/v1/user.py) to learn more about the structure of the `user` in `response.users`.
 
 Similarly, the `search_groups` method is available and the shape of the
 `Group` object can be [found

--- a/docs/content/socket-mode.md
+++ b/docs/content/socket-mode.md
@@ -1,17 +1,10 @@
 # Socket Mode Client
 
-Socket Mode is a method of connecting your app to the Slack APIs using
-WebSockets instead of HTTP. You can use
-`slack_sdk.socket_mode.SocketModeClient` for managing [Socket
-Mode](https://api.slack.com/apis/connections/socket) connections and
-performing interactions with Slack.
+Socket Mode is a method of connecting your app to the Slack APIs using WebSockets instead of HTTP. You can use `slack_sdk.socket_mode.SocketModeClient` for managing [Socket Mode](https://api.slack.com/apis/connections/socket) connections and performing interactions with Slack.
 
 ## Using Socket Mode
 
-First off, let's start with enabling Socket Mode. Visit [the Slack App
-configuration page](http://api.slack.com/apps), choose the app you're
-working on, and go to **Settings** on the left pane. There are a few
-things to do on the page.
+First off, let's start with enabling Socket Mode. Visit [the Slack App configuration page](http://api.slack.com/apps), choose the app you're working on, and go to **Settings** on the left pane. There are a few things to do on the page.
 
 -   Go to **Settings** \> **Basic Information**, then add a new
     **App-Level Token** with the `connections:write` scope

--- a/docs/content/v3-migration.md
+++ b/docs/content/v3-migration.md
@@ -4,8 +4,7 @@ sidebar_label: Migrating from slackclient
 
 # Migrating from v2.x to v3.x
 
-You may still view the legacy `slackclient` v2 [documentation](/legacy/). However, the **slackclient** project is in maintenance
-mode now and this **slack_sdk** project is the successor.
+You may still view the legacy `slackclient` v2 [documentation](/legacy/). However, the **slackclient** project is in maintenance mode now and this **slack_sdk** project is the successor.
 
 ## From slackclient 2.x
 

--- a/docs/content/web.md
+++ b/docs/content/web.md
@@ -1,15 +1,10 @@
 # Web Client
 
-The Slack Web API allows you to build applications that interact with
-Slack in more complex ways than the integrations we provide out of the
-box.
+The Slack Web API allows you to build applications that interact with Slack in more complex ways than the integrations we provide out of the box.
 
-Access the Slack API methods requires an OAuth token — see the [Tokens
-& Authentication](/installation#handling-tokens) section for more on how
-Slack uses OAuth tokens as well as best practices.
+Access the Slack API methods requires an OAuth token — see the [Tokens & Authentication](/installation#handling-tokens) section for more on how Slack uses OAuth tokens as well as best practices.
 
-[Each of these API methods](https://api.slack.com/methods) is fully
-documented in our [API documentation site](https://api.slack.com).
+[Each of these API methods](https://api.slack.com/methods) is fully documented in our [API documentation site](https://api.slack.com).
 
 ---
 

--- a/docs/content/webhook.md
+++ b/docs/content/webhook.md
@@ -2,14 +2,9 @@
 
 ## Incoming Webhooks
 
-You can use `slack_sdk.webhook.WebhookClient` for [Incoming
-Webhooks](https://api.slack.com/messaging/webhooks) and message
-responses using [response_url in
-payloads](https://api.slack.com/interactivity/handling#message_responses).
+You can use `slack_sdk.webhook.WebhookClient` for [Incoming Webhooks](https://api.slack.com/messaging/webhooks) and message responses using [response_url in payloads](https://api.slack.com/interactivity/handling#message_responses).
 
-To use [Incoming Webhooks](https://api.slack.com/messaging/webhooks),
-just calling `WebhookClient(url)#send(payload)` method works for you.
-The call posts a message in a channel associated with the webhook URL.
+To use [Incoming Webhooks](https://api.slack.com/messaging/webhooks), just calling `WebhookClient(url)#send(payload)` method works for you. The call posts a message in a channel associated with the webhook URL.
 
 ``` python
 from slack_sdk.webhook import WebhookClient


### PR DESCRIPTION
## Summary

The classic code practice of breaking lines at x characters long messed up the unfurls. Removed the line breaks

<img width="362" alt="image" src="https://github.com/user-attachments/assets/8386a712-3835-494c-a7cd-fa9ceefda463">

Oh I just noticed the path in this template still says `/docs-src` so I changed it to `/docs` in this PR too

### Testing

You can run it locally to see that it works, but it works. You can't test unfurls locally though

### Category <!-- place an `x` in each of the `[ ]`  -->

- [X] `/docs` (Documents)

## Requirements <!-- place an `x` in each `[ ]` -->

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
