### PR TITLE
chore: clean up project based on 3.6 removal

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-  - package-ecosystem: "npm"
-    directory: "/docs"
-    schedule:
-      interval: "monthly"
-    groups:
-      docusaurus:
-        patterns:
-          - "@docusaurus/*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"

--- a/scripts/build_pypi_package.sh
+++ b/scripts/build_pypi_package.sh
@@ -5,7 +5,7 @@ cd ${script_dir}/..
 rm -rf ./slack_sdk.egg-info
 
 pip install -U pip && \
-  pip install twine build && \
+  pip install -U twine build && \
   rm -rf dist/ build/ slack_sdk.egg-info/ && \
   python -m build --sdist --wheel && \
   twine check dist/*

--- a/scripts/deploy_to_prod_pypi_org.sh
+++ b/scripts/deploy_to_prod_pypi_org.sh
@@ -5,7 +5,7 @@ cd ${script_dir}/..
 rm -rf ./slack_sdk.egg-info
 
 pip install -U pip && \
-  pip install twine build && \
+  pip install -U twine build && \
   rm -rf dist/ build/ slack_sdk.egg-info/ && \
   python -m build --sdist --wheel && \
   twine check dist/* && \

--- a/scripts/deploy_to_test_pypi_org.sh
+++ b/scripts/deploy_to_test_pypi_org.sh
@@ -5,7 +5,7 @@ cd ${script_dir}/..
 rm -rf ./slack_sdk.egg-info
 
 pip install -U pip && \
-  pip install twine build && \
+  pip install -U twine build && \
   rm -rf dist/ build/ slack_sdk.egg-info/ && \
   python -m build --sdist --wheel && \
   twine check dist/* && \

--- a/scripts/generate_api_docs.sh
+++ b/scripts/generate_api_docs.sh
@@ -6,6 +6,11 @@ cd ${script_dir}/..
 
 pip install -U -r requirements/documentation.txt
 pip install -U -r requirements/optional.txt
-rm -rf docs/static/api-docs
-pdoc slack_sdk --html -o docs/static/api-docs
-open docs/static/api-docs/slack_sdk/index.html
+
+rm -rf docs/reference
+
+pdoc slack_sdk --html -o docs/reference
+cp -R docs/reference/slack_sdk/* docs/reference/
+rm -rf docs/reference/slack_sdk
+
+open docs/reference/index.html

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -9,8 +9,8 @@ script_dir=`dirname $0`
 cd ${script_dir}/..
 
 pip install -U pip
-pip install -r requirements/testing.txt \
-  -r requirements/optional.txt
+pip install -U -r requirements/testing.txt \
+  -U -r requirements/optional.txt
 
 echo "Generating code ..." && python scripts/codegen.py --path .
 echo "Running black (code formatter) ..." && black slack_sdk/

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -7,7 +7,7 @@ script_dir=$(dirname $0)
 cd ${script_dir}/..
 
 pip install -U pip setuptools wheel
-pip install -r requirements/testing.txt \
-  -r requirements/optional.txt
+pip install -U -r requirements/testing.txt \
+  -U -r requirements/optional.txt
 
 mypy --config-file pyproject.toml

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -9,8 +9,8 @@ script_dir=`dirname $0`
 cd ${script_dir}/..
 
 pip install -U pip
-pip install -r requirements/testing.txt \
-  -r requirements/optional.txt
+pip install -U -r requirements/testing.txt \
+  -U -r requirements/optional.txt
 
 echo "Generating code ..." && python scripts/codegen.py --path .
 echo "Running black (code formatter) ..." && black slack_sdk/

--- a/scripts/run_validation.sh
+++ b/scripts/run_validation.sh
@@ -7,9 +7,8 @@ set -e
 script_dir=`dirname $0`
 cd ${script_dir}/..
 
-pip install -U pip setuptools wheel
-pip install -r requirements/testing.txt \
-  -r requirements/optional.txt
+pip install -U -r requirements/testing.txt \
+  -U -r requirements/optional.txt
 
 echo "Generating code ..." && python scripts/codegen.py --path .
 echo "Running black (code formatter) ..." && black slack_sdk/

--- a/slack_sdk/oauth/installation_store/internals.py
+++ b/slack_sdk/oauth/installation_store/internals.py
@@ -1,18 +1,11 @@
-import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Type, TypeVar, Union
 
 
 def _from_iso_format_to_datetime(iso_datetime_str: str) -> datetime:
-    if sys.version_info[:2] == (3, 6):
-        format = "%Y-%m-%d %H:%M:%S"
-        if "." in iso_datetime_str:
-            format += ".%f"
-        return datetime.strptime(iso_datetime_str, format).replace(tzinfo=timezone.utc)
-    else:
-        if "+" not in iso_datetime_str:
-            iso_datetime_str += "+00:00"
-        return datetime.fromisoformat(iso_datetime_str)
+    if "+" not in iso_datetime_str:
+        iso_datetime_str += "+00:00"
+    return datetime.fromisoformat(iso_datetime_str)
 
 
 def _from_iso_format_to_unix_timestamp(iso_datetime_str: str) -> float:

--- a/slack_sdk/scim/v1/internal_utils.py
+++ b/slack_sdk/scim/v1/internal_utils.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 import re
-import sys
 from typing import Dict, Callable
 from typing import Union, Optional, Any
 from urllib.parse import quote
@@ -43,10 +42,7 @@ def _to_dict_without_not_given(obj: Any) -> dict:
 
 
 def _create_copy(original: Any) -> Any:
-    if sys.version_info.major == 3 and sys.version_info.minor <= 6:
-        return copy.copy(original)
-    else:
-        return copy.deepcopy(original)
+    return copy.deepcopy(original)
 
 
 def _to_camel_case_key(key: str) -> str:

--- a/tests/slack_sdk/oauth/installation_store/test_internals.py
+++ b/tests/slack_sdk/oauth/installation_store/test_internals.py
@@ -39,7 +39,7 @@ def test_timestamp_to_type(ts, target_type, expected_result):
 
 
 def test_timestamp_to_type_invalid_str():
-    match = "Invalid isoformat string" if sys.version_info[:2] > (3, 6) else "time data .* does not match format"
+    match = "Invalid isoformat string"
     with pytest.raises(ValueError, match=match):
         _timestamp_to_type("not-a-timestamp", int)
 


### PR DESCRIPTION
## Summary

These are minor changes that clean up the project based on python 3.6 support drop in #1735

### Testing

The CI should cover the testing

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
