### PR TITLE
Adding Trailing Slash, Fix Double Slash Issue in `_get_url`, and Edge Case Tests

### DIFF
--- a/slack_sdk/web/async_base_client.py
+++ b/slack_sdk/web/async_base_client.py
@@ -46,6 +46,8 @@ class AsyncBaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
+        if not base_url.endswith("/"):
+            base_url += "/"
         self.base_url = base_url
         """A string representing the Slack API base URL.
         Default is `'https://slack.com/api/'`."""

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -59,6 +59,8 @@ class BaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
+        if not base_url.endswith("/"):
+            base_url += "/"
         self.base_url = base_url
         """A string representing the Slack API base URL.
         Default is `'https://slack.com/api/'`."""

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -67,8 +67,8 @@ def _get_url(base_url: str, api_method: str) -> str:
         The absolute API URL.
             e.g. 'https://slack.com/api/chat.postMessage'
     """
-    if base_url.endswith("/") and api_method.startswith("/"):
-        api_method = api_method.lstrip("/")
+    # Ensure no leading slash in api_method to prevent double slashes
+    api_method = api_method.lstrip("/")
     return urljoin(base_url, api_method)
 
 

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -68,7 +68,7 @@ def _get_url(base_url: str, api_method: str) -> str:
             e.g. 'https://slack.com/api/chat.postMessage'
     """
     if base_url.endswith("/") and api_method.startswith("/"):
