### PR TITLE
feat(models): add markdown block

### DIFF
--- a/slack_sdk/models/blocks/__init__.py
+++ b/slack_sdk/models/blocks/__init__.py
@@ -58,6 +58,7 @@ from .blocks import FileBlock
 from .blocks import HeaderBlock
 from .blocks import ImageBlock
 from .blocks import InputBlock
+from .blocks import MarkdownBlock
 from .blocks import SectionBlock
 from .blocks import VideoBlock
 from .blocks import RichTextBlock
@@ -115,6 +116,7 @@ __all__ = [
     "HeaderBlock",
     "ImageBlock",
     "InputBlock",
+    "MarkdownBlock",
     "SectionBlock",
     "VideoBlock",
     "RichTextBlock",

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -20,6 +20,7 @@ from slack_sdk.models.blocks import (
     PlainTextObject,
     MarkdownTextObject,
     HeaderBlock,
+    MarkdownBlock,
     VideoBlock,
     Option,
     RichTextBlock,
@@ -30,8 +31,8 @@ from slack_sdk.models.blocks import (
     RichTextElementParts,
 )
 from slack_sdk.models.blocks.basic_components import SlackFile
-from . import STRING_3001_CHARS
 
+from . import STRING_3001_CHARS
 
 # https://api.slack.com/reference/block-kit/blocks
 
@@ -802,6 +803,39 @@ class HeaderBlockTests(unittest.TestCase):
         }
         with self.assertRaises(SlackObjectFormationError):
             HeaderBlock(**input).validate_json()
+
+
+# ----------------------------------------------
+# MarkdownBlock
+# ----------------------------------------------
+
+
+class MarkdownBlockTests(unittest.TestCase):
+    def test_document(self):
+        input = {
+            "type": "markdown",
+            "block_id": "introduction",
+            "text": "**Welcome!**",
+        }
+        self.assertDictEqual(input, MarkdownBlock(**input).to_dict())
+        self.assertDictEqual(input, Block.parse(input).to_dict())
+
+    def test_text_length_12000(self):
+        input = {
+            "type": "markdown",
+            "block_id": "numbers",
+            "text": "1234567890" * 1200,
+        }
+        MarkdownBlock(**input).validate_json()
+
+    def test_text_length_12001(self):
+        input = {
+            "type": "markdown",
+            "block_id": "numbers",
+            "text": "1234567890" * 1200 + "1",
+        }
+        with self.assertRaises(SlackObjectFormationError):
+            MarkdownBlock(**input).validate_json()
 
 
 # ----------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds the `markdown` block to fix #1688.

📚 Reference: https://docs.slack.dev/reference/block-kit/blocks/markdown-block/

### Testing

The following commands can confirm typing as expected in a sample app:

```
$ slack create asdf -t slack-samples/bolt-python-getting-started-app
$ cd asdf
$ source .venv/bin/activate  # Setup virtual environment
$ vim app.py                 # Update with contents below
$ slack run                  # Invite bot to channel and say "hello"
```

```py
from slack_sdk.models.blocks import MarkdownBlock
...

@app.message("hello")
def message_hello(say):
    say(
        blocks=[
            MarkdownBlock(text="**lets's go!**"),
        ],
        text="let's go!",
    )
```


### Category

- [x] **slack_sdk.models** (UI component builders)

### Notes

I'm finding the unit tests hang for RTM tests on my machine... Will confirm this passes in CI! 🤖 

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
