### PR TITLE
Add support for assistant.search.context

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2014,6 +2014,45 @@ class AsyncWebClient(AsyncBaseClient):
         kwargs.update({"refresh_token": refresh_token})
         return await self.api_call("tooling.tokens.rotate", params=kwargs)
 
+    async def assistant_search_context(
+        self,
+        *,
+        query: str,
+        action_token: str,
+        channel_types: Optional[Union[str, Sequence[str]]] = None,
+        content_types: Optional[Union[str, Sequence[str]]] = None,
+        context_channel_id: Optional[str] = None,
+        cursor: Optional[str] = None,
+        include_bots: Optional[bool] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -> AsyncSlackResponse:
+        """Searches messages across your Slack organization—perfect for broad, specific, and real-time data retrieval.
+        https://api.slack.com/methods/assistant.search.context
+        """
+        kwargs.update(
+            {
+                "query": query,
+                "action_token": action_token,
+                "context_channel_id": context_channel_id,
+                "cursor": cursor,
+                "include_bots": include_bots,
+                "limit": limit,
+            }
+        )
+
+        if isinstance(channel_types, (list, tuple)):
+            kwargs.update({"channel_types": ",".join(channel_types)})
+        else:
+            kwargs.update({"channel_types": channel_types})
+
+        if isinstance(content_types, (list, tuple)):
+            kwargs.update({"content_types": ",".join(content_types)})
+        else:
+            kwargs.update({"content_types": content_types})
+
+        return await self.api_call("assistant.search.context", params=kwargs)
+
     async def assistant_threads_setStatus(
         self,
         *,

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2004,6 +2004,45 @@ class WebClient(BaseClient):
         kwargs.update({"refresh_token": refresh_token})
         return self.api_call("tooling.tokens.rotate", params=kwargs)
 
+    def assistant_search_context(
+        self,
+        *,
+        query: str,
+        action_token: str,
+        channel_types: Optional[Union[str, Sequence[str]]] = None,
+        content_types: Optional[Union[str, Sequence[str]]] = None,
+        context_channel_id: Optional[str] = None,
+        cursor: Optional[str] = None,
+        include_bots: Optional[bool] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -> SlackResponse:
+        """Searches messages across your Slack organization—perfect for broad, specific, and real-time data retrieval.
+        https://api.slack.com/methods/assistant.search.context
+        """
+        kwargs.update(
+            {
+                "query": query,
+                "action_token": action_token,
+                "context_channel_id": context_channel_id,
+                "cursor": cursor,
+                "include_bots": include_bots,
+                "limit": limit,
+            }
+        )
+
+        if isinstance(channel_types, (list, tuple)):
+            kwargs.update({"channel_types": ",".join(channel_types)})
+        else:
+            kwargs.update({"channel_types": channel_types})
+
+        if isinstance(content_types, (list, tuple)):
+            kwargs.update({"content_types": ",".join(content_types)})
+        else:
+            kwargs.update({"content_types": content_types})
+
+        return self.api_call("assistant.search.context", params=kwargs)
+
     def assistant_threads_setStatus(
         self,
         *,

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2016,6 +2016,45 @@ class LegacyWebClient(LegacyBaseClient):
         kwargs.update({"refresh_token": refresh_token})
         return self.api_call("tooling.tokens.rotate", params=kwargs)
 
+    def assistant_search_context(
+        self,
+        *,
+        query: str,
+        action_token: str,
+        channel_types: Optional[Union[str, Sequence[str]]] = None,
+        content_types: Optional[Union[str, Sequence[str]]] = None,
+        context_channel_id: Optional[str] = None,
+        cursor: Optional[str] = None,
+        include_bots: Optional[bool] = None,
+        limit: Optional[int] = None,
+        **kwargs,
+    ) -> Union[Future, SlackResponse]:
+        """Searches messages across your Slack organization—perfect for broad, specific, and real-time data retrieval.
+        https://api.slack.com/methods/assistant.search.context
+        """
+        kwargs.update(
+            {
+                "query": query,
+                "action_token": action_token,
+                "context_channel_id": context_channel_id,
+                "cursor": cursor,
+                "include_bots": include_bots,
+                "limit": limit,
+            }
+        )
+
+        if isinstance(channel_types, (list, tuple)):
+            kwargs.update({"channel_types": ",".join(channel_types)})
+        else:
+            kwargs.update({"channel_types": channel_types})
+
+        if isinstance(content_types, (list, tuple)):
+            kwargs.update({"content_types": ",".join(content_types)})
+        else:
+            kwargs.update({"content_types": content_types})
+
+        return self.api_call("assistant.search.context", params=kwargs)
+
     def assistant_threads_setStatus(
         self,
         *,


### PR DESCRIPTION
## Summary

Add support for assistant.search.context . Although listed in docs, it is yet to be supported. 

There's a discrepancy between https://api.slack.com/methods/assistant.search.context and https://api.slack.com/docs/apps/data-access-api#use-action-token on whether `action_token` is required. From my testing it is so I set it as such. Lmk if that's not the case.

### Testing

Ran it using my app and workspace

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
