### PR TITLE
Add is_send_allowed to assistant.threads.setStatus arguments

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2019,12 +2019,15 @@ class AsyncWebClient(AsyncBaseClient):
         channel_id: str,
         thread_ts: str,
         status: str,
+        is_send_allowed: Optional[bool] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Revokes a token.
         https://api.slack.com/methods/assistant.threads.setStatus
         """
-        kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "status": status})
+        kwargs.update(
+            {"channel_id": channel_id, "thread_ts": thread_ts, "status": status, "is_send_allowed": is_send_allowed}
+        )
         return await self.api_call("assistant.threads.setStatus", params=kwargs)
 
     async def assistant_threads_setTitle(

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2010,12 +2010,15 @@ class WebClient(BaseClient):
         channel_id: str,
         thread_ts: str,
         status: str,
+        is_send_allowed: Optional[bool] = None,
         **kwargs,
     ) -> SlackResponse:
         """Revokes a token.
         https://api.slack.com/methods/assistant.threads.setStatus
         """
-        kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "status": status})
+        kwargs.update(
+            {"channel_id": channel_id, "thread_ts": thread_ts, "status": status, "is_send_allowed": is_send_allowed}
+        )
         return self.api_call("assistant.threads.setStatus", params=kwargs)
 
     def assistant_threads_setTitle(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2021,12 +2021,15 @@ class LegacyWebClient(LegacyBaseClient):
         channel_id: str,
         thread_ts: str,
         status: str,
+        is_send_allowed: Optional[bool] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Revokes a token.
         https://api.slack.com/methods/assistant.threads.setStatus
         """
-        kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "status": status})
+        kwargs.update(
+            {"channel_id": channel_id, "thread_ts": thread_ts, "status": status, "is_send_allowed": is_send_allowed}
+        )
         return self.api_call("assistant.threads.setStatus", params=kwargs)
 
     def assistant_threads_setTitle(


### PR DESCRIPTION
## Summary

This pull request adds a new argument to https://api.slack.com/methods/assistant.threads.setStatus 

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
