### PR TITLE
Add channels param to files.upload v2 method

### DIFF
--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -3747,6 +3747,7 @@ class WebClient(BaseClient):
         # To upload multiple files at a time
         file_uploads: Optional[List[Dict[str, Any]]] = None,
         channel: Optional[str] = None,
+        channels: Optional[List[str]] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
         request_file_info: bool = True,  # since v3.23, this flag is no longer necessary
@@ -3768,20 +3769,8 @@ class WebClient(BaseClient):
             raise e.SlackRequestError("You cannot specify both the file and the content argument.")
 
         # deprecated arguments:
-        channels, filetype = kwargs.get("channels"), kwargs.get("filetype")
+        filetype = kwargs.get("filetype")
 
-        if channels is not None:
-            warnings.warn(
-                "Although the channels parameter is still supported for smooth migration from legacy files.upload, "
-                "we recommend using the new channel parameter with a single str value instead for more clarity."
-            )
-            if (isinstance(channels, (list, tuple)) and len(channels) > 1) or (
-                isinstance(channels, str) and len(channels.split(",")) > 1
-            ):
-                raise e.SlackRequestError(
-                    "Sharing files with multiple channels is no longer supported in v2. "
-                    "Share files in each channel separately instead."
-                )
         if filetype is not None:
             warnings.warn("The filetype parameter is no longer supported. Please remove it from the arguments.")
 
@@ -3835,15 +3824,10 @@ class WebClient(BaseClient):
                 raise e.SlackRequestError(message)
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
-        channel_to_share = channel
-        if channels is not None:
-            if isinstance(channels, str):
-                channel_to_share = channels.split(",")[0]
-            else:
-                channel_to_share = channels[0]
         completion = self.files_completeUploadExternal(
             files=[{"id": f["file_id"], "title": f["title"]} for f in files],
-            channel_id=channel_to_share,
+            channel_id=channel,
+            channels=channels,
             initial_comment=initial_comment,
             thread_ts=thread_ts,
             **kwargs,
@@ -3879,6 +3863,7 @@ class WebClient(BaseClient):
         *,
         files: List[Dict[str, str]],
         channel_id: Optional[str] = None,
+        channels: Optional[List[str]] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
         **kwargs,
@@ -3895,6 +3880,8 @@ class WebClient(BaseClient):
                 "thread_ts": thread_ts,
             }
         )
+        if channels:
+            kwargs["channels"] = ",".join(channels)
         return self.api_call("files.completeUploadExternal", params=kwargs)
 
     def functions_completeSuccess(

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3759,6 +3759,7 @@ class LegacyWebClient(LegacyBaseClient):
         # To upload multiple files at a time
         file_uploads: Optional[List[Dict[str, Any]]] = None,
         channel: Optional[str] = None,
+        channels: Optional[List[str]] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
         request_file_info: bool = True,  # since v3.23, this flag is no longer necessary
@@ -3780,20 +3781,8 @@ class LegacyWebClient(LegacyBaseClient):
             raise e.SlackRequestError("You cannot specify both the file and the content argument.")
 
         # deprecated arguments:
-        channels, filetype = kwargs.get("channels"), kwargs.get("filetype")
+        filetype = kwargs.get("filetype")
 
-        if channels is not None:
-            warnings.warn(
-                "Although the channels parameter is still supported for smooth migration from legacy files.upload, "
-                "we recommend using the new channel parameter with a single str value instead for more clarity."
-            )
-            if (isinstance(channels, (list, tuple)) and len(channels) > 1) or (
-                isinstance(channels, str) and len(channels.split(",")) > 1
-            ):
-                raise e.SlackRequestError(
-                    "Sharing files with multiple channels is no longer supported in v2. "
-                    "Share files in each channel separately instead."
-                )
         if filetype is not None:
             warnings.warn("The filetype parameter is no longer supported. Please remove it from the arguments.")
 
@@ -3847,15 +3836,10 @@ class LegacyWebClient(LegacyBaseClient):
                 raise e.SlackRequestError(message)
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
-        channel_to_share = channel
-        if channels is not None:
-            if isinstance(channels, str):
-                channel_to_share = channels.split(",")[0]
-            else:
-                channel_to_share = channels[0]
         completion = self.files_completeUploadExternal(
             files=[{"id": f["file_id"], "title": f["title"]} for f in files],
-            channel_id=channel_to_share,
+            channel_id=channel,
+            channels=channels,
             initial_comment=initial_comment,
             thread_ts=thread_ts,
             **kwargs,
@@ -3891,6 +3875,7 @@ class LegacyWebClient(LegacyBaseClient):
         *,
         files: List[Dict[str, str]],
         channel_id: Optional[str] = None,
+        channels: Optional[List[str]] = None,
         initial_comment: Optional[str] = None,
         thread_ts: Optional[str] = None,
         **kwargs,
@@ -3907,6 +3892,8 @@ class LegacyWebClient(LegacyBaseClient):
                 "thread_ts": thread_ts,
             }
         )
+        if channels:
+            kwargs["channels"] = ",".join(channels)
         return self.api_call("files.completeUploadExternal", params=kwargs)
 
     def functions_completeSuccess(


### PR DESCRIPTION
## Summary

This pull request adds the newly added "channels" parameter to files.upload v2 method and its underlying API endpoint
See also: https://github.com/slackapi/java-slack-sdk/pull/1427

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
