### PR TITLE
Support pathlike objects in upload util

### DIFF
--- a/integration_tests/web/test_files_upload_v2.py
+++ b/integration_tests/web/test_files_upload_v2.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 import unittest
 from io import BytesIO
 
@@ -53,6 +54,18 @@ class TestWebClient_FilesUploads_V2(unittest.TestCase):
             channels=self.channel_id,
             file=BytesIO(bytearray("This is a test!", "utf-8")),
             filename="test.txt",
+            title="Test code",
+        )
+        self.assertIsNotNone(upload)
+        self.assertIsNotNone(upload.get("files")[0].get("id"))
+        self.assertIsNotNone(upload.get("files")[0].get("title"))
+
+    def test_uploading_text_files_path(self):
+        client = self.sync_client
+        file = __file__
+        upload = client.files_upload_v2(
+            channel=self.channel_id,
+            file=Path(file),
             title="Test code",
         )
         self.assertIsNotNone(upload)

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -3749,7 +3749,7 @@ class AsyncWebClient(AsyncBaseClient):
         *,
         # for sending a single file
         filename: Optional[str] = None,  # you can skip this only when sending along with content parameter
-        file: Optional[Union[str, bytes, IOBase]] = None,
+        file: Optional[Union[str, bytes, IOBase, os.PathLike]] = None,
         content: Optional[Union[str, bytes]] = None,
         title: Optional[str] = None,
         alt_txt: Optional[str] = None,

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -3739,7 +3739,7 @@ class WebClient(BaseClient):
         *,
         # for sending a single file
         filename: Optional[str] = None,  # you can skip this only when sending along with content parameter
-        file: Optional[Union[str, bytes, IOBase]] = None,
+        file: Optional[Union[str, bytes, IOBase, os.PathLike]] = None,
         content: Optional[Union[str, bytes]] = None,
         title: Optional[str] = None,
         alt_txt: Optional[str] = None,

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -317,8 +317,8 @@ def _to_v2_file_upload_item(upload_file: Dict[str, Any]) -> Dict[str, Optional[A
     content = upload_file.get("content")
     data: Optional[bytes] = None
     if file is not None:
-        if isinstance(file, str):  # filepath
-            with open(file.encode("utf-8", "ignore"), "rb") as readable:
+        if isinstance(file, (str, os.PathLike)):  # filepath
+            with open(os.fsencode(file), "rb") as readable:
                 data = readable.read()
         elif isinstance(file, bytes):
             data = file
@@ -339,8 +339,8 @@ def _to_v2_file_upload_item(upload_file: Dict[str, Any]) -> Dict[str, Optional[A
     filename = upload_file.get("filename")
     if filename is None:
         # use the local filename if filename is missing
-        if isinstance(file, str):
-            filename = file.split(os.path.sep)[-1]
+        if isinstance(file, (str, os.PathLike)):
+            filename = os.fspath(file).split(os.path.sep)[-1]
         else:
             filename = "Uploaded file"
 

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3751,7 +3751,7 @@ class LegacyWebClient(LegacyBaseClient):
         *,
         # for sending a single file
         filename: Optional[str] = None,  # you can skip this only when sending along with content parameter
-        file: Optional[Union[str, bytes, IOBase]] = None,
+        file: Optional[Union[str, bytes, IOBase, os.PathLike]] = None,
         content: Optional[Union[str, bytes]] = None,
         title: Optional[str] = None,
         alt_txt: Optional[str] = None,

--- a/tests/slack_sdk/web/test_internal_utils.py
+++ b/tests/slack_sdk/web/test_internal_utils.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 from io import BytesIO
+from pathlib import Path
 from typing import Dict, Sequence, Union
 
 import pytest
@@ -100,6 +101,13 @@ class TestInternalUtils(unittest.TestCase):
         assert file_io_item.get("filename") == "Uploaded file"
         file_io_item = _to_v2_file_upload_item({"file": file_io, "filename": "foo.txt"})
         assert file_io_item.get("filename") == "foo.txt"
+
+    def test_to_v2_file_upload_item_can_accept_file_as_path(self):
+        filepath = "tests/slack_sdk/web/test_internal_utils.py"
+        upload_item_str = _to_v2_file_upload_item({"file": filepath})
+        upload_item_path = _to_v2_file_upload_item({"file": Path(filepath)})
+        assert upload_item_path == upload_item_str
+        assert upload_item_str.get("filename") == "test_internal_utils.py"
 
     def test_next_cursor_is_present(self):
         assert _next_cursor_is_present({"next_cursor": "next-page"}) is True


### PR DESCRIPTION
## Summary

Allow passing Path objects into file upload functions.

### Testing

Attempt to pass a `Path` object to one of the file upload functions that takes a string path. Also pass a string path to ensure there are no regressions.

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.

I did get S3 test failures with the latter (without my change), FYI.