### PR TITLE
fix: aiohttp test_init_with_loop broken test

### DIFF
--- a/tests/slack_sdk_async/socket_mode/test_aiohttp.py
+++ b/tests/slack_sdk_async/socket_mode/test_aiohttp.py
@@ -37,7 +37,7 @@ class TestAiohttp(unittest.TestCase):
             app_token="xapp-A111-222-xyz",
             web_client=self.web_client,
             auto_reconnect_enabled=False,
-            loop=asyncio.new_event_loop(),
+            loop=asyncio.get_event_loop(),
         )
         try:
             self.assertIsNotNone(client)


### PR DESCRIPTION
## Summary

`tests/slack_sdk_async/socket_mode/test_aiohttp.py:test_init_with_loop` was broken by `aiohttp` [version 3.12.6](https://github.com/aio-libs/aiohttp/releases/tag/v3.12.6) with the following error

```txt
RuntimeError: Session and connector has to use same event loop

env_3.13.1/lib/python3.13/site-packages/aiohttp/client.py:368: RuntimeError
```

The test aims to validate that a `loop` can be passed to the `SocketModeClient`, previously a new loop was created and passed to the `SocketModeClient` constructor, this PR changes this behavior by passing the existing loop related to the unit tests.

### Testing

N/A

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
