### PR TITLE
chore: group docusaurus dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     directory: "/docs"
     schedule:
       interval: "monthly"
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"


### PR DESCRIPTION
## Summary

#1547 Failed with the following error message found in the CI pipeline
```
[cause]: Error: Invalid name=docusaurus-plugin-content-docs version number=3.5.2.
  All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.4.0).
  Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
```

This PR attempts to configure [dependabot grouping](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) for `docusaurus` dependencies. This should allow dependabot to update all `docusaurus` dependencies in one since PR preventing this type of breakage 🤔 

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
