### PR TITLE
Google Cloud Storage OAuth backend

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -6,6 +6,7 @@ aiodns>1.0
 aiohttp>=3.7.3,<4
 # used only under slack_sdk/*_store
 boto3<=2
+google-cloud-storage>=2.7.0,<3
 # InstallationStore/OAuthStateStore
 # Since v3.20, we no longer support SQLAlchemy 1.3 or older.
 # If you need to use a legacy version, please add our v3.19.5 code to your project.

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -14,6 +14,7 @@ click==8.0.4  # black is affected by https://github.com/pallets/click/issues/222
 psutil>=6.0.0,<7
 #  used only under slack_sdk/*_store
 boto3<=2
+google-cloud-storage>=2.7.0,<3
 # For AWS tests
 moto>=4.0.13,<6
 mypy<=1.13.0

--- a/slack_sdk/oauth/installation_store/google_cloud_storage/__init__.py
+++ b/slack_sdk/oauth/installation_store/google_cloud_storage/__init__.py
@@ -1,0 +1,347 @@
+# -*- coding: utf-8 -*-
+"""Store Slack bot install data to a Google Cloud Storage bucket."""
+
+import json
+import logging
+from logging import Logger
+from typing import Optional
+
+from google.cloud.storage import Client  # type: ignore[import-untyped]
+
+from slack_sdk.oauth.installation_store.async_installation_store import AsyncInstallationStore
+from slack_sdk.oauth.installation_store.installation_store import InstallationStore
+from slack_sdk.oauth.installation_store.models.bot import Bot
+from slack_sdk.oauth.installation_store.models.installation import Installation
+
+
+class GoogleCloudStorageInstallationStore(InstallationStore, AsyncInstallationStore):
+    """Store Slack user installation data to a Google Cloud Storage bucket.
+
+    https://api.slack.com/authentication/oauth-v2
+
+    Attributes:
+        storage_client (Client): A Google Cloud Storage client to access the bucket
+        bucket_name (str): Bucket to store user installation data for current Slack app
+        client_id (str): Slack application client id
+    """
+
+    def __init__(
+        self,
+        *,
+        storage_client: Client,
+        bucket_name: str,
+        client_id: str,
+        logger: Logger = logging.getLogger(__name__),
+    ):
+        """Creates a new instance.
+
+        Args:
+            storage_client (Client): A Google Cloud Storage client to access the bucket
+            bucket_name (str): Bucket to store user installation data for current Slack app
+            client_id (str): Slack application client id
+            logger (Logger): Custom logger for logging. Defaults to a new logger for this module.
+        """
+        self.storage_client = storage_client
+        self.bucket = self.storage_client.bucket(bucket_name)
+        self.client_id = client_id
+        self._logger = logger
+
+    @property
+    def logger(self) -> Logger:
+        """Gets the internal logger if it exists, otherwise creates a new one.
+
+        Returns:
+            Logger: the logger
+        """
+        if self._logger is None:
+            self._logger = logging.getLogger(__name__)
+        return self._logger
+
+    async def async_save(self, installation: Installation):
+        """Save user's app authorization.
+
+        Args:
+            installation (Installation): information about the user and the app usage authorization
+        """
+        self.save(installation)
+
+    def save(self, installation: Installation):
+        """Save user's app authorization.
+
+        Args:
+            installation (Installation): information about the user and the app usage authorization
+        """
+        # save bot data
+        self.save_bot(installation.to_bot())
+
+        # per workspace
+        entity = json.dumps(installation.__dict__)
+        self._save_entity(
+            data_type="installer",
+            entity=entity,
+            enterprise_id=installation.enterprise_id,
+            team_id=installation.team_id,
+            user_id=None,
+        )
+        self.logger.debug("Uploaded %s to Google bucket as installer", entity)
+
+        # per workspace per user
+        self._save_entity(
+            data_type="installer",
+            entity=entity,
+            enterprise_id=installation.enterprise_id,
+            team_id=installation.team_id,
+            user_id=installation.user_id or "none",
+        )
+        self.logger.debug("Uploaded %s to Google bucket as installer-%s", entity, installation.user_id)
+
+    async def async_save_bot(self, bot: Bot):
+        """Save bot user authorization.
+
+        Args:
+            bot (Bot): data bout the bot
+        """
+        self.save_bot(bot)
+
+    def save_bot(self, bot: Bot):
+        """Save bot user authorization.
+
+        Args:
+            bot (Bot): data bout the bot
+        """
+        entity = json.dumps(bot.__dict__)
+        self._save_entity(data_type="bot", entity=entity, enterprise_id=bot.enterprise_id, team_id=bot.team_id, user_id=None)
+        self.logger.debug("Uploaded %s to Google bucket as bot", entity)
+
+    def _save_entity(
+        self, data_type: str, entity: str, enterprise_id: Optional[str], team_id: Optional[str], user_id: Optional[str]
+    ):
+        """Saves data to a GCS bucket.
+
+        Args:
+            data_type (str): data type
+            entity (str): data payload
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+            user_id (Optional[str]): Slack user ID
+        """
+        key = self._key(data_type=data_type, enterprise_id=enterprise_id, team_id=team_id, user_id=user_id)
+        blob = self.bucket.blob(key)
+        blob.upload_from_string(entity)
+
+    async def async_find_bot(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Bot]:
+        """Check if a Slack bot user has been installed in a Slack workspace.
+
+        Args:
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+            is_enterprise_install (Optional[str]): True if the Slack app is installed across multiple workspaces in an
+                                                   Enterprise Grid. Defaults to False.
+
+        Returns:
+            Optional[Bot]: A Slack bot/app identifier object if found, else None
+        """
+        return self.find_bot(
+            enterprise_id=enterprise_id,
+            team_id=team_id,
+            is_enterprise_install=is_enterprise_install,
+        )
+
+    def find_bot(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Bot]:
+        """Check if a Slack bot user has been installed in a Slack workspace.
+
+        Args:
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+            is_enterprise_install (Optional[str]): True if the Slack app is installed across multiple workspaces in an
+                                                   Enterprise Grid. Defaults to False
+
+        Returns:
+            Optional[Bot]: A Slack bot/app identifier object if found, else None
+        """
+        key = self._key(
+            data_type="bot",
+            enterprise_id=enterprise_id,
+            is_enterprise_install=is_enterprise_install,
+            team_id=team_id,
+            user_id=None,
+        )
+        try:
+            blob = self.bucket.blob(key)
+            body = blob.download_as_text(encoding="utf-8")
+            self.logger.debug("Downloaded %s from Google bucket", body)
+            data = json.loads(body)
+            return Bot(**data)
+        except Exception as exc:
+            self.logger.warning(
+                "Failed to find bot installation data for enterprise: %s, team: %s: %s", enterprise_id, team_id, exc
+            )
+            return None
+
+    async def async_find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        """Check if a Slack user has installed the app.
+
+        Args:
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+            user_id (Optional[str]): Slack user ID. Defaults to None.
+            is_enterprise_install (Optional[str]): True if the Slack app is installed across multiple workspaces in an
+                                                   Enterprise Grid. Defaults to False
+
+        Returns:
+            Optional[Installation]: A installation identifier object if found, else None
+        """
+        return self.find_installation(
+            enterprise_id=enterprise_id,
+            team_id=team_id,
+            user_id=user_id,
+            is_enterprise_install=is_enterprise_install,
+        )
+
+    def find_installation(
+        self,
+        *,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str] = None,
+        is_enterprise_install: Optional[bool] = False,
+    ) -> Optional[Installation]:
+        """Check if a Slack user has installed the app.
+
+        Args:
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+            user_id (Optional[str]): Slack user ID. Defaults to None.
+            is_enterprise_install (Optional[str]): True if the Slack app is installed across multiple workspaces in an
+                                                   Enterprise Grid. Defaults to False
+
+        Returns:
+            Optional[Installation]: A installation identifier object if found, else None
+        """
+        key = self._key(
+            data_type="installer",
+            enterprise_id=enterprise_id,
+            is_enterprise_install=is_enterprise_install,
+            team_id=team_id,
+            user_id=user_id,
+        )
+        try:
+            blob = self.bucket.blob(key)
+            body = blob.download_as_text(encoding="utf-8")
+            self.logger.debug("Downloaded %s from Google bucket", body)
+            data = json.loads(body)
+            return Installation(**data)
+        except Exception as exc:
+            self.logger.warning(
+                "Failed to find an installation data for enterprise: %s, team: %s: %s", enterprise_id, team_id, exc
+            )
+            return None
+
+    #
+    # adaptation of https://gist.github.com/seratch/d81a445ef4467b16f047156bf859cda8
+    #
+
+    async def async_delete_installation(
+        self, *, enterprise_id: Optional[str], team_id: Optional[str], user_id: Optional[str] = None
+    ) -> None:
+        """Deletes a user's Slack installation data.
+
+        Args:
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+            user_id (Optional[str]): Slack user ID
+        """
+        self.delete_installation(enterprise_id=enterprise_id, team_id=team_id, user_id=user_id)
+
+    def delete_installation(
+        self, *, enterprise_id: Optional[str], team_id: Optional[str], user_id: Optional[str] = None
+    ) -> None:
+        """Deletes a user's Slack installation data.
+
+        Args:
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+            user_id (Optional[str]): Slack user ID
+        """
+        self._delete_entity(data_type="installer", enterprise_id=enterprise_id, team_id=team_id, user_id=user_id)
+        self.logger.debug("Uninstalled app for enterprise: %s, team: %s, user: %s", enterprise_id, team_id, user_id)
+
+    async def async_delete_bot(self, *, enterprise_id: Optional[str], team_id: Optional[str]) -> None:
+        """Deletes Slack bot user install data from the workspace.
+
+        Args:
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+        """
+        self.delete_bot(enterprise_id=enterprise_id, team_id=team_id)
+
+    def delete_bot(self, *, enterprise_id: Optional[str], team_id: Optional[str]) -> None:
+        """Deletes Slack bot user install data from the workspace.
+
+        Args:
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+        """
+        self._delete_entity(data_type="bot", enterprise_id=enterprise_id, team_id=team_id, user_id=None)
+        self.logger.debug("Uninstalled bot for enterprise: %s, team: %s", enterprise_id, team_id)
+
+    def _delete_entity(
+        self, data_type: str, enterprise_id: Optional[str], team_id: Optional[str], user_id: Optional[str]
+    ) -> None:
+        """Deletes an object from a Google Cloud Storage bucket.
+
+        Args:
+            data_type (str): data type
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+            user_id (Optional[str]): Slack user ID
+        """
+        key = self._key(data_type=data_type, enterprise_id=enterprise_id, team_id=team_id, user_id=user_id)
+        blob = self.bucket.blob(key)
+        if blob.exists():
+            blob.delete()
+
+    def _key(
+        self,
+        data_type: str,
+        enterprise_id: Optional[str],
+        team_id: Optional[str],
+        user_id: Optional[str],
+        is_enterprise_install: Optional[bool] = None,
+    ) -> str:
+        """Helper method to create a path to an object in a GCS bucket.
+
+        Args:
+            data_type (str): object type
+            enterprise_id (Optional[str]): Slack Enterprise Grid ID
+            team_id (Optional[str]): Slack workspace/team ID
+            user_id (Optional[str]): Slack user ID
+
+        Returns:
+            str: path to data corresponding to input args
+        """
+        none = "none"
+        e_id = enterprise_id or none
+        t_id = none if is_enterprise_install else team_id or none
+
+        workspace_path = f"{self.client_id}/{e_id}-{t_id}"
+        return f"{workspace_path}/{data_type}-{user_id}" if user_id else f"{workspace_path}/{data_type}"

