### PR TITLE
chore: remove 3.6 references 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Are you looking for [slackclient](https://pypi.org/project/slackclient/)? The sl
 
 ---
 
-This library requires Python 3.6 and above. If you require Python 2, please use our [SlackClient - v1.x][slackclientv1]. If you're unsure how to check what version of Python you're on, you can check it using the following:
+This library requires Python 3.7 and above. If you require Python 2, please use our [SlackClient - v1.x][slackclientv1]. If you're unsure how to check what version of Python you're on, you can check it using the following:
 
 > **Note:** You may need to use `python3` before your commands to ensure you use the correct Python path. e.g. `python3 --version`
 

--- a/docs/english/installation.md
+++ b/docs/english/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-This package supports Python 3.6 and higher. We recommend using [PyPI](https://pypi.python.org/pypi) for installation. Run the following command:
+This package supports Python 3.7 and higher. We recommend using [PyPI](https://pypi.python.org/pypi) for installation. Run the following command:
 
 ```bash
 pip install slack-sdk

--- a/docs/english/legacy/index.md
+++ b/docs/english/legacy/index.md
@@ -10,7 +10,7 @@ Refer to the [migration guide](/tools/python-slack-sdk/v3-migration) to learn ho
 
 Slack APIs allow anyone to build full featured integrations that extend and expand the capabilities of your Slack workspace. These APIs allow you to build applications that interact with Slack just like the people on your team. They can post messages, respond to events that happen, and build complex UIs for getting work done.
 
-To make it easier for Python programmers to build Slack applications, we've provided this open source SDK that will help you get started building Python apps as quickly as possible. The current version is built for Python 3.6 and higher — if you need to target Python 2.x, you might consider using v1 of the SDK.
+To make it easier for Python programmers to build Slack applications, we've provided this open source SDK that will help you get started building Python apps as quickly as possible. The current version is built for Python 3.7 and higher — if you need to target Python 2.x, you might consider using v1 of the SDK.
 
 ## Slack platform basics {#platform-basics}
 

--- a/docs/english/tutorial/uploading-files.md
+++ b/docs/english/tutorial/uploading-files.md
@@ -56,7 +56,7 @@ With this, all your Slack app configuration is done. Let's start coding.
 
 ### Creating a new project {#create-new-project}
 
-First, ensure you're using Python version 3.6 or above. While the current standard is for the `python3` and `pip3` commands to use Python 3.6 or above, it's best to ensure your runtime is always using the latest version of Python. [pyenv](https://github.com/pyenv/pyenv) is a handy tool that can do this for you. 
+First, ensure you're using Python version 3.7 or above. While the current standard is for the `python3` and `pip3` commands to use Python 3.7 or above, it's best to ensure your runtime is always using the latest version of Python. [pyenv](https://github.com/pyenv/pyenv) is a handy tool that can do this for you. 
 
 We'll create a brand new virtual environment and install the required library dependencies using the following commands.
 

--- a/docs/english/v3-migration.md
+++ b/docs/english/v3-migration.md
@@ -69,7 +69,7 @@ If you don't wish to upgrade yet, be sure to pin your module for the Python `sla
 
 ### Minimum Python versions {#minimum-versions}
 
-`slackclient` v2.x requires Python 3.6 (or higher). Support for Python 2.7 is maintained in the existing `slackclient` v1.x.
+`slackclient` v2.x requires Python 3.7 (or higher). Support for Python 2.7 is maintained in the existing `slackclient` v1.x.
 
 Client v1 support:
 - Python 2: Python 2.7 was supported in the 1.x version of the client up until Dec 31st, 2019.

--- a/integration_tests/web/test_issue_480.py
+++ b/integration_tests/web/test_issue_480.py
@@ -43,7 +43,7 @@ class TestWebClient(unittest.TestCase):
         after = len(multiprocessing.active_children())
         self.assertEqual(0, after - before)
 
-    # fails with Python 3.6
+    # fails with Python 3.6 (no longer supported)
     def test_issue_480_threads(self):
         client = self.sync_client
         before = threading.active_count()
@@ -53,7 +53,7 @@ class TestWebClient(unittest.TestCase):
         after = threading.active_count()
         self.assertEqual(0, after - before)
 
-    # fails with Python 3.6
+    # fails with Python 3.6 (no longer supported)
     @async_test
     async def test_issue_480_threads_async(self):
         client = self.async_client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "slack_sdk"
 dynamic = ["version", "readme", "authors", "optional-dependencies"]
 description = "The Slack API Platform SDK for Python"
 license = { text = "MIT" }
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 keywords = [
 	"slack",
 	"slack-api",
@@ -27,7 +27,6 @@ classifiers = [
 	"License :: OSI Approved :: MIT License",
 	"Programming Language :: Python",
 	"Programming Language :: Python :: 3 :: Only",
-	"Programming Language :: Python :: 3.6",
 	"Programming Language :: Python :: 3.7",
 	"Programming Language :: Python :: 3.8",
 	"Programming Language :: Python :: 3.9",

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,12 +4,12 @@ pytest>=7.0.1,<9
 pytest-asyncio<2  # for async
 pytest-cov>=2,<7
 # while flake8 5.x have issues with Python 3.12, flake8 6.x requires Python >= 3.8.1,
-# so 5.x should be kept in order to stay compatible with Python 3.6/3.7
+# so 5.x should be kept in order to stay compatible with Python 3.7/3.8
 flake8>=5.0.4,<8
 #  Don't change this version without running CI builds;
 #  The latest version may not be available for older Python runtime
-black>=22.8.0; python_version=="3.6"
-black==22.10.0; python_version>"3.6"
+black>=22.8.0; python_version=="3.7"
+black==22.10.0; python_version>"3.7"
 click==8.0.4  # black is affected by https://github.com/pallets/click/issues/2225
 psutil>=6.0.0,<8
 #  used only under slack_sdk/*_store

--- a/slack/web/async_internal_utils.py
+++ b/slack/web/async_internal_utils.py
@@ -56,7 +56,7 @@ def _get_headers(
             e.g. {
                 'Content-Type': 'application/json;charset=utf-8',
                 'Authorization': 'Bearer xoxb-1234-1243',
-                'User-Agent': 'Python/3.6.8 slack/2.1.0 Darwin/17.7.0'
+                'User-Agent': 'Python/3.7.0 slack/2.1.0 Darwin/17.7.0'
             }
     """
     final_headers = {

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -44,7 +44,7 @@ def get_user_agent(prefix: Optional[str] = None, suffix: Optional[str] = None):
 
     Returns:
         The user agent string.
-        e.g. 'Python/3.6.7 slackclient/2.0.0 Darwin/17.7.0'
+        e.g. 'Python/3.7.0 slackclient/2.0.0 Darwin/17.7.0'
     """
     # __name__ returns all classes, we only want the client
     client = "{0}/{1}".format("slackclient", version.__version__)
@@ -91,7 +91,7 @@ def _get_headers(
             e.g. {
                 'Content-Type': 'application/json;charset=utf-8',
                 'Authorization': 'Bearer xoxb-1234-1243',
-                'User-Agent': 'Python/3.6.8 slack/2.1.0 Darwin/17.7.0'
+                'User-Agent': 'Python/3.7.0 slack/2.1.0 Darwin/17.7.0'
             }
     """
     final_headers = {

--- a/tests/test_aiohttp_version_checker.py
+++ b/tests/test_aiohttp_version_checker.py
@@ -19,7 +19,7 @@ class TestAiohttpVersionChecker(unittest.TestCase):
 
         validate_aiohttp_version("2.1.3", print)
         self.assertEqual(state["counter"], 1)
-        validate_aiohttp_version("3.6.3", print)
+        validate_aiohttp_version("3.7.0", print)
         self.assertEqual(state["counter"], 2)
         validate_aiohttp_version("3.7.0", print)
         self.assertEqual(state["counter"], 3)

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -21,14 +21,14 @@ As you complete each task you'll see the message update with a green checkmark.
 1. A Slack team.
 Before anything else you'll need a Slack team. You can [Sign into an existing Slack workspace](https://get.slack.help/hc/en-us/articles/212681477-Sign-in-to-Slack) or you can [create a new Slack workspace](https://get.slack.help/hc/en-us/articles/206845317-Create-a-Slack-workspace) to test your app first.
 
-2. A terminal with Python 3.6+ installed.
+2. A terminal with Python 3.7+ installed.
 Check your installation by running the following command in your terminal:
 ```
 $ python3 --version
--> Python 3.6.7
+-> Python 3.7.0
 ```
 
-You'll need to install Python 3.6 if you receive the following error:
+You'll need to install Python 3.7 if you receive the following error:
 ```
 -> bash: python3: command not found
 ```


### PR DESCRIPTION
## Summary

Remove Python 3.6 support by updating all references to reflect the minimum of Python 3.7+.

### Testing

n/a

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [X] `/docs` (Documents)
- [] `/tutorial` (PythOnBoardingBot tutorial)
- [X] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [X] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
