### PR TITLE
Fix max length for static option values

### DIFF
--- a/slack_sdk/models/blocks/basic_components.py
+++ b/slack_sdk/models/blocks/basic_components.py
@@ -170,7 +170,7 @@ class Option(JsonObject):
     logger = logging.getLogger(__name__)
 
     label_max_length = 75
-    value_max_length = 75
+    value_max_length = 150
 
     def __init__(
         self,
@@ -201,7 +201,7 @@ class Option(JsonObject):
                 Cannot exceed 75 characters.
             value: A short string that identifies this particular option to your
                 application. It will be part of the payload when this option is selected
-                . Cannot exceed 75 characters.
+                . Cannot exceed 150 characters.
             description: A user-facing string that provides more details about
                 this option. Only supported in legacy message actions, not in blocks or
                 dialogs.


### PR DESCRIPTION
## Summary

According to the docs, this property accepts a maximum length of 150 chars whereas the SDK enforces 75.

 - https://api.slack.com/reference/block-kit/composition-objects#option

> `value`: (String) A unique string value that will be passed to your app when this option is chosen. Maximum length for this field is 150 characters.

Without this fix, we can get validation errors:

```
slack_sdk.errors.SlackObjectFormationError: value attribute cannot exceed 75 characters
```

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
