### PR TITLE
fix(web-client): update `thread_ts` to be required for `chat_startStream`

### DIFF
--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -3004,7 +3004,7 @@ and message responses using response_url in payloads.</p></div>
         self,
         *,
         channel: str,
-        thread_ts: Optional[str] = None,
+        thread_ts: str,
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
@@ -10268,7 +10268,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_startStream"><code class="name flex">
-<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str | None = None,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10279,7 +10279,7 @@ Each authorization represents an app installation that the event is visible to.
     self,
     *,
     channel: str,
-    thread_ts: Optional[str] = None,
+    thread_ts: str,
     markdown_text: Optional[str] = None,
     recipient_team_id: Optional[str] = None,
     recipient_user_id: Optional[str] = None,

--- a/docs/reference/oauth/installation_store/file/index.html
+++ b/docs/reference/oauth/installation_store/file/index.html
@@ -48,7 +48,7 @@ el.replaceWith(d);
 <dl>
 <dt id="slack_sdk.oauth.installation_store.file.FileInstallationStore"><code class="flex name class">
 <span>class <span class="ident">FileInstallationStore</span></span>
-<span>(</span><span>*,<br>base_dir: str = '/Users/eden.zimbelman/.bolt-app-installation',<br>historical_data_enabled: bool = True,<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*,<br>base_dir: str = '/Users/michael.brooks/.bolt-app-installation',<br>historical_data_enabled: bool = True,<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/oauth/installation_store/index.html
+++ b/docs/reference/oauth/installation_store/index.html
@@ -327,7 +327,7 @@ el.replaceWith(d);
 </dd>
 <dt id="slack_sdk.oauth.installation_store.FileInstallationStore"><code class="flex name class">
 <span>class <span class="ident">FileInstallationStore</span></span>
-<span>(</span><span>*,<br>base_dir: str = '/Users/eden.zimbelman/.bolt-app-installation',<br>historical_data_enabled: bool = True,<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*,<br>base_dir: str = '/Users/michael.brooks/.bolt-app-installation',<br>historical_data_enabled: bool = True,<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/oauth/state_store/file/index.html
+++ b/docs/reference/oauth/state_store/file/index.html
@@ -48,7 +48,7 @@ el.replaceWith(d);
 <dl>
 <dt id="slack_sdk.oauth.state_store.file.FileOAuthStateStore"><code class="flex name class">
 <span>class <span class="ident">FileOAuthStateStore</span></span>
-<span>(</span><span>*,<br>expiration_seconds: int,<br>base_dir: str = '/Users/eden.zimbelman/.bolt-app-oauth-state',<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*,<br>expiration_seconds: int,<br>base_dir: str = '/Users/michael.brooks/.bolt-app-oauth-state',<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/oauth/state_store/index.html
+++ b/docs/reference/oauth/state_store/index.html
@@ -77,7 +77,7 @@ el.replaceWith(d);
 <dl>
 <dt id="slack_sdk.oauth.state_store.FileOAuthStateStore"><code class="flex name class">
 <span>class <span class="ident">FileOAuthStateStore</span></span>
-<span>(</span><span>*,<br>expiration_seconds: int,<br>base_dir: str = '/Users/eden.zimbelman/.bolt-app-oauth-state',<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*,<br>expiration_seconds: int,<br>base_dir: str = '/Users/michael.brooks/.bolt-app-oauth-state',<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/web/async_client.html
+++ b/docs/reference/web/async_client.html
@@ -2900,7 +2900,7 @@ el.replaceWith(d);
         self,
         *,
         channel: str,
-        thread_ts: Optional[str] = None,
+        thread_ts: str,
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
@@ -10164,7 +10164,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_startStream"><code class="name flex">
-<span>async def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str | None = None,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10175,7 +10175,7 @@ Each authorization represents an app installation that the event is visible to.
     self,
     *,
     channel: str,
-    thread_ts: Optional[str] = None,
+    thread_ts: str,
     markdown_text: Optional[str] = None,
     recipient_team_id: Optional[str] = None,
     recipient_user_id: Optional[str] = None,

--- a/docs/reference/web/client.html
+++ b/docs/reference/web/client.html
@@ -2900,7 +2900,7 @@ el.replaceWith(d);
         self,
         *,
         channel: str,
-        thread_ts: Optional[str] = None,
+        thread_ts: str,
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
@@ -10164,7 +10164,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_startStream"><code class="name flex">
-<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str | None = None,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10175,7 +10175,7 @@ Each authorization represents an app installation that the event is visible to.
     self,
     *,
     channel: str,
-    thread_ts: Optional[str] = None,
+    thread_ts: str,
     markdown_text: Optional[str] = None,
     recipient_team_id: Optional[str] = None,
     recipient_user_id: Optional[str] = None,

--- a/docs/reference/web/index.html
+++ b/docs/reference/web/index.html
@@ -3261,7 +3261,7 @@ This method returns it's own object. e.g. 'self'</p>
         self,
         *,
         channel: str,
-        thread_ts: Optional[str] = None,
+        thread_ts: str,
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
@@ -10525,7 +10525,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_startStream"><code class="name flex">
-<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str | None = None,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10536,7 +10536,7 @@ Each authorization represents an app installation that the event is visible to.
     self,
     *,
     channel: str,
-    thread_ts: Optional[str] = None,
+    thread_ts: str,
     markdown_text: Optional[str] = None,
     recipient_team_id: Optional[str] = None,
     recipient_user_id: Optional[str] = None,

--- a/docs/reference/web/legacy_client.html
+++ b/docs/reference/web/legacy_client.html
@@ -2899,7 +2899,7 @@ el.replaceWith(d);
         self,
         *,
         channel: str,
-        thread_ts: Optional[str] = None,
+        thread_ts: str,
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
@@ -10163,7 +10163,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_startStream"><code class="name flex">
-<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str | None = None,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10174,7 +10174,7 @@ Each authorization represents an app installation that the event is visible to.
     self,
     *,
     channel: str,
-    thread_ts: Optional[str] = None,
+    thread_ts: str,
     markdown_text: Optional[str] = None,
     recipient_team_id: Optional[str] = None,
     recipient_user_id: Optional[str] = None,

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2878,7 +2878,7 @@ class AsyncWebClient(AsyncBaseClient):
         self,
         *,
         channel: str,
-        thread_ts: Optional[str] = None,
+        thread_ts: str,
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2868,7 +2868,7 @@ class WebClient(BaseClient):
         self,
         *,
         channel: str,
-        thread_ts: Optional[str] = None,
+        thread_ts: str,
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2880,7 +2880,7 @@ class LegacyWebClient(LegacyBaseClient):
         self,
         *,
         channel: str,
-        thread_ts: Optional[str] = None,
+        thread_ts: str,
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,

--- a/tests/slack_sdk_async/web/test_web_client_coverage.py
+++ b/tests/slack_sdk_async/web/test_web_client_coverage.py
@@ -568,10 +568,10 @@ class TestWebClientCoverage(unittest.TestCase):
                 self.api_methods_to_call.remove(method()["method"])
                 await async_method()
             elif method_name == "chat_startStream":
-                self.api_methods_to_call.remove(method(channel="C123")["method"])
-                method(channel="C123", recipient_team_id="T123", recipient_user_id="U123")
-                await async_method(channel="C123")
-                await async_method(channel="C123", recipient_team_id="T123", recipient_user_id="U123")
+                self.api_methods_to_call.remove(method(channel="C123", thread_ts="123.123")["method"])
+                await async_method(channel="C123", thread_ts="123.123")
+                method(channel="C123", thread_ts="123.123", recipient_team_id="T123", recipient_user_id="U123")
+                await async_method(channel="C123", thread_ts="123.123", recipient_team_id="T123", recipient_user_id="U123")
             elif method_name == "chat_stopStream":
                 self.api_methods_to_call.remove(
                     method(channel="C123", ts="123.123", blocks=[{"type": "markdown", "text": "**twelve**"}])["method"]


### PR DESCRIPTION
## Summary

This pull request updates the `chat_startStream` method to require the `thread_ts` argument.

I've categorized this as a fix, since the Slack API has been updated to now require `thread_ts` when starting a conversation stream.

We'll want to update our AI Sample app to also require `thread_ts` once this is merged.

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
