### PR TITLE
Docs: new URL (HOLD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@
         <img alt="PyPI - Version" src="https://img.shields.io/pypi/v/slack-sdk"></a>
     <a href="https://pypi.org/project/slack-sdk/">
         <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/slack-sdk.svg"></a>
-    <a href="https://slack.dev/python-slack-sdk/">
+    <a href="https://tools.slack.dev/python-slack-sdk/">
         <img alt="Documentation" src="https://img.shields.io/badge/dev-docs-yellow"></a>
 </p>
 
 The Slack platform offers several APIs to build apps. Each Slack API delivers part of the capabilities from the platform, so that you can pick just those that fit for your needs. This SDK offers a corresponding package for each of Slack’s APIs. They are small and powerful when used independently, and work seamlessly when used together, too.
 
-**Comprehensive documentation on using the Slack Python can be found at [https://slack.dev/python-slack-sdk/](https://slack.dev/python-slack-sdk/)**
+**Comprehensive documentation on using the Slack Python can be found at [https://tools.slack.dev/python-slack-sdk/](https://tools.slack.dev/python-slack-sdk/)**
 
 ---
 
@@ -36,11 +36,11 @@ The **Python Slack SDK** allows interaction with:
 - `slack_sdk.models`: for constructing [Block Kit](https://api.slack.com/block-kit) UI components using easy-to-use builders
 - `slack_sdk.rtm`: for utilizing the [RTM API][rtm-docs]
 
-If you want to use our [Events API][events-docs] and Interactivity features, please check the [Bolt for Python][bolt-python] library. Details on the Tokens and Authentication can be found in our [Auth Guide](https://slack.dev/python-slack-sdk/installation/).
+If you want to use our [Events API][events-docs] and Interactivity features, please check the [Bolt for Python][bolt-python] library. Details on the Tokens and Authentication can be found in our [Auth Guide](https://tools.slack.dev/python-slack-sdk/installation/).
 
 ## slackclient is in maintenance mode
 
-Are you looking for [slackclient](https://pypi.org/project/slackclient/)? The website is live [here](https://slack.dev/python-slackclient/) just like before. However, the slackclient project is in maintenance mode now and this [`slack_sdk`](https://pypi.org/project/slack-sdk/) is the successor. If you have time to make a migration to slack_sdk v3, please follow [our migration guide](https://slack.dev/python-slack-sdk/v3-migration/) to ensure your app continues working after updating.
+Are you looking for [slackclient](https://pypi.org/project/slackclient/)? The website is live [here](https://tools.slack.dev/python-slackclient/) just like before. However, the slackclient project is in maintenance mode now and this [`slack_sdk`](https://pypi.org/project/slack-sdk/) is the successor. If you have time to make a migration to slack_sdk v3, please follow [our migration guide](https://tools.slack.dev/python-slack-sdk/v3-migration/) to ensure your app continues working after updating.
 
 ## Table of contents
 
@@ -98,7 +98,7 @@ We've created this [tutorial](https://github.com/slackapi/python-slack-sdk/tree/
 
 ---
 
-Slack provide a Web API that gives you the ability to build applications that interact with Slack in a variety of ways. This Development Kit is a module based wrapper that makes interaction with that API easier. We have a basic example here with some of the more common uses but a full list of the available methods are available [here][api-methods]. More detailed examples can be found in [our guide](https://slack.dev/python-slack-sdk/web/).
+Slack provide a Web API that gives you the ability to build applications that interact with Slack in a variety of ways. This Development Kit is a module based wrapper that makes interaction with that API easier. We have a basic example here with some of the more common uses but a full list of the available methods are available [here][api-methods]. More detailed examples can be found in [our guide](https://tools.slack.dev/python-slack-sdk/web/).
 
 #### Sending a message to Slack
 
@@ -267,7 +267,7 @@ print(response)
 
 If you're migrating from slackclient v2.x of slack_sdk to v3.x, Please follow our migration guide to ensure your app continues working after updating.
 
-**[Check out the Migration Guide here!](https://slack.dev/python-slack-sdk/v3-migration/)**
+**[Check out the Migration Guide here!](https://tools.slack.dev/python-slack-sdk/v3-migration/)**
 
 ### Migrating from v1
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# slack.dev/python-slack-sdk
+# tools.slack.dev/python-slack-sdk
 
 This website is built using [Docusaurus](https://docusaurus.io/). 'Tis cool.
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -18,7 +18,7 @@ The Slack platform offers several APIs to build apps. Each Slack API delivers pa
 | Request Signature Verification | Verify incoming requests from the Slack API servers.                                          | ``slack_sdk.signature``            |
 | UI Builders                    | Construct UI components using easy-to-use builders.                                           | ``slack_sdk.models``               |
 
-You can also view the [Python module documents](https://slack.dev/python-slack-sdk/api-docs/slack_sdk/)!
+You can also view the [Python module documents](https://tools.slack.dev/python-slack-sdk/api-docs/slack_sdk/)!
 
 ## Getting help
 

--- a/docs/content/legacy/changelog.md
+++ b/docs/content/legacy/changelog.md
@@ -10,7 +10,7 @@ This is the first stable version of [slack_sdk](https://pypi.org/project/slack-s
     warnings
 
 Refer to [v3.0.0 milestone](https://github.com/slackapi/python-slack-sdk/milestone/10?closed=1)
-and [the website](https://slack.dev/python-slack-sdk/) for details. If you're a `slackclient` user, the migration guide for `slackclient` v2.x users is available at https://slack.dev/python-slack-sdk/v3-migration/
+and [the website](https://tools.slack.dev/python-slack-sdk/) for details. If you're a `slackclient` user, the migration guide for `slackclient` v2.x users is available at https://tools.slack.dev/python-slack-sdk/v3-migration/
 
 ## v2.9.3 (2020-10-20)
 

--- a/docs/content/legacy/index.md
+++ b/docs/content/legacy/index.md
@@ -6,7 +6,7 @@ The [slackclient](https://pypi.org/project/slackclient/) PyPI project is in main
 
 :::
 
-Refer to [the migration guide](https://slack.dev/python-slack-sdk/v3-migration/index.html#from-slackclient-2-x) to learn how to smoothly migrate your existing code.
+Refer to [the migration guide](https://tools.slack.dev/python-slack-sdk/v3-migration/index.html#from-slackclient-2-x) to learn how to smoothly migrate your existing code.
 
 Slack APIs allow anyone to build full featured integrations that extend and expand the capabilities of your Slack workspace. These APIs allow you to build applications that interact with Slack just like the people on your team — they can post messages, respond to events that happen — as well as build complex UIs for getting work done.
 

--- a/docs/content/oauth.md
+++ b/docs/content/oauth.md
@@ -4,7 +4,7 @@ This section explains the details about how to handle the Slack OAuth flow.
 
 If you're looking for a much easier way to do the same, check [Bolt for Python](https://github.com/slackapi/bolt-python), which is a full-stack Slack App framework. With Bolt, you don't need to implement most of the following code on your own.
 
-View the [Python document for this module](https://slack.dev/python-slack-sdk/api-docs/slack_sdk/)
+View the [Python document for this module](https://tools.slack.dev/python-slack-sdk/api-docs/slack_sdk/)
 
 
 ## App Installation Flow

--- a/docs/content/scim.md
+++ b/docs/content/scim.md
@@ -6,7 +6,7 @@
 
 Refer to [the API document](https://api.slack.com/scim) for more details.
 
-View the [Python document for this module](https://slack.dev/python-slack-sdk/api-docs/slack_sdk/)
+View the [Python document for this module](https://tools.slack.dev/python-slack-sdk/api-docs/slack_sdk/)
 
 ## SCIMClient
 

--- a/docs/content/v3-migration.md
+++ b/docs/content/v3-migration.md
@@ -56,7 +56,7 @@ is not so simple that we recommend manually replacing imports for those.
 That said, all existing code can be migrated to v3 without any code
 changes. If you don't have time for it, you can use `slack` package
 with deprecation warnings saying
-`UserWarning: slack package is deprecated. Please use slack_sdk.web/webhook/rtm package instead. For more info, go to https://slack.dev/python-slack-sdk/v3-migration/`
+`UserWarning: slack package is deprecated. Please use slack_sdk.web/webhook/rtm package instead. For more info, go to https://tools.slack.dev/python-slack-sdk/v3-migration/`
 for a while. We won't remove the compatibility in the short term.
 
 ------------------------------------------------------------------------

--- a/docs/content/web.md
+++ b/docs/content/web.md
@@ -78,7 +78,7 @@ can include full user interfaces composed of
 The chat.postMessage method takes an optional `blocks` argument that
 allows you to customize the layout of a message. Blocks can be specified
 in a single array of either dict values or
-[slack_sdk.models.blocks.Block](https://slack.dev/python-slack-sdk/api-docs/slack_sdk/models/blocks/index.html)
+[slack_sdk.models.blocks.Block](https://tools.slack.dev/python-slack-sdk/api-docs/slack_sdk/models/blocks/index.html)
 objects.
 
 To send a message to a channel, use the channel's ID. For IMs, use the

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -12,7 +12,7 @@ const config = {
   tagline: "Official frameworks, libraries, and SDKs for Slack developers",
   favicon: "img/favicon.ico",
 
-  url: "https://slack.dev",
+  url: "https://tools.slack.dev",
   baseUrl: "/python-slack-sdk/",
   organizationName: "slackapi",
   projectName: "python-slack-sdk",
@@ -76,7 +76,7 @@ const config = {
         logo: {
           alt: "Slack logo",
           src: "img/slack-logo.svg",
-          href: "https://slack.dev",
+          href: "https://tools.slack.dev",
           target: "_self",
         },
         items: [
@@ -87,17 +87,17 @@ const config = {
             items: [
               {
                 label: "Java",
-                to: "https://slack.dev/java-slack-sdk/guides/bolt-basics",
+                to: "https://tools.slack.dev/java-slack-sdk/guides/bolt-basics",
                 target: "_self",
               },
               {
                 label: "JavaScript",
-                to: "https://slack.dev/bolt-js",
+                to: "https://tools.slack.dev/bolt-js",
                 target: "_self",
               },
               {
                 label: "Python",
-                to: "https://slack.dev/bolt-python",
+                to: "https://tools.slack.dev/bolt-python",
                 target: "_self",
               },
             ],
@@ -109,17 +109,17 @@ const config = {
             items: [
               {
                 label: "Java Slack SDK",
-                to: "https://slack.dev/java-slack-sdk/",
+                to: "https://tools.slack.dev/java-slack-sdk/",
                 target: "_self",
               },
               {
                 label: "Node Slack SDK",
-                to: "https://slack.dev/node-slack-sdk/",
+                to: "https://tools.slack.dev/node-slack-sdk/",
                 target: "_self",
               },
               {
                 label: "Python Slack SDK",
-                to: "https://slack.dev/python-slack-sdk/",
+                to: "https://tools.slack.dev/python-slack-sdk/",
                 target: "_self",
               },
               {
@@ -136,7 +136,7 @@ const config = {
             items: [
               {
                 label: "Community tools",
-                to: "https://slack.dev/community-tools",
+                to: "https://tools.slack.dev/community-tools",
                 target: "_self",
               },
               {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -51,7 +51,7 @@ const sidebars = {
     {
       type: "link",
       label: "Reference",
-      href: "https://slack.dev/python-slack-sdk/api-docs/slack_sdk/",
+      href: "https://tools.slack.dev/python-slack-sdk/api-docs/slack_sdk/",
     },
     { type: "html", value: "<hr>" },
     {


### PR DESCRIPTION
## Summary

Switching from slack.dev to tools.slack.dev

### Testing

It's just a name swap! Can't fully test until deployment though 🤞 

### Category <!-- place an `x` in each of the `[ ]`  -->

- [X] `/docs` (Documents)

## Requirements <!-- place an `x` in each `[ ]` -->

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
