### PR TITLE
Remove quotes from cookie value in OAuthStateUtils

### DIFF
--- a/slack_sdk/oauth/state_utils/__init__.py
+++ b/slack_sdk/oauth/state_utils/__init__.py
@@ -36,6 +36,7 @@ class OAuthStateUtils:
         for cookie in cookies:
             values = cookie.split(";")
             for value in values:
-                if value.strip() == f"{self.cookie_name}={state}":
+                 # handle quoted cookie values (e.g. due to base64 encoding)
+                 if value.strip().replace('"', "").replace("'", "") == f"{self.cookie_name}={state}":
                     return True
         return False

--- a/slack_sdk/oauth/state_utils/__init__.py
+++ b/slack_sdk/oauth/state_utils/__init__.py
@@ -36,7 +36,7 @@ class OAuthStateUtils:
         for cookie in cookies:
             values = cookie.split(";")
             for value in values:
-                 # handle quoted cookie values (e.g. due to base64 encoding)
-                 if value.strip().replace('"', "").replace("'", "") == f"{self.cookie_name}={state}":
+                # handle quoted cookie values (e.g. due to base64 encoding)
+                if value.strip().replace('"', "").replace("'", "") == f"{self.cookie_name}={state}":
                     return True
         return False


### PR DESCRIPTION
## Summary

Fixes https://github.com/slackapi/python-slack-sdk/issues/1647.

Note that the second replace("'", "") was not needed in my case - but to future proof for any quoting issues

### Testing

Follow the flow in https://github.com/slackapi/python-slack-sdk/issues/1647

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [X] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
