### PR TITLE
health: publish test results to code cov

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,20 +36,28 @@ jobs:
           cache: pip
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
+          pip install -U pip
           pip install -r requirements/testing.txt
           pip install -r requirements/optional.txt
       - name: Run validation (black/flake8/pytest)
         run: |
           black --check slack/ slack_sdk/ tests/ integration_tests/
           flake8 slack/ slack_sdk/
-          PYTHONPATH=$PWD:$PYTHONPATH pytest --cov-report=xml --cov=slack_sdk/ tests/
+          PYTHONPATH=$PWD:$PYTHONPATH pytest --cov-report=xml --cov=slack_sdk/ --junitxml=reports/test_report.xml tests/
       - name: Run tests for SQLAlchemy v1.4 (backward-compatibility)
         run: |
           # Install v1.4 for testing
           pip install "SQLAlchemy>=1.4,<2"
           PYTHONPATH=$PWD:$PYTHONPATH pytest tests/slack_sdk/oauth/installation_store/test_sqlalchemy.py
           PYTHONPATH=$PWD:$PYTHONPATH pytest tests/slack_sdk/oauth/state_store/test_sqlalchemy.py
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          directory: ./reports/
+          flags: ${{ matrix.python-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
       - name: Run codecov (only with latest supported version)
         if: startsWith(matrix.python-version, '3.13')
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -58,7 +58,7 @@ jobs:
           flags: ${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
-      - name: Run codecov (only with latest supported version)
+      - name: Upload test coverage to Codecov (only with latest supported version)
         if: startsWith(matrix.python-version, '3.13')
         uses: codecov/codecov-action@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ venv*/
 .coverage*
 cov_*
 coverage.xml
+reports/
 
 # due to using tox and pytest
 .tox


### PR DESCRIPTION
## Summary

This PR is inspired by https://github.com/slackapi/node-slack-sdk/pull/2178

It updates the CI pipeline to publish the test results to codcov and provide some [neat reporting details](https://docs.codecov.com/docs/test-analytics#reporting)

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
