### PR TITLE
docs: typo for conversations in chat stream docs

### DIFF
--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -3064,7 +3064,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; ChatStream:
         &#34;&#34;&#34;Stream markdown text into a conversation.
 
-        This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+        This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
         the stream can be stopped with concluding arguments such as &#34;blocks&#34; for gathering feedback.
 
         The following methods are used:
@@ -10421,7 +10421,7 @@ Each authorization represents an app installation that the event is visible to.
 ) -&gt; ChatStream:
     &#34;&#34;&#34;Stream markdown text into a conversation.
 
-    This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+    This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
     the stream can be stopped with concluding arguments such as &#34;blocks&#34; for gathering feedback.
 
     The following methods are used:
@@ -10473,7 +10473,7 @@ Each authorization represents an app installation that the event is visible to.
     )</code></pre>
 </details>
 <div class="desc"><p>Stream markdown text into a conversation.</p>
-<p>This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+<p>This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
 the stream can be stopped with concluding arguments such as "blocks" for gathering feedback.</p>
 <p>The following methods are used:</p>
 <ul>

--- a/docs/reference/web/async_client.html
+++ b/docs/reference/web/async_client.html
@@ -2960,7 +2960,7 @@ el.replaceWith(d);
     ) -&gt; AsyncChatStream:
         &#34;&#34;&#34;Stream markdown text into a conversation.
 
-        This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+        This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
         the stream can be stopped with concluding arguments such as &#34;blocks&#34; for gathering feedback.
 
         The following methods are used:
@@ -10317,7 +10317,7 @@ Each authorization represents an app installation that the event is visible to.
 ) -&gt; AsyncChatStream:
     &#34;&#34;&#34;Stream markdown text into a conversation.
 
-    This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+    This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
     the stream can be stopped with concluding arguments such as &#34;blocks&#34; for gathering feedback.
 
     The following methods are used:
@@ -10369,7 +10369,7 @@ Each authorization represents an app installation that the event is visible to.
     )</code></pre>
 </details>
 <div class="desc"><p>Stream markdown text into a conversation.</p>
-<p>This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+<p>This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
 the stream can be stopped with concluding arguments such as "blocks" for gathering feedback.</p>
 <p>The following methods are used:</p>
 <ul>

--- a/docs/reference/web/client.html
+++ b/docs/reference/web/client.html
@@ -2960,7 +2960,7 @@ el.replaceWith(d);
     ) -&gt; ChatStream:
         &#34;&#34;&#34;Stream markdown text into a conversation.
 
-        This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+        This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
         the stream can be stopped with concluding arguments such as &#34;blocks&#34; for gathering feedback.
 
         The following methods are used:
@@ -10317,7 +10317,7 @@ Each authorization represents an app installation that the event is visible to.
 ) -&gt; ChatStream:
     &#34;&#34;&#34;Stream markdown text into a conversation.
 
-    This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+    This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
     the stream can be stopped with concluding arguments such as &#34;blocks&#34; for gathering feedback.
 
     The following methods are used:
@@ -10369,7 +10369,7 @@ Each authorization represents an app installation that the event is visible to.
     )</code></pre>
 </details>
 <div class="desc"><p>Stream markdown text into a conversation.</p>
-<p>This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+<p>This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
 the stream can be stopped with concluding arguments such as "blocks" for gathering feedback.</p>
 <p>The following methods are used:</p>
 <ul>

--- a/docs/reference/web/index.html
+++ b/docs/reference/web/index.html
@@ -3329,7 +3329,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; ChatStream:
         &#34;&#34;&#34;Stream markdown text into a conversation.
 
-        This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+        This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
         the stream can be stopped with concluding arguments such as &#34;blocks&#34; for gathering feedback.
 
         The following methods are used:
@@ -10686,7 +10686,7 @@ Each authorization represents an app installation that the event is visible to.
 ) -&gt; ChatStream:
     &#34;&#34;&#34;Stream markdown text into a conversation.
 
-    This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+    This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
     the stream can be stopped with concluding arguments such as &#34;blocks&#34; for gathering feedback.
 
     The following methods are used:
@@ -10738,7 +10738,7 @@ Each authorization represents an app installation that the event is visible to.
     )</code></pre>
 </details>
 <div class="desc"><p>Stream markdown text into a conversation.</p>
-<p>This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+<p>This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
 the stream can be stopped with concluding arguments such as "blocks" for gathering feedback.</p>
 <p>The following methods are used:</p>
 <ul>

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2939,7 +2939,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncChatStream:
         """Stream markdown text into a conversation.
 
-        This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+        This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
         the stream can be stopped with concluding arguments such as "blocks" for gathering feedback.
 
         The following methods are used:

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2929,7 +2929,7 @@ class WebClient(BaseClient):
     ) -> ChatStream:
         """Stream markdown text into a conversation.
 
-        This method starts a new chat stream in a coversation that can be appended to. After appending an entire message,
+        This method starts a new chat stream in a conversation that can be appended to. After appending an entire message,
         the stream can be stopped with concluding arguments such as "blocks" for gathering feedback.
 
         The following methods are used:


### PR DESCRIPTION
## Summary

This PR fixes a typo for the word "conversations" found from the kind @lukegalbraithrussell in https://github.com/slackapi/node-slack-sdk/pull/2392!

### Testing

📚 Code has been generated and documentation updated!

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] `/docs` (Documents)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
