### PR TITLE
fix infinite looping when socket goes stale in gevent

### DIFF
--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -216,7 +216,6 @@ def _receive_messages(
                     # Note that bad connections can be detected by monitoring threads
                     # the Socket Mode client automatically reconnects to a new endpoint later.
                     logger.debug("The connection seems to be already closed.")
-                    return bytes()
                 raise e
 
     return _fetch_messages(


### PR DESCRIPTION
## Summary
When Running in socket mode using gevent, after a while it just goes into infinite loop and becomes unresponsive.
<img width="1910" height="304" alt="image" src="https://github.com/user-attachments/assets/c45e5eee-1962-4493-8e6b-44af880fb475" />

Technically `receive` function can raise an exception on broken socket on certains errno, 
instead of empty bytes indicating clean closure.


### Testing
- Run after gevent patching.
- Disconnect network or let socket go inactive. 
- CHeck the process stat, pyspy  stuck in 100% cpu.

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