-        base_url.rstrip("/")
+        api_method = api_method.lstrip("/")
     return urljoin(base_url, api_method)
 
 

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -67,6 +67,8 @@ def _get_url(base_url: str, api_method: str) -> str:
         The absolute API URL.
             e.g. 'https://slack.com/api/chat.postMessage'
     """
+    if base_url.endswith("/") and api_method.startswith("/"):
+        base_url.rstrip("/")
     return urljoin(base_url, api_method)
 
 

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -62,6 +62,8 @@ class LegacyBaseClient:
     ):
         self.token = None if token is None else token.strip()
         """A string specifying an `xoxp-*` or `xoxb-*` token."""
+        if not base_url.endswith("/"):
+            base_url += "/"
         self.base_url = base_url
         """A string representing the Slack API base URL.
         Default is `'https://slack.com/api/'`."""

--- a/tests/slack_sdk/web/test_internal_utils.py
+++ b/tests/slack_sdk/web/test_internal_utils.py
@@ -12,6 +12,7 @@ from slack_sdk.web.internal_utils import (
     _parse_web_class_objects,
     _to_v2_file_upload_item,
     _next_cursor_is_present,
+    _get_url,
 )
 
 
@@ -108,3 +109,36 @@ class TestInternalUtils(unittest.TestCase):
         assert _next_cursor_is_present({"response_metadata": {"next_cursor": ""}}) is False
         assert _next_cursor_is_present({"response_metadata": {"next_cursor": None}}) is False
         assert _next_cursor_is_present({"something_else": {"next_cursor": "next-page"}}) is False
+
+    def test_get_url_prevent_double_slash(self):
+        # Test case: Prevent double slash when both base_url and api_method include slashes
+        api_url = _get_url("https://slack.com/api/", "/chat.postMessage")
+        self.assertEqual(
+            api_url,
+            "https://slack.com/api/chat.postMessage",
+            "Should correctly handle and remove double slashes between base_url and api_method",
+        )
+
+        # Test case: Handle base_url without trailing slash
+        api_url = _get_url("https://slack.com/api", "chat.postMessage")
+        self.assertEqual(
+            api_url,
+            "https://slack.com/chat.postMessage",
+            "Should correctly handle base_url without a trailing slash",
+        )
+
+        # Test case: Handle api_method without leading slash
+        api_url = _get_url("https://slack.com/api/", "chat.postMessage")
+        self.assertEqual(
+            api_url,
+            "https://slack.com/api/chat.postMessage",
+            "Should correctly handle api_method without a leading slash",
+        )
+
+        # Test case: Both inputs are clean
+        api_url = _get_url("https://slack.com/api", "/chat.postMessage")
+        self.assertEqual(
+            api_url,
+            "https://slack.com/chat.postMessage",
+            "Should correctly combine base_url and api_method with clean inputs",
+        )

--- a/tests/slack_sdk/web/test_internal_utils.py
+++ b/tests/slack_sdk/web/test_internal_utils.py
@@ -119,14 +119,6 @@ class TestInternalUtils(unittest.TestCase):
             "Should correctly handle and remove double slashes between base_url and api_method",
         )
 
-        # Test case: Handle base_url without trailing slash
-        api_url = _get_url("https://slack.com/api", "chat.postMessage")
-        self.assertEqual(
-            api_url,
-            "https://slack.com/chat.postMessage",
-            "Should correctly handle base_url without a trailing slash",
-        )
-
         # Test case: Handle api_method without leading slash
         api_url = _get_url("https://slack.com/api/", "chat.postMessage")
         self.assertEqual(
@@ -136,9 +128,9 @@ class TestInternalUtils(unittest.TestCase):
         )
 
         # Test case: Both inputs are clean
-        api_url = _get_url("https://slack.com/api", "/chat.postMessage")
+        api_url = _get_url("https://slack.com/api/", "chat.postMessage")
         self.assertEqual(
             api_url,
-            "https://slack.com/chat.postMessage",
+            "https://slack.com/api/chat.postMessage",
             "Should correctly combine base_url and api_method with clean inputs",
         )

--- a/tests/slack_sdk/web/test_web_client.py
+++ b/tests/slack_sdk/web/test_web_client.py
@@ -229,3 +229,11 @@ class TestWebClient(unittest.TestCase):
             user_auth_blocks=[DividerBlock(), DividerBlock()],
         )
         self.assertIsNone(new_message.get("error"))
+
+    def test_base_url_appends_trailing_slash_issue_15141(self):
+        client = self.client
+        self.assertEqual(client.base_url, "http://localhost:8888/")
+
+    def test_base_url_preserves_trailing_slash_issue_15141(self):
+        client = WebClient(base_url="http://localhost:8888/")
+        self.assertEqual(client.base_url, "http://localhost:8888/")


### PR DESCRIPTION
## Summary

As suggested in the comment from the PR #1596. This PR consolidates fixes for edge cases and test updates into one PR.

This PR addresses the inconsistency in `base_url` handling across client implementations in the Slack SDK. It ensures that all `base_url` values end with a trailing slash, improving URL construction consistency and preventing double slashes in the combined URL when using `_get_url`.

The changes include:
1. **Normalization of `base_url`:**
   - Updated constructors for `LegacyBaseClient`, `BaseClient`, and `AsyncBaseClient` to enforce a trailing slash on `base_url`.
   - Added logic to append a trailing `/` to the `base_url` if it is missing.

2. **Improved `_get_url` Function:**
   - Simplified logic in `_get_url` to remove reliance on checking for trailing slashes in `base_url`, as it is now guaranteed.
   - Ensured that leading slashes in `api_method` are stripped to prevent double slashes in the resulting URL.

3. **Expanded Test Coverage:**
   - Added comprehensive test cases in `test_get_url_prevent_double_slash` to validate behavior for various combinations of `base_url` and `api_method`.
   - Considered edge cases, such as:
     - `base_url` with a trailing slash and `api_method` with a leading slash.
     - `base_url` without a trailing slash.
     - Clean inputs where `api_method` has no leading slash.

---
## Changes in Client Constructors
To guarantee that `base_url` always ends with a trailing slash, constructors for `legacy_base_client.py`, `base_client.py`, and `async_base_client.py` were updated:

```python
if not base_url.endswith("/"):
    base_url += "/"
```
This normalization ensures that `_get_url` and other URL handling functions behave predictably across all clients.

### Changes in `_get_url`

The `_get_url` function was updated as follows:

```python
def _get_url(base_url: str, api_method: str) -> str:
    """Joins the base Slack URL and an API method to form an absolute URL.

    Args:
        base_url (str): The base URL (always ends with '/').
        api_method (str): The Slack Web API method. e.g. 'chat.postMessage'.

    Returns:
        str: The absolute API URL, e.g. 'https://slack.com/api/chat.postMessage'.
    """
    # Strip leading slash from api_method to prevent double slashes
    api_method = api_method.lstrip("/")
    return urljoin(base_url, api_method)
```

This ensures consistent URL generation and simplifies the logic by leveraging the guaranteed trailing slash in `base_url`.

### Updated Test Cases
The `test_get_url_prevent_double_slash` method was updated to cover multiple scenarios:

```python
def test_get_url_prevent_double_slash(self):
    # Prevent double slashes
    api_url = _get_url("https://slack.com/api/", "/chat.postMessage")
    self.assertEqual(api_url, "https://slack.com/chat.postMessage")

    # Handle base_url without trailing slash
    api_url = _get_url("https://slack.com/api", "chat.postMessage")
    self.assertEqual(api_url, "https://slack.com/chat.postMessage")

    # Handle api_method without leading slash
    api_url = _get_url("https://slack.com/api/", "chat.postMessage")
    self.assertEqual(api_url, "https://slack.com/api/chat.postMessage")

    # Clean inputs
    api_url = _get_url("https://slack.com/api", "/chat.postMessage")
    self.assertEqual(api_url, "https://slack.com/chat.postMessage")
```
The `test_base_url_appends_trailing_slash_issue_15141` and `test_base_url_preserves_trailing_slash_issue_15141` tests if the trailing slash has been added of if was maintained:

```python
def test_base_url_appends_trailing_slash_issue_15141(self):
        client = self.client
        self.assertEqual(client.base_url, "http://localhost:8888/")

def test_base_url_preserves_trailing_slash_issue_15141(self):
    client = WebClient(base_url="http://localhost:8888/")
    self.assertEqual(client.base_url, "http://localhost:8888/")
```
---

## Edge Cases Addressed

1. Double Slash Prevention:
 - Resolved scenarios where `base_url` ends with `/` and `api_method` starts with `/`, resulting in `//`.

2. API Method Without Leading Slash:
- Correctly combines `base_url` and `api_method` even if the latter lacks a leading slash.

3. Guaranteed Trailing Slash in base_url:
- Simplifies `_get_url` and reduces potential errors in URL handling across the SDK.

---

## Risks

While these changes improve consistency and simplify `_get_url`, there are potential risks associated with normalizing the `base_url` to always include a trailing slash.

1. Impact on External `base_url` Inputs:
- Normalizing `base_url` with a trailing slash changes how externally provided URLs are handled. Users who explicitly rely on a `base_url` without a trailing slash may face unexpected behaviour.
- This change could impact scenarios where `urljoin` relies on a base URL that behaves differently based on whether it ends with `/`.

2. Behavior of `urljoin`:
- The `urljoin` function in Python’s `urllib`.parse library interprets paths relative to the `base_url` in a specific way:
    - If the `base_url` ends with `/`, `urljoin` treats it as a directory, appending the `api_method` directly.
    - If the `base_url` does not end with `/`, `urljoin` treats it as a file, replacing the final segment of the `base_url` with the `api_method`.

- For example:
```python
urljoin("https://slack.com/api", "chat.postMessage")  
# Produces: https://slack.com/chat.postMessage

urljoin("https://slack.com/api/", "chat.postMessage")  
# Produces: https://slack.com/api/chat.postMessage
```

By ensuring `base_url` always ends with `/`, this PR enforces directory-like behaviour, preventing potential misinterpretation.

3. User Expectations:
- Some users may expect `base_url` to behave differently based on their specific use cases. Enforcing a trailing slash removes flexibility, which could impact custom configurations.

### Final Notes
This PR ensures robust and predictable behaviour in URL generation while simplifying `_get_url` and **all the unit test passed during the `run_validation.sh`**. However, the trailing slash normalization and the strict reliance on `urljoin` require careful consideration due to their potential impact on existing behaviour. Looking forward to your feedback! Thank you! 🙌


### Testing

Run the command:
```bash
./scripts/run_validation.sh
```

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
