### PR TITLE
Switch canvases.* APIs to application/json format for more stability

### DIFF
--- a/integration_tests/web/test_canvases.py
+++ b/integration_tests/web/test_canvases.py
@@ -32,10 +32,14 @@ class TestWebClient(unittest.TestCase):
             document_content={
                 "type": "markdown",
                 "markdown": """# My canvas
-                ---
-                ## Hey
-                What's up?
-                """,
+
+## Hey
+
+What's up?
+
+- foo
+- bar
+""",
             },
         )
         self.assertIsNone(channel_canvas.get("error"))
@@ -46,10 +50,14 @@ class TestWebClient(unittest.TestCase):
             document_content={
                 "type": "markdown",
                 "markdown": """# My canvas
-                ---
-                ## Hey
-                What's up?
-                """,
+
+## Hey
+
+What's up?
+
+- foo
+- bar
+""",
             },
         )
         self.assertIsNone(standalone_canvas.get("error"))
@@ -96,10 +104,14 @@ class TestWebClient(unittest.TestCase):
             document_content={
                 "type": "markdown",
                 "markdown": """# My canvas
-                ---
-                ## Hey
-                What's up?
-                """,
+
+## Hey
+
+What's up?
+
+- foo
+- bar
+""",
             },
         )
         self.assertIsNone(channel_canvas.get("error"))
@@ -110,10 +122,14 @@ class TestWebClient(unittest.TestCase):
             document_content={
                 "type": "markdown",
                 "markdown": """# My canvas
-                ---
-                ## Hey
-                What's up?
-                """,
+
+## Hey
+
+What's up?
+
+- foo
+- bar
+""",
             },
         )
         self.assertIsNone(standalone_canvas.get("error"))

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2300,8 +2300,8 @@ class AsyncWebClient(AsyncBaseClient):
         """Create Canvas for a user
         https://api.slack.com/methods/canvases.create
         """
-        kwargs.update({"title": title, "document_content": json.dumps(document_content)})
-        return await self.api_call("canvases.create", params=kwargs)
+        kwargs.update({"title": title, "document_content": document_content})
+        return await self.api_call("canvases.create", json=kwargs)
 
     async def canvases_edit(
         self,
@@ -2313,8 +2313,8 @@ class AsyncWebClient(AsyncBaseClient):
         """Update an existing canvas
         https://api.slack.com/methods/canvases.edit
         """
-        kwargs.update({"canvas_id": canvas_id, "changes": json.dumps(changes)})
-        return await self.api_call("canvases.edit", params=kwargs)
+        kwargs.update({"canvas_id": canvas_id, "changes": changes})
+        return await self.api_call("canvases.edit", json=kwargs)
 
     async def canvases_delete(
         self,
@@ -3353,8 +3353,8 @@ class AsyncWebClient(AsyncBaseClient):
         """Create a Channel Canvas for a channel
         https://api.slack.com/methods/conversations.canvases.create
         """
-        kwargs.update({"channel_id": channel_id, "document_content": json.dumps(document_content)})
-        return await self.api_call("conversations.canvases.create", params=kwargs)
+        kwargs.update({"channel_id": channel_id, "document_content": document_content})
+        return await self.api_call("conversations.canvases.create", json=kwargs)
 
     async def dialog_open(
         self,

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2291,8 +2291,8 @@ class WebClient(BaseClient):
         """Create Canvas for a user
         https://api.slack.com/methods/canvases.create
         """
-        kwargs.update({"title": title, "document_content": json.dumps(document_content)})
-        return self.api_call("canvases.create", params=kwargs)
+        kwargs.update({"title": title, "document_content": document_content})
+        return self.api_call("canvases.create", json=kwargs)
 
     def canvases_edit(
         self,
@@ -2304,8 +2304,8 @@ class WebClient(BaseClient):
         """Update an existing canvas
         https://api.slack.com/methods/canvases.edit
         """
-        kwargs.update({"canvas_id": canvas_id, "changes": json.dumps(changes)})
-        return self.api_call("canvases.edit", params=kwargs)
+        kwargs.update({"canvas_id": canvas_id, "changes": changes})
+        return self.api_call("canvases.edit", json=kwargs)
 
     def canvases_delete(
         self,
@@ -3344,8 +3344,8 @@ class WebClient(BaseClient):
         """Create a Channel Canvas for a channel
         https://api.slack.com/methods/conversations.canvases.create
         """
-        kwargs.update({"channel_id": channel_id, "document_content": json.dumps(document_content)})
-        return self.api_call("conversations.canvases.create", params=kwargs)
+        kwargs.update({"channel_id": channel_id, "document_content": document_content})
+        return self.api_call("conversations.canvases.create", json=kwargs)
 
     def dialog_open(
         self,

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2302,8 +2302,8 @@ class LegacyWebClient(LegacyBaseClient):
         """Create Canvas for a user
         https://api.slack.com/methods/canvases.create
         """
-        kwargs.update({"title": title, "document_content": json.dumps(document_content)})
-        return self.api_call("canvases.create", params=kwargs)
+        kwargs.update({"title": title, "document_content": document_content})
+        return self.api_call("canvases.create", json=kwargs)
 
     def canvases_edit(
         self,
@@ -2315,8 +2315,8 @@ class LegacyWebClient(LegacyBaseClient):
         """Update an existing canvas
         https://api.slack.com/methods/canvases.edit
         """
-        kwargs.update({"canvas_id": canvas_id, "changes": json.dumps(changes)})
-        return self.api_call("canvases.edit", params=kwargs)
+        kwargs.update({"canvas_id": canvas_id, "changes": changes})
+        return self.api_call("canvases.edit", json=kwargs)
 
     def canvases_delete(
         self,
@@ -3355,8 +3355,8 @@ class LegacyWebClient(LegacyBaseClient):
         """Create a Channel Canvas for a channel
         https://api.slack.com/methods/conversations.canvases.create
         """
-        kwargs.update({"channel_id": channel_id, "document_content": json.dumps(document_content)})
-        return self.api_call("conversations.canvases.create", params=kwargs)
+        kwargs.update({"channel_id": channel_id, "document_content": document_content})
+        return self.api_call("conversations.canvases.create", json=kwargs)
 
     def dialog_open(
         self,


### PR DESCRIPTION
## Summary

Our internal users detected an issue with the form data request for canvases API calls when the markdown data is relatively large. This pull request switches the underlying request body data format to JSON for even better compatibility with the server-side.

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
