### PR TITLE
Fix RichTextElementParts.Date.timestamp to be an int

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -2104,7 +2104,7 @@ class RichTextElementParts:
         def __init__(
             self,
             *,
-            timestamp: str,
+            timestamp: int,
             format: str,
             url: Optional[str] = None,
             fallback: Optional[str] = None,


### PR DESCRIPTION
## Summary
Fix the type.

If passing an actual `str`:
```
slack_sdk.errors.SlackApiError: The request to the Slack API failed. (url: https://slack.com/api/chat.postMessage, status: 200)
The server responded with: {'ok': False, 'error': 'invalid_blocks', 'errors': ['must provide an integer [json-pointer:/blocks/1/elements/0/elements/1/timestamp]'], 'response_metadata': {'messages': ['[ERROR] must provide an integer [json-pointer:/blocks/1/elements/0/elements/1/timestamp]']}}
```

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
