### PR TITLE
docs(oauth): use a variable "base_dir" home path for file stores

### DIFF
--- a/docs/reference/oauth/installation_store/file/index.html
+++ b/docs/reference/oauth/installation_store/file/index.html
@@ -48,7 +48,7 @@ el.replaceWith(d);
 <dl>
 <dt id="slack_sdk.oauth.installation_store.file.FileInstallationStore"><code class="flex name class">
 <span>class <span class="ident">FileInstallationStore</span></span>
-<span>(</span><span>*,<br>base_dir: str = '/home/runner/.bolt-app-installation',<br>historical_data_enabled: bool = True,<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*,<br>base_dir: str = '$HOME/.bolt-app-installation',<br>historical_data_enabled: bool = True,<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/oauth/installation_store/index.html
+++ b/docs/reference/oauth/installation_store/index.html
@@ -327,7 +327,7 @@ el.replaceWith(d);
 </dd>
 <dt id="slack_sdk.oauth.installation_store.FileInstallationStore"><code class="flex name class">
 <span>class <span class="ident">FileInstallationStore</span></span>
-<span>(</span><span>*,<br>base_dir: str = '/home/runner/.bolt-app-installation',<br>historical_data_enabled: bool = True,<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*,<br>base_dir: str = '$HOME/.bolt-app-installation',<br>historical_data_enabled: bool = True,<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.installation_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/oauth/state_store/file/index.html
+++ b/docs/reference/oauth/state_store/file/index.html
@@ -48,7 +48,7 @@ el.replaceWith(d);
 <dl>
 <dt id="slack_sdk.oauth.state_store.file.FileOAuthStateStore"><code class="flex name class">
 <span>class <span class="ident">FileOAuthStateStore</span></span>
-<span>(</span><span>*,<br>expiration_seconds: int,<br>base_dir: str = '/home/runner/.bolt-app-oauth-state',<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*,<br>expiration_seconds: int,<br>base_dir: str = '$HOME/.bolt-app-oauth-state',<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/oauth/state_store/index.html
+++ b/docs/reference/oauth/state_store/index.html
@@ -77,7 +77,7 @@ el.replaceWith(d);
 <dl>
 <dt id="slack_sdk.oauth.state_store.FileOAuthStateStore"><code class="flex name class">
 <span>class <span class="ident">FileOAuthStateStore</span></span>
-<span>(</span><span>*,<br>expiration_seconds: int,<br>base_dir: str = '/home/runner/.bolt-app-oauth-state',<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
+<span>(</span><span>*,<br>expiration_seconds: int,<br>base_dir: str = '$HOME/.bolt-app-oauth-state',<br>client_id: str | None = None,<br>logger: logging.Logger = &lt;Logger slack_sdk.oauth.state_store.file (WARNING)&gt;)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/scripts/generate_api_docs.sh
+++ b/scripts/generate_api_docs.sh
@@ -9,7 +9,7 @@ pip install -U -r requirements/optional.txt
 
 rm -rf docs/reference
 
-pdoc slack_sdk --html -o docs/reference
+HOME="\$HOME" pdoc slack_sdk --html -o docs/reference
 cp -R docs/reference/slack_sdk/* docs/reference/
 rm -rf docs/reference/slack_sdk
 


### PR DESCRIPTION
## Summary

This PR replaces the `base_dir` default shown in documentation to use the "$HOME" placeholder instead of a particular path. Fixes #1752.

### Testing

No changes to functionalities! The docs I hope are more clear with this change too 📚 

### Notes

- Super open to other suggestions instead of "$HOME"! 

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] `/docs` (Documents)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
