### PR TITLE
Fix #1517 initial_value for RichTextInputElement should also accept type RichTextBlock

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -1352,7 +1352,7 @@ class RichTextInputElement(InputInteractiveElement):
             }
         )
 
-    def __init__(
+    def __init__(  # type: ignore
         self,
         *,
         action_id: Optional[str] = None,

--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -1357,7 +1357,8 @@ class RichTextInputElement(InputInteractiveElement):
         *,
         action_id: Optional[str] = None,
         placeholder: Optional[Union[str, dict, TextObject]] = None,
-        initial_value: Optional[Dict[str, Any]] = None,  # TODO: Add rich_text block class and its element classes
+        # To avoid circular imports, the RichTextBlock type here is intentionally a string
+        initial_value: Optional[Union[Dict[str, Any], "RichTextBlock"]] = None,  # noqa: F821
         dispatch_action_config: Optional[Union[dict, DispatchActionConfig]] = None,
         focus_on_load: Optional[bool] = None,
         **others: dict,

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -27,6 +27,7 @@ from slack_sdk.models.blocks import (
     InputInteractiveElement,
     InteractiveElement,
     PlainTextObject,
+    RichTextBlock,
 )
 from slack_sdk.models.blocks.basic_components import SlackFile
 from slack_sdk.models.blocks.block_elements import (
@@ -37,6 +38,8 @@ from slack_sdk.models.blocks.block_elements import (
     WorkflowButtonElement,
     RichTextInputElement,
     FileInputElement,
+    RichTextSectionElement,
+    RichTextElementParts,
 )
 from . import STRING_3001_CHARS, STRING_301_CHARS
 
@@ -1068,6 +1071,43 @@ class RichTextInputElementTests(unittest.TestCase):
             "placeholder": {"type": "plain_text", "text": "Enter text"},
         }
         self.assertDictEqual(input, RichTextInputElement(**input).to_dict())
+
+    def test_issue_1571(self):
+        self.assertDictEqual(
+            RichTextInputElement(
+                action_id="contents",
+                initial_value=RichTextBlock(
+                    elements=[
+                        RichTextSectionElement(
+                            elements=[
+                                RichTextElementParts.Text(text="Hey, "),
+                                RichTextElementParts.Text(text="this", style={"italic": True}),
+                                RichTextElementParts.Text(text="is what you should be looking at. "),
+                                RichTextElementParts.Text(text="Please", style={"bold": True}),
+                            ]
+                        )
+                    ],
+                ),
+            ).to_dict(),
+            {
+                "action_id": "contents",
+                "initial_value": {
+                    "elements": [
+                        {
+                            "elements": [
+                                {"text": "Hey, ", "type": "text"},
+                                {"style": {"italic": True}, "text": "this", "type": "text"},
+                                {"text": "is what you should be looking at. ", "type": "text"},
+                                {"style": {"bold": True}, "text": "Please", "type": "text"},
+                            ],
+                            "type": "rich_text_section",
+                        }
+                    ],
+                    "type": "rich_text",
+                },
+                "type": "rich_text_input",
+            },
+        )
 
 
 class PlainTextInputElementTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

This pull request resolves #1517 

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
