### PR TITLE
add trailing slash to the end of the url

### DIFF
--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -46,7 +46,6 @@ class AsyncBaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
-        # self.base_url = base_url
         if not base_url.endswith("/"):
             base_url += "/"
         self.base_url = base_url

--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -46,6 +46,9 @@ class AsyncBaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
+        # self.base_url = base_url
+        if not base_url.endswith("/"):
+            base_url += "/"
         self.base_url = base_url
         """A string representing the Slack API base URL.
         Default is `'https://slack.com/api/'`."""

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -59,6 +59,9 @@ class BaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
+        # self.base_url = base_url
+        if not base_url.endswith("/"):
+            base_url += "/"
         self.base_url = base_url
         """A string representing the Slack API base URL.
         Default is `'https://slack.com/api/'`."""

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -59,7 +59,6 @@ class BaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
-        # self.base_url = base_url
         if not base_url.endswith("/"):
             base_url += "/"
         self.base_url = base_url

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -62,6 +62,8 @@ class LegacyBaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
+        if not base_url.endswith("/"):
+            base_url += "/"
         self.base_url = base_url
         """A string representing the Slack API base URL.
         Default is `'https://slack.com/api/'`."""

--- a/tests/slack_sdk/web/test_web_client.py
+++ b/tests/slack_sdk/web/test_web_client.py
@@ -229,3 +229,11 @@ class TestWebClient(unittest.TestCase):
             user_auth_blocks=[DividerBlock(), DividerBlock()],
         )
         self.assertIsNone(new_message.get("error"))
+
+    def test_base_url_appends_trailing_slash_issue_15141(self):
+        client = self.client
+        self.assertEqual(client.base_url, "http://localhost:8888/")
+
+    def test_base_url_preserves_trailing_slash_issue_15141(self):
+        client = WebClient(base_url="http://localhost:8888/")
+        self.assertEqual(client.base_url, "http://localhost:8888/")


### PR DESCRIPTION
## Summary
This PR addresses issue #1541 by ensuring that a trailing `/` is appended to the end of the URL in base_url if it is not already provided. This change ensures consistent URL formatting and avoids potential issues caused by missing trailing slashes in API calls.

### Testing

1. Unit Tests
Run the following command to ensure all relevant test cases pass:
```bash
./scripts/run_unit_tests.sh tests/slack_sdk/web/test_web_client.py
```
2. Manual Testing
- Use a custom `base_url` without a trailing `/` in a sample implementation. Confirm that the URL is automatically appended with a `/ `during API calls.
- Use a `base_url` with a trailing `/` and verify that no additional `/` is appended.

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
