### PR TITLE
preventing double slash in the api_url

### DIFF
--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -67,6 +67,8 @@ def _get_url(base_url: str, api_method: str) -> str:
         The absolute API URL.
             e.g. 'https://slack.com/api/chat.postMessage'
     """
+    if base_url.endswith("/") and api_method.startswith("/"):
+        base_url = base_url.rstrip("/")
     return urljoin(base_url, api_method)
 
 


### PR DESCRIPTION
## Summary

<!-- Describe the goal of this PR. Mention any related issue numbers -->
This pull request addresses issue #1595  by ensuring that URLs generated for Slack API requests are correctly formatted to prevent double slashes (`//`) cause by the previous PR #1594 . The issue occurs when the `base_url` ends with a trailing slash (`/`) and the `api_method` starts with a leading slash (`/`). This PR modifies the `_get_url` function to handle such cases by trimming the trailing slash from the `base_url` when necessary.

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->
Run either `./scripts/run_validation.sh` or  `./scripts/run_unit_tests.sh tests/web/test_web_client.py`

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
