### PR TITLE
chore: remove 3.6 CI support

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,6 +22,7 @@ jobs:
           - "3.8"
           - "3.7"
           - "pypy3.10"
+          - "pypy3.11"
     env:
       CI_LARGE_SOCKET_MODE_PAYLOAD_TESTING_DISABLED: "1"
       FORCE_COLOR: "1"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   build:
-    # Avoiding -latest due to https://github.com/actions/setup-python/issues/162
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -22,7 +21,6 @@ jobs:
           - "3.9"
           - "3.8"
           - "3.7"
-          - "3.6"
           - "pypy3.10"
     env:
       CI_LARGE_SOCKET_MODE_PAYLOAD_TESTING_DISABLED: "1"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,7 +22,6 @@ jobs:
           - "3.8"
           - "3.7"
           - "pypy3.10"
-          - "pypy3.11"
     env:
       CI_LARGE_SOCKET_MODE_PAYLOAD_TESTING_DISABLED: "1"
       FORCE_COLOR: "1"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-15 (https://github.com/actions/runner-images/issues/11101). The next [available image](https://github.com/actions/runner-images?tab=readme-ov-file#available-images) is [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md), but it does not support Python 3.6.
```
Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04.
```
The project is in the process of dropping support for `python 3.6` until this is done the team will need to manually validate compatibility with `python 3.6`

Steps:
1. `pyenv shell 3.6.15`
2. `python --version` -> `Python 3.6.15`
3. `python -m venv env_3.6.15`
4. `source env_3.6.15/bin/activate`
5.  `scripts/run_validation.sh`
6. No tests fail

### Testing

n/a

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
