### PR TITLE
build: enable tests that are now stable

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,7 +26,6 @@ jobs:
           - "pypy3.10"
     env:
       CI_LARGE_SOCKET_MODE_PAYLOAD_TESTING_DISABLED: "1"
-      CI_UNSTABLE_TESTS_SKIP_ENABLED: "1"
       FORCE_COLOR: "1"
     steps:
       - uses: actions/checkout@v4

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -24,7 +24,3 @@ def remove_os_env_temporarily() -> dict:
 
 def restore_os_env(old_env: dict) -> None:
     os.environ.update(old_env)
-
-
-def is_ci_unstable_test_skip_enabled() -> bool:
-    return os.environ.get("CI_UNSTABLE_TESTS_SKIP_ENABLED") == "1"

--- a/tests/slack_sdk/socket_mode/test_interactions_websocket_client.py
+++ b/tests/slack_sdk/socket_mode/test_interactions_websocket_client.py
@@ -11,7 +11,6 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 
 from slack_sdk import WebClient
 from slack_sdk.socket_mode.websocket_client import SocketModeClient
-from tests.helpers import is_ci_unstable_test_skip_enabled
 from tests.slack_sdk.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
     socket_mode_envelopes,
@@ -90,10 +89,6 @@ class TestInteractionsWebSocketClient(unittest.TestCase):
             client.close()
 
     def test_send_message_while_disconnection(self):
-        if is_ci_unstable_test_skip_enabled():
-            # this test tends to fail on the GitHub Actions platform
-            return
-
         try:
             client = SocketModeClient(
                 app_token="xapp-A111-222-xyz",


### PR DESCRIPTION
## Summary

#1023 disabled units that were found to be unstable in our CI pipeline, #1615 improved the stability of these tests, this PR aims to reenable these unit tests in our CI pipeline

### Testing

Test in CI pipeline

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
