### PR TITLE
chore: support python 3.13

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -52,8 +52,8 @@ jobs:
           pip install "SQLAlchemy>=1.4,<2"
           python setup.py unit_tests --test-target tests/slack_sdk/oauth/installation_store/test_sqlalchemy.py && \
           python setup.py unit_tests --test-target tests/slack_sdk/oauth/state_store/test_sqlalchemy.py
-      - name: Run codecov (only 3.9)
-        if: startsWith(matrix.python-version, '3.9')
+      - name: Run codecov (only with latest supported version)
+        if: startsWith(matrix.python-version, '3.13')
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,7 +3,7 @@ name: CI Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -15,47 +15,47 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.12'
-          - '3.11'
-          - '3.10'
-          - '3.9'
-          - '3.8'
-          - '3.7'
-          - '3.6'
-          - 'pypy3.10'
+          - "3.13"
+          - "3.12"
+          - "3.11"
+          - "3.10"
+          - "3.9"
+          - "3.8"
+          - "3.7"
+          - "3.6"
+          - "pypy3.10"
     env:
-      CI_LARGE_SOCKET_MODE_PAYLOAD_TESTING_DISABLED: '1'
-      CI_UNSTABLE_TESTS_SKIP_ENABLED: '1'
-      FORCE_COLOR: '1'
+      CI_LARGE_SOCKET_MODE_PAYLOAD_TESTING_DISABLED: "1"
+      CI_UNSTABLE_TESTS_SKIP_ENABLED: "1"
+      FORCE_COLOR: "1"
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-    - name: Install dependencies
-      run: |
-        pip install -U pip setuptools wheel
-        pip install -r requirements/testing.txt
-        pip install -r requirements/optional.txt
-    - name: Run codegen
-      run: |
-        python setup.py codegen
-    - name: Run validation (black/flake8/pytest)
-      run: |
-        python setup.py validate
-    - name: Run tests for SQLAlchemy v1.4 (backward-compatibility)
-      run: |
-        # Install v1.4 for testing
-        pip install "SQLAlchemy>=1.4,<2"
-        python setup.py unit_tests --test-target tests/slack_sdk/oauth/installation_store/test_sqlalchemy.py && \
-        python setup.py unit_tests --test-target tests/slack_sdk/oauth/state_store/test_sqlalchemy.py
-    - name: Run codecov (only 3.9)
-      if: startsWith(matrix.python-version, '3.9')
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        # python setup.py validate generates the coverage file
-        files: ./coverage.xml
-
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install dependencies
+        run: |
+          pip install -U pip setuptools wheel
+          pip install -r requirements/testing.txt
+          pip install -r requirements/optional.txt
+      - name: Run codegen
+        run: |
+          python setup.py codegen
+      - name: Run validation (black/flake8/pytest)
+        run: |
+          python setup.py validate
+      - name: Run tests for SQLAlchemy v1.4 (backward-compatibility)
+        run: |
+          # Install v1.4 for testing
+          pip install "SQLAlchemy>=1.4,<2"
+          python setup.py unit_tests --test-target tests/slack_sdk/oauth/installation_store/test_sqlalchemy.py && \
+          python setup.py unit_tests --test-target tests/slack_sdk/oauth/state_store/test_sqlalchemy.py
+      - name: Run codecov (only 3.9)
+        if: startsWith(matrix.python-version, '3.9')
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # python setup.py validate generates the coverage file
+          files: ./coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
 	"Programming Language :: Python :: 3.12",
+	"Programming Language :: Python :: 3.13",
 	"Programming Language :: Python :: Implementation :: CPython",
 	"Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
## Summary

This PR aims to add official support for python 3.13

### Testing

Unit tests pass locally 🟢 
Manually tested basic apps 🟢 

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
