### PR TITLE
docs: adds google analytics tag

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -43,6 +43,9 @@ const config = {
         theme: {
           customCss: "./src/css/custom.css",
         },
+        gtag: {
+          trackingID: "G-9H1YZW28BG",
+        },
       }),
     ],
   ],


### PR DESCRIPTION
## Summary

adds google analytics to docs site

### Testing

It's not live until in prod!

### Category <!-- place an `x` in each of the `[ ]`  -->

- [X] `/docs` (Documents)

## Requirements <!-- place an `x` in each `[ ]` -->

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
