### PR TITLE
Enable rich_text_* elements to have an empty 'elements' property

### DIFF
--- a/slack_sdk/models/basic_objects.py
+++ b/slack_sdk/models/basic_objects.py
@@ -12,9 +12,13 @@ class BaseObject:
         return f"<slack_sdk.{self.__class__.__name__}>"
 
 
-# Usually, Block Kit components do not allow an empty array for a property value,
-# but there are some exceptions (as of October 2024, only rich_text_section's elements property).
-EMPTY_ALLOWED_TYPE_AND_PROPERTY_LIST = [{"type": "rich_text_section", "property": "elements"}]
+# Usually, Block Kit components do not allow an empty array for a property value, but there are some exceptions.
+EMPTY_ALLOWED_TYPE_AND_PROPERTY_LIST = [
+    {"type": "rich_text_section", "property": "elements"},
+    {"type": "rich_text_list", "property": "elements"},
+    {"type": "rich_text_preformatted", "property": "elements"},
+    {"type": "rich_text_quote", "property": "elements"},
+]
 
 
 class JsonObject(BaseObject, metaclass=ABCMeta):
@@ -57,9 +61,8 @@ class JsonObject(BaseObject, metaclass=ABCMeta):
             if value is None:
                 return False
 
-            # Usually, Block Kit components do not allow an empty array for a property value,
-            # but there are some exceptions (as of October 2024, only rich_text_section's elements property).
-            # The following code deals with this exception:
+            # Usually, Block Kit components do not allow an empty array for a property value, but there are some exceptions.
+            # The following code deals with these exceptions:
             type_value = getattr(self, "type", None)
             for empty_allowed in EMPTY_ALLOWED_TYPE_AND_PROPERTY_LIST:
                 if type_value == empty_allowed["type"] and key == empty_allowed["property"]:

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -1149,15 +1149,21 @@ class RichTextBlockTests(unittest.TestCase):
             "block_id": "my-block",
             "type": "rich_text",
             "elements": [
-                {
-                    "type": "rich_text_section",
-                    "elements": [],
-                },
+                {"type": "rich_text_section", "elements": []},
+                {"type": "rich_text_list", "style": "bullet", "elements": []},
+                {"type": "rich_text_preformatted", "elements": []},
+                {"type": "rich_text_quote", "elements": []},
             ],
         }
         block = RichTextBlock(**empty_element_block)
         self.assertIsInstance(block.elements[0], RichTextSectionElement)
         self.assertIsNotNone(block.elements[0].elements)
+        self.assertIsNotNone(block.elements[1].elements)
+        self.assertIsNotNone(block.elements[2].elements)
+        self.assertIsNotNone(block.elements[3].elements)
 
         block_dict = block.to_dict()
         self.assertIsNotNone(block_dict["elements"][0].get("elements"))
+        self.assertIsNotNone(block_dict["elements"][1].get("elements"))
+        self.assertIsNotNone(block_dict["elements"][2].get("elements"))
+        self.assertIsNotNone(block_dict["elements"][3].get("elements"))

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -1143,3 +1143,21 @@ class RichTextBlockTests(unittest.TestCase):
         self.assertIsInstance(block.elements[3], RichTextListElement)
         self.assertIsInstance(block.elements[3].elements[0], RichTextSectionElement)
         self.assertIsInstance(block.elements[3].elements[0].elements[0], RichTextElementParts.Text)
+
+    def test_parsing_empty_block_elements(self):
+        empty_element_block = {
+            "block_id": "my-block",
+            "type": "rich_text",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [],
+                },
+            ],
+        }
+        block = RichTextBlock(**empty_element_block)
+        self.assertIsInstance(block.elements[0], RichTextSectionElement)
+        self.assertIsNotNone(block.elements[0].elements)
+
+        block_dict = block.to_dict()
+        self.assertIsNotNone(block_dict["elements"][0].get("elements"))


### PR DESCRIPTION
## Summary

This pull request resolves a bug where a few rich_text block element representation in slack_sdk.models package does not an empty value for "element" property. An empty array must be allowed for the property while most other properties in Block Kid do not allow empty arrays.

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
