### PR TITLE
fix: `channel_id` instead of `channel` in `files_upload_v2` documentation

### DIFF
--- a/docs/content/tutorial/uploading-files.md
+++ b/docs/content/tutorial/uploading-files.md
@@ -182,11 +182,11 @@ By doing this, you'll be able to see the file within Slack.
 
 ### Specifying a channel when uploading a file {#specifying-channel}
 
-While this exercise was very informative, having to do these two steps every time we upload a file is a bit cumbersome. Instead, we can specify the `channel_id` parameter to the function. This is the more common way of uploading a file from an app.
+While this exercise was very informative, having to do these two steps every time we upload a file is a bit cumbersome. Instead, we can specify the `channel` parameter to the function. This is the more common way of uploading a file from an app.
 
 ```python
 upload_and_then_share_file = client.files_upload_v2(
-    channel_id="C123456789",
+    channel="C123456789",
     title="Test text data",
     filename="test.txt",
     content="Hi there! This is a text file!",
@@ -210,7 +210,7 @@ Next, within the same directory, execute the following code. We'll specify the f
 
 ```python
 upload_text_file = client.files_upload_v2(
-    channel_id="C123456789",
+    channel="C123456789",
     title="Test text data",
     file="./test.txt",
     initial_comment="Here is the file:",


### PR DESCRIPTION
## Summary

This aims to fix #1669, by updating the docs to use `channel` argument rather then `channel_id` this is what the [source code expects](https://github.com/slackapi/python-slack-sdk/blob/897449acec0a810dd4a460008d22554ffcdcdd46/slack_sdk/web/client.py#L3749C9-L3749C16)


### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
