### PR TITLE
Additional check for exceptions from aiohttp

### DIFF
--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -241,7 +241,7 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                             message_data = message.data
                             if isinstance(message_data, bytes):
                                 message_data = message_data.decode("utf-8")
-                            if message_data is not None and len(message_data) > 0:
+                            if message_data is not None and isinstance(message_data, (str, bytes)) and len(message_data) > 0:
                                 # To skip the empty message that Slack server-side often sends
                                 self.logger.debug(
                                     f"Received message "


### PR DESCRIPTION
Try to avoid internal exceptions from aiohttp in `message_data`

## Summary

Fix for #1622 

### Testing

I couldn't figure out a way to unit test for this, and the integration tests were over my head.

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [X] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [X] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
