### PR TITLE
bug: revert "add trailing slash to the end of the url"

### DIFF
--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -46,8 +46,6 @@ class AsyncBaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
-        if not base_url.endswith("/"):
-            base_url += "/"
         self.base_url = base_url
         """A string representing the Slack API base URL.
         Default is `'https://slack.com/api/'`."""

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -59,8 +59,6 @@ class BaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
-        if not base_url.endswith("/"):
-            base_url += "/"
         self.base_url = base_url
         """A string representing the Slack API base URL.
         Default is `'https://slack.com/api/'`."""

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -62,8 +62,6 @@ class LegacyBaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
-        if not base_url.endswith("/"):
-            base_url += "/"
         self.base_url = base_url
         """A string representing the Slack API base URL.
         Default is `'https://slack.com/api/'`."""

--- a/tests/slack_sdk/web/test_web_client.py
+++ b/tests/slack_sdk/web/test_web_client.py
@@ -229,11 +229,3 @@ class TestWebClient(unittest.TestCase):
             user_auth_blocks=[DividerBlock(), DividerBlock()],
         )
         self.assertIsNone(new_message.get("error"))
-
-    def test_base_url_appends_trailing_slash_issue_15141(self):
-        client = self.client
-        self.assertEqual(client.base_url, "http://localhost:8888/")
-
-    def test_base_url_preserves_trailing_slash_issue_15141(self):
-        client = WebClient(base_url="http://localhost:8888/")
-        self.assertEqual(client.base_url, "http://localhost:8888/")


### PR DESCRIPTION
This PR reverts slackapi/python-slack-sdk#1594 in order to unblock potential future releases.

A potential bug was identified by @HTSagara in [a comment](https://github.com/slackapi/python-slack-sdk/pull/1594#issuecomment-2486311143) on #1594. This was luckily brought up before a new version of the python-slack-sdk was released preventing users from being affected 💯 🥇 

The changes introduced by #1594 are available in the [issue-#1541](https://github.com/slackapi/python-slack-sdk/tree/issue-%231541) branch, please commit further changes to this branch 🙏 