### PR TITLE
Fix #1611 Add expand attribute to SectionBlock

### DIFF
--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -115,7 +115,7 @@ class SectionBlock(Block):
 
     @property
     def attributes(self) -> Set[str]:  # type: ignore[override]
-        return super().attributes.union({"text", "fields", "accessory"})
+        return super().attributes.union({"text", "fields", "accessory", "expand"})
 
     def __init__(
         self,
@@ -124,6 +124,7 @@ class SectionBlock(Block):
         text: Optional[Union[str, dict, TextObject]] = None,
         fields: Optional[Sequence[Union[str, dict, TextObject]]] = None,
         accessory: Optional[Union[dict, BlockElement]] = None,
+        expand: Optional[bool] = None,
         **others: dict,
     ):
         """A section is one of the most flexible blocks available.
@@ -144,6 +145,10 @@ class SectionBlock(Block):
                 in a compact format that allows for 2 columns of side-by-side text.
                 Maximum number of items is 10. Maximum length for the text in each item is 2000 characters.
             accessory: One of the available element objects.
+            expand: Whether or not this section block's text should always expand when rendered.
+                If false or not provided, it may be rendered with a 'see more' option to expand and show the full text.
+                For AI Assistant apps, this allows the app to post long messages without users needing
+                to click 'see more' to expand the message.
         """
         super().__init__(type=self.type, block_id=block_id)
         show_unknown_key_warning(self, others)
@@ -166,6 +171,7 @@ class SectionBlock(Block):
                 self.logger.warning(f"Unsupported filed detected and skipped {f}")
         self.fields = field_objects
         self.accessory = BlockElement.parse(accessory)  # type: ignore[arg-type]
+        self.expand = expand
 
     @JsonValidator("text or fields attribute must be specified")
     def _validate_text_or_fields_populated(self):

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -127,6 +127,18 @@ class SectionBlockTests(unittest.TestCase):
         }
         self.assertDictEqual(input, SectionBlock(**input).to_dict())
 
+    def test_parse_2(self):
+        input = {
+            "type": "section",
+            "text": {
+                "type": "plain_text",
+                "text": "This is a plain text section block.",
+                "emoji": True,
+            },
+            "expand": True,
+        }
+        self.assertDictEqual(input, SectionBlock(**input).to_dict())
+
     def test_json(self):
         self.assertDictEqual(
             {


### PR DESCRIPTION
## Summary

This pull request resolves #1611 

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
