### PR TITLE
Remove pytest-runner from build-system.requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "pytest-runner"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The `pytest-runner` package has been deprecated upstream for some time, and the project is now archived:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice

Furthermore, the "setup.py test" command was removed in setuptools 72: https://github.com/pypa/setuptools/blob/v75.8.0/NEWS.rst#v7200

This does not affect running the tests with pytest.

## Summary

<!-- Describe the goal of this PR. Mention any related issue numbers -->

Removes the dependency on the deprecated `pytest-runner` package, which – since this project does not use the deprecated/removed `setup.py test` for running tests and does not use the deprecated `tests_require` for expressing test dependencies – was no longer doing anything useful anyway.

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

Run the tests, in any of the usual ways, and observe that everything still works.

Consult the [linked deprecation notice for `pytest-runner`](https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice).

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