--- a/slack_sdk/oauth/installation_store/google_cloud_storage/__init__.py
+++ b/slack_sdk/oauth/installation_store/google_cloud_storage/__init__.py
@@ -99,7 +99,7 @@ class GoogleCloudStorageInstallationStore(InstallationStore, AsyncInstallationSt
         """Save bot user authorization.
 
         Args:
-            bot (Bot): data bout the bot
+            bot (Bot): data about the bot
         """
         self.save_bot(bot)
 
@@ -107,7 +107,7 @@ class GoogleCloudStorageInstallationStore(InstallationStore, AsyncInstallationSt
         """Save bot user authorization.
 
         Args:
-            bot (Bot): data bout the bot
+            bot (Bot): data about the bot
         """
         entity = json.dumps(bot.__dict__)
         self._save_entity(data_type="bot", entity=entity, enterprise_id=bot.enterprise_id, team_id=bot.team_id, user_id=None)
@@ -255,10 +255,6 @@ class GoogleCloudStorageInstallationStore(InstallationStore, AsyncInstallationSt
                 "Failed to find an installation data for enterprise: %s, team: %s: %s", enterprise_id, team_id, exc
             )
             return None
-
-    #
-    # adaptation of https://gist.github.com/seratch/d81a445ef4467b16f047156bf859cda8
-    #
 
     async def async_delete_installation(
         self, *, enterprise_id: Optional[str], team_id: Optional[str], user_id: Optional[str] = None

--- a/slack_sdk/oauth/state_store/google_cloud_storage/__init__.py
+++ b/slack_sdk/oauth/state_store/google_cloud_storage/__init__.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Store OAuth tokens/state in a Google Cloud Storage bucket."""
+
+import logging
+import time
+from logging import Logger
+from uuid import uuid4
+
+from google.cloud.storage import Client  # type: ignore[import-untyped]
+
+from slack_sdk.oauth.state_store.async_state_store import AsyncOAuthStateStore
+from slack_sdk.oauth.state_store import OAuthStateStore
+
+
+class GoogleCloudStorageOAuthStateStore(OAuthStateStore, AsyncOAuthStateStore):
+    """Implements OAuthStateStore and AsyncOAuthStateStore for storing Slack bot auth data to Google Cloud Storage.
+
+    Attributes:
+        storage_client (Client): A Google Cloud Storage client to access the bucket
+        bucket_name (str): Bucket to store OAuth data
+        expiration_seconds (int): expiration time for the Oauth token
+    """
+
+    def __init__(
+        self,
+        *,
+        storage_client: Client,
+        bucket_name: str,
+        expiration_seconds: int,
+        logger: Logger = logging.getLogger(__name__),
+    ):
+        """Creates a new instance.
+
+        Args:
+            storage_client (Client): A Google Cloud Storage client to access the bucket
+            bucket_name (str): Bucket to store OAuth data
+            expiration_seconds (int): expiration time for the Oauth token
+            logger (Logger): Custom logger for logging. Defaults to a new logger for this module.
+        """
+        self.storage_client = storage_client
+        self.bucket_name = bucket_name
+        self.expiration_seconds = expiration_seconds
+        self._logger = logger
+
+    @property
+    def logger(self) -> Logger:
+        """Gets the internal logger if it exists, otherwise creates a new one.
+
+        Returns:
+            Logger: the logger
+        """
+        if self._logger is None:
+            self._logger = logging.getLogger(__name__)
+        return self._logger
+
+    async def async_issue(self, *args, **kwargs) -> str:
+        """Creates and stores a new OAuth token.
+
+        Args:
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            str: the token
+        """
+        return self.issue(*args, **kwargs)
+
+    async def async_consume(self, state: str) -> bool:
+        """Reads the token and checks if it's a valid one.
+
+        Args:
+            state (str): the token
+
+        Returns:
+            bool: True if the token is valid
+        """
+        return self.consume(state)
+
+    def issue(self, *args, **kwargs) -> str:
+        """Creates and stores a new OAuth token.
+
+        Args:
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            str: the token
+        """
+        state = str(uuid4())
+        bucket = self.storage_client.bucket(self.bucket_name)
+        blob = bucket.blob(state)
+        blob.upload_from_string(str(time.time()))
+        self.logger.debug("Issued %s to the Google bucket", state)
+        return state
+
+    def consume(self, state: str) -> bool:
+        """Reads the token and checks if it's a valid one.
+
+        Args:
+            state (str): the token
+
+        Returns:
+            bool: True if the token is valid
+        """
+        try:
+            bucket = self.storage_client.bucket(self.bucket_name)
+            blob = bucket.blob(state)
+            body = blob.download_as_text(encoding="utf-8")
+
+            self.logger.debug("Downloaded %s from Google bucket", state)
+            created = float(body)
+            expiration = created + self.expiration_seconds
+            still_valid: bool = time.time() < expiration
+
+            blob.delete()
+            self.logger.debug("Deleted %s from Google bucket", state)
+            return still_valid
+        except Exception as exc:  # pylint: disable=broad-except
+            self.logger.warning("Failed to find any persistent data for state: %s - %s", state, exc)
+            return False

--- a/tests/slack_sdk/oauth/installation_store/test_google_cloud_storage.py
+++ b/tests/slack_sdk/oauth/installation_store/test_google_cloud_storage.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+"""Tests for oauth/installation_store/google_cloud_storage/__init__.py"""
+
+import json
+import time
+import logging
+import unittest
+from unittest.mock import Mock, call, patch
+from google.cloud.storage.blob import Blob
+from google.cloud.storage.bucket import Bucket
+
+from google.cloud.storage.client import Client
+from slack_sdk.oauth.installation_store.models.installation import Installation
+from slack_sdk.oauth.installation_store.google_cloud_storage import GoogleCloudStorageInstallationStore
+
+
+class TestGoogleInstallationStore(unittest.IsolatedAsyncioTestCase):
+    """Tests for GoogleCloudStorageInstallationStore"""
+
+    async def asyncSetUp(self):
+        """Setup test"""
+        self.blob = Mock(spec=Blob)
+        self.bucket = Mock(spec=Bucket)
+        self.bucket.blob.return_value = self.blob
+
+        self.storage_client = Mock(spec=Client)
+        self.storage_client.bucket.return_value = self.bucket
+
+        self.bucket_name = "bucket"
+        self.client_id = "clid"
+        self.logger = logging.getLogger()
+        self.logger.handlers = []
+
+        self.installation_store = GoogleCloudStorageInstallationStore(
+            storage_client=self.storage_client, bucket_name=self.bucket_name, client_id=self.client_id, logger=self.logger
+        )
+
+        self.entr_installation = Installation(user_id="uid", team_id=None, is_enterprise_install=True, enterprise_id="eid")
+        self.team_installation = Installation(user_id="uid", team_id="tid", is_enterprise_install=False, enterprise_id=None)
+
+    def test_get_logger(self):
+        """Test get_logger method"""
+        self.assertEqual(self.installation_store.logger, self.logger)
+
+    @patch("slack_sdk.oauth.installation_store.google_cloud_storage.GoogleCloudStorageInstallationStore._save_entity")
+    async def test_async_save_install(self, save_entity: Mock):
+        """Test async_save method"""
+        await self.installation_store.async_save(self.entr_installation)
+        self.storage_client.bucket.assert_called_once_with(self.bucket_name)
+        save_entity.assert_has_calls(
+            [
+                call(
+                    data_type="bot",
+                    entity=json.dumps(self.entr_installation.to_bot().__dict__),
+                    enterprise_id=self.entr_installation.enterprise_id,
+                    team_id=self.entr_installation.team_id,
+                    user_id=None,
+                ),
+                call(
+                    data_type="installer",
+                    entity=json.dumps(self.entr_installation.__dict__),
+                    enterprise_id=self.entr_installation.enterprise_id,
+                    team_id=self.entr_installation.team_id,
+                    user_id=None,
+                ),
+                call(
+                    data_type="installer",
+                    entity=json.dumps(self.entr_installation.__dict__),
+                    enterprise_id=self.entr_installation.enterprise_id,
+                    team_id=self.entr_installation.team_id,
+                    user_id=self.entr_installation.user_id,
+                ),
+            ]
+        )
+
+    @patch("slack_sdk.oauth.installation_store.google_cloud_storage.GoogleCloudStorageInstallationStore._save_entity")
+    async def test_async_save_bot(self, save_entity: Mock):
+        """Test async_save_bot method"""
+        await self.installation_store.async_save_bot(bot=self.entr_installation.to_bot())
+        save_entity.assert_called_once_with(
+            data_type="bot",
+            entity=json.dumps(self.entr_installation.to_bot().__dict__),
+            enterprise_id=self.entr_installation.enterprise_id,
+            team_id=self.entr_installation.team_id,
+            user_id=None,
+        )
+
+    def test_save_entity_and_test_key(self):
+        """Test _save_entity and _key methods"""
+        entity = "some data"
+        # test upload user data enterprise install + normal workspace
+        for install in [self.entr_installation, self.team_installation]:
+            self.installation_store._save_entity(
+                data_type="dtype",
+                entity=entity,
+                enterprise_id=install.enterprise_id,
+                team_id=install.team_id,
+                user_id=install.user_id,
+            )
+            self.bucket.blob.assert_called_once_with(
+                f"{self.client_id}/{install.enterprise_id or 'none'}-{install.team_id or 'none'}" f"/dtype-{install.user_id}"
+            )
+            self.blob.upload_from_string.assert_called_once_with(entity)
+
+            self.bucket.reset_mock()
+
+        # test upload user data enterprise install + normal workspace
+        for install in [self.entr_installation, self.team_installation]:
+            self.installation_store._save_entity(
+                data_type="dtype", entity=entity, enterprise_id=install.enterprise_id, team_id=install.team_id, user_id=None
+            )
+            self.bucket.blob.assert_called_once_with(
+                f"{self.client_id}/{install.enterprise_id or 'none'}-{install.team_id or 'none'}/dtype"
+            )
+
+            self.bucket.reset_mock()
+
+    async def test_async_find_bot(self):
+        """Test async_find_bot method"""
+        self.blob.download_as_text.return_value = json.dumps(
+            {"bot_token": "xoxb-token", "bot_id": "bid", "bot_user_id": "buid", "installed_at": time.time()}
+        )
+        # test bot found enterprise installation + normal workspace
+        for install in [self.entr_installation, self.team_installation]:
+            bot = await self.installation_store.async_find_bot(
+                enterprise_id=install.enterprise_id,
+                team_id=install.team_id,
+                is_enterprise_install=install.is_enterprise_install,
+            )
+            self.storage_client.bucket.assert_called_once_with(self.bucket_name)
+            self.bucket.blob.assert_called_once_with(
+                f"{self.client_id}/{install.enterprise_id or 'none'}-{install.team_id or 'none'}/bot"
+            )
+            self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
+            self.assertIsNotNone(bot)
+            self.assertEqual(bot.bot_token, "xoxb-token")
+
+            self.blob.reset_mock()
+            self.bucket.reset_mock()
+
+        # test bot not found
+        self.blob.download_as_text.side_effect = Exception()
+        bot = await self.installation_store.async_find_bot(
+            enterprise_id=self.entr_installation.enterprise_id,
+            team_id=self.entr_installation.team_id,
+            is_enterprise_install=self.entr_installation.is_enterprise_install,
+        )
+        self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
+        self.assertIsNone(bot)
+
+    async def test_async_find_installation(self):
+        """Test async_find_installation method"""
+        self.blob.download_as_text.return_value = json.dumps({"user_id": self.entr_installation.user_id})
+        # test installation found on enterprise install + normal workspace
+        for expect_install in [self.entr_installation, self.team_installation]:
+            actual_install = await self.installation_store.async_find_installation(
+                enterprise_id=expect_install.enterprise_id,
+                team_id=expect_install.team_id,
+                user_id=expect_install.user_id,
+                is_enterprise_install=expect_install.is_enterprise_install,
+            )
+            self.storage_client.bucket.assert_called_once_with(self.bucket_name)
+            self.bucket.blob.assert_called_once_with(
+                f"{self.client_id}/{expect_install.enterprise_id or 'none'}-{expect_install.team_id or 'none'}/"
+                f"installer-{expect_install.user_id}"
+            )
+            self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
+            self.assertIsNotNone(actual_install)
+            self.assertEqual(actual_install.user_id, self.entr_installation.user_id)
+
+            self.blob.reset_mock()
+            self.bucket.reset_mock()
+
+        # test installation not found
+        self.blob.download_as_text.side_effect = Exception()
+        actual_install = await self.installation_store.async_find_installation(
+            enterprise_id=self.entr_installation.enterprise_id,
+            team_id=self.entr_installation.team_id,
+            user_id=self.entr_installation.user_id,
+            is_enterprise_install=self.entr_installation.is_enterprise_install,
+        )
+        self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
+        self.assertIsNone(actual_install)
+
+    async def test_async_delete_installation_and_test_delete_entity(self):
+        """Test async_delete_installation and test_delete_entity methods"""
+        self.blob.exists.return_value = True
+        # test delete enterprise install + normal workspace when blob exists
+        for install in [self.entr_installation, self.team_installation]:
+            await self.installation_store.async_delete_installation(
+                enterprise_id=install.enterprise_id, team_id=install.team_id, user_id=install.user_id
+            )
+            self.storage_client.bucket.assert_called_once_with(self.bucket_name)
+            self.bucket.blob.assert_called_once_with(
+                f"{self.client_id}/{install.enterprise_id or 'none'}-{install.team_id or 'none'}/"
+                f"installer-{self.entr_installation.user_id}"
+            )
+            self.blob.exists.assert_called_once()
+            self.blob.delete.assert_called_once()
+
+            self.blob.reset_mock()
+            self.bucket.reset_mock()
+
+        # test delete blob doesn't exist
+        self.blob.exists.return_value = False
+        await self.installation_store.async_delete_installation(
+            enterprise_id=self.entr_installation.enterprise_id,
+            team_id=self.entr_installation.team_id,
+            user_id=self.entr_installation.user_id,
+        )
+        self.blob.exists.assert_called_once()
+        self.blob.delete.assert_not_called()
+
+    @patch("slack_sdk.oauth.installation_store.google_cloud_storage.GoogleCloudStorageInstallationStore._delete_entity")
+    async def test_async_delete_bot(self, delete_entity: Mock):
+        """Test async_delete_bot method"""
+        # test delete bot from enterprise install + normal workspace
+        for install in [self.entr_installation, self.team_installation]:
+            await self.installation_store.async_delete_bot(enterprise_id=install.enterprise_id, team_id=install.team_id)
+            delete_entity.assert_called_once_with(
+                data_type="bot", enterprise_id=install.enterprise_id, team_id=install.team_id, user_id=None
+            )
+
+            delete_entity.reset_mock()

--- a/tests/slack_sdk/oauth/state_store/test_google_cloud_storage.py
+++ b/tests/slack_sdk/oauth/state_store/test_google_cloud_storage.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""Tests for oauth/state_store/google_cloud_storage/__init__.py"""
+
+import time
+import logging
+import unittest
+from unittest.mock import Mock
+
+from google.cloud.storage.blob import Blob
+from google.cloud.storage.bucket import Bucket
+from google.cloud.storage.client import Client
+
+from slack_sdk.oauth.state_store.google_cloud_storage import GoogleCloudStorageOAuthStateStore
+
+
+class TestGoogleStateStore(unittest.IsolatedAsyncioTestCase):
+    """Test GoogleCloudStorageOAuthStateStore class"""
+
+    async def asyncSetUp(self):
+        """Setup tests"""
+        self.blob = Mock(spec=Blob)
+        self.blob.download_as_text.return_value = str(time.time())
+
+        self.bucket = Mock(spec=Bucket)
+        self.bucket.blob.return_value = self.blob
+
+        self.storage_client = Mock(spec=Client)
+        self.storage_client.bucket.return_value = self.bucket
+
+        self.logger = logging.getLogger()
+        self.logger.handlers = []
+
+        self.bucket_name = "bucket"
+        self.state_store = GoogleCloudStorageOAuthStateStore(
+            storage_client=self.storage_client, bucket_name=self.bucket_name, expiration_seconds=10, logger=self.logger
+        )
+
+    def test_get_logger(self):
+        """Test get_logger method"""
+        self.assertEqual(self.state_store.logger, self.logger)
+
+    async def test_async_issue(self):
+        """Test async_issue method"""
+        state = await self.state_store.async_issue()
+        self.storage_client.bucket.assert_called_once_with(self.bucket_name)
+        self.bucket.blob.assert_called_once()
+        self.assertEqual(self.bucket.blob.call_args.args[0], state)
+        self.blob.upload_from_string.assert_called_once()
+        self.assertRegex(self.blob.upload_from_string.call_args.args[0], r"\d{10,}.\d{5,}")
+
+    async def test_async_comsume(self):
+        """Test async_comsume method"""
+        state = "state"
+        # test consume returns valid
+        valid = await self.state_store.async_consume(state=state)
+        self.storage_client.bucket.assert_called_once_with(self.bucket_name)
+        self.bucket.blob.assert_called_once_with(state)
+        self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
+        self.assertTrue(time.time() < float(self.blob.download_as_text.return_value) + self.state_store.expiration_seconds)
+        self.blob.delete.assert_called_once()
+        self.assertTrue(valid)
+
+        self.blob.reset_mock()
+
+        # test consume returns invalid
+        self.state_store.expiration_seconds = 0
+        valid = await self.state_store.async_consume(state=state)
+        self.assertFalse(time.time() < float(self.blob.download_as_text.return_value) + self.state_store.expiration_seconds)
+        self.assertFalse(valid)
+
+        self.blob.reset_mock()
+
+        # test consume throw exception
+        self.blob.download_as_text.side_effect = Exception()
+        valid = await self.state_store.async_consume(state=state)
+        self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
+        self.assertFalse(valid)


### PR DESCRIPTION
## Summary
Add Google Cloud Storage (GCS) support for OAuth installation and state stores, as a follow up from https://github.com/slackapi/bolt-python/issues/962#issuecomment-1745873853.
(_ported from [ccaruceru/slack-multireact/multi_reaction_add/oauth](https://github.com/ccaruceru/slack-multireact/tree/bf38fb55361dfb06f1d818921da7006dff8362d0/multi_reaction_add/oauth)_)

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

- create/reuse a slack app and install it in a workspace
- use Bolt to write a small app to ask the user for some permissions on app installation, in conjunction with the newly added GCS storage
e.g.
```python
from google.cloud.storage import Client
from slack_bolt import App
from slack_bolt.oauth.oauth_settings import OAuthSettings
from slack_sdk.oauth.state_store.google_cloud_storage import GoogleCloudStorageOAuthStateStore
from slack_sdk.oauth.installation_store.google_cloud_storage import GoogleCloudStorageInstallationStore

bucket_name = "GOOGLE_BUCKET_NAME"
slack_client_id = "SLACK_CLIENT_ID"
slack_client_secret = "SLACK_CLIENT_SECRET"
slack_signing_secret = "SLACK_SIGNING_SECRET"

storage_client = Client()

app = App(
    signing_secret=slack_signing_secret,
    oauth_settings=OAuthSettings(
        install_page_rendering_enabled=False,
        client_id=slack_client_id,
        client_secret=slack_client_secret,
        scopes=[],  # scopes for bot operations
        user_scopes=["reactions:write"], # scopes for operations on behalf of user
        installation_store=GoogleCloudStorageInstallationStore(
            storage_client=storage_client,
            bucket_name=bucket_name,
            client_id=slack_client_id
        ),
        state_store=GoogleCloudStorageOAuthStateStore(
            storage_client=storage_client,
            bucket_name=bucket_name,
            expiration_seconds=600
        )
    )
)

@app.event("message")
def handle_message_events(event, client, context):
    """Listens for messages containing 'thumbs up' and reacts with a :thumbsup: emoji"""
    text = event.get("text", "").lower()
    channel = event.get("channel")
    timestamp = event.get("ts")
    if "thumbs up" in text:
        client.token = context.user_token
        client.reactions_add(
            channel=channel,
            name="thumbsup",
            timestamp=timestamp,
        )
        print("Added :thumbsup: reaction!")
```
- go to app's `/slack/install` page
    - observe a temporary oauth token is issued in the bucket
- finish the install flow
    - observe that the temporary token is gone
    - observe that `bot*` and `installer*` files are created
- interact with the newly added app (e.g. for the above app: add/invite the app to a public channel, type a message with "thumbs up" in it and see if the :thumbsup: emoji is added to the message)
    - check that there are no errors in the app logs
    - check that the `bot` and `installer` files are unchanged

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
