### PR TITLE
fix(web): send structured values to "assistant.threads.setStatus" method using json content type

### DIFF
--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -2210,7 +2210,8 @@ and message responses using response_url in payloads.</p></div>
         kwargs.update(
             {&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status, &#34;loading_messages&#34;: loading_messages}
         )
-        return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;assistant.threads.setStatus&#34;, json=kwargs)
 
     def assistant_threads_setTitle(
         self,
@@ -8991,7 +8992,8 @@ Each authorization represents an app installation that the event is visible to.
     kwargs.update(
         {&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status, &#34;loading_messages&#34;: loading_messages}
     )
-    return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)</code></pre>
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;assistant.threads.setStatus&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the status for an AI assistant thread.
 <a href="https://api.slack.com/methods/assistant.threads.setStatus">https://api.slack.com/methods/assistant.threads.setStatus</a></p></div>

--- a/docs/reference/web/async_client.html
+++ b/docs/reference/web/async_client.html
@@ -2106,7 +2106,8 @@ el.replaceWith(d);
         kwargs.update(
             {&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status, &#34;loading_messages&#34;: loading_messages}
         )
-        return await self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;assistant.threads.setStatus&#34;, json=kwargs)
 
     async def assistant_threads_setTitle(
         self,
@@ -8887,7 +8888,8 @@ Each authorization represents an app installation that the event is visible to.
     kwargs.update(
         {&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status, &#34;loading_messages&#34;: loading_messages}
     )
-    return await self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)</code></pre>
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;assistant.threads.setStatus&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the status for an AI assistant thread.
 <a href="https://api.slack.com/methods/assistant.threads.setStatus">https://api.slack.com/methods/assistant.threads.setStatus</a></p></div>

--- a/docs/reference/web/client.html
+++ b/docs/reference/web/client.html
@@ -2106,7 +2106,8 @@ el.replaceWith(d);
         kwargs.update(
             {&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status, &#34;loading_messages&#34;: loading_messages}
         )
-        return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;assistant.threads.setStatus&#34;, json=kwargs)
 
     def assistant_threads_setTitle(
         self,
@@ -8887,7 +8888,8 @@ Each authorization represents an app installation that the event is visible to.
     kwargs.update(
         {&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status, &#34;loading_messages&#34;: loading_messages}
     )
-    return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)</code></pre>
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;assistant.threads.setStatus&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the status for an AI assistant thread.
 <a href="https://api.slack.com/methods/assistant.threads.setStatus">https://api.slack.com/methods/assistant.threads.setStatus</a></p></div>

--- a/docs/reference/web/index.html
+++ b/docs/reference/web/index.html
@@ -2467,7 +2467,8 @@ This method returns it's own object. e.g. 'self'</p>
         kwargs.update(
             {&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status, &#34;loading_messages&#34;: loading_messages}
         )
-        return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;assistant.threads.setStatus&#34;, json=kwargs)
 
     def assistant_threads_setTitle(
         self,
@@ -9248,7 +9249,8 @@ Each authorization represents an app installation that the event is visible to.
     kwargs.update(
         {&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status, &#34;loading_messages&#34;: loading_messages}
     )
-    return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)</code></pre>
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;assistant.threads.setStatus&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the status for an AI assistant thread.
 <a href="https://api.slack.com/methods/assistant.threads.setStatus">https://api.slack.com/methods/assistant.threads.setStatus</a></p></div>

--- a/docs/reference/web/legacy_client.html
+++ b/docs/reference/web/legacy_client.html
@@ -2105,7 +2105,8 @@ el.replaceWith(d);
         kwargs.update(
             {&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status, &#34;loading_messages&#34;: loading_messages}
         )
-        return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;assistant.threads.setStatus&#34;, json=kwargs)
 
     def assistant_threads_setTitle(
         self,
@@ -8886,7 +8887,8 @@ Each authorization represents an app installation that the event is visible to.
     kwargs.update(
         {&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status, &#34;loading_messages&#34;: loading_messages}
     )
-    return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)</code></pre>
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;assistant.threads.setStatus&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the status for an AI assistant thread.
 <a href="https://api.slack.com/methods/assistant.threads.setStatus">https://api.slack.com/methods/assistant.threads.setStatus</a></p></div>

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2084,7 +2084,8 @@ class AsyncWebClient(AsyncBaseClient):
         kwargs.update(
             {"channel_id": channel_id, "thread_ts": thread_ts, "status": status, "loading_messages": loading_messages}
         )
-        return await self.api_call("assistant.threads.setStatus", params=kwargs)
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call("assistant.threads.setStatus", json=kwargs)
 
     async def assistant_threads_setTitle(
         self,

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2074,7 +2074,8 @@ class WebClient(BaseClient):
         kwargs.update(
             {"channel_id": channel_id, "thread_ts": thread_ts, "status": status, "loading_messages": loading_messages}
         )
-        return self.api_call("assistant.threads.setStatus", params=kwargs)
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call("assistant.threads.setStatus", json=kwargs)
 
     def assistant_threads_setTitle(
         self,

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2086,7 +2086,8 @@ class LegacyWebClient(LegacyBaseClient):
         kwargs.update(
             {"channel_id": channel_id, "thread_ts": thread_ts, "status": status, "loading_messages": loading_messages}
         )
-        return self.api_call("assistant.threads.setStatus", params=kwargs)
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call("assistant.threads.setStatus", json=kwargs)
 
     def assistant_threads_setTitle(
         self,

--- a/tests/slack_sdk_async/web/test_web_client_coverage.py
+++ b/tests/slack_sdk_async/web/test_web_client_coverage.py
@@ -425,7 +425,19 @@ class TestWebClientCoverage(unittest.TestCase):
                 self.api_methods_to_call.remove(
                     method(channel_id="D111", thread_ts="111.222", status="is typing...")["method"]
                 )
+                method(
+                    channel_id="D111",
+                    thread_ts="111.222",
+                    status="is typing...",
+                    loading_states=["Thinking...", "Writing..."],
+                )
                 await async_method(channel_id="D111", thread_ts="111.222", status="is typing...")
+                await async_method(
+                    channel_id="D111",
+                    thread_ts="111.222",
+                    status="is typing...",
+                    loading_states=["Thinking...", "Writing..."],
+                )
             elif method_name == "assistant_threads_setTitle":
                 self.api_methods_to_call.remove(method(channel_id="D111", thread_ts="111.222", title="New chat")["method"])
                 await async_method(channel_id="D111", thread_ts="111.222", title="New chat")


### PR DESCRIPTION
## Summary

This PR uses the JSON content type to send structured values, such as an array of `loading_messages` to the server with correct encodings 🤖 

### Testing

Test cases now include arguments that require this `json` content type!

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
