### PR TITLE
Fix #1592 by encoding aiohttp client session pings

### DIFF
--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -172,7 +172,7 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                         if self.last_ping_pong_time is None:
                             self.last_ping_pong_time = float(t)
                         try:
-                            await session.ping(f"sdk-ping-pong:{t}")
+                            await session.ping(f"sdk-ping-pong:{t}".encode("utf-8"))
                         except Exception as e:
                             # The ping() method can fail for some reason.
                             # To establish a new connection even in this scenario,
@@ -387,7 +387,7 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                 if self.logger.level <= logging.DEBUG:
                     self.logger.debug(f"Sending a ping message with the newly established connection ({session_id})...")
                 t = time.time()
-                await self.current_session.ping(f"sdk-ping-pong:{t}")
+                await self.current_session.ping(f"sdk-ping-pong:{t}".encode("utf-8"))
 
                 if self.current_session_monitor is not None:
                     self.current_session_monitor.cancel()


### PR DESCRIPTION
## Summary

Fixes https://github.com/slackapi/python-slack-sdk/issues/1592

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
