### PR TITLE
fix(web-api): remove unfurl arguments from chat.startStream method

### DIFF
--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -3009,8 +3009,6 @@ and message responses using response_url in payloads.</p></div>
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
-        unfurl_links: Optional[bool] = None,
-        unfurl_media: Optional[bool] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Starts a new streaming conversation.
@@ -3023,8 +3021,6 @@ and message responses using response_url in payloads.</p></div>
                 &#34;markdown_text&#34;: markdown_text,
                 &#34;recipient_team_id&#34;: recipient_team_id,
                 &#34;recipient_user_id&#34;: recipient_user_id,
-                &#34;unfurl_links&#34;: unfurl_links,
-                &#34;unfurl_media&#34;: unfurl_media,
             }
         )
         kwargs = _remove_none_values(kwargs)
@@ -10333,7 +10329,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_startStream"><code class="name flex">
-<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10348,8 +10344,6 @@ Each authorization represents an app installation that the event is visible to.
     markdown_text: Optional[str] = None,
     recipient_team_id: Optional[str] = None,
     recipient_user_id: Optional[str] = None,
-    unfurl_links: Optional[bool] = None,
-    unfurl_media: Optional[bool] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Starts a new streaming conversation.
@@ -10362,8 +10356,6 @@ Each authorization represents an app installation that the event is visible to.
             &#34;markdown_text&#34;: markdown_text,
             &#34;recipient_team_id&#34;: recipient_team_id,
             &#34;recipient_user_id&#34;: recipient_user_id,
-            &#34;unfurl_links&#34;: unfurl_links,
-            &#34;unfurl_media&#34;: unfurl_media,
         }
     )
     kwargs = _remove_none_values(kwargs)

--- a/docs/reference/web/async_client.html
+++ b/docs/reference/web/async_client.html
@@ -2905,8 +2905,6 @@ el.replaceWith(d);
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
-        unfurl_links: Optional[bool] = None,
-        unfurl_media: Optional[bool] = None,
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Starts a new streaming conversation.
@@ -2919,8 +2917,6 @@ el.replaceWith(d);
                 &#34;markdown_text&#34;: markdown_text,
                 &#34;recipient_team_id&#34;: recipient_team_id,
                 &#34;recipient_user_id&#34;: recipient_user_id,
-                &#34;unfurl_links&#34;: unfurl_links,
-                &#34;unfurl_media&#34;: unfurl_media,
             }
         )
         kwargs = _remove_none_values(kwargs)
@@ -10229,7 +10225,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_startStream"><code class="name flex">
-<span>async def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10244,8 +10240,6 @@ Each authorization represents an app installation that the event is visible to.
     markdown_text: Optional[str] = None,
     recipient_team_id: Optional[str] = None,
     recipient_user_id: Optional[str] = None,
-    unfurl_links: Optional[bool] = None,
-    unfurl_media: Optional[bool] = None,
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Starts a new streaming conversation.
@@ -10258,8 +10252,6 @@ Each authorization represents an app installation that the event is visible to.
             &#34;markdown_text&#34;: markdown_text,
             &#34;recipient_team_id&#34;: recipient_team_id,
             &#34;recipient_user_id&#34;: recipient_user_id,
-            &#34;unfurl_links&#34;: unfurl_links,
-            &#34;unfurl_media&#34;: unfurl_media,
         }
     )
     kwargs = _remove_none_values(kwargs)

--- a/docs/reference/web/client.html
+++ b/docs/reference/web/client.html
@@ -2905,8 +2905,6 @@ el.replaceWith(d);
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
-        unfurl_links: Optional[bool] = None,
-        unfurl_media: Optional[bool] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Starts a new streaming conversation.
@@ -2919,8 +2917,6 @@ el.replaceWith(d);
                 &#34;markdown_text&#34;: markdown_text,
                 &#34;recipient_team_id&#34;: recipient_team_id,
                 &#34;recipient_user_id&#34;: recipient_user_id,
-                &#34;unfurl_links&#34;: unfurl_links,
-                &#34;unfurl_media&#34;: unfurl_media,
             }
         )
         kwargs = _remove_none_values(kwargs)
@@ -10229,7 +10225,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_startStream"><code class="name flex">
-<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10244,8 +10240,6 @@ Each authorization represents an app installation that the event is visible to.
     markdown_text: Optional[str] = None,
     recipient_team_id: Optional[str] = None,
     recipient_user_id: Optional[str] = None,
-    unfurl_links: Optional[bool] = None,
-    unfurl_media: Optional[bool] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Starts a new streaming conversation.
@@ -10258,8 +10252,6 @@ Each authorization represents an app installation that the event is visible to.
             &#34;markdown_text&#34;: markdown_text,
             &#34;recipient_team_id&#34;: recipient_team_id,
             &#34;recipient_user_id&#34;: recipient_user_id,
-            &#34;unfurl_links&#34;: unfurl_links,
-            &#34;unfurl_media&#34;: unfurl_media,
         }
     )
     kwargs = _remove_none_values(kwargs)

--- a/docs/reference/web/index.html
+++ b/docs/reference/web/index.html
@@ -3274,8 +3274,6 @@ This method returns it's own object. e.g. 'self'</p>
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
-        unfurl_links: Optional[bool] = None,
-        unfurl_media: Optional[bool] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Starts a new streaming conversation.
@@ -3288,8 +3286,6 @@ This method returns it's own object. e.g. 'self'</p>
                 &#34;markdown_text&#34;: markdown_text,
                 &#34;recipient_team_id&#34;: recipient_team_id,
                 &#34;recipient_user_id&#34;: recipient_user_id,
