### PR TITLE
fix: 'ClientConnection' object has no attribute 'closed'

### DIFF
--- a/slack_sdk/socket_mode/websockets/__init__.py
+++ b/slack_sdk/socket_mode/websockets/__init__.py
@@ -36,9 +36,14 @@ from ..logger.messages import debug_redacted_message_string
 
 
 def _session_closed(session: Optional[ClientConnection]):
+    if session is None:
+        return True
+    if hasattr(session, "closed"):
+        # The session is a WebSocketClientProtocol instance
+        return session.closed
     # WebSocket close code, defined in https://datatracker.ietf.org/doc/html/rfc6455.html#section-7.1.5
     # None if the connection isn’t closed yet.
-    return session is None or session.close_code is not None
+    return session.close_code is not None
 
 
 class SocketModeClient(AsyncBaseSocketModeClient):

--- a/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
@@ -14,6 +14,7 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
 from slack_sdk.socket_mode.websockets import SocketModeClient
 from slack_sdk.web.async_client import AsyncWebClient
+from tests.helpers import is_ci_unstable_test_skip_enabled
 from tests.slack_sdk.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
     socket_mode_envelopes,
@@ -103,6 +104,9 @@ class TestInteractionsWebsockets(unittest.TestCase):
 
     @async_test
     async def test_send_message_while_disconnection(self):
+        if is_ci_unstable_test_skip_enabled():
+            # this test tends to fail on the GitHub Actions platform
+            return
         t = Thread(target=start_socket_mode_server(self, 3001))
         t.daemon = True
         t.start()

--- a/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
@@ -14,7 +14,6 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
 from slack_sdk.socket_mode.websockets import SocketModeClient
 from slack_sdk.web.async_client import AsyncWebClient
-from tests.helpers import is_ci_unstable_test_skip_enabled
 from tests.slack_sdk.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
     socket_mode_envelopes,
@@ -104,9 +103,6 @@ class TestInteractionsWebsockets(unittest.TestCase):
 
     @async_test
     async def test_send_message_while_disconnection(self):
-        if is_ci_unstable_test_skip_enabled():
-            # this test tends to fail on the GitHub Actions platform
-            return
         t = Thread(target=start_socket_mode_server(self, 3001))
         t.daemon = True
         t.start()


### PR DESCRIPTION
## Summary

This PR aims to resolve #1612

Followed [Upgrade to the new asyncio implementation](https://websockets.readthedocs.io/en/stable/howto/upgrade.html) to come up with these changes. Socket mode uses `websockets.WebSocketClientProtocol` in its implementation, this class was replaced with [websockets.asyncio.client.ClientConnection](https://websockets.readthedocs.io/en/stable/reference/asyncio/client.html#websockets.asyncio.client.ClientConnection). 

These interfaces are very similar but `ClientConnection` lacks the `closed` method found in `WebSocketClientProtocol`. As a workaround proposed to use `.close_code is not None` to determine if a session is closed or in the process of being closed. Close code is defined in [RFC 6455 sec 7.1.5](https://datatracker.ietf.org/doc/html/rfc6455.html#section-7.1.5)

### Testing

1. Pull this branch
2. `scripts/build_pypi_package.sh`
3. Use `path/to/python-slack-sdk/dist/slack_sdk-3.33.5-py2.py3-none-any.whl` to pip install the changes in the following project
```py
import sys
import os
import logging
import asyncio
from slack_bolt.async_app import AsyncApp
from slack_bolt.adapter.socket_mode.websockets import AsyncSocketModeHandler

# Initializes your app with your bot token and socket mode handler
app = AsyncApp(token=os.environ.get("SLACK_BOT_TOKEN"))

logging.basicConfig(level=logging.DEBUG)

# Start your app
if __name__ == "__main__":
    if sys.version.startswith("3.6"):
        loop = asyncio.get_event_loop()
        loop.run_until_complete(
            AsyncSocketModeHandler(app, os.environ["SLACK_APP_TOKEN"]).start_async()
        )
    else:
        asyncio.run(
            AsyncSocketModeHandler(app, os.environ["SLACK_APP_TOKEN"]).start_async()
        )
```

```txt
slack_bolt==1.21.3
path/to/python-slack-sdk/dist/slack_sdk-3.33.5-py2.py3-none-any.whl
aiohttp>=3.7.3,<4
websockets>=9.1,<15
```

Manually tested with python 3.6 and 3.12

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