-                &#34;unfurl_links&#34;: unfurl_links,
-                &#34;unfurl_media&#34;: unfurl_media,
             }
         )
         kwargs = _remove_none_values(kwargs)
@@ -10598,7 +10594,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_startStream"><code class="name flex">
-<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10613,8 +10609,6 @@ Each authorization represents an app installation that the event is visible to.
     markdown_text: Optional[str] = None,
     recipient_team_id: Optional[str] = None,
     recipient_user_id: Optional[str] = None,
-    unfurl_links: Optional[bool] = None,
-    unfurl_media: Optional[bool] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Starts a new streaming conversation.
@@ -10627,8 +10621,6 @@ Each authorization represents an app installation that the event is visible to.
             &#34;markdown_text&#34;: markdown_text,
             &#34;recipient_team_id&#34;: recipient_team_id,
             &#34;recipient_user_id&#34;: recipient_user_id,
-            &#34;unfurl_links&#34;: unfurl_links,
-            &#34;unfurl_media&#34;: unfurl_media,
         }
     )
     kwargs = _remove_none_values(kwargs)

--- a/docs/reference/web/legacy_client.html
+++ b/docs/reference/web/legacy_client.html
@@ -2904,8 +2904,6 @@ el.replaceWith(d);
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
-        unfurl_links: Optional[bool] = None,
-        unfurl_media: Optional[bool] = None,
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Starts a new streaming conversation.
@@ -2918,8 +2916,6 @@ el.replaceWith(d);
                 &#34;markdown_text&#34;: markdown_text,
                 &#34;recipient_team_id&#34;: recipient_team_id,
                 &#34;recipient_user_id&#34;: recipient_user_id,
-                &#34;unfurl_links&#34;: unfurl_links,
-                &#34;unfurl_media&#34;: unfurl_media,
             }
         )
         kwargs = _remove_none_values(kwargs)
@@ -10165,7 +10161,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_startStream"><code class="name flex">
-<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+<span>def <span class="ident">chat_startStream</span></span>(<span>self,<br>*,<br>channel: str,<br>thread_ts: str,<br>markdown_text: str | None = None,<br>recipient_team_id: str | None = None,<br>recipient_user_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10180,8 +10176,6 @@ Each authorization represents an app installation that the event is visible to.
     markdown_text: Optional[str] = None,
     recipient_team_id: Optional[str] = None,
     recipient_user_id: Optional[str] = None,
-    unfurl_links: Optional[bool] = None,
-    unfurl_media: Optional[bool] = None,
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Starts a new streaming conversation.
@@ -10194,8 +10188,6 @@ Each authorization represents an app installation that the event is visible to.
             &#34;markdown_text&#34;: markdown_text,
             &#34;recipient_team_id&#34;: recipient_team_id,
             &#34;recipient_user_id&#34;: recipient_user_id,
-            &#34;unfurl_links&#34;: unfurl_links,
-            &#34;unfurl_media&#34;: unfurl_media,
         }
     )
     kwargs = _remove_none_values(kwargs)

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2884,8 +2884,6 @@ class AsyncWebClient(AsyncBaseClient):
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
-        unfurl_links: Optional[bool] = None,
-        unfurl_media: Optional[bool] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Starts a new streaming conversation.
@@ -2898,8 +2896,6 @@ class AsyncWebClient(AsyncBaseClient):
                 "markdown_text": markdown_text,
                 "recipient_team_id": recipient_team_id,
                 "recipient_user_id": recipient_user_id,
-                "unfurl_links": unfurl_links,
-                "unfurl_media": unfurl_media,
             }
         )
         kwargs = _remove_none_values(kwargs)

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2874,8 +2874,6 @@ class WebClient(BaseClient):
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
-        unfurl_links: Optional[bool] = None,
-        unfurl_media: Optional[bool] = None,
         **kwargs,
     ) -> SlackResponse:
         """Starts a new streaming conversation.
@@ -2888,8 +2886,6 @@ class WebClient(BaseClient):
                 "markdown_text": markdown_text,
                 "recipient_team_id": recipient_team_id,
                 "recipient_user_id": recipient_user_id,
-                "unfurl_links": unfurl_links,
-                "unfurl_media": unfurl_media,
             }
         )
         kwargs = _remove_none_values(kwargs)

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2885,8 +2885,6 @@ class LegacyWebClient(LegacyBaseClient):
         markdown_text: Optional[str] = None,
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
-        unfurl_links: Optional[bool] = None,
-        unfurl_media: Optional[bool] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Starts a new streaming conversation.
@@ -2899,8 +2897,6 @@ class LegacyWebClient(LegacyBaseClient):
                 "markdown_text": markdown_text,
                 "recipient_team_id": recipient_team_id,
                 "recipient_user_id": recipient_user_id,
-                "unfurl_links": unfurl_links,
-                "unfurl_media": unfurl_media,
             }
         )
         kwargs = _remove_none_values(kwargs)


### PR DESCRIPTION
## Summary

This PR removes `unfurl_links` and `unfurl_media` arguments from the "chat.startStream" method to align with the backend.

### Testing

Calls without these arguments should continue to succeed.

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] `/docs` (Documents)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
