### PR TITLE
docs: replace links from api.slack.com to docs.slack.dev redirects

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_document.md
+++ b/.github/ISSUE_TEMPLATE/03_document.md
@@ -10,7 +10,7 @@ assignees: ""
 
 ### The page URLs
 
-- https://slack.dev/python-slack-sdk/
+- https://docs.slack.dev/tools/python-slack-sdk/
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Whether you're building a custom app for your team, or integrating a third party
 The **Python Slack SDK** allows interaction with:
 
 - `slack_sdk.web`: for calling the [Web API methods][api-methods]
-- `slack_sdk.webhook`: for utilizing the [Incoming Webhooks](https://api.slack.com/messaging/webhooks) and [`response_url`s in payloads](https://api.slack.com/interactivity/handling#message_responses)
-- `slack_sdk.signature`: for [verifying incoming requests from the Slack API server](https://api.slack.com/authentication/verifying-requests-from-slack)
-- `slack_sdk.socket_mode`: for receiving and sending messages over [Socket Mode](https://api.slack.com/socket-mode) connections
-- `slack_sdk.audit_logs`: for utilizing [Audit Logs APIs](https://api.slack.com/admins/audit-logs)
-- `slack_sdk.scim`: for utilizing [SCIM APIs](https://api.slack.com/admins/scim)
-- `slack_sdk.oauth`: for implementing the [Slack OAuth flow](https://api.slack.com/authentication/oauth-v2)
-- `slack_sdk.models`: for constructing [Block Kit](https://api.slack.com/block-kit) UI components using easy-to-use builders
+- `slack_sdk.webhook`: for utilizing the [Incoming Webhooks](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/) and [`response_url`s in payloads](https://docs.slack.dev/interactivity/handling-user-interaction/#message_responses)
+- `slack_sdk.signature`: for [verifying incoming requests from the Slack API server](https://docs.slack.dev/authentication/verifying-requests-from-slack/)
+- `slack_sdk.socket_mode`: for receiving and sending messages over [Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode/) connections
+- `slack_sdk.audit_logs`: for utilizing [Audit Logs APIs](https://docs.slack.dev/admins/audit-logs-api/)
+- `slack_sdk.scim`: for utilizing [SCIM APIs](https://docs.slack.dev/admins/scim-api/)
+- `slack_sdk.oauth`: for implementing the [Slack OAuth flow](https://docs.slack.dev/authentication/installing-with-oauth/)
+- `slack_sdk.models`: for constructing [Block Kit](https://docs.slack.dev/block-kit/) UI components using easy-to-use builders
 - `slack_sdk.rtm`: for utilizing the [RTM API][rtm-docs]
 
 If you want to use our [Events API][events-docs] and Interactivity features, please check the [Bolt for Python][bolt-python] library. Details on the Tokens and Authentication can be found in our [Auth Guide](https://docs.slack.dev/tools/python-slack-sdk/installation/).
@@ -293,9 +293,9 @@ helpful and collaborative way.
 <!-- Markdown links -->
 
 [slackclientv1]: https://github.com/slackapi/python-slackclient/tree/v1
-[api-methods]: https://api.slack.com/methods
-[rtm-docs]: https://api.slack.com/rtm
-[events-docs]: https://api.slack.com/events-api
+[api-methods]: https://docs.slack.dev/reference/methods
+[rtm-docs]: https://docs.slack.dev/legacy/legacy-rtm-api/
+[events-docs]: https://docs.slack.dev/apis/events-api/
 [bolt-python]: https://github.com/slackapi/bolt-python
 [pypi]: https://pypi.org/
 [gh-issues]: https://github.com/slackapi/python-slack-sdk/issues

--- a/docs/reference/audit_logs/async_client.html
+++ b/docs/reference/audit_logs/async_client.html
@@ -87,7 +87,7 @@ el.replaceWith(d);
         retry_handlers: Optional[List[AsyncRetryHandler]] = None,
     ):
         &#34;&#34;&#34;API client for Audit Logs API
-        See https://api.slack.com/admins/audit-logs for more details
+        See https://docs.slack.dev/admins/audit-logs-api/ for more details
 
         Args:
             token: An admin user&#39;s token, which starts with `xoxp-`
@@ -389,7 +389,7 @@ el.replaceWith(d);
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for Audit Logs API
-See <a href="https://api.slack.com/admins/audit-logs">https://api.slack.com/admins/audit-logs</a> for more details</p>
+See <a href="https://docs.slack.dev/admins/audit-logs-api/">https://docs.slack.dev/admins/audit-logs-api/</a> for more details</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>token</code></strong></dt>

--- a/docs/reference/audit_logs/index.html
+++ b/docs/reference/audit_logs/index.html
@@ -37,7 +37,7 @@ el.replaceWith(d);
 </header>
 <section id="section-intro">
 <p>Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.</p>
-<p>Refer to <a href="https://slack.dev/python-slack-sdk/audit-logs/">https://slack.dev/python-slack-sdk/audit-logs/</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/python-slack-sdk/audit-logs">https://docs.slack.dev/tools/python-slack-sdk/audit-logs</a> for details.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -94,7 +94,7 @@ el.replaceWith(d);
         retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         &#34;&#34;&#34;API client for Audit Logs API
-        See https://api.slack.com/admins/audit-logs for more details
+        See https://docs.slack.dev/admins/audit-logs-api/ for more details
 
         Args:
             token: An admin user&#39;s token, which starts with `xoxp-`
@@ -402,7 +402,7 @@ el.replaceWith(d);
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for Audit Logs API
-See <a href="https://api.slack.com/admins/audit-logs">https://api.slack.com/admins/audit-logs</a> for more details</p>
+See <a href="https://docs.slack.dev/admins/audit-logs-api/">https://docs.slack.dev/admins/audit-logs-api/</a> for more details</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>token</code></strong></dt>

--- a/docs/reference/audit_logs/v1/async_client.html
+++ b/docs/reference/audit_logs/v1/async_client.html
@@ -37,7 +37,7 @@ el.replaceWith(d);
 </header>
 <section id="section-intro">
 <p>Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.</p>
-<p>Refer to <a href="https://slack.dev/python-slack-sdk/audit-logs/">https://slack.dev/python-slack-sdk/audit-logs/</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/python-slack-sdk/audit-logs">https://docs.slack.dev/tools/python-slack-sdk/audit-logs</a> for details.</p>
 </section>
 <section>
 </section>
@@ -89,7 +89,7 @@ el.replaceWith(d);
         retry_handlers: Optional[List[AsyncRetryHandler]] = None,
     ):
         &#34;&#34;&#34;API client for Audit Logs API
-        See https://api.slack.com/admins/audit-logs for more details
+        See https://docs.slack.dev/admins/audit-logs-api/ for more details
 
         Args:
             token: An admin user&#39;s token, which starts with `xoxp-`
@@ -391,7 +391,7 @@ el.replaceWith(d);
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for Audit Logs API
-See <a href="https://api.slack.com/admins/audit-logs">https://api.slack.com/admins/audit-logs</a> for more details</p>
+See <a href="https://docs.slack.dev/admins/audit-logs-api/">https://docs.slack.dev/admins/audit-logs-api/</a> for more details</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>token</code></strong></dt>

--- a/docs/reference/audit_logs/v1/client.html
+++ b/docs/reference/audit_logs/v1/client.html
@@ -37,7 +37,7 @@ el.replaceWith(d);
 </header>
 <section id="section-intro">
 <p>Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.</p>
-<p>Refer to <a href="https://slack.dev/python-slack-sdk/audit-logs/">https://slack.dev/python-slack-sdk/audit-logs/</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/python-slack-sdk/audit-logs">https://docs.slack.dev/tools/python-slack-sdk/audit-logs</a> for details.</p>
 </section>
 <section>
 </section>
@@ -83,7 +83,7 @@ el.replaceWith(d);
         retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         &#34;&#34;&#34;API client for Audit Logs API
-        See https://api.slack.com/admins/audit-logs for more details
+        See https://docs.slack.dev/admins/audit-logs-api/ for more details
 
         Args:
             token: An admin user&#39;s token, which starts with `xoxp-`
@@ -391,7 +391,7 @@ el.replaceWith(d);
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for Audit Logs API
-See <a href="https://api.slack.com/admins/audit-logs">https://api.slack.com/admins/audit-logs</a> for more details</p>
+See <a href="https://docs.slack.dev/admins/audit-logs-api/">https://docs.slack.dev/admins/audit-logs-api/</a> for more details</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>token</code></strong></dt>

--- a/docs/reference/audit_logs/v1/index.html
+++ b/docs/reference/audit_logs/v1/index.html
@@ -37,7 +37,7 @@ el.replaceWith(d);
 </header>
 <section id="section-intro">
 <p>Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.</p>
-<p>Refer to <a href="https://slack.dev/python-slack-sdk/audit-logs/">https://slack.dev/python-slack-sdk/audit-logs/</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/python-slack-sdk/audit-logs">https://docs.slack.dev/tools/python-slack-sdk/audit-logs</a> for details.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 <meta name="generator" content="pdoc3 0.11.6">
 <title>slack_sdk API documentation</title>
-<meta name="description" content="* The SDK website: https://slack.dev/python-slack-sdk/
+<meta name="description" content="* The SDK website: https://docs.slack.dev/tools/python-slack-sdk
 * PyPI package: https://pypi.org/project/slack-sdk/ …">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/sanitize.min.css" integrity="sha512-y1dtMcuvtTMJc1yPgEqF0ZjQbhnc/bFhyvIyVNb9Zk5mIGtqVaAB1Ttl28su8AvFMOY0EwRbAe+HCLqj6W7/KA==" crossorigin>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/13.0.0/typography.min.css" integrity="sha512-Y1DYSb995BAfxobCkKepB1BqJJTPrOp3zPL74AWFugHHmmdcvO+C48WLrUOlhGMc0QG7AE3f7gmvvcrmX2fDoA==" crossorigin>
@@ -38,7 +38,7 @@ el.replaceWith(d);
 </header>
 <section id="section-intro">
 <ul>
-<li>The SDK website: <a href="https://slack.dev/python-slack-sdk/">https://slack.dev/python-slack-sdk/</a></li>
+<li>The SDK website: <a href="https://docs.slack.dev/tools/python-slack-sdk">https://docs.slack.dev/tools/python-slack-sdk</a></li>
 <li>PyPI package: <a href="https://pypi.org/project/slack-sdk/">https://pypi.org/project/slack-sdk/</a></li>
 </ul>
 <p>Here is the list of key modules in this SDK:</p>
@@ -163,7 +163,7 @@ and message responses using response_url in payloads.</p></div>
 <pre><code class="python">class WebClient(BaseClient):
     &#34;&#34;&#34;A WebClient allows apps to communicate with the Slack Platform&#39;s Web API.
 
-    https://api.slack.com/methods
+    https://docs.slack.dev/reference/methods
 
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
@@ -234,7 +234,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve analytics data for a given date, presented as a compressed JSON file
-        https://api.slack.com/methods/admin.analytics.getFile
+        https://docs.slack.dev/reference/methods/admin.analytics.getFile
         &#34;&#34;&#34;
         kwargs.update({&#34;type&#34;: type})
         if date is not None:
@@ -256,7 +256,7 @@ and message responses using response_url in payloads.</p></div>
         Either app_id or request_id is required.
         These IDs can be obtained either directly via the app_requested event,
         or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.approve
+        https://docs.slack.dev/reference/methods/admin.apps.approve
         &#34;&#34;&#34;
         if app_id:
             kwargs.update({&#34;app_id&#34;: app_id})
@@ -283,7 +283,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List approved apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.approved.list
+        https://docs.slack.dev/reference/methods/admin.apps.approved.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -304,7 +304,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Clear an app resolution
-        https://api.slack.com/methods/admin.apps.clearResolution
+        https://docs.slack.dev/reference/methods/admin.apps.clearResolution
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -324,7 +324,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.cancel
+        https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -344,7 +344,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.list
+        https://docs.slack.dev/reference/methods/admin.apps.requests.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -368,7 +368,7 @@ and message responses using response_url in payloads.</p></div>
         Exactly one of the team_id or enterprise_id arguments is required, not both.
         Either app_id or request_id is required. These IDs can be obtained either directly
         via the app_requested event, or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.restrict
+        https://docs.slack.dev/reference/methods/admin.apps.restrict
         &#34;&#34;&#34;
         if app_id:
             kwargs.update({&#34;app_id&#34;: app_id})
@@ -395,7 +395,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List restricted apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.restricted.list
+        https://docs.slack.dev/reference/methods/admin.apps.restricted.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -417,7 +417,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Uninstall an app from one or many workspaces, or an entire enterprise organization.
         With an org-level token, enterprise_id or team_ids is required.
-        https://api.slack.com/methods/admin.apps.uninstall
+        https://docs.slack.dev/reference/methods/admin.apps.uninstall
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         if enterprise_id is not None:
@@ -448,7 +448,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get logs for a specified team/org
-        https://api.slack.com/methods/admin.apps.activities.list
+        https://docs.slack.dev/reference/methods/admin.apps.activities.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -476,7 +476,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Look up the app config for connectors by their IDs
-        https://api.slack.com/methods/admin.apps.config.lookup
+        https://docs.slack.dev/reference/methods/admin.apps.config.lookup
         &#34;&#34;&#34;
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -493,7 +493,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the app config for a connector
-        https://api.slack.com/methods/admin.apps.config.set
+        https://docs.slack.dev/reference/methods/admin.apps.config.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -515,7 +515,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.
-        https://api.slack.com/methods/admin.auth.policy.getEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
         &#34;&#34;&#34;
         kwargs.update({&#34;policy_name&#34;: policy_name})
         if cursor is not None:
@@ -535,7 +535,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Assign entities to a particular authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.assignEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
         &#34;&#34;&#34;
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -554,7 +554,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove specified entities from a specified authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.removeEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
         &#34;&#34;&#34;
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -573,7 +573,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a Salesforce channel for the corresponding object provided.
-        https://api.slack.com/methods/admin.conversations.createForObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
         &#34;&#34;&#34;
         kwargs.update(
             {&#34;object_id&#34;: object_id, &#34;salesforce_org_id&#34;: salesforce_org_id, &#34;invite_object_team&#34;: invite_object_team}
@@ -589,7 +589,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Link a Salesforce record to a channel.
-        https://api.slack.com/methods/admin.conversations.linkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -608,7 +608,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Unlink a Salesforce record from a channel.
-        https://api.slack.com/methods/admin.conversations.unlinkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -627,7 +627,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create an Information Barrier
-        https://api.slack.com/methods/admin.barriers.create
+        https://docs.slack.dev/reference/methods/admin.barriers.create
         &#34;&#34;&#34;
         kwargs.update({&#34;primary_usergroup_id&#34;: primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -647,7 +647,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Delete an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.delete
+        https://docs.slack.dev/reference/methods/admin.barriers.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;barrier_id&#34;: barrier_id})
         return self.api_call(&#34;admin.barriers.delete&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -662,7 +662,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.update
+        https://docs.slack.dev/reference/methods/admin.barriers.update
         &#34;&#34;&#34;
         kwargs.update({&#34;barrier_id&#34;: barrier_id, &#34;primary_usergroup_id&#34;: primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -683,7 +683,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get all Information Barriers for your organization
-        https://api.slack.com/methods/admin.barriers.list&#34;&#34;&#34;
+        https://docs.slack.dev/reference/methods/admin.barriers.list&#34;&#34;&#34;
         kwargs.update(
             {
                 &#34;cursor&#34;: cursor,
@@ -703,7 +703,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a public or private channel-based conversation.
-        https://api.slack.com/methods/admin.conversations.create
+        https://docs.slack.dev/reference/methods/admin.conversations.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -723,7 +723,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Delete a public or private channel.
-        https://api.slack.com/methods/admin.conversations.delete
+        https://docs.slack.dev/reference/methods/admin.conversations.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.delete&#34;, params=kwargs)
@@ -736,7 +736,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invite a user to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.invite
+        https://docs.slack.dev/reference/methods/admin.conversations.invite
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(user_ids, (list, tuple)):
@@ -753,7 +753,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Archive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.archive&#34;, params=kwargs)
@@ -765,7 +765,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Unarchive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.unarchive&#34;, params=kwargs)
@@ -778,7 +778,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Rename a public or private channel.
-        https://api.slack.com/methods/admin.conversations.rename
+        https://docs.slack.dev/reference/methods/admin.conversations.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;name&#34;: name})
         return self.api_call(&#34;admin.conversations.rename&#34;, params=kwargs)
@@ -796,7 +796,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.
-        https://api.slack.com/methods/admin.conversations.search
+        https://docs.slack.dev/reference/methods/admin.conversations.search
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -827,7 +827,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Convert a public channel to a private channel.
-        https://api.slack.com/methods/admin.conversations.convertToPrivate
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.convertToPrivate&#34;, params=kwargs)
@@ -839,7 +839,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Convert a privte channel to a public channel.
-        https://api.slack.com/methods/admin.conversations.convertToPublic
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.convertToPublic&#34;, params=kwargs)
@@ -852,7 +852,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the posting permissions for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(prefs, dict):
@@ -868,7 +868,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get conversation preferences for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.getConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.getConversationPrefs&#34;, params=kwargs)
@@ -881,7 +881,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Disconnect a connected channel from one or more workspaces.
-        https://api.slack.com/methods/admin.conversations.disconnectShared
+        https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(leaving_team_ids, (list, tuple)):
@@ -901,7 +901,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Returns channels on the given team using the filters.
-        https://api.slack.com/methods/admin.conversations.lookup
+        https://docs.slack.dev/reference/methods/admin.conversations.lookup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -929,7 +929,7 @@ and message responses using response_url in payloads.</p></div>
         &#34;&#34;&#34;List all disconnected channels—i.e.,
         channels that were once connected to other workspaces and then disconnected—and
         the corresponding original channel IDs for key revocation with EKM.
-        https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+        https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -956,7 +956,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an allowlist of IDP groups for accessing a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -979,7 +979,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all IDP Groups linked to a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1002,7 +1002,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a linked IDP group linked from a private channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1027,7 +1027,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.setTeams
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1051,7 +1051,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a channel.
-        https://api.slack.com/methods/admin.conversations.getTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.getTeams
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1069,7 +1069,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.getCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.getCustomRetention&#34;, params=kwargs)
@@ -1081,7 +1081,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.removeCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.removeCustomRetention&#34;, params=kwargs)
@@ -1094,7 +1094,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.setCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;duration_days&#34;: duration_days})
         return self.api_call(&#34;admin.conversations.setCustomRetention&#34;, params=kwargs)
@@ -1106,7 +1106,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Archive public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkArchive
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
         return self.api_call(&#34;admin.conversations.bulkArchive&#34;, params=kwargs)
@@ -1131,7 +1131,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Move public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkMove
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1149,7 +1149,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an emoji.
-        https://api.slack.com/methods/admin.emoji.add
+        https://docs.slack.dev/reference/methods/admin.emoji.add
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;url&#34;: url})
         return self.api_call(&#34;admin.emoji.add&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1162,7 +1162,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an emoji alias.
-        https://api.slack.com/methods/admin.emoji.addAlias
+        https://docs.slack.dev/reference/methods/admin.emoji.addAlias
         &#34;&#34;&#34;
         kwargs.update({&#34;alias_for&#34;: alias_for, &#34;name&#34;: name})
         return self.api_call(&#34;admin.emoji.addAlias&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1175,7 +1175,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List emoji for an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.list
+        https://docs.slack.dev/reference/methods/admin.emoji.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1187,7 +1187,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove an emoji across an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.remove
+        https://docs.slack.dev/reference/methods/admin.emoji.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name})
         return self.api_call(&#34;admin.emoji.remove&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1200,7 +1200,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Rename an emoji.
-        https://api.slack.com/methods/admin.emoji.rename
+        https://docs.slack.dev/reference/methods/admin.emoji.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;new_name&#34;: new_name})
         return self.api_call(&#34;admin.emoji.rename&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1215,7 +1215,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Look up functions by a set of apps
-        https://api.slack.com/methods/admin.functions.list
+        https://docs.slack.dev/reference/methods/admin.functions.list
         &#34;&#34;&#34;
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -1238,7 +1238,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lookup the visibility of multiple Slack functions
         and include the users if it is limited to particular named entities.
-        https://api.slack.com/methods/admin.functions.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
         &#34;&#34;&#34;
         if isinstance(function_ids, (list, tuple)):
             kwargs.update({&#34;function_ids&#34;: &#34;,&#34;.join(function_ids)})
@@ -1256,7 +1256,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the visibility of a Slack function
         and define the users or workspaces if it is set to named_entities
-        https://api.slack.com/methods/admin.functions.permissions.set
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1280,7 +1280,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds members to the specified role with the specified scopes
-        https://api.slack.com/methods/admin.roles.addAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.addAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;role_id&#34;: role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1305,7 +1305,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists assignments for all roles across entities.
             Options to scope results by any combination of roles or entities
-        https://api.slack.com/methods/admin.roles.listAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.listAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;sort_dir&#34;: sort_dir})
         if isinstance(entity_ids, (list, tuple)):
@@ -1327,7 +1327,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a set of users from a role for the given scopes and entities
-        https://api.slack.com/methods/admin.roles.removeAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;role_id&#34;: role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1349,7 +1349,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Wipes all valid sessions on all devices for a given user.
-        https://api.slack.com/methods/admin.users.session.reset
+        https://docs.slack.dev/reference/methods/admin.users.session.reset
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1369,7 +1369,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-        https://api.slack.com/methods/admin.users.session.resetBulk
+        https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1391,7 +1391,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invalidate a single session for a user by session_id.
-        https://api.slack.com/methods/admin.users.session.invalidate
+        https://docs.slack.dev/reference/methods/admin.users.session.invalidate
         &#34;&#34;&#34;
         kwargs.update({&#34;session_id&#34;: session_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.users.session.invalidate&#34;, params=kwargs)
@@ -1406,7 +1406,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all active user sessions for an organization
-        https://api.slack.com/methods/admin.users.session.list
+        https://docs.slack.dev/reference/methods/admin.users.session.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1426,7 +1426,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the default channels of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1443,7 +1443,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get user-specific session settings—the session duration
         and what happens when the client closes—given a list of users.
-        https://api.slack.com/methods/admin.users.session.getSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.getSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1461,7 +1461,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Configure the user-level session settings—the session duration
         and what happens when the client closes—for one or more users.
-        https://api.slack.com/methods/admin.users.session.setSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.setSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1483,7 +1483,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Clear user-specific session settings—the session duration
         and what happens when the client closes—for a list of users.
-        https://api.slack.com/methods/admin.users.session.clearSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1500,7 +1500,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ask Slackbot to send you an export listing all workspace members using unsupported software,
         presented as a zipped CSV file.
-        https://api.slack.com/methods/admin.users.unsupportedVersions.export
+        https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1518,7 +1518,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Approve a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.approve
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.inviteRequests.approve&#34;, params=kwargs)
@@ -1532,7 +1532,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all approved workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.approved.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1552,7 +1552,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all denied workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.denied.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1571,7 +1571,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deny a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.deny
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.inviteRequests.deny&#34;, params=kwargs)
@@ -1592,7 +1592,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.inviteRequests.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1613,7 +1613,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create an Enterprise team.
-        https://api.slack.com/methods/admin.teams.create
+        https://docs.slack.dev/reference/methods/admin.teams.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1633,7 +1633,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all teams on an Enterprise organization.
-        https://api.slack.com/methods/admin.teams.list
+        https://docs.slack.dev/reference/methods/admin.teams.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
@@ -1647,7 +1647,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.teams.owners.list
+        https://docs.slack.dev/reference/methods/admin.teams.owners.list
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.teams.owners.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1659,7 +1659,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Fetch information about settings in a workspace
-        https://api.slack.com/methods/admin.teams.settings.info
+        https://docs.slack.dev/reference/methods/admin.teams.settings.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.teams.settings.info&#34;, params=kwargs)
@@ -1672,7 +1672,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the description of a given workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDescription
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;description&#34;: description})
         return self.api_call(&#34;admin.teams.settings.setDescription&#34;, params=kwargs)
@@ -1685,7 +1685,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;discoverability&#34;: discoverability})
         return self.api_call(&#34;admin.teams.settings.setDiscoverability&#34;, params=kwargs)
@@ -1698,7 +1698,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setIcon
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;image_url&#34;: image_url})
         return self.api_call(&#34;admin.teams.settings.setIcon&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1711,7 +1711,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setName
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setName
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;name&#34;: name})
         return self.api_call(&#34;admin.teams.settings.setName&#34;, params=kwargs)
@@ -1725,7 +1725,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.addChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;usergroup_id&#34;: usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1743,7 +1743,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Associate one or more default workspaces with an organization-wide IDP group.
-        https://api.slack.com/methods/admin.usergroups.addTeams
+        https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup_id&#34;: usergroup_id, &#34;auto_provision&#34;: auto_provision})
         if isinstance(team_ids, (list, tuple)):
@@ -1761,7 +1761,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.listChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1780,7 +1780,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.removeChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup_id&#34;: usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1800,7 +1800,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an Enterprise user to a workspace.
-        https://api.slack.com/methods/admin.users.assign
+        https://docs.slack.dev/reference/methods/admin.users.assign
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1832,7 +1832,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invite a user to a workspace.
-        https://api.slack.com/methods/admin.users.invite
+        https://docs.slack.dev/reference/methods/admin.users.invite
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1856,7 +1856,7 @@ and message responses using response_url in payloads.</p></div>
     def admin_users_list(
         self,
         *,
-        team_id: str,
+        team_id: Optional[str] = None,
         include_deactivated_user_workspaces: Optional[bool] = None,
         is_active: Optional[bool] = None,
         cursor: Optional[str] = None,
@@ -1864,7 +1864,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List users on a workspace
-        https://api.slack.com/methods/admin.users.list
+        https://docs.slack.dev/reference/methods/admin.users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1885,7 +1885,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a user from a workspace.
-        https://api.slack.com/methods/admin.users.remove
+        https://docs.slack.dev/reference/methods/admin.users.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.remove&#34;, params=kwargs)
@@ -1898,7 +1898,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an existing guest, regular user, or owner to be an admin user.
-        https://api.slack.com/methods/admin.users.setAdmin
+        https://docs.slack.dev/reference/methods/admin.users.setAdmin
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setAdmin&#34;, params=kwargs)
@@ -1912,7 +1912,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an expiration for a guest user.
-        https://api.slack.com/methods/admin.users.setExpiration
+        https://docs.slack.dev/reference/methods/admin.users.setExpiration
         &#34;&#34;&#34;
         kwargs.update({&#34;expiration_ts&#34;: expiration_ts, &#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setExpiration&#34;, params=kwargs)
@@ -1925,7 +1925,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an existing guest, regular user, or admin user to be a workspace owner.
-        https://api.slack.com/methods/admin.users.setOwner
+        https://docs.slack.dev/reference/methods/admin.users.setOwner
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setOwner&#34;, params=kwargs)
@@ -1938,7 +1938,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an existing guest user, admin user, or owner to be a regular user.
-        https://api.slack.com/methods/admin.users.setRegular
+        https://docs.slack.dev/reference/methods/admin.users.setRegular
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setRegular&#34;, params=kwargs)
@@ -1959,7 +1959,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Search workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.search
+        https://docs.slack.dev/reference/methods/admin.workflows.search
         &#34;&#34;&#34;
         if collaborator_ids is not None:
             if isinstance(collaborator_ids, (list, tuple)):
@@ -1989,7 +1989,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Look up the permissions for a set of workflows
-        https://api.slack.com/methods/admin.workflows.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
         &#34;&#34;&#34;
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -2010,7 +2010,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add collaborators to workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.add
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
         &#34;&#34;&#34;
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -2030,7 +2030,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove collaborators from workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.remove
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
         &#34;&#34;&#34;
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -2049,7 +2049,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Unpublish workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.unpublish
+        https://docs.slack.dev/reference/methods/admin.workflows.unpublish
         &#34;&#34;&#34;
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -2064,7 +2064,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Checks API calling code.
-        https://api.slack.com/methods/api.test
+        https://docs.slack.dev/reference/methods/api.test
         &#34;&#34;&#34;
         kwargs.update({&#34;error&#34;: error})
         return self.api_call(&#34;api.test&#34;, params=kwargs)
@@ -2077,7 +2077,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Generate a temporary Socket Mode WebSocket URL that your app can connect to
         in order to receive events and interactive payloads
-        https://api.slack.com/methods/apps.connections.open
+        https://docs.slack.dev/reference/methods/apps.connections.open
         &#34;&#34;&#34;
         kwargs.update({&#34;token&#34;: app_token})
         return self.api_call(&#34;apps.connections.open&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2092,7 +2092,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get a list of authorizations for the given event context.
         Each authorization represents an app installation that the event is visible to.
-        https://api.slack.com/methods/apps.event.authorizations.list
+        https://docs.slack.dev/reference/methods/apps.event.authorizations.list
         &#34;&#34;&#34;
         kwargs.update({&#34;event_context&#34;: event_context, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;apps.event.authorizations.list&#34;, params=kwargs)
@@ -2105,7 +2105,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Uninstalls your app from a workspace.
-        https://api.slack.com/methods/apps.uninstall
+        https://docs.slack.dev/reference/methods/apps.uninstall
         &#34;&#34;&#34;
         kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret})
         return self.api_call(&#34;apps.uninstall&#34;, params=kwargs)
@@ -2117,7 +2117,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.create
+        https://docs.slack.dev/reference/methods/apps.manifest.create
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2132,7 +2132,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Permanently deletes an app created through app manifests
-        https://api.slack.com/methods/apps.manifest.delete
+        https://docs.slack.dev/reference/methods/apps.manifest.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         return self.api_call(&#34;apps.manifest.delete&#34;, params=kwargs)
@@ -2144,7 +2144,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Export an app manifest from an existing app
-        https://api.slack.com/methods/apps.manifest.export
+        https://docs.slack.dev/reference/methods/apps.manifest.export
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         return self.api_call(&#34;apps.manifest.export&#34;, params=kwargs)
@@ -2157,7 +2157,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.update
+        https://docs.slack.dev/reference/methods/apps.manifest.update
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2174,7 +2174,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Validate an app manifest
-        https://api.slack.com/methods/apps.manifest.validate
+        https://docs.slack.dev/reference/methods/apps.manifest.validate
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2190,7 +2190,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a refresh token for a new app configuration token
-        https://api.slack.com/methods/tooling.tokens.rotate
+        https://docs.slack.dev/reference/methods/tooling.tokens.rotate
         &#34;&#34;&#34;
         kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return self.api_call(&#34;tooling.tokens.rotate&#34;, params=kwargs)
@@ -2204,7 +2204,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setStatus
+        https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status})
         return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)
@@ -2218,7 +2218,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setTitle
+        https://docs.slack.dev/reference/methods/assistant.threads.setTitle
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;title&#34;: title})
         return self.api_call(&#34;assistant.threads.setTitle&#34;, params=kwargs)
@@ -2233,7 +2233,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+        https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
         if title is not None:
@@ -2247,7 +2247,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/auth.revoke
+        https://docs.slack.dev/reference/methods/auth.revoke
         &#34;&#34;&#34;
         kwargs.update({&#34;test&#34;: test})
         return self.api_call(&#34;auth.revoke&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2257,7 +2257,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Checks authentication &amp; identity.
-        https://api.slack.com/methods/auth.test
+        https://docs.slack.dev/reference/methods/auth.test
         &#34;&#34;&#34;
         return self.api_call(&#34;auth.test&#34;, params=kwargs)
 
@@ -2269,7 +2269,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List the workspaces a token can access.
-        https://api.slack.com/methods/auth.teams.list
+        https://docs.slack.dev/reference/methods/auth.teams.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;include_icon&#34;: include_icon})
         return self.api_call(&#34;auth.teams.list&#34;, params=kwargs)
@@ -2287,7 +2287,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add bookmark to a channel.
-        https://api.slack.com/methods/bookmarks.add
+        https://docs.slack.dev/reference/methods/bookmarks.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2313,7 +2313,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Edit bookmark.
-        https://api.slack.com/methods/bookmarks.edit
+        https://docs.slack.dev/reference/methods/bookmarks.edit
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2333,7 +2333,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List bookmark for the channel.
-        https://api.slack.com/methods/bookmarks.list
+        https://docs.slack.dev/reference/methods/bookmarks.list
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;bookmarks.list&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2346,7 +2346,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove bookmark from the channel.
-        https://api.slack.com/methods/bookmarks.remove
+        https://docs.slack.dev/reference/methods/bookmarks.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;bookmark_id&#34;: bookmark_id, &#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;bookmarks.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2359,7 +2359,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a bot user.
-        https://api.slack.com/methods/bots.info
+        https://docs.slack.dev/reference/methods/bots.info
         &#34;&#34;&#34;
         kwargs.update({&#34;bot&#34;: bot, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;bots.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2378,7 +2378,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Registers a new Call.
-        https://api.slack.com/methods/calls.add
+        https://docs.slack.dev/reference/methods/calls.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2405,7 +2405,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ends a Call.
-        https://api.slack.com/methods/calls.end
+        https://docs.slack.dev/reference/methods/calls.end
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id, &#34;duration&#34;: duration})
         return self.api_call(&#34;calls.end&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2417,7 +2417,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Returns information about a Call.
-        https://api.slack.com/methods/calls.info
+        https://docs.slack.dev/reference/methods/calls.info
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         return self.api_call(&#34;calls.info&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2430,7 +2430,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Registers new participants added to a Call.
-        https://api.slack.com/methods/calls.participants.add
+        https://docs.slack.dev/reference/methods/calls.participants.add
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         _update_call_participants(kwargs, users)
@@ -2444,7 +2444,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Registers participants removed from a Call.
-        https://api.slack.com/methods/calls.participants.remove
+        https://docs.slack.dev/reference/methods/calls.participants.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         _update_call_participants(kwargs, users)
@@ -2460,7 +2460,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Updates information about a Call.
-        https://api.slack.com/methods/calls.update
+        https://docs.slack.dev/reference/methods/calls.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2480,7 +2480,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create Canvas for a user
-        https://api.slack.com/methods/canvases.create
+        https://docs.slack.dev/reference/methods/canvases.create
         &#34;&#34;&#34;
         kwargs.update({&#34;title&#34;: title, &#34;document_content&#34;: document_content})
         return self.api_call(&#34;canvases.create&#34;, json=kwargs)
@@ -2493,7 +2493,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an existing canvas
-        https://api.slack.com/methods/canvases.edit
+        https://docs.slack.dev/reference/methods/canvases.edit
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;changes&#34;: changes})
         return self.api_call(&#34;canvases.edit&#34;, json=kwargs)
@@ -2505,7 +2505,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a canvas
-        https://api.slack.com/methods/canvases.delete
+        https://docs.slack.dev/reference/methods/canvases.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id})
         return self.api_call(&#34;canvases.delete&#34;, params=kwargs)
@@ -2520,7 +2520,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the access level to a canvas for specified entities
-        https://api.slack.com/methods/canvases.access.set
+        https://docs.slack.dev/reference/methods/canvases.access.set
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;access_level&#34;: access_level})
         if channel_ids is not None:
@@ -2545,7 +2545,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a Channel Canvas for a channel
-        https://api.slack.com/methods/canvases.access.delete
+        https://docs.slack.dev/reference/methods/canvases.access.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id})
         if channel_ids is not None:
@@ -2568,7 +2568,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Find sections matching the provided criteria
-        https://api.slack.com/methods/canvases.sections.lookup
+        https://docs.slack.dev/reference/methods/canvases.sections.lookup
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;criteria&#34;: json.dumps(criteria)})
         return self.api_call(&#34;canvases.sections.lookup&#34;, params=kwargs)
@@ -2576,7 +2576,7 @@ and message responses using response_url in payloads.</p></div>
     # --------------------------
     # Deprecated: channels.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def channels_archive(
@@ -2755,7 +2755,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a message.
-        https://api.slack.com/methods/chat.delete
+        https://docs.slack.dev/reference/methods/chat.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts, &#34;as_user&#34;: as_user})
         return self.api_call(&#34;chat.delete&#34;, params=kwargs)
@@ -2769,7 +2769,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a scheduled message.
-        https://api.slack.com/methods/chat.deleteScheduledMessage
+        https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2788,7 +2788,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a permalink URL for a specific extant message
-        https://api.slack.com/methods/chat.getPermalink
+        https://docs.slack.dev/reference/methods/chat.getPermalink
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;message_ts&#34;: message_ts})
         return self.api_call(&#34;chat.getPermalink&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2801,7 +2801,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Share a me message into a channel.
-        https://api.slack.com/methods/chat.meMessage
+        https://docs.slack.dev/reference/methods/chat.meMessage
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;text&#34;: text})
         return self.api_call(&#34;chat.meMessage&#34;, params=kwargs)
@@ -2821,10 +2821,11 @@ and message responses using response_url in payloads.</p></div>
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sends an ephemeral message to a user in a channel.
-        https://api.slack.com/methods/chat.postEphemeral
+        https://docs.slack.dev/reference/methods/chat.postEphemeral
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2840,11 +2841,12 @@ and message responses using response_url in payloads.</p></div>
                 &#34;link_names&#34;: link_names,
                 &#34;username&#34;: username,
                 &#34;parse&#34;: parse,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.postEphemeral&#34;, json=kwargs)
 
@@ -2868,10 +2870,11 @@ and message responses using response_url in payloads.</p></div>
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sends a message to a channel.
-        https://api.slack.com/methods/chat.postMessage
+        https://docs.slack.dev/reference/methods/chat.postMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2892,11 +2895,12 @@ and message responses using response_url in payloads.</p></div>
                 &#34;username&#34;: username,
                 &#34;parse&#34;: parse,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postMessage&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.postMessage&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.postMessage&#34;, json=kwargs)
 
@@ -2905,7 +2909,7 @@ and message responses using response_url in payloads.</p></div>
         *,
         channel: str,
         post_at: Union[str, int],
-        text: str,
+        text: Optional[str] = None,
         as_user: Optional[bool] = None,
         attachments: Optional[Union[str, Sequence[Union[Dict, Attachment]]]] = None,
         blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
@@ -2916,10 +2920,11 @@ and message responses using response_url in payloads.</p></div>
         unfurl_media: Optional[bool] = None,
         link_names: Optional[bool] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Schedules a message.
-        https://api.slack.com/methods/chat.scheduleMessage
+        https://docs.slack.dev/reference/methods/chat.scheduleMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2936,11 +2941,12 @@ and message responses using response_url in payloads.</p></div>
                 &#34;unfurl_media&#34;: unfurl_media,
                 &#34;link_names&#34;: link_names,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.scheduleMessage&#34;, json=kwargs)
 
@@ -2959,7 +2965,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Provide custom unfurl behavior for user-posted URLs.
-        https://api.slack.com/methods/chat.unfurl
+        https://docs.slack.dev/reference/methods/chat.unfurl
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2993,10 +2999,11 @@ and message responses using response_url in payloads.</p></div>
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Updates a message in a channel.
-        https://api.slack.com/methods/chat.update
+        https://docs.slack.dev/reference/methods/chat.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3010,6 +3017,7 @@ and message responses using response_url in payloads.</p></div>
                 &#34;parse&#34;: parse,
                 &#34;reply_broadcast&#34;: reply_broadcast,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         if isinstance(file_ids, (list, tuple)):
@@ -3018,7 +3026,7 @@ and message responses using response_url in payloads.</p></div>
             kwargs.update({&#34;file_ids&#34;: file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.update&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.update&#34;, kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return self.api_call(&#34;chat.update&#34;, json=kwargs)
 
@@ -3034,7 +3042,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all scheduled messages.
-        https://api.slack.com/methods/chat.scheduledMessages.list
+        https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3060,7 +3068,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Accepts an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.acceptSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
         &#34;&#34;&#34;
         if channel_id is None and invite_id is None:
             raise e.SlackRequestError(&#34;Either channel_id or invite_id must be provided.&#34;)
@@ -3084,7 +3092,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Approves an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.approveSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
         return self.api_call(&#34;conversations.approveSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -3096,7 +3104,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Archives a conversation.
-        https://api.slack.com/methods/conversations.archive
+        https://docs.slack.dev/reference/methods/conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.archive&#34;, params=kwargs)
@@ -3108,7 +3116,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Closes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.close
+        https://docs.slack.dev/reference/methods/conversations.close
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.close&#34;, params=kwargs)
@@ -3122,7 +3130,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Initiates a public or private channel-based conversation
-        https://api.slack.com/methods/conversations.create
+        https://docs.slack.dev/reference/methods/conversations.create
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;is_private&#34;: is_private, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;conversations.create&#34;, params=kwargs)
@@ -3135,7 +3143,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Declines a Slack Connect channel invite.
-        https://api.slack.com/methods/conversations.declineSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
         return self.api_call(&#34;conversations.declineSharedInvite&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3144,7 +3152,7 @@ and message responses using response_url in payloads.</p></div>
         self, *, action: str, channel: str, target_team: str, **kwargs
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-        https://api.slack.com/methods/conversations.externalInvitePermissions.set
+        https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3168,7 +3176,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Fetches a conversation&#39;s history of messages and events.
-        https://api.slack.com/methods/conversations.history
+        https://docs.slack.dev/reference/methods/conversations.history
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3192,7 +3200,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve information about a conversation.
-        https://api.slack.com/methods/conversations.info
+        https://docs.slack.dev/reference/methods/conversations.info
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3212,7 +3220,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invites users to a channel.
-        https://api.slack.com/methods/conversations.invite
+        https://docs.slack.dev/reference/methods/conversations.invite
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3235,7 +3243,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sends an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.inviteShared
+        https://docs.slack.dev/reference/methods/conversations.inviteShared
         &#34;&#34;&#34;
         if emails is None and user_ids is None:
             raise e.SlackRequestError(&#34;Either emails or user ids must be provided.&#34;)
@@ -3257,7 +3265,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Joins an existing conversation.
-        https://api.slack.com/methods/conversations.join
+        https://docs.slack.dev/reference/methods/conversations.join
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.join&#34;, params=kwargs)
@@ -3270,7 +3278,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a user from a conversation.
-        https://api.slack.com/methods/conversations.kick
+        https://docs.slack.dev/reference/methods/conversations.kick
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;user&#34;: user})
         return self.api_call(&#34;conversations.kick&#34;, params=kwargs)
@@ -3282,7 +3290,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Leaves a conversation.
-        https://api.slack.com/methods/conversations.leave
+        https://docs.slack.dev/reference/methods/conversations.leave
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.leave&#34;, params=kwargs)
@@ -3298,7 +3306,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all channels in a Slack team.
-        https://api.slack.com/methods/conversations.list
+        https://docs.slack.dev/reference/methods/conversations.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3324,7 +3332,7 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List shared channel invites that have been generated
         or received but have not yet been approved by all parties.
-        https://api.slack.com/methods/conversations.listConnectInvites
+        https://docs.slack.dev/reference/methods/conversations.listConnectInvites
         &#34;&#34;&#34;
         kwargs.update({&#34;count&#34;: count, &#34;cursor&#34;: cursor, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;conversations.listConnectInvites&#34;, params=kwargs)
@@ -3337,7 +3345,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the read cursor in a channel.
-        https://api.slack.com/methods/conversations.mark
+        https://docs.slack.dev/reference/methods/conversations.mark
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts})
         return self.api_call(&#34;conversations.mark&#34;, params=kwargs)
@@ -3351,7 +3359,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve members of a conversation.
-        https://api.slack.com/methods/conversations.members
+        https://docs.slack.dev/reference/methods/conversations.members
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;conversations.members&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3365,7 +3373,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Opens or resumes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.open
+        https://docs.slack.dev/reference/methods/conversations.open
         &#34;&#34;&#34;
         if channel is None and users is None:
             raise e.SlackRequestError(&#34;Either channel or users must be provided.&#34;)
@@ -3384,7 +3392,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Renames a conversation.
-        https://api.slack.com/methods/conversations.rename
+        https://docs.slack.dev/reference/methods/conversations.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name})
         return self.api_call(&#34;conversations.rename&#34;, params=kwargs)
@@ -3403,7 +3411,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a thread of messages posted to a conversation
-        https://api.slack.com/methods/conversations.replies
+        https://docs.slack.dev/reference/methods/conversations.replies
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3429,7 +3437,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-        https://api.slack.com/methods/conversations.requestSharedInvite.approve
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3450,7 +3458,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deny a request to invite an external user to a channel.
-        https://api.slack.com/methods/conversations.requestSharedInvite.deny
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;message&#34;: message})
         return self.api_call(&#34;conversations.requestSharedInvite.deny&#34;, params=kwargs)
@@ -3468,7 +3476,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists requests to add external users to channels with ability to filter.
-        https://api.slack.com/methods/conversations.requestSharedInvite.list
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3495,7 +3503,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the purpose for a conversation.
-        https://api.slack.com/methods/conversations.setPurpose
+        https://docs.slack.dev/reference/methods/conversations.setPurpose
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;purpose&#34;: purpose})
         return self.api_call(&#34;conversations.setPurpose&#34;, params=kwargs)
@@ -3508,7 +3516,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the topic for a conversation.
-        https://api.slack.com/methods/conversations.setTopic
+        https://docs.slack.dev/reference/methods/conversations.setTopic
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;topic&#34;: topic})
         return self.api_call(&#34;conversations.setTopic&#34;, params=kwargs)
@@ -3520,7 +3528,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Reverses conversation archival.
-        https://api.slack.com/methods/conversations.unarchive
+        https://docs.slack.dev/reference/methods/conversations.unarchive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.unarchive&#34;, params=kwargs)
@@ -3533,7 +3541,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a Channel Canvas for a channel
-        https://api.slack.com/methods/conversations.canvases.create
+        https://docs.slack.dev/reference/methods/conversations.canvases.create
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;document_content&#34;: document_content})
         return self.api_call(&#34;conversations.canvases.create&#34;, json=kwargs)
@@ -3546,7 +3554,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Open a dialog with a user.
-        https://api.slack.com/methods/dialog.open
+        https://docs.slack.dev/reference/methods/dialog.open
         &#34;&#34;&#34;
         kwargs.update({&#34;dialog&#34;: dialog, &#34;trigger_id&#34;: trigger_id})
         kwargs = _remove_none_values(kwargs)
@@ -3558,7 +3566,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ends the current user&#39;s Do Not Disturb session immediately.
-        https://api.slack.com/methods/dnd.endDnd
+        https://docs.slack.dev/reference/methods/dnd.endDnd
         &#34;&#34;&#34;
         return self.api_call(&#34;dnd.endDnd&#34;, params=kwargs)
 
@@ -3567,7 +3575,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ends the current user&#39;s snooze mode immediately.
-        https://api.slack.com/methods/dnd.endSnooze
+        https://docs.slack.dev/reference/methods/dnd.endSnooze
         &#34;&#34;&#34;
         return self.api_call(&#34;dnd.endSnooze&#34;, params=kwargs)
 
@@ -3579,7 +3587,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieves a user&#39;s current Do Not Disturb status.
-        https://api.slack.com/methods/dnd.info
+        https://docs.slack.dev/reference/methods/dnd.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
         return self.api_call(&#34;dnd.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3591,7 +3599,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Turns on Do Not Disturb mode for the current user, or changes its duration.
-        https://api.slack.com/methods/dnd.setSnooze
+        https://docs.slack.dev/reference/methods/dnd.setSnooze
         &#34;&#34;&#34;
         kwargs.update({&#34;num_minutes&#34;: num_minutes})
         return self.api_call(&#34;dnd.setSnooze&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3603,7 +3611,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieves the Do Not Disturb status for users on a team.
-        https://api.slack.com/methods/dnd.teamInfo
+        https://docs.slack.dev/reference/methods/dnd.teamInfo
         &#34;&#34;&#34;
         if isinstance(users, (list, tuple)):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -3618,7 +3626,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists custom emoji for a team.
-        https://api.slack.com/methods/emoji.list
+        https://docs.slack.dev/reference/methods/emoji.list
         &#34;&#34;&#34;
         kwargs.update({&#34;include_categories&#34;: include_categories})
         return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3631,7 +3639,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes an existing comment on a file.
-        https://api.slack.com/methods/files.comments.delete
+        https://docs.slack.dev/reference/methods/files.comments.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file, &#34;id&#34;: id})
         return self.api_call(&#34;files.comments.delete&#34;, params=kwargs)
@@ -3643,7 +3651,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a file.
-        https://api.slack.com/methods/files.delete
+        https://docs.slack.dev/reference/methods/files.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.delete&#34;, params=kwargs)
@@ -3659,7 +3667,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a team file.
-        https://api.slack.com/methods/files.info
+        https://docs.slack.dev/reference/methods/files.info
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3687,7 +3695,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists &amp; filters team files.
-        https://api.slack.com/methods/files.list
+        https://docs.slack.dev/reference/methods/files.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3715,7 +3723,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.info
+        https://docs.slack.dev/reference/methods/files.remote.info
         &#34;&#34;&#34;
         kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
         return self.api_call(&#34;files.remote.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3731,7 +3739,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.list
+        https://docs.slack.dev/reference/methods/files.remote.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3756,7 +3764,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds a file from a remote service.
-        https://api.slack.com/methods/files.remote.add
+        https://docs.slack.dev/reference/methods/files.remote.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3795,7 +3803,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Updates an existing remote file.
-        https://api.slack.com/methods/files.remote.update
+        https://docs.slack.dev/reference/methods/files.remote.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3830,7 +3838,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a remote file.
-        https://api.slack.com/methods/files.remote.remove
+        https://docs.slack.dev/reference/methods/files.remote.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
         return self.api_call(&#34;files.remote.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -3844,7 +3852,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Share a remote file into a channel.
-        https://api.slack.com/methods/files.remote.share
+        https://docs.slack.dev/reference/methods/files.remote.share
         &#34;&#34;&#34;
         if external_id is None and file is None:
             raise e.SlackRequestError(&#34;Either external_id or file must be provided.&#34;)
@@ -3862,7 +3870,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes public/external sharing access for a file
-        https://api.slack.com/methods/files.revokePublicURL
+        https://docs.slack.dev/reference/methods/files.revokePublicURL
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.revokePublicURL&#34;, params=kwargs)
@@ -3874,7 +3882,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Enables a file for public/external sharing.
-        https://api.slack.com/methods/files.sharedPublicURL
+        https://docs.slack.dev/reference/methods/files.sharedPublicURL
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.sharedPublicURL&#34;, params=kwargs)
@@ -3893,7 +3901,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Uploads or creates a file.
-        https://api.slack.com/methods/files.upload
+        https://docs.slack.dev/reference/methods/files.upload
         &#34;&#34;&#34;
         _print_files_upload_v2_suggestion()
 
@@ -3946,12 +3954,12 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;This wrapper method provides an easy way to upload files using the following endpoints:
 
-        - step1: https://api.slack.com/methods/files.getUploadURLExternal
+        - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
         - step2: &#34;https://files.slack.com/upload/v1/...&#34; URLs returned from files.getUploadURLExternal API
 
-        - step3: https://api.slack.com/methods/files.completeUploadExternal
-            and https://api.slack.com/methods/files.info
+        - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+            and https://docs.slack.dev/reference/methods/files.info
 
         &#34;&#34;&#34;
         if file is None and content is None and file_uploads is None:
@@ -4037,7 +4045,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets a URL for an edge external upload.
-        https://api.slack.com/methods/files.getUploadURLExternal
+        https://docs.slack.dev/reference/methods/files.getUploadURLExternal
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4060,7 +4068,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Finishes an upload started with files.getUploadURLExternal.
-        https://api.slack.com/methods/files.completeUploadExternal
+        https://docs.slack.dev/reference/methods/files.completeUploadExternal
         &#34;&#34;&#34;
         _files = [{k: v for k, v in f.items() if v is not None} for f in files]
         kwargs.update(
@@ -4083,7 +4091,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Signal the successful completion of a function
-        https://api.slack.com/methods/functions.completeSuccess
+        https://docs.slack.dev/reference/methods/functions.completeSuccess
         &#34;&#34;&#34;
         kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;outputs&#34;: json.dumps(outputs)})
         return self.api_call(&#34;functions.completeSuccess&#34;, params=kwargs)
@@ -4096,7 +4104,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Signal the failure to execute a function
-        https://api.slack.com/methods/functions.completeError
+        https://docs.slack.dev/reference/methods/functions.completeError
         &#34;&#34;&#34;
         kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;error&#34;: error})
         return self.api_call(&#34;functions.completeError&#34;, params=kwargs)
@@ -4104,7 +4112,7 @@ and message responses using response_url in payloads.</p></div>
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def groups_archive(
@@ -4285,7 +4293,7 @@ and message responses using response_url in payloads.</p></div>
     # --------------------------
     # Deprecated: im.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def im_close(
@@ -4361,7 +4369,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;For Enterprise Grid workspaces, map local user IDs to global user IDs
-        https://api.slack.com/methods/migration.exchange
+        https://docs.slack.dev/reference/methods/migration.exchange
         &#34;&#34;&#34;
         if isinstance(users, (list, tuple)):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -4373,7 +4381,7 @@ and message responses using response_url in payloads.</p></div>
     # --------------------------
     # Deprecated: mpim.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def mpim_close(
@@ -4460,7 +4468,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.v2.access
+        https://docs.slack.dev/reference/methods/oauth.v2.access
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4486,7 +4494,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.access
+        https://docs.slack.dev/reference/methods/oauth.access
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4506,7 +4514,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
-        https://api.slack.com/methods/oauth.v2.exchange
+        https://docs.slack.dev/reference/methods/oauth.v2.exchange
         &#34;&#34;&#34;
         kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token})
         return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
@@ -4522,7 +4530,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.token
+        https://docs.slack.dev/reference/methods/openid.connect.token
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4543,7 +4551,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get the identity of a user who has authorized Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.userInfo
+        https://docs.slack.dev/reference/methods/openid.connect.userInfo
         &#34;&#34;&#34;
         return self.api_call(&#34;openid.connect.userInfo&#34;, params=kwargs)
 
@@ -4555,7 +4563,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Pins an item to a channel.
-        https://api.slack.com/methods/pins.add
+        https://docs.slack.dev/reference/methods/pins.add
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;pins.add&#34;, params=kwargs)
@@ -4567,7 +4575,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists items pinned to a channel.
-        https://api.slack.com/methods/pins.list
+        https://docs.slack.dev/reference/methods/pins.list
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;pins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4580,7 +4588,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Un-pins an item from a channel.
-        https://api.slack.com/methods/pins.remove
+        https://docs.slack.dev/reference/methods/pins.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;pins.remove&#34;, params=kwargs)
@@ -4594,7 +4602,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds a reaction to an item.
-        https://api.slack.com/methods/reactions.add
+        https://docs.slack.dev/reference/methods/reactions.add
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;reactions.add&#34;, params=kwargs)
@@ -4610,7 +4618,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets reactions for an item.
-        https://api.slack.com/methods/reactions.get
+        https://docs.slack.dev/reference/methods/reactions.get
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4636,7 +4644,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists reactions made by a user.
-        https://api.slack.com/methods/reactions.list
+        https://docs.slack.dev/reference/methods/reactions.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4662,7 +4670,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a reaction from an item.
-        https://api.slack.com/methods/reactions.remove
+        https://docs.slack.dev/reference/methods/reactions.remove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4686,7 +4694,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Creates a reminder.
-        https://api.slack.com/methods/reminders.add
+        https://docs.slack.dev/reference/methods/reminders.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4707,7 +4715,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Marks a reminder as complete.
-        https://api.slack.com/methods/reminders.complete
+        https://docs.slack.dev/reference/methods/reminders.complete
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.complete&#34;, params=kwargs)
@@ -4720,7 +4728,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a reminder.
-        https://api.slack.com/methods/reminders.delete
+        https://docs.slack.dev/reference/methods/reminders.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.delete&#34;, params=kwargs)
@@ -4733,7 +4741,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a reminder.
-        https://api.slack.com/methods/reminders.info
+        https://docs.slack.dev/reference/methods/reminders.info
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4745,7 +4753,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all reminders created by or for a given user.
-        https://api.slack.com/methods/reminders.list
+        https://docs.slack.dev/reference/methods/reminders.list
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4758,7 +4766,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.connect
+        https://docs.slack.dev/reference/methods/rtm.connect
         &#34;&#34;&#34;
         kwargs.update({&#34;batch_presence_aware&#34;: batch_presence_aware, &#34;presence_sub&#34;: presence_sub})
         return self.api_call(&#34;rtm.connect&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4776,7 +4784,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.start
+        https://docs.slack.dev/reference/methods/rtm.start
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4804,7 +4812,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Searches for messages and files matching a query.
-        https://api.slack.com/methods/search.all
+        https://docs.slack.dev/reference/methods/search.all
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4832,7 +4840,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Searches for files matching a query.
-        https://api.slack.com/methods/search.files
+        https://docs.slack.dev/reference/methods/search.files
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4861,7 +4869,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Searches for messages matching a query.
-        https://api.slack.com/methods/search.messages
+        https://docs.slack.dev/reference/methods/search.messages
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4887,7 +4895,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds a star to an item.
-        https://api.slack.com/methods/stars.add
+        https://docs.slack.dev/reference/methods/stars.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4910,7 +4918,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists stars for a user.
-        https://api.slack.com/methods/stars.list
+        https://docs.slack.dev/reference/methods/stars.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4933,7 +4941,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a star from an item.
-        https://api.slack.com/methods/stars.remove
+        https://docs.slack.dev/reference/methods/stars.remove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4957,7 +4965,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets the access logs for the current team.
-        https://api.slack.com/methods/team.accessLogs
+        https://docs.slack.dev/reference/methods/team.accessLogs
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4979,7 +4987,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets billable users information for the current team.
-        https://api.slack.com/methods/team.billableInfo
+        https://docs.slack.dev/reference/methods/team.billableInfo
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
         return self.api_call(&#34;team.billableInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4989,7 +4997,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Reads a workspace&#39;s billing plan information.
-        https://api.slack.com/methods/team.billing.info
+        https://docs.slack.dev/reference/methods/team.billing.info
         &#34;&#34;&#34;
         return self.api_call(&#34;team.billing.info&#34;, params=kwargs)
 
@@ -5000,7 +5008,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Disconnects an external organization.
-        https://api.slack.com/methods/team.externalTeams.disconnect
+        https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5022,7 +5030,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
-        https://api.slack.com/methods/team.externalTeams.list
+        https://docs.slack.dev/reference/methods/team.externalTeams.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5053,7 +5061,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about the current team.
-        https://api.slack.com/methods/team.info
+        https://docs.slack.dev/reference/methods/team.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team&#34;: team, &#34;domain&#34;: domain})
         return self.api_call(&#34;team.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5071,7 +5079,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets the integration logs for the current team.
-        https://api.slack.com/methods/team.integrationLogs
+        https://docs.slack.dev/reference/methods/team.integrationLogs
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5093,7 +5101,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a team&#39;s profile.
-        https://api.slack.com/methods/team.profile.get
+        https://docs.slack.dev/reference/methods/team.profile.get
         &#34;&#34;&#34;
         kwargs.update({&#34;visibility&#34;: visibility})
         return self.api_call(&#34;team.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5103,7 +5111,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a list of a workspace&#39;s team preferences.
-        https://api.slack.com/methods/team.preferences.list
+        https://docs.slack.dev/reference/methods/team.preferences.list
         &#34;&#34;&#34;
         return self.api_call(&#34;team.preferences.list&#34;, params=kwargs)
 
@@ -5119,7 +5127,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a User Group
-        https://api.slack.com/methods/usergroups.create
+        https://docs.slack.dev/reference/methods/usergroups.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5145,7 +5153,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Disable an existing User Group
-        https://api.slack.com/methods/usergroups.disable
+        https://docs.slack.dev/reference/methods/usergroups.disable
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;usergroups.disable&#34;, params=kwargs)
@@ -5159,7 +5167,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Enable a User Group
-        https://api.slack.com/methods/usergroups.enable
+        https://docs.slack.dev/reference/methods/usergroups.enable
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;usergroups.enable&#34;, params=kwargs)
@@ -5174,7 +5182,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all User Groups for a team
-        https://api.slack.com/methods/usergroups.list
+        https://docs.slack.dev/reference/methods/usergroups.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5199,7 +5207,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an existing User Group
-        https://api.slack.com/methods/usergroups.update
+        https://docs.slack.dev/reference/methods/usergroups.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5226,7 +5234,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all users in a User Group
-        https://api.slack.com/methods/usergroups.users.list
+        https://docs.slack.dev/reference/methods/usergroups.users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5247,7 +5255,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update the list of users for a User Group
-        https://api.slack.com/methods/usergroups.users.update
+        https://docs.slack.dev/reference/methods/usergroups.users.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5274,7 +5282,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List conversations the calling user may access.
-        https://api.slack.com/methods/users.conversations
+        https://docs.slack.dev/reference/methods/users.conversations
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5296,7 +5304,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Delete the user profile photo
-        https://api.slack.com/methods/users.deletePhoto
+        https://docs.slack.dev/reference/methods/users.deletePhoto
         &#34;&#34;&#34;
         return self.api_call(&#34;users.deletePhoto&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
@@ -5307,7 +5315,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets user presence information.
-        https://api.slack.com/methods/users.getPresence
+        https://docs.slack.dev/reference/methods/users.getPresence
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user})
         return self.api_call(&#34;users.getPresence&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5317,7 +5325,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get a user&#39;s identity.
-        https://api.slack.com/methods/users.identity
+        https://docs.slack.dev/reference/methods/users.identity
         &#34;&#34;&#34;
         return self.api_call(&#34;users.identity&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
@@ -5329,7 +5337,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a user.
-        https://api.slack.com/methods/users.info
+        https://docs.slack.dev/reference/methods/users.info
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user, &#34;include_locale&#34;: include_locale})
         return self.api_call(&#34;users.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5344,7 +5352,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all users in a Slack team.
-        https://api.slack.com/methods/users.list
+        https://docs.slack.dev/reference/methods/users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5363,7 +5371,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Find a user with an email address.
-        https://api.slack.com/methods/users.lookupByEmail
+        https://docs.slack.dev/reference/methods/users.lookupByEmail
         &#34;&#34;&#34;
         kwargs.update({&#34;email&#34;: email})
         return self.api_call(&#34;users.lookupByEmail&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5378,7 +5386,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the user profile photo
-        https://api.slack.com/methods/users.setPhoto
+        https://docs.slack.dev/reference/methods/users.setPhoto
         &#34;&#34;&#34;
         kwargs.update({&#34;crop_w&#34;: crop_w, &#34;crop_x&#34;: crop_x, &#34;crop_y&#34;: crop_y})
         return self.api_call(&#34;users.setPhoto&#34;, files={&#34;image&#34;: image}, data=kwargs)
@@ -5390,7 +5398,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Manually sets user presence.
-        https://api.slack.com/methods/users.setPresence
+        https://docs.slack.dev/reference/methods/users.setPresence
         &#34;&#34;&#34;
         kwargs.update({&#34;presence&#34;: presence})
         return self.api_call(&#34;users.setPresence&#34;, params=kwargs)
@@ -5401,7 +5409,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lookup an email address to see if someone is on Slack
-        https://api.slack.com/methods/users.discoverableContacts.lookup
+        https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
         &#34;&#34;&#34;
         kwargs.update({&#34;email&#34;: email})
         return self.api_call(&#34;users.discoverableContacts.lookup&#34;, params=kwargs)
@@ -5414,7 +5422,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieves a user&#39;s profile information.
-        https://api.slack.com/methods/users.profile.get
+        https://docs.slack.dev/reference/methods/users.profile.get
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user, &#34;include_labels&#34;: include_labels})
         return self.api_call(&#34;users.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5429,7 +5437,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the profile information for a user.
-        https://api.slack.com/methods/users.profile.set
+        https://docs.slack.dev/reference/methods/users.profile.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5452,8 +5460,8 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Open a view for a user.
-        https://api.slack.com/methods/views.open
-        See https://api.slack.com/surfaces/modals for details.
+        https://docs.slack.dev/reference/methods/views.open
+        See https://docs.slack.dev/surfaces/modals/ for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
         if isinstance(view, View):
@@ -5476,9 +5484,9 @@ and message responses using response_url in payloads.</p></div>
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/surfaces/modals)
+        Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
         to learn more about the lifecycle and intricacies of views.
-        https://api.slack.com/methods/views.push
+        https://docs.slack.dev/reference/methods/views.push
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
         if isinstance(view, View):
@@ -5501,9 +5509,9 @@ and message responses using response_url in payloads.</p></div>
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+        See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
-        https://api.slack.com/methods/views.update
+        https://docs.slack.dev/reference/methods/views.update
         &#34;&#34;&#34;
         if isinstance(view, View):
             kwargs.update({&#34;view&#34;: view.to_dict()})
@@ -5530,8 +5538,8 @@ and message responses using response_url in payloads.</p></div>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Publish a static view for a User.
         Create or update the view that comprises an
-        app&#39;s Home tab (https://api.slack.com/surfaces/tabs)
-        https://api.slack.com/methods/views.publish
+        app&#39;s Home tab (https://docs.slack.dev/surfaces/app-home/)
+        https://docs.slack.dev/reference/methods/views.publish
         &#34;&#34;&#34;
         kwargs.update({&#34;user_id&#34;: user_id, &#34;hash&#34;: hash})
         if isinstance(view, View):
@@ -5542,6 +5550,72 @@ and message responses using response_url in payloads.</p></div>
         # NOTE: Intentionally using json for the &#34;view&#34; parameter
         return self.api_call(&#34;views.publish&#34;, json=kwargs)
 
+    def workflows_featured_add(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Add featured workflows to a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.add
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.add&#34;, params=kwargs)
+
+    def workflows_featured_list(
+        self,
+        *,
+        channel_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;List the featured workflows for specified channels.
+        https://docs.slack.dev/reference/methods/workflows.featured.list
+        &#34;&#34;&#34;
+        if isinstance(channel_ids, (list, tuple)):
+            kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
+        else:
+            kwargs.update({&#34;channel_ids&#34;: channel_ids})
+        return self.api_call(&#34;workflows.featured.list&#34;, params=kwargs)
+
+    def workflows_featured_remove(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Remove featured workflows from a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.remove
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.remove&#34;, params=kwargs)
+
+    def workflows_featured_set(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Set featured workflows for a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.set
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.set&#34;, params=kwargs)
+
     def workflows_stepCompleted(
         self,
         *,
@@ -5550,7 +5624,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Indicate a successful outcome of a workflow step&#39;s execution.
-        https://api.slack.com/methods/workflows.stepCompleted
+        https://docs.slack.dev/reference/methods/workflows.stepCompleted
         &#34;&#34;&#34;
         kwargs.update({&#34;workflow_step_execute_id&#34;: workflow_step_execute_id})
         if outputs is not None:
@@ -5567,7 +5641,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Indicate an unsuccessful outcome of a workflow step&#39;s execution.
-        https://api.slack.com/methods/workflows.stepFailed
+        https://docs.slack.dev/reference/methods/workflows.stepFailed
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5588,7 +5662,7 @@ and message responses using response_url in payloads.</p></div>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update the configuration for a workflow extension step.
-        https://api.slack.com/methods/workflows.updateStep
+        https://docs.slack.dev/reference/methods/workflows.updateStep
         &#34;&#34;&#34;
         kwargs.update({&#34;workflow_step_edit_id&#34;: workflow_step_edit_id})
         if inputs is not None:
@@ -5600,7 +5674,7 @@ and message responses using response_url in payloads.</p></div>
         return self.api_call(&#34;workflows.updateStep&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>A WebClient allows apps to communicate with the Slack Platform's Web API.</p>
-<p><a href="https://api.slack.com/methods">https://api.slack.com/methods</a></p>
+<p><a href="https://docs.slack.dev/reference/methods">https://docs.slack.dev/reference/methods</a></p>
 <p>The Slack Web API is an interface for querying information from
 and enacting change in a Slack workspace.</p>
 <p>This client handles constructing and sending HTTP requests to Slack
@@ -5680,7 +5754,7 @@ removed at anytime.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve analytics data for a given date, presented as a compressed JSON file
-    https://api.slack.com/methods/admin.analytics.getFile
+    https://docs.slack.dev/reference/methods/admin.analytics.getFile
     &#34;&#34;&#34;
     kwargs.update({&#34;type&#34;: type})
     if date is not None:
@@ -5690,7 +5764,7 @@ removed at anytime.</p></div>
     return self.api_call(&#34;admin.analytics.getFile&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve analytics data for a given date, presented as a compressed JSON file
-<a href="https://api.slack.com/methods/admin.analytics.getFile">https://api.slack.com/methods/admin.analytics.getFile</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.analytics.getFile">https://docs.slack.dev/reference/methods/admin.analytics.getFile</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_activities_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_activities_list</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>component_id: str | None = None,<br>component_type: str | None = None,<br>log_event_type: str | None = None,<br>max_date_created: int | None = None,<br>min_date_created: int | None = None,<br>min_log_level: str | None = None,<br>sort_direction: str | None = None,<br>source: str | None = None,<br>team_id: str | None = None,<br>trace_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5719,7 +5793,7 @@ removed at anytime.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get logs for a specified team/org
-    https://api.slack.com/methods/admin.apps.activities.list
+    https://docs.slack.dev/reference/methods/admin.apps.activities.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5741,7 +5815,7 @@ removed at anytime.</p></div>
     return self.api_call(&#34;admin.apps.activities.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get logs for a specified team/org
-<a href="https://api.slack.com/methods/admin.apps.activities.list">https://api.slack.com/methods/admin.apps.activities.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.activities.list">https://docs.slack.dev/reference/methods/admin.apps.activities.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_approve"><code class="name flex">
 <span>def <span class="ident">admin_apps_approve</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>request_id: str | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5764,7 +5838,7 @@ removed at anytime.</p></div>
     Either app_id or request_id is required.
     These IDs can be obtained either directly via the app_requested event,
     or by the admin.apps.requests.list method.
-    https://api.slack.com/methods/admin.apps.approve
+    https://docs.slack.dev/reference/methods/admin.apps.approve
     &#34;&#34;&#34;
     if app_id:
         kwargs.update({&#34;app_id&#34;: app_id})
@@ -5785,7 +5859,7 @@ removed at anytime.</p></div>
 Either app_id or request_id is required.
 These IDs can be obtained either directly via the app_requested event,
 or by the admin.apps.requests.list method.
-<a href="https://api.slack.com/methods/admin.apps.approve">https://api.slack.com/methods/admin.apps.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.approve">https://docs.slack.dev/reference/methods/admin.apps.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_approved_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_approved_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5805,7 +5879,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List approved apps for an org or workspace.
-    https://api.slack.com/methods/admin.apps.approved.list
+    https://docs.slack.dev/reference/methods/admin.apps.approved.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5818,7 +5892,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.approved.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List approved apps for an org or workspace.
-<a href="https://api.slack.com/methods/admin.apps.approved.list">https://api.slack.com/methods/admin.apps.approved.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.approved.list">https://docs.slack.dev/reference/methods/admin.apps.approved.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_clearResolution"><code class="name flex">
 <span>def <span class="ident">admin_apps_clearResolution</span></span>(<span>self,<br>*,<br>app_id: str,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5837,7 +5911,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Clear an app resolution
-    https://api.slack.com/methods/admin.apps.clearResolution
+    https://docs.slack.dev/reference/methods/admin.apps.clearResolution
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5849,7 +5923,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.clearResolution&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Clear an app resolution
-<a href="https://api.slack.com/methods/admin.apps.clearResolution">https://api.slack.com/methods/admin.apps.clearResolution</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.clearResolution">https://docs.slack.dev/reference/methods/admin.apps.clearResolution</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_config_lookup"><code class="name flex">
 <span>def <span class="ident">admin_apps_config_lookup</span></span>(<span>self, *, app_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5866,7 +5940,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Look up the app config for connectors by their IDs
-    https://api.slack.com/methods/admin.apps.config.lookup
+    https://docs.slack.dev/reference/methods/admin.apps.config.lookup
     &#34;&#34;&#34;
     if isinstance(app_ids, (list, tuple)):
         kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -5875,7 +5949,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.config.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up the app config for connectors by their IDs
-<a href="https://api.slack.com/methods/admin.apps.config.lookup">https://api.slack.com/methods/admin.apps.config.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.config.lookup">https://docs.slack.dev/reference/methods/admin.apps.config.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_config_set"><code class="name flex">
 <span>def <span class="ident">admin_apps_config_set</span></span>(<span>self,<br>*,<br>app_id: str,<br>domain_restrictions: Dict[str, Any] | None = None,<br>workflow_auth_strategy: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5894,7 +5968,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the app config for a connector
-    https://api.slack.com/methods/admin.apps.config.set
+    https://docs.slack.dev/reference/methods/admin.apps.config.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5907,7 +5981,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.config.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the app config for a connector
-<a href="https://api.slack.com/methods/admin.apps.config.set">https://api.slack.com/methods/admin.apps.config.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.config.set">https://docs.slack.dev/reference/methods/admin.apps.config.set</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_requests_cancel"><code class="name flex">
 <span>def <span class="ident">admin_apps_requests_cancel</span></span>(<span>self,<br>*,<br>request_id: str,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5926,7 +6000,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List app requests for a team/workspace.
-    https://api.slack.com/methods/admin.apps.requests.cancel
+    https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5938,7 +6012,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.requests.cancel&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List app requests for a team/workspace.
-<a href="https://api.slack.com/methods/admin.apps.requests.cancel">https://api.slack.com/methods/admin.apps.requests.cancel</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.requests.cancel">https://docs.slack.dev/reference/methods/admin.apps.requests.cancel</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_requests_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_requests_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5957,7 +6031,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List app requests for a team/workspace.
-    https://api.slack.com/methods/admin.apps.requests.list
+    https://docs.slack.dev/reference/methods/admin.apps.requests.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5969,7 +6043,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.requests.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List app requests for a team/workspace.
-<a href="https://api.slack.com/methods/admin.apps.requests.list">https://api.slack.com/methods/admin.apps.requests.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.requests.list">https://docs.slack.dev/reference/methods/admin.apps.requests.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_restrict"><code class="name flex">
 <span>def <span class="ident">admin_apps_restrict</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>request_id: str | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5992,7 +6066,7 @@ or by the admin.apps.requests.list method.
     Exactly one of the team_id or enterprise_id arguments is required, not both.
     Either app_id or request_id is required. These IDs can be obtained either directly
     via the app_requested event, or by the admin.apps.requests.list method.
-    https://api.slack.com/methods/admin.apps.restrict
+    https://docs.slack.dev/reference/methods/admin.apps.restrict
     &#34;&#34;&#34;
     if app_id:
         kwargs.update({&#34;app_id&#34;: app_id})
@@ -6013,7 +6087,7 @@ or by the admin.apps.requests.list method.
 Exactly one of the team_id or enterprise_id arguments is required, not both.
 Either app_id or request_id is required. These IDs can be obtained either directly
 via the app_requested event, or by the admin.apps.requests.list method.
-<a href="https://api.slack.com/methods/admin.apps.restrict">https://api.slack.com/methods/admin.apps.restrict</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.restrict">https://docs.slack.dev/reference/methods/admin.apps.restrict</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_restricted_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_restricted_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6033,7 +6107,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List restricted apps for an org or workspace.
-    https://api.slack.com/methods/admin.apps.restricted.list
+    https://docs.slack.dev/reference/methods/admin.apps.restricted.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6046,7 +6120,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.restricted.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List restricted apps for an org or workspace.
-<a href="https://api.slack.com/methods/admin.apps.restricted.list">https://api.slack.com/methods/admin.apps.restricted.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.restricted.list">https://docs.slack.dev/reference/methods/admin.apps.restricted.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_apps_uninstall"><code class="name flex">
 <span>def <span class="ident">admin_apps_uninstall</span></span>(<span>self,<br>*,<br>app_id: str,<br>enterprise_id: str | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6066,7 +6140,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Uninstall an app from one or many workspaces, or an entire enterprise organization.
     With an org-level token, enterprise_id or team_ids is required.
-    https://api.slack.com/methods/admin.apps.uninstall
+    https://docs.slack.dev/reference/methods/admin.apps.uninstall
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     if enterprise_id is not None:
@@ -6080,7 +6154,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
 </details>
 <div class="desc"><p>Uninstall an app from one or many workspaces, or an entire enterprise organization.
 With an org-level token, enterprise_id or team_ids is required.
-<a href="https://api.slack.com/methods/admin.apps.uninstall">https://api.slack.com/methods/admin.apps.uninstall</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.uninstall">https://docs.slack.dev/reference/methods/admin.apps.uninstall</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_auth_policy_assignEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_assignEntities</span></span>(<span>self,<br>*,<br>entity_ids: str | Sequence[str],<br>policy_name: str,<br>entity_type: str,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6099,7 +6173,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Assign entities to a particular authentication policy.
-    https://api.slack.com/methods/admin.auth.policy.assignEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
     &#34;&#34;&#34;
     if isinstance(entity_ids, (list, tuple)):
         kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -6110,7 +6184,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Assign entities to a particular authentication policy.
-<a href="https://api.slack.com/methods/admin.auth.policy.assignEntities">https://api.slack.com/methods/admin.auth.policy.assignEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_auth_policy_getEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_getEntities</span></span>(<span>self,<br>*,<br>policy_name: str,<br>cursor: str | None = None,<br>entity_type: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6130,7 +6204,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.
-    https://api.slack.com/methods/admin.auth.policy.getEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
     &#34;&#34;&#34;
     kwargs.update({&#34;policy_name&#34;: policy_name})
     if cursor is not None:
@@ -6142,7 +6216,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetch all the entities assigned to a particular authentication policy by name.
-<a href="https://api.slack.com/methods/admin.auth.policy.getEntities">https://api.slack.com/methods/admin.auth.policy.getEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_auth_policy_removeEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_removeEntities</span></span>(<span>self,<br>*,<br>entity_ids: str | Sequence[str],<br>policy_name: str,<br>entity_type: str,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6161,7 +6235,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove specified entities from a specified authentication policy.
-    https://api.slack.com/methods/admin.auth.policy.removeEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
     &#34;&#34;&#34;
     if isinstance(entity_ids, (list, tuple)):
         kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -6172,7 +6246,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove specified entities from a specified authentication policy.
-<a href="https://api.slack.com/methods/admin.auth.policy.removeEntities">https://api.slack.com/methods/admin.auth.policy.removeEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_barriers_create"><code class="name flex">
 <span>def <span class="ident">admin_barriers_create</span></span>(<span>self,<br>*,<br>barriered_from_usergroup_ids: str | Sequence[str],<br>primary_usergroup_id: str,<br>restricted_subjects: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6191,7 +6265,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create an Information Barrier
-    https://api.slack.com/methods/admin.barriers.create
+    https://docs.slack.dev/reference/methods/admin.barriers.create
     &#34;&#34;&#34;
     kwargs.update({&#34;primary_usergroup_id&#34;: primary_usergroup_id})
     if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -6205,7 +6279,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.create&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.create">https://api.slack.com/methods/admin.barriers.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.create">https://docs.slack.dev/reference/methods/admin.barriers.create</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_barriers_delete"><code class="name flex">
 <span>def <span class="ident">admin_barriers_delete</span></span>(<span>self, *, barrier_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6222,13 +6296,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Delete an existing Information Barrier
-    https://api.slack.com/methods/admin.barriers.delete
+    https://docs.slack.dev/reference/methods/admin.barriers.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;barrier_id&#34;: barrier_id})
     return self.api_call(&#34;admin.barriers.delete&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete an existing Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.delete">https://api.slack.com/methods/admin.barriers.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.delete">https://docs.slack.dev/reference/methods/admin.barriers.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_barriers_list"><code class="name flex">
 <span>def <span class="ident">admin_barriers_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6246,7 +6320,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get all Information Barriers for your organization
-    https://api.slack.com/methods/admin.barriers.list&#34;&#34;&#34;
+    https://docs.slack.dev/reference/methods/admin.barriers.list&#34;&#34;&#34;
     kwargs.update(
         {
             &#34;cursor&#34;: cursor,
@@ -6256,7 +6330,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get all Information Barriers for your organization
-<a href="https://api.slack.com/methods/admin.barriers.list">https://api.slack.com/methods/admin.barriers.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.list">https://docs.slack.dev/reference/methods/admin.barriers.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_barriers_update"><code class="name flex">
 <span>def <span class="ident">admin_barriers_update</span></span>(<span>self,<br>*,<br>barrier_id: str,<br>barriered_from_usergroup_ids: str | Sequence[str],<br>primary_usergroup_id: str,<br>restricted_subjects: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6276,7 +6350,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an existing Information Barrier
-    https://api.slack.com/methods/admin.barriers.update
+    https://docs.slack.dev/reference/methods/admin.barriers.update
     &#34;&#34;&#34;
     kwargs.update({&#34;barrier_id&#34;: barrier_id, &#34;primary_usergroup_id&#34;: primary_usergroup_id})
     if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -6290,7 +6364,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.update&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.update">https://api.slack.com/methods/admin.barriers.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.update">https://docs.slack.dev/reference/methods/admin.barriers.update</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_archive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_archive</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6307,13 +6381,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Archive a public or private channel.
-    https://api.slack.com/methods/admin.conversations.archive
+    https://docs.slack.dev/reference/methods/admin.conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.archive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archive a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.archive">https://api.slack.com/methods/admin.conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.archive">https://docs.slack.dev/reference/methods/admin.conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_bulkArchive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_bulkArchive</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6330,13 +6404,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Archive public or private channels in bulk.
-    https://api.slack.com/methods/admin.conversations.bulkArchive
+    https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
     return self.api_call(&#34;admin.conversations.bulkArchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archive public or private channels in bulk.
-<a href="https://api.slack.com/methods/admin.conversations.bulkArchive">https://api.slack.com/methods/admin.conversations.bulkArchive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive">https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_bulkDelete"><code class="name flex">
 <span>def <span class="ident">admin_conversations_bulkDelete</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6377,7 +6451,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Move public or private channels in bulk.
-    https://api.slack.com/methods/admin.conversations.bulkMove
+    https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6388,7 +6462,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.bulkMove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Move public or private channels in bulk.
-<a href="https://api.slack.com/methods/admin.conversations.bulkMove">https://api.slack.com/methods/admin.conversations.bulkMove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.bulkMove">https://docs.slack.dev/reference/methods/admin.conversations.bulkMove</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_convertToPrivate"><code class="name flex">
 <span>def <span class="ident">admin_conversations_convertToPrivate</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6405,13 +6479,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Convert a public channel to a private channel.
-    https://api.slack.com/methods/admin.conversations.convertToPrivate
+    https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.convertToPrivate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Convert a public channel to a private channel.
-<a href="https://api.slack.com/methods/admin.conversations.convertToPrivate">https://api.slack.com/methods/admin.conversations.convertToPrivate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate">https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_convertToPublic"><code class="name flex">
 <span>def <span class="ident">admin_conversations_convertToPublic</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6428,13 +6502,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Convert a privte channel to a public channel.
-    https://api.slack.com/methods/admin.conversations.convertToPublic
+    https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.convertToPublic&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Convert a privte channel to a public channel.
-<a href="https://api.slack.com/methods/admin.conversations.convertToPublic">https://api.slack.com/methods/admin.conversations.convertToPublic</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic">https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_create"><code class="name flex">
 <span>def <span class="ident">admin_conversations_create</span></span>(<span>self,<br>*,<br>is_private: bool,<br>name: str,<br>description: str | None = None,<br>org_wide: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6455,7 +6529,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a public or private channel-based conversation.
-    https://api.slack.com/methods/admin.conversations.create
+    https://docs.slack.dev/reference/methods/admin.conversations.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6469,7 +6543,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a public or private channel-based conversation.
-<a href="https://api.slack.com/methods/admin.conversations.create">https://api.slack.com/methods/admin.conversations.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.create">https://docs.slack.dev/reference/methods/admin.conversations.create</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_createForObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_createForObjects</span></span>(<span>self,<br>*,<br>object_id: str,<br>salesforce_org_id: str,<br>invite_object_team: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6488,7 +6562,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a Salesforce channel for the corresponding object provided.
-    https://api.slack.com/methods/admin.conversations.createForObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
     &#34;&#34;&#34;
     kwargs.update(
         {&#34;object_id&#34;: object_id, &#34;salesforce_org_id&#34;: salesforce_org_id, &#34;invite_object_team&#34;: invite_object_team}
@@ -6496,7 +6570,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.createForObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Salesforce channel for the corresponding object provided.
-<a href="https://api.slack.com/methods/admin.conversations.createForObjects">https://api.slack.com/methods/admin.conversations.createForObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.createForObjects">https://docs.slack.dev/reference/methods/admin.conversations.createForObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_delete"><code class="name flex">
 <span>def <span class="ident">admin_conversations_delete</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6513,13 +6587,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Delete a public or private channel.
-    https://api.slack.com/methods/admin.conversations.delete
+    https://docs.slack.dev/reference/methods/admin.conversations.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.delete">https://api.slack.com/methods/admin.conversations.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.delete">https://docs.slack.dev/reference/methods/admin.conversations.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_disconnectShared"><code class="name flex">
 <span>def <span class="ident">admin_conversations_disconnectShared</span></span>(<span>self,<br>*,<br>channel_id: str,<br>leaving_team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6537,7 +6611,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Disconnect a connected channel from one or more workspaces.
-    https://api.slack.com/methods/admin.conversations.disconnectShared
+    https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(leaving_team_ids, (list, tuple)):
@@ -6547,7 +6621,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.disconnectShared&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disconnect a connected channel from one or more workspaces.
-<a href="https://api.slack.com/methods/admin.conversations.disconnectShared">https://api.slack.com/methods/admin.conversations.disconnectShared</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared">https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_ekm_listOriginalConnectedChannelInfo"><code class="name flex">
 <span>def <span class="ident">admin_conversations_ekm_listOriginalConnectedChannelInfo</span></span>(<span>self,<br>*,<br>channel_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6569,7 +6643,7 @@ With an org-level token, enterprise_id or team_ids is required.
     &#34;&#34;&#34;List all disconnected channels—i.e.,
     channels that were once connected to other workspaces and then disconnected—and
     the corresponding original channel IDs for key revocation with EKM.
-    https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+    https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6590,7 +6664,7 @@ With an org-level token, enterprise_id or team_ids is required.
 <div class="desc"><p>List all disconnected channels—i.e.,
 channels that were once connected to other workspaces and then disconnected—and
 the corresponding original channel IDs for key revocation with EKM.
-<a href="https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo">https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo">https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_getConversationPrefs"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getConversationPrefs</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6607,13 +6681,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get conversation preferences for a public or private channel.
-    https://api.slack.com/methods/admin.conversations.getConversationPrefs
+    https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.getConversationPrefs&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get conversation preferences for a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.getConversationPrefs">https://api.slack.com/methods/admin.conversations.getConversationPrefs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs">https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_getCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getCustomRetention</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6630,13 +6704,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.getCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.getCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.getCustomRetention">https://api.slack.com/methods/admin.conversations.getCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_getTeams"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getTeams</span></span>(<span>self,<br>*,<br>channel_id: str,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6655,7 +6729,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a channel.
-    https://api.slack.com/methods/admin.conversations.getTeams
+    https://docs.slack.dev/reference/methods/admin.conversations.getTeams
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6667,7 +6741,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the workspaces in an Enterprise grid org that connect to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.getTeams">https://api.slack.com/methods/admin.conversations.getTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getTeams">https://docs.slack.dev/reference/methods/admin.conversations.getTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_invite"><code class="name flex">
 <span>def <span class="ident">admin_conversations_invite</span></span>(<span>self, *, channel_id: str, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6685,7 +6759,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invite a user to a public or private channel.
-    https://api.slack.com/methods/admin.conversations.invite
+    https://docs.slack.dev/reference/methods/admin.conversations.invite
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(user_ids, (list, tuple)):
@@ -6696,7 +6770,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invite a user to a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.invite">https://api.slack.com/methods/admin.conversations.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.invite">https://docs.slack.dev/reference/methods/admin.conversations.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_linkObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_linkObjects</span></span>(<span>self, *, channel: str, record_id: str, salesforce_org_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6715,7 +6789,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Link a Salesforce record to a channel.
-    https://api.slack.com/methods/admin.conversations.linkObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6727,7 +6801,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.linkObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Link a Salesforce record to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.linkObjects">https://api.slack.com/methods/admin.conversations.linkObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.linkObjects">https://docs.slack.dev/reference/methods/admin.conversations.linkObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_lookup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_lookup</span></span>(<span>self,<br>*,<br>last_message_activity_before: int,<br>team_ids: str | Sequence[str],<br>cursor: str | None = None,<br>limit: int | None = None,<br>max_member_count: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6748,7 +6822,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Returns channels on the given team using the filters.
-    https://api.slack.com/methods/admin.conversations.lookup
+    https://docs.slack.dev/reference/methods/admin.conversations.lookup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6765,7 +6839,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns channels on the given team using the filters.
-<a href="https://api.slack.com/methods/admin.conversations.lookup">https://api.slack.com/methods/admin.conversations.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.lookup">https://docs.slack.dev/reference/methods/admin.conversations.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_removeCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_removeCustomRetention</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6782,13 +6856,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.removeCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.removeCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.removeCustomRetention">https://api.slack.com/methods/admin.conversations.removeCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_rename"><code class="name flex">
 <span>def <span class="ident">admin_conversations_rename</span></span>(<span>self, *, channel_id: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6806,13 +6880,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Rename a public or private channel.
-    https://api.slack.com/methods/admin.conversations.rename
+    https://docs.slack.dev/reference/methods/admin.conversations.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;name&#34;: name})
     return self.api_call(&#34;admin.conversations.rename&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Rename a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.rename">https://api.slack.com/methods/admin.conversations.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.rename">https://docs.slack.dev/reference/methods/admin.conversations.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_restrictAccess_addGroup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_addGroup</span></span>(<span>self, *, channel_id: str, group_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6831,7 +6905,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an allowlist of IDP groups for accessing a channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6847,7 +6921,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>Add an allowlist of IDP groups for accessing a channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup">https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_restrictAccess_listGroups"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_listGroups</span></span>(<span>self, *, channel_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6865,7 +6939,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all IDP Groups linked to a channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6880,7 +6954,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>List all IDP Groups linked to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups">https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_restrictAccess_removeGroup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_removeGroup</span></span>(<span>self, *, channel_id: str, group_id: str, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6899,7 +6973,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a linked IDP group linked from a private channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6915,7 +6989,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>Remove a linked IDP group linked from a private channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup">https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_search"><code class="name flex">
 <span>def <span class="ident">admin_conversations_search</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>query: str | None = None,<br>search_channel_types: str | Sequence[str] | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6938,7 +7012,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.
-    https://api.slack.com/methods/admin.conversations.search
+    https://docs.slack.dev/reference/methods/admin.conversations.search
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6963,7 +7037,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Search for public or private channels in an Enterprise organization.
-<a href="https://api.slack.com/methods/admin.conversations.search">https://api.slack.com/methods/admin.conversations.search</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.search">https://docs.slack.dev/reference/methods/admin.conversations.search</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_setConversationPrefs"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setConversationPrefs</span></span>(<span>self, *, channel_id: str, prefs: str | Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6981,7 +7055,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the posting permissions for a public or private channel.
-    https://api.slack.com/methods/admin.conversations.setConversationPrefs
+    https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(prefs, dict):
@@ -6991,7 +7065,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.setConversationPrefs&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the posting permissions for a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.setConversationPrefs">https://api.slack.com/methods/admin.conversations.setConversationPrefs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs">https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_setCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setCustomRetention</span></span>(<span>self, *, channel_id: str, duration_days: int, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7009,13 +7083,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.setCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;duration_days&#34;: duration_days})
     return self.api_call(&#34;admin.conversations.setCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.setCustomRetention">https://api.slack.com/methods/admin.conversations.setCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_setTeams"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setTeams</span></span>(<span>self,<br>*,<br>channel_id: str,<br>org_channel: bool | None = None,<br>target_team_ids: str | Sequence[str] | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7035,7 +7109,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-    https://api.slack.com/methods/admin.conversations.setTeams
+    https://docs.slack.dev/reference/methods/admin.conversations.setTeams
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7051,7 +7125,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.setTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.setTeams">https://api.slack.com/methods/admin.conversations.setTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setTeams">https://docs.slack.dev/reference/methods/admin.conversations.setTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_unarchive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_unarchive</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7068,13 +7142,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Unarchive a public or private channel.
-    https://api.slack.com/methods/admin.conversations.archive
+    https://docs.slack.dev/reference/methods/admin.conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.unarchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unarchive a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.archive">https://api.slack.com/methods/admin.conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.archive">https://docs.slack.dev/reference/methods/admin.conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_conversations_unlinkObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_unlinkObjects</span></span>(<span>self, *, channel: str, new_name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7092,7 +7166,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Unlink a Salesforce record from a channel.
-    https://api.slack.com/methods/admin.conversations.unlinkObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7103,7 +7177,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.unlinkObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unlink a Salesforce record from a channel.
-<a href="https://api.slack.com/methods/admin.conversations.unlinkObjects">https://api.slack.com/methods/admin.conversations.unlinkObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects">https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_emoji_add"><code class="name flex">
 <span>def <span class="ident">admin_emoji_add</span></span>(<span>self, *, name: str, url: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7121,13 +7195,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an emoji.
-    https://api.slack.com/methods/admin.emoji.add
+    https://docs.slack.dev/reference/methods/admin.emoji.add
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;url&#34;: url})
     return self.api_call(&#34;admin.emoji.add&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an emoji.
-<a href="https://api.slack.com/methods/admin.emoji.add">https://api.slack.com/methods/admin.emoji.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.add">https://docs.slack.dev/reference/methods/admin.emoji.add</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_emoji_addAlias"><code class="name flex">
 <span>def <span class="ident">admin_emoji_addAlias</span></span>(<span>self, *, alias_for: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7145,13 +7219,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an emoji alias.
-    https://api.slack.com/methods/admin.emoji.addAlias
+    https://docs.slack.dev/reference/methods/admin.emoji.addAlias
     &#34;&#34;&#34;
     kwargs.update({&#34;alias_for&#34;: alias_for, &#34;name&#34;: name})
     return self.api_call(&#34;admin.emoji.addAlias&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an emoji alias.
-<a href="https://api.slack.com/methods/admin.emoji.addAlias">https://api.slack.com/methods/admin.emoji.addAlias</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.addAlias">https://docs.slack.dev/reference/methods/admin.emoji.addAlias</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_emoji_list"><code class="name flex">
 <span>def <span class="ident">admin_emoji_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7169,13 +7243,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List emoji for an Enterprise Grid organization.
-    https://api.slack.com/methods/admin.emoji.list
+    https://docs.slack.dev/reference/methods/admin.emoji.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List emoji for an Enterprise Grid organization.
-<a href="https://api.slack.com/methods/admin.emoji.list">https://api.slack.com/methods/admin.emoji.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.list">https://docs.slack.dev/reference/methods/admin.emoji.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_emoji_remove"><code class="name flex">
 <span>def <span class="ident">admin_emoji_remove</span></span>(<span>self, *, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7192,13 +7266,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove an emoji across an Enterprise Grid organization.
-    https://api.slack.com/methods/admin.emoji.remove
+    https://docs.slack.dev/reference/methods/admin.emoji.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name})
     return self.api_call(&#34;admin.emoji.remove&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove an emoji across an Enterprise Grid organization.
-<a href="https://api.slack.com/methods/admin.emoji.remove">https://api.slack.com/methods/admin.emoji.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.remove">https://docs.slack.dev/reference/methods/admin.emoji.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_emoji_rename"><code class="name flex">
 <span>def <span class="ident">admin_emoji_rename</span></span>(<span>self, *, name: str, new_name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7216,13 +7290,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Rename an emoji.
-    https://api.slack.com/methods/admin.emoji.rename
+    https://docs.slack.dev/reference/methods/admin.emoji.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;new_name&#34;: new_name})
     return self.api_call(&#34;admin.emoji.rename&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Rename an emoji.
-<a href="https://api.slack.com/methods/admin.emoji.rename">https://api.slack.com/methods/admin.emoji.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.rename">https://docs.slack.dev/reference/methods/admin.emoji.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_functions_list"><code class="name flex">
 <span>def <span class="ident">admin_functions_list</span></span>(<span>self,<br>*,<br>app_ids: str | Sequence[str],<br>team_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7242,7 +7316,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Look up functions by a set of apps
-    https://api.slack.com/methods/admin.functions.list
+    https://docs.slack.dev/reference/methods/admin.functions.list
     &#34;&#34;&#34;
     if isinstance(app_ids, (list, tuple)):
         kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -7258,7 +7332,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.functions.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up functions by a set of apps
-<a href="https://api.slack.com/methods/admin.functions.list">https://api.slack.com/methods/admin.functions.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.list">https://docs.slack.dev/reference/methods/admin.functions.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_functions_permissions_lookup"><code class="name flex">
 <span>def <span class="ident">admin_functions_permissions_lookup</span></span>(<span>self, *, function_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7276,7 +7350,7 @@ the corresponding original channel IDs for key revocation with EKM.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lookup the visibility of multiple Slack functions
     and include the users if it is limited to particular named entities.
-    https://api.slack.com/methods/admin.functions.permissions.lookup
+    https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
     &#34;&#34;&#34;
     if isinstance(function_ids, (list, tuple)):
         kwargs.update({&#34;function_ids&#34;: &#34;,&#34;.join(function_ids)})
@@ -7286,7 +7360,7 @@ the corresponding original channel IDs for key revocation with EKM.
 </details>
 <div class="desc"><p>Lookup the visibility of multiple Slack functions
 and include the users if it is limited to particular named entities.
-<a href="https://api.slack.com/methods/admin.functions.permissions.lookup">https://api.slack.com/methods/admin.functions.permissions.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup">https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_functions_permissions_set"><code class="name flex">
 <span>def <span class="ident">admin_functions_permissions_set</span></span>(<span>self,<br>*,<br>function_id: str,<br>visibility: str,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7306,7 +7380,7 @@ and include the users if it is limited to particular named entities.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the visibility of a Slack function
     and define the users or workspaces if it is set to named_entities
-    https://api.slack.com/methods/admin.functions.permissions.set
+    https://docs.slack.dev/reference/methods/admin.functions.permissions.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7323,7 +7397,7 @@ and include the users if it is limited to particular named entities.
 </details>
 <div class="desc"><p>Set the visibility of a Slack function
 and define the users or workspaces if it is set to named_entities
-<a href="https://api.slack.com/methods/admin.functions.permissions.set">https://api.slack.com/methods/admin.functions.permissions.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.permissions.set">https://docs.slack.dev/reference/methods/admin.functions.permissions.set</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_inviteRequests_approve"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_approve</span></span>(<span>self, *, invite_request_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7341,13 +7415,13 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Approve a workspace invite request.
-    https://api.slack.com/methods/admin.inviteRequests.approve
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.inviteRequests.approve&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approve a workspace invite request.
-<a href="https://api.slack.com/methods/admin.inviteRequests.approve">https://api.slack.com/methods/admin.inviteRequests.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.approve">https://docs.slack.dev/reference/methods/admin.inviteRequests.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_inviteRequests_approved_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_approved_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7366,7 +7440,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all approved workspace invite requests.
-    https://api.slack.com/methods/admin.inviteRequests.approved.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7378,7 +7452,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all approved workspace invite requests.
-<a href="https://api.slack.com/methods/admin.inviteRequests.approved.list">https://api.slack.com/methods/admin.inviteRequests.approved.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_inviteRequests_denied_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_denied_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7397,7 +7471,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all denied workspace invite requests.
-    https://api.slack.com/methods/admin.inviteRequests.denied.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7409,7 +7483,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all denied workspace invite requests.
-<a href="https://api.slack.com/methods/admin.inviteRequests.denied.list">https://api.slack.com/methods/admin.inviteRequests.denied.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_inviteRequests_deny"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_deny</span></span>(<span>self, *, invite_request_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7427,13 +7501,13 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deny a workspace invite request.
-    https://api.slack.com/methods/admin.inviteRequests.deny
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.inviteRequests.deny&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deny a workspace invite request.
-<a href="https://api.slack.com/methods/admin.inviteRequests.deny">https://api.slack.com/methods/admin.inviteRequests.deny</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.deny">https://docs.slack.dev/reference/methods/admin.inviteRequests.deny</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_inviteRequests_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_list</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7469,7 +7543,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds members to the specified role with the specified scopes
-    https://api.slack.com/methods/admin.roles.addAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.addAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;role_id&#34;: role_id})
     if isinstance(entity_ids, (list, tuple)):
@@ -7483,7 +7557,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.roles.addAssignments&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds members to the specified role with the specified scopes
-<a href="https://api.slack.com/methods/admin.roles.addAssignments">https://api.slack.com/methods/admin.roles.addAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.addAssignments">https://docs.slack.dev/reference/methods/admin.roles.addAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_roles_listAssignments"><code class="name flex">
 <span>def <span class="ident">admin_roles_listAssignments</span></span>(<span>self,<br>*,<br>role_ids: str | Sequence[str] | None = None,<br>entity_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: str | int | None = None,<br>sort_dir: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7505,7 +7579,7 @@ and define the users or workspaces if it is set to named_entities
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists assignments for all roles across entities.
         Options to scope results by any combination of roles or entities
-    https://api.slack.com/methods/admin.roles.listAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.listAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;sort_dir&#34;: sort_dir})
     if isinstance(entity_ids, (list, tuple)):
@@ -7520,7 +7594,7 @@ and define the users or workspaces if it is set to named_entities
 </details>
 <div class="desc"><p>Lists assignments for all roles across entities.
 Options to scope results by any combination of roles or entities
-<a href="https://api.slack.com/methods/admin.roles.listAssignments">https://api.slack.com/methods/admin.roles.listAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.listAssignments">https://docs.slack.dev/reference/methods/admin.roles.listAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_roles_removeAssignments"><code class="name flex">
 <span>def <span class="ident">admin_roles_removeAssignments</span></span>(<span>self,<br>*,<br>role_id: str,<br>entity_ids: str | Sequence[str],<br>user_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7539,7 +7613,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a set of users from a role for the given scopes and entities
-    https://api.slack.com/methods/admin.roles.removeAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;role_id&#34;: role_id})
     if isinstance(entity_ids, (list, tuple)):
@@ -7553,7 +7627,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.roles.removeAssignments&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a set of users from a role for the given scopes and entities
-<a href="https://api.slack.com/methods/admin.roles.removeAssignments">https://api.slack.com/methods/admin.roles.removeAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.removeAssignments">https://docs.slack.dev/reference/methods/admin.roles.removeAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_teams_admins_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_admins_list</span></span>(<span>self, *, team_id: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7572,7 +7646,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all of the admins on a given workspace.
-    https://api.slack.com/methods/admin.inviteRequests.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7584,7 +7658,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.admins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all of the admins on a given workspace.
-<a href="https://api.slack.com/methods/admin.inviteRequests.list">https://api.slack.com/methods/admin.inviteRequests.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_teams_create"><code class="name flex">
 <span>def <span class="ident">admin_teams_create</span></span>(<span>self,<br>*,<br>team_domain: str,<br>team_name: str,<br>team_description: str | None = None,<br>team_discoverability: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7604,7 +7678,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create an Enterprise team.
-    https://api.slack.com/methods/admin.teams.create
+    https://docs.slack.dev/reference/methods/admin.teams.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7617,7 +7691,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an Enterprise team.
-<a href="https://api.slack.com/methods/admin.teams.create">https://api.slack.com/methods/admin.teams.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.create">https://docs.slack.dev/reference/methods/admin.teams.create</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_teams_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7635,13 +7709,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all teams on an Enterprise organization.
-    https://api.slack.com/methods/admin.teams.list
+    https://docs.slack.dev/reference/methods/admin.teams.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all teams on an Enterprise organization.
-<a href="https://api.slack.com/methods/admin.teams.list">https://api.slack.com/methods/admin.teams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.list">https://docs.slack.dev/reference/methods/admin.teams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_teams_owners_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_owners_list</span></span>(<span>self, *, team_id: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7660,13 +7734,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all of the admins on a given workspace.
-    https://api.slack.com/methods/admin.teams.owners.list
+    https://docs.slack.dev/reference/methods/admin.teams.owners.list
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.teams.owners.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all of the admins on a given workspace.
-<a href="https://api.slack.com/methods/admin.teams.owners.list">https://api.slack.com/methods/admin.teams.owners.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.owners.list">https://docs.slack.dev/reference/methods/admin.teams.owners.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_teams_settings_info"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_info</span></span>(<span>self, *, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7683,13 +7757,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Fetch information about settings in a workspace
-    https://api.slack.com/methods/admin.teams.settings.info
+    https://docs.slack.dev/reference/methods/admin.teams.settings.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.teams.settings.info&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetch information about settings in a workspace
-<a href="https://api.slack.com/methods/admin.teams.settings.info">https://api.slack.com/methods/admin.teams.settings.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.info">https://docs.slack.dev/reference/methods/admin.teams.settings.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_teams_settings_setDefaultChannels"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDefaultChannels</span></span>(<span>self, *, team_id: str, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7707,7 +7781,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the default channels of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7717,7 +7791,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.settings.setDefaultChannels&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the default channels of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDefaultChannels">https://api.slack.com/methods/admin.teams.settings.setDefaultChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels">https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_teams_settings_setDescription"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDescription</span></span>(<span>self, *, team_id: str, description: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7735,13 +7809,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the description of a given workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDescription
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;description&#34;: description})
     return self.api_call(&#34;admin.teams.settings.setDescription&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the description of a given workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDescription">https://api.slack.com/methods/admin.teams.settings.setDescription</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription">https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_teams_settings_setDiscoverability"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDiscoverability</span></span>(<span>self, *, team_id: str, discoverability: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7759,13 +7833,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;discoverability&#34;: discoverability})
     return self.api_call(&#34;admin.teams.settings.setDiscoverability&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDiscoverability">https://api.slack.com/methods/admin.teams.settings.setDiscoverability</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability">https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_teams_settings_setIcon"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setIcon</span></span>(<span>self, *, team_id: str, image_url: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7783,13 +7857,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setIcon
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;image_url&#34;: image_url})
     return self.api_call(&#34;admin.teams.settings.setIcon&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setIcon">https://api.slack.com/methods/admin.teams.settings.setIcon</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon">https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_teams_settings_setName"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setName</span></span>(<span>self, *, team_id: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7807,13 +7881,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setName
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setName
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;name&#34;: name})
     return self.api_call(&#34;admin.teams.settings.setName&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setName">https://api.slack.com/methods/admin.teams.settings.setName</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setName">https://docs.slack.dev/reference/methods/admin.teams.settings.setName</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_usergroups_addChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_addChannels</span></span>(<span>self,<br>*,<br>channel_ids: str | Sequence[str],<br>usergroup_id: str,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7832,7 +7906,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.addChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;usergroup_id&#34;: usergroup_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7842,7 +7916,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.addChannels">https://api.slack.com/methods/admin.usergroups.addChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.addChannels">https://docs.slack.dev/reference/methods/admin.usergroups.addChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_usergroups_addTeams"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_addTeams</span></span>(<span>self,<br>*,<br>usergroup_id: str,<br>team_ids: str | Sequence[str],<br>auto_provision: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7861,7 +7935,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Associate one or more default workspaces with an organization-wide IDP group.
-    https://api.slack.com/methods/admin.usergroups.addTeams
+    https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup_id&#34;: usergroup_id, &#34;auto_provision&#34;: auto_provision})
     if isinstance(team_ids, (list, tuple)):
@@ -7871,7 +7945,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Associate one or more default workspaces with an organization-wide IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.addTeams">https://api.slack.com/methods/admin.usergroups.addTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.addTeams">https://docs.slack.dev/reference/methods/admin.usergroups.addTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_usergroups_listChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_listChannels</span></span>(<span>self,<br>*,<br>usergroup_id: str,<br>include_num_members: bool | None = None,<br>team_id: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7890,7 +7964,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.listChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7902,7 +7976,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.listChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.listChannels">https://api.slack.com/methods/admin.usergroups.listChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.listChannels">https://docs.slack.dev/reference/methods/admin.usergroups.listChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_usergroups_removeChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_removeChannels</span></span>(<span>self, *, usergroup_id: str, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7920,7 +7994,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.removeChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup_id&#34;: usergroup_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7930,7 +8004,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.removeChannels">https://api.slack.com/methods/admin.usergroups.removeChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels">https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_assign"><code class="name flex">
 <span>def <span class="ident">admin_users_assign</span></span>(<span>self,<br>*,<br>team_id: str,<br>user_id: str,<br>channel_ids: str | Sequence[str] | None = None,<br>is_restricted: bool | None = None,<br>is_ultra_restricted: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7951,7 +8025,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an Enterprise user to a workspace.
-    https://api.slack.com/methods/admin.users.assign
+    https://docs.slack.dev/reference/methods/admin.users.assign
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7968,7 +8042,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.assign&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an Enterprise user to a workspace.
-<a href="https://api.slack.com/methods/admin.users.assign">https://api.slack.com/methods/admin.users.assign</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.assign">https://docs.slack.dev/reference/methods/admin.users.assign</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_invite"><code class="name flex">
 <span>def <span class="ident">admin_users_invite</span></span>(<span>self,<br>*,<br>team_id: str,<br>email: str,<br>channel_ids: str | Sequence[str],<br>custom_message: str | None = None,<br>email_password_policy_enabled: bool | None = None,<br>guest_expiration_ts: str | float | None = None,<br>is_restricted: bool | None = None,<br>is_ultra_restricted: bool | None = None,<br>real_name: str | None = None,<br>resend: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7994,7 +8068,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invite a user to a workspace.
-    https://api.slack.com/methods/admin.users.invite
+    https://docs.slack.dev/reference/methods/admin.users.invite
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8016,10 +8090,10 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invite a user to a workspace.
-<a href="https://api.slack.com/methods/admin.users.invite">https://api.slack.com/methods/admin.users.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.invite">https://docs.slack.dev/reference/methods/admin.users.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_list"><code class="name flex">
-<span>def <span class="ident">admin_users_list</span></span>(<span>self,<br>*,<br>team_id: str,<br>include_deactivated_user_workspaces: bool | None = None,<br>is_active: bool | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">admin_users_list</span></span>(<span>self,<br>*,<br>team_id: str | None = None,<br>include_deactivated_user_workspaces: bool | None = None,<br>is_active: bool | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -8029,7 +8103,7 @@ Options to scope results by any combination of roles or entities
 <pre><code class="python">def admin_users_list(
     self,
     *,
-    team_id: str,
+    team_id: Optional[str] = None,
     include_deactivated_user_workspaces: Optional[bool] = None,
     is_active: Optional[bool] = None,
     cursor: Optional[str] = None,
@@ -8037,7 +8111,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List users on a workspace
-    https://api.slack.com/methods/admin.users.list
+    https://docs.slack.dev/reference/methods/admin.users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8051,7 +8125,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List users on a workspace
-<a href="https://api.slack.com/methods/admin.users.list">https://api.slack.com/methods/admin.users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.list">https://docs.slack.dev/reference/methods/admin.users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_remove"><code class="name flex">
 <span>def <span class="ident">admin_users_remove</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8069,13 +8143,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a user from a workspace.
-    https://api.slack.com/methods/admin.users.remove
+    https://docs.slack.dev/reference/methods/admin.users.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a user from a workspace.
-<a href="https://api.slack.com/methods/admin.users.remove">https://api.slack.com/methods/admin.users.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.remove">https://docs.slack.dev/reference/methods/admin.users.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_session_clearSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_clearSettings</span></span>(<span>self, *, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8093,7 +8167,7 @@ Options to scope results by any combination of roles or entities
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Clear user-specific session settings—the session duration
     and what happens when the client closes—for a list of users.
-    https://api.slack.com/methods/admin.users.session.clearSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8103,7 +8177,7 @@ Options to scope results by any combination of roles or entities
 </details>
 <div class="desc"><p>Clear user-specific session settings—the session duration
 and what happens when the client closes—for a list of users.
-<a href="https://api.slack.com/methods/admin.users.session.clearSettings">https://api.slack.com/methods/admin.users.session.clearSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.clearSettings">https://docs.slack.dev/reference/methods/admin.users.session.clearSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_session_getSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_getSettings</span></span>(<span>self, *, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8121,7 +8195,7 @@ and what happens when the client closes—for a list of users.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get user-specific session settings—the session duration
     and what happens when the client closes—given a list of users.
-    https://api.slack.com/methods/admin.users.session.getSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.getSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8131,7 +8205,7 @@ and what happens when the client closes—for a list of users.
 </details>
 <div class="desc"><p>Get user-specific session settings—the session duration
 and what happens when the client closes—given a list of users.
-<a href="https://api.slack.com/methods/admin.users.session.getSettings">https://api.slack.com/methods/admin.users.session.getSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.getSettings">https://docs.slack.dev/reference/methods/admin.users.session.getSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_session_invalidate"><code class="name flex">
 <span>def <span class="ident">admin_users_session_invalidate</span></span>(<span>self, *, session_id: str, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8149,13 +8223,13 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invalidate a single session for a user by session_id.
-    https://api.slack.com/methods/admin.users.session.invalidate
+    https://docs.slack.dev/reference/methods/admin.users.session.invalidate
     &#34;&#34;&#34;
     kwargs.update({&#34;session_id&#34;: session_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.users.session.invalidate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invalidate a single session for a user by session_id.
-<a href="https://api.slack.com/methods/admin.users.session.invalidate">https://api.slack.com/methods/admin.users.session.invalidate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.invalidate">https://docs.slack.dev/reference/methods/admin.users.session.invalidate</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_session_list"><code class="name flex">
 <span>def <span class="ident">admin_users_session_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8175,7 +8249,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all active user sessions for an organization
-    https://api.slack.com/methods/admin.users.session.list
+    https://docs.slack.dev/reference/methods/admin.users.session.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8188,7 +8262,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all active user sessions for an organization
-<a href="https://api.slack.com/methods/admin.users.session.list">https://api.slack.com/methods/admin.users.session.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.list">https://docs.slack.dev/reference/methods/admin.users.session.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_session_reset"><code class="name flex">
 <span>def <span class="ident">admin_users_session_reset</span></span>(<span>self,<br>*,<br>user_id: str,<br>mobile_only: bool | None = None,<br>web_only: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8207,7 +8281,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Wipes all valid sessions on all devices for a given user.
-    https://api.slack.com/methods/admin.users.session.reset
+    https://docs.slack.dev/reference/methods/admin.users.session.reset
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8219,7 +8293,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.reset&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Wipes all valid sessions on all devices for a given user.
-<a href="https://api.slack.com/methods/admin.users.session.reset">https://api.slack.com/methods/admin.users.session.reset</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.reset">https://docs.slack.dev/reference/methods/admin.users.session.reset</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_session_resetBulk"><code class="name flex">
 <span>def <span class="ident">admin_users_session_resetBulk</span></span>(<span>self,<br>*,<br>user_ids: str | Sequence[str],<br>mobile_only: bool | None = None,<br>web_only: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8238,7 +8312,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-    https://api.slack.com/methods/admin.users.session.resetBulk
+    https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8253,7 +8327,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.resetBulk&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-<a href="https://api.slack.com/methods/admin.users.session.resetBulk">https://api.slack.com/methods/admin.users.session.resetBulk</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.resetBulk">https://docs.slack.dev/reference/methods/admin.users.session.resetBulk</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_session_setSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_setSettings</span></span>(<span>self,<br>*,<br>user_ids: str | Sequence[str],<br>desktop_app_browser_quit: bool | None = None,<br>duration: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8273,7 +8347,7 @@ and what happens when the client closes—given a list of users.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Configure the user-level session settings—the session duration
     and what happens when the client closes—for one or more users.
-    https://api.slack.com/methods/admin.users.session.setSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.setSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8289,7 +8363,7 @@ and what happens when the client closes—given a list of users.
 </details>
 <div class="desc"><p>Configure the user-level session settings—the session duration
 and what happens when the client closes—for one or more users.
-<a href="https://api.slack.com/methods/admin.users.session.setSettings">https://api.slack.com/methods/admin.users.session.setSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.setSettings">https://docs.slack.dev/reference/methods/admin.users.session.setSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_setAdmin"><code class="name flex">
 <span>def <span class="ident">admin_users_setAdmin</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8307,13 +8381,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an existing guest, regular user, or owner to be an admin user.
-    https://api.slack.com/methods/admin.users.setAdmin
+    https://docs.slack.dev/reference/methods/admin.users.setAdmin
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setAdmin&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest, regular user, or owner to be an admin user.
-<a href="https://api.slack.com/methods/admin.users.setAdmin">https://api.slack.com/methods/admin.users.setAdmin</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setAdmin">https://docs.slack.dev/reference/methods/admin.users.setAdmin</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_setExpiration"><code class="name flex">
 <span>def <span class="ident">admin_users_setExpiration</span></span>(<span>self, *, expiration_ts: int, user_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8332,13 +8406,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an expiration for a guest user.
-    https://api.slack.com/methods/admin.users.setExpiration
+    https://docs.slack.dev/reference/methods/admin.users.setExpiration
     &#34;&#34;&#34;
     kwargs.update({&#34;expiration_ts&#34;: expiration_ts, &#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setExpiration&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an expiration for a guest user.
-<a href="https://api.slack.com/methods/admin.users.setExpiration">https://api.slack.com/methods/admin.users.setExpiration</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setExpiration">https://docs.slack.dev/reference/methods/admin.users.setExpiration</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_setOwner"><code class="name flex">
 <span>def <span class="ident">admin_users_setOwner</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8356,13 +8430,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an existing guest, regular user, or admin user to be a workspace owner.
-    https://api.slack.com/methods/admin.users.setOwner
+    https://docs.slack.dev/reference/methods/admin.users.setOwner
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setOwner&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest, regular user, or admin user to be a workspace owner.
-<a href="https://api.slack.com/methods/admin.users.setOwner">https://api.slack.com/methods/admin.users.setOwner</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setOwner">https://docs.slack.dev/reference/methods/admin.users.setOwner</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_setRegular"><code class="name flex">
 <span>def <span class="ident">admin_users_setRegular</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8380,13 +8454,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an existing guest user, admin user, or owner to be a regular user.
-    https://api.slack.com/methods/admin.users.setRegular
+    https://docs.slack.dev/reference/methods/admin.users.setRegular
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setRegular&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest user, admin user, or owner to be a regular user.
-<a href="https://api.slack.com/methods/admin.users.setRegular">https://api.slack.com/methods/admin.users.setRegular</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setRegular">https://docs.slack.dev/reference/methods/admin.users.setRegular</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_users_unsupportedVersions_export"><code class="name flex">
 <span>def <span class="ident">admin_users_unsupportedVersions_export</span></span>(<span>self,<br>*,<br>date_end_of_support: str | int | None = None,<br>date_sessions_started: str | int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8405,7 +8479,7 @@ and what happens when the client closes—for one or more users.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ask Slackbot to send you an export listing all workspace members using unsupported software,
     presented as a zipped CSV file.
-    https://api.slack.com/methods/admin.users.unsupportedVersions.export
+    https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8417,7 +8491,7 @@ and what happens when the client closes—for one or more users.
 </details>
 <div class="desc"><p>Ask Slackbot to send you an export listing all workspace members using unsupported software,
 presented as a zipped CSV file.
-<a href="https://api.slack.com/methods/admin.users.unsupportedVersions.export">https://api.slack.com/methods/admin.users.unsupportedVersions.export</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export">https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_workflows_collaborators_add"><code class="name flex">
 <span>def <span class="ident">admin_workflows_collaborators_add</span></span>(<span>self,<br>*,<br>collaborator_ids: str | Sequence[str],<br>workflow_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8435,7 +8509,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add collaborators to workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.collaborators.add
+    https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
     &#34;&#34;&#34;
     if isinstance(collaborator_ids, (list, tuple)):
         kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -8448,7 +8522,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.collaborators.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add collaborators to workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.collaborators.add">https://api.slack.com/methods/admin.workflows.collaborators.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add">https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_workflows_collaborators_remove"><code class="name flex">
 <span>def <span class="ident">admin_workflows_collaborators_remove</span></span>(<span>self,<br>*,<br>collaborator_ids: str | Sequence[str],<br>workflow_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8466,7 +8540,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove collaborators from workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.collaborators.remove
+    https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
     &#34;&#34;&#34;
     if isinstance(collaborator_ids, (list, tuple)):
         kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -8479,7 +8553,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.collaborators.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove collaborators from workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.collaborators.remove">https://api.slack.com/methods/admin.workflows.collaborators.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove">https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_workflows_permissions_lookup"><code class="name flex">
 <span>def <span class="ident">admin_workflows_permissions_lookup</span></span>(<span>self,<br>*,<br>workflow_ids: str | Sequence[str],<br>max_workflow_triggers: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8497,7 +8571,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Look up the permissions for a set of workflows
-    https://api.slack.com/methods/admin.workflows.permissions.lookup
+    https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
     &#34;&#34;&#34;
     if isinstance(workflow_ids, (list, tuple)):
         kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -8511,7 +8585,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.permissions.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up the permissions for a set of workflows
-<a href="https://api.slack.com/methods/admin.workflows.permissions.lookup">https://api.slack.com/methods/admin.workflows.permissions.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup">https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_workflows_search"><code class="name flex">
 <span>def <span class="ident">admin_workflows_search</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>collaborator_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>no_collaborators: bool | None = None,<br>num_trigger_ids: int | None = None,<br>query: str | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>source: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8537,7 +8611,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Search workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.search
+    https://docs.slack.dev/reference/methods/admin.workflows.search
     &#34;&#34;&#34;
     if collaborator_ids is not None:
         if isinstance(collaborator_ids, (list, tuple)):
@@ -8560,7 +8634,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.search&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Search workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.search">https://api.slack.com/methods/admin.workflows.search</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.search">https://docs.slack.dev/reference/methods/admin.workflows.search</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.admin_workflows_unpublish"><code class="name flex">
 <span>def <span class="ident">admin_workflows_unpublish</span></span>(<span>self, *, workflow_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8577,7 +8651,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Unpublish workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.unpublish
+    https://docs.slack.dev/reference/methods/admin.workflows.unpublish
     &#34;&#34;&#34;
     if isinstance(workflow_ids, (list, tuple)):
         kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -8586,7 +8660,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.unpublish&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unpublish workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.unpublish">https://api.slack.com/methods/admin.workflows.unpublish</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.unpublish">https://docs.slack.dev/reference/methods/admin.workflows.unpublish</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.api_test"><code class="name flex">
 <span>def <span class="ident">api_test</span></span>(<span>self, *, error: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8603,13 +8677,13 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Checks API calling code.
-    https://api.slack.com/methods/api.test
+    https://docs.slack.dev/reference/methods/api.test
     &#34;&#34;&#34;
     kwargs.update({&#34;error&#34;: error})
     return self.api_call(&#34;api.test&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Checks API calling code.
-<a href="https://api.slack.com/methods/api.test">https://api.slack.com/methods/api.test</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/api.test">https://docs.slack.dev/reference/methods/api.test</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.apps_connections_open"><code class="name flex">
 <span>def <span class="ident">apps_connections_open</span></span>(<span>self, *, app_token: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8627,14 +8701,14 @@ presented as a zipped CSV file.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Generate a temporary Socket Mode WebSocket URL that your app can connect to
     in order to receive events and interactive payloads
-    https://api.slack.com/methods/apps.connections.open
+    https://docs.slack.dev/reference/methods/apps.connections.open
     &#34;&#34;&#34;
     kwargs.update({&#34;token&#34;: app_token})
     return self.api_call(&#34;apps.connections.open&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Generate a temporary Socket Mode WebSocket URL that your app can connect to
 in order to receive events and interactive payloads
-<a href="https://api.slack.com/methods/apps.connections.open">https://api.slack.com/methods/apps.connections.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.connections.open">https://docs.slack.dev/reference/methods/apps.connections.open</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.apps_event_authorizations_list"><code class="name flex">
 <span>def <span class="ident">apps_event_authorizations_list</span></span>(<span>self,<br>*,<br>event_context: str,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8654,14 +8728,14 @@ in order to receive events and interactive payloads
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get a list of authorizations for the given event context.
     Each authorization represents an app installation that the event is visible to.
-    https://api.slack.com/methods/apps.event.authorizations.list
+    https://docs.slack.dev/reference/methods/apps.event.authorizations.list
     &#34;&#34;&#34;
     kwargs.update({&#34;event_context&#34;: event_context, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;apps.event.authorizations.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a list of authorizations for the given event context.
 Each authorization represents an app installation that the event is visible to.
-<a href="https://api.slack.com/methods/apps.event.authorizations.list">https://api.slack.com/methods/apps.event.authorizations.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.event.authorizations.list">https://docs.slack.dev/reference/methods/apps.event.authorizations.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.apps_manifest_create"><code class="name flex">
 <span>def <span class="ident">apps_manifest_create</span></span>(<span>self, *, manifest: str | Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8678,7 +8752,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create an app from an app manifest
-    https://api.slack.com/methods/apps.manifest.create
+    https://docs.slack.dev/reference/methods/apps.manifest.create
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8687,7 +8761,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an app from an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.create">https://api.slack.com/methods/apps.manifest.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.create">https://docs.slack.dev/reference/methods/apps.manifest.create</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.apps_manifest_delete"><code class="name flex">
 <span>def <span class="ident">apps_manifest_delete</span></span>(<span>self, *, app_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8704,13 +8778,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Permanently deletes an app created through app manifests
-    https://api.slack.com/methods/apps.manifest.delete
+    https://docs.slack.dev/reference/methods/apps.manifest.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     return self.api_call(&#34;apps.manifest.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Permanently deletes an app created through app manifests
-<a href="https://api.slack.com/methods/apps.manifest.delete">https://api.slack.com/methods/apps.manifest.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.delete">https://docs.slack.dev/reference/methods/apps.manifest.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.apps_manifest_export"><code class="name flex">
 <span>def <span class="ident">apps_manifest_export</span></span>(<span>self, *, app_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8727,13 +8801,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Export an app manifest from an existing app
-    https://api.slack.com/methods/apps.manifest.export
+    https://docs.slack.dev/reference/methods/apps.manifest.export
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     return self.api_call(&#34;apps.manifest.export&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Export an app manifest from an existing app
-<a href="https://api.slack.com/methods/apps.manifest.export">https://api.slack.com/methods/apps.manifest.export</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.export">https://docs.slack.dev/reference/methods/apps.manifest.export</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.apps_manifest_update"><code class="name flex">
 <span>def <span class="ident">apps_manifest_update</span></span>(<span>self, *, app_id: str, manifest: str | Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8751,7 +8825,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an app from an app manifest
-    https://api.slack.com/methods/apps.manifest.update
+    https://docs.slack.dev/reference/methods/apps.manifest.update
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8761,7 +8835,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an app from an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.update">https://api.slack.com/methods/apps.manifest.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.update">https://docs.slack.dev/reference/methods/apps.manifest.update</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.apps_manifest_validate"><code class="name flex">
 <span>def <span class="ident">apps_manifest_validate</span></span>(<span>self, *, manifest: str | Dict[str, Any], app_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8779,7 +8853,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Validate an app manifest
-    https://api.slack.com/methods/apps.manifest.validate
+    https://docs.slack.dev/reference/methods/apps.manifest.validate
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8789,7 +8863,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.validate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Validate an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.validate">https://api.slack.com/methods/apps.manifest.validate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.validate">https://docs.slack.dev/reference/methods/apps.manifest.validate</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.apps_uninstall"><code class="name flex">
 <span>def <span class="ident">apps_uninstall</span></span>(<span>self, *, client_id: str, client_secret: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8807,13 +8881,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Uninstalls your app from a workspace.
-    https://api.slack.com/methods/apps.uninstall
+    https://docs.slack.dev/reference/methods/apps.uninstall
     &#34;&#34;&#34;
     kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret})
     return self.api_call(&#34;apps.uninstall&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Uninstalls your app from a workspace.
-<a href="https://api.slack.com/methods/apps.uninstall">https://api.slack.com/methods/apps.uninstall</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.uninstall">https://docs.slack.dev/reference/methods/apps.uninstall</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.assistant_threads_setStatus"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setStatus</span></span>(<span>self, *, channel_id: str, thread_ts: str, status: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8832,13 +8906,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setStatus
+    https://docs.slack.dev/reference/methods/assistant.threads.setStatus
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status})
     return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setStatus">https://api.slack.com/methods/assistant.threads.setStatus</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setStatus">https://docs.slack.dev/reference/methods/assistant.threads.setStatus</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.assistant_threads_setSuggestedPrompts"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8858,7 +8932,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+    https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
     if title is not None:
@@ -8866,7 +8940,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setSuggestedPrompts">https://api.slack.com/methods/assistant.threads.setSuggestedPrompts</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts">https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.assistant_threads_setTitle"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setTitle</span></span>(<span>self, *, channel_id: str, thread_ts: str, title: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8885,13 +8959,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setTitle
+    https://docs.slack.dev/reference/methods/assistant.threads.setTitle
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;title&#34;: title})
     return self.api_call(&#34;assistant.threads.setTitle&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setTitle">https://api.slack.com/methods/assistant.threads.setTitle</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setTitle">https://docs.slack.dev/reference/methods/assistant.threads.setTitle</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.auth_revoke"><code class="name flex">
 <span>def <span class="ident">auth_revoke</span></span>(<span>self, *, test: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8908,13 +8982,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/auth.revoke
+    https://docs.slack.dev/reference/methods/auth.revoke
     &#34;&#34;&#34;
     kwargs.update({&#34;test&#34;: test})
     return self.api_call(&#34;auth.revoke&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/auth.revoke">https://api.slack.com/methods/auth.revoke</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.revoke">https://docs.slack.dev/reference/methods/auth.revoke</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.auth_teams_list"><code class="name flex">
 <span>def <span class="ident">auth_teams_list</span></span>(<span>self,<br>cursor: str | None = None,<br>limit: int | None = None,<br>include_icon: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8932,13 +9006,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List the workspaces a token can access.
-    https://api.slack.com/methods/auth.teams.list
+    https://docs.slack.dev/reference/methods/auth.teams.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;include_icon&#34;: include_icon})
     return self.api_call(&#34;auth.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List the workspaces a token can access.
-<a href="https://api.slack.com/methods/auth.teams.list">https://api.slack.com/methods/auth.teams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.teams.list">https://docs.slack.dev/reference/methods/auth.teams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.auth_test"><code class="name flex">
 <span>def <span class="ident">auth_test</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8953,12 +9027,12 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Checks authentication &amp; identity.
-    https://api.slack.com/methods/auth.test
+    https://docs.slack.dev/reference/methods/auth.test
     &#34;&#34;&#34;
     return self.api_call(&#34;auth.test&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Checks authentication &amp; identity.
-<a href="https://api.slack.com/methods/auth.test">https://api.slack.com/methods/auth.test</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.test">https://docs.slack.dev/reference/methods/auth.test</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.bookmarks_add"><code class="name flex">
 <span>def <span class="ident">bookmarks_add</span></span>(<span>self,<br>*,<br>channel_id: str,<br>title: str,<br>type: str,<br>emoji: str | None = None,<br>entity_id: str | None = None,<br>link: str | None = None,<br>parent_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8981,7 +9055,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add bookmark to a channel.
-    https://api.slack.com/methods/bookmarks.add
+    https://docs.slack.dev/reference/methods/bookmarks.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8997,7 +9071,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;bookmarks.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add bookmark to a channel.
-<a href="https://api.slack.com/methods/bookmarks.add">https://api.slack.com/methods/bookmarks.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.add">https://docs.slack.dev/reference/methods/bookmarks.add</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.bookmarks_edit"><code class="name flex">
 <span>def <span class="ident">bookmarks_edit</span></span>(<span>self,<br>*,<br>bookmark_id: str,<br>channel_id: str,<br>emoji: str | None = None,<br>link: str | None = None,<br>title: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9018,7 +9092,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Edit bookmark.
-    https://api.slack.com/methods/bookmarks.edit
+    https://docs.slack.dev/reference/methods/bookmarks.edit
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9032,7 +9106,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;bookmarks.edit&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Edit bookmark.
-<a href="https://api.slack.com/methods/bookmarks.edit">https://api.slack.com/methods/bookmarks.edit</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.edit">https://docs.slack.dev/reference/methods/bookmarks.edit</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.bookmarks_list"><code class="name flex">
 <span>def <span class="ident">bookmarks_list</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9049,13 +9123,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List bookmark for the channel.
-    https://api.slack.com/methods/bookmarks.list
+    https://docs.slack.dev/reference/methods/bookmarks.list
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;bookmarks.list&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List bookmark for the channel.
-<a href="https://api.slack.com/methods/bookmarks.list">https://api.slack.com/methods/bookmarks.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.list">https://docs.slack.dev/reference/methods/bookmarks.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.bookmarks_remove"><code class="name flex">
 <span>def <span class="ident">bookmarks_remove</span></span>(<span>self, *, bookmark_id: str, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9073,13 +9147,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove bookmark from the channel.
-    https://api.slack.com/methods/bookmarks.remove
+    https://docs.slack.dev/reference/methods/bookmarks.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;bookmark_id&#34;: bookmark_id, &#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;bookmarks.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove bookmark from the channel.
-<a href="https://api.slack.com/methods/bookmarks.remove">https://api.slack.com/methods/bookmarks.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.remove">https://docs.slack.dev/reference/methods/bookmarks.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.bots_info"><code class="name flex">
 <span>def <span class="ident">bots_info</span></span>(<span>self, *, bot: str | None = None, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9097,13 +9171,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a bot user.
-    https://api.slack.com/methods/bots.info
+    https://docs.slack.dev/reference/methods/bots.info
     &#34;&#34;&#34;
     kwargs.update({&#34;bot&#34;: bot, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;bots.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a bot user.
-<a href="https://api.slack.com/methods/bots.info">https://api.slack.com/methods/bots.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bots.info">https://docs.slack.dev/reference/methods/bots.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.calls_add"><code class="name flex">
 <span>def <span class="ident">calls_add</span></span>(<span>self,<br>*,<br>external_unique_id: str,<br>join_url: str,<br>created_by: str | None = None,<br>date_start: int | None = None,<br>desktop_app_join_url: str | None = None,<br>external_display_id: str | None = None,<br>title: str | None = None,<br>users: str | Sequence[Dict[str, str]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9127,7 +9201,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Registers a new Call.
-    https://api.slack.com/methods/calls.add
+    https://docs.slack.dev/reference/methods/calls.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9147,7 +9221,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;calls.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers a new Call.
-<a href="https://api.slack.com/methods/calls.add">https://api.slack.com/methods/calls.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.add">https://docs.slack.dev/reference/methods/calls.add</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.calls_end"><code class="name flex">
 <span>def <span class="ident">calls_end</span></span>(<span>self, *, id: str, duration: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9165,13 +9239,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ends a Call.
-    https://api.slack.com/methods/calls.end
+    https://docs.slack.dev/reference/methods/calls.end
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id, &#34;duration&#34;: duration})
     return self.api_call(&#34;calls.end&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends a Call.
-<a href="https://api.slack.com/methods/calls.end">https://api.slack.com/methods/calls.end</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.end">https://docs.slack.dev/reference/methods/calls.end</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.calls_info"><code class="name flex">
 <span>def <span class="ident">calls_info</span></span>(<span>self, *, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9188,13 +9262,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Returns information about a Call.
-    https://api.slack.com/methods/calls.info
+    https://docs.slack.dev/reference/methods/calls.info
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     return self.api_call(&#34;calls.info&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns information about a Call.
-<a href="https://api.slack.com/methods/calls.info">https://api.slack.com/methods/calls.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.info">https://docs.slack.dev/reference/methods/calls.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.calls_participants_add"><code class="name flex">
 <span>def <span class="ident">calls_participants_add</span></span>(<span>self, *, id: str, users: str | Sequence[Dict[str, str]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9212,14 +9286,14 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Registers new participants added to a Call.
-    https://api.slack.com/methods/calls.participants.add
+    https://docs.slack.dev/reference/methods/calls.participants.add
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     _update_call_participants(kwargs, users)
     return self.api_call(&#34;calls.participants.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers new participants added to a Call.
-<a href="https://api.slack.com/methods/calls.participants.add">https://api.slack.com/methods/calls.participants.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.participants.add">https://docs.slack.dev/reference/methods/calls.participants.add</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.calls_participants_remove"><code class="name flex">
 <span>def <span class="ident">calls_participants_remove</span></span>(<span>self, *, id: str, users: str | Sequence[Dict[str, str]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9237,14 +9311,14 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Registers participants removed from a Call.
-    https://api.slack.com/methods/calls.participants.remove
+    https://docs.slack.dev/reference/methods/calls.participants.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     _update_call_participants(kwargs, users)
     return self.api_call(&#34;calls.participants.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers participants removed from a Call.
-<a href="https://api.slack.com/methods/calls.participants.remove">https://api.slack.com/methods/calls.participants.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.participants.remove">https://docs.slack.dev/reference/methods/calls.participants.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.calls_update"><code class="name flex">
 <span>def <span class="ident">calls_update</span></span>(<span>self,<br>*,<br>id: str,<br>desktop_app_join_url: str | None = None,<br>join_url: str | None = None,<br>title: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9264,7 +9338,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Updates information about a Call.
-    https://api.slack.com/methods/calls.update
+    https://docs.slack.dev/reference/methods/calls.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9277,7 +9351,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;calls.update&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Updates information about a Call.
-<a href="https://api.slack.com/methods/calls.update">https://api.slack.com/methods/calls.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.update">https://docs.slack.dev/reference/methods/calls.update</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.canvases_access_delete"><code class="name flex">
 <span>def <span class="ident">canvases_access_delete</span></span>(<span>self,<br>*,<br>canvas_id: str,<br>channel_ids: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9296,7 +9370,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a Channel Canvas for a channel
-    https://api.slack.com/methods/canvases.access.delete
+    https://docs.slack.dev/reference/methods/canvases.access.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id})
     if channel_ids is not None:
@@ -9312,7 +9386,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;canvases.access.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Channel Canvas for a channel
-<a href="https://api.slack.com/methods/canvases.access.delete">https://api.slack.com/methods/canvases.access.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.access.delete">https://docs.slack.dev/reference/methods/canvases.access.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.canvases_access_set"><code class="name flex">
 <span>def <span class="ident">canvases_access_set</span></span>(<span>self,<br>*,<br>canvas_id: str,<br>access_level: str,<br>channel_ids: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9332,7 +9406,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the access level to a canvas for specified entities
-    https://api.slack.com/methods/canvases.access.set
+    https://docs.slack.dev/reference/methods/canvases.access.set
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;access_level&#34;: access_level})
     if channel_ids is not None:
@@ -9349,7 +9423,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;canvases.access.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the access level to a canvas for specified entities
-<a href="https://api.slack.com/methods/canvases.access.set">https://api.slack.com/methods/canvases.access.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.access.set">https://docs.slack.dev/reference/methods/canvases.access.set</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.canvases_create"><code class="name flex">
 <span>def <span class="ident">canvases_create</span></span>(<span>self, *, title: str | None = None, document_content: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9367,13 +9441,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create Canvas for a user
-    https://api.slack.com/methods/canvases.create
+    https://docs.slack.dev/reference/methods/canvases.create
     &#34;&#34;&#34;
     kwargs.update({&#34;title&#34;: title, &#34;document_content&#34;: document_content})
     return self.api_call(&#34;canvases.create&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create Canvas for a user
-<a href="https://api.slack.com/methods/canvases.create">https://api.slack.com/methods/canvases.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.create">https://docs.slack.dev/reference/methods/canvases.create</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.canvases_delete"><code class="name flex">
 <span>def <span class="ident">canvases_delete</span></span>(<span>self, *, canvas_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9390,13 +9464,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a canvas
-    https://api.slack.com/methods/canvases.delete
+    https://docs.slack.dev/reference/methods/canvases.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id})
     return self.api_call(&#34;canvases.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a canvas
-<a href="https://api.slack.com/methods/canvases.delete">https://api.slack.com/methods/canvases.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.delete">https://docs.slack.dev/reference/methods/canvases.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.canvases_edit"><code class="name flex">
 <span>def <span class="ident">canvases_edit</span></span>(<span>self, *, canvas_id: str, changes: Sequence[Dict[str, Any]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9414,13 +9488,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an existing canvas
-    https://api.slack.com/methods/canvases.edit
+    https://docs.slack.dev/reference/methods/canvases.edit
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;changes&#34;: changes})
     return self.api_call(&#34;canvases.edit&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing canvas
-<a href="https://api.slack.com/methods/canvases.edit">https://api.slack.com/methods/canvases.edit</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.edit">https://docs.slack.dev/reference/methods/canvases.edit</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.canvases_sections_lookup"><code class="name flex">
 <span>def <span class="ident">canvases_sections_lookup</span></span>(<span>self, *, canvas_id: str, criteria: Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9438,13 +9512,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Find sections matching the provided criteria
-    https://api.slack.com/methods/canvases.sections.lookup
+    https://docs.slack.dev/reference/methods/canvases.sections.lookup
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;criteria&#34;: json.dumps(criteria)})
     return self.api_call(&#34;canvases.sections.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Find sections matching the provided criteria
-<a href="https://api.slack.com/methods/canvases.sections.lookup">https://api.slack.com/methods/canvases.sections.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.sections.lookup">https://docs.slack.dev/reference/methods/canvases.sections.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.channels_archive"><code class="name flex">
 <span>def <span class="ident">channels_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9778,13 +9852,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a message.
-    https://api.slack.com/methods/chat.delete
+    https://docs.slack.dev/reference/methods/chat.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts, &#34;as_user&#34;: as_user})
     return self.api_call(&#34;chat.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a message.
-<a href="https://api.slack.com/methods/chat.delete">https://api.slack.com/methods/chat.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.delete">https://docs.slack.dev/reference/methods/chat.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_deleteScheduledMessage"><code class="name flex">
 <span>def <span class="ident">chat_deleteScheduledMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>scheduled_message_id: str,<br>as_user: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9803,7 +9877,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a scheduled message.
-    https://api.slack.com/methods/chat.deleteScheduledMessage
+    https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9815,7 +9889,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.deleteScheduledMessage&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a scheduled message.
-<a href="https://api.slack.com/methods/chat.deleteScheduledMessage">https://api.slack.com/methods/chat.deleteScheduledMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage">https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_getPermalink"><code class="name flex">
 <span>def <span class="ident">chat_getPermalink</span></span>(<span>self, *, channel: str, message_ts: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9833,13 +9907,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a permalink URL for a specific extant message
-    https://api.slack.com/methods/chat.getPermalink
+    https://docs.slack.dev/reference/methods/chat.getPermalink
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;message_ts&#34;: message_ts})
     return self.api_call(&#34;chat.getPermalink&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a permalink URL for a specific extant message
-<a href="https://api.slack.com/methods/chat.getPermalink">https://api.slack.com/methods/chat.getPermalink</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.getPermalink">https://docs.slack.dev/reference/methods/chat.getPermalink</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_meMessage"><code class="name flex">
 <span>def <span class="ident">chat_meMessage</span></span>(<span>self, *, channel: str, text: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9857,16 +9931,16 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Share a me message into a channel.
-    https://api.slack.com/methods/chat.meMessage
+    https://docs.slack.dev/reference/methods/chat.meMessage
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;text&#34;: text})
     return self.api_call(&#34;chat.meMessage&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Share a me message into a channel.
-<a href="https://api.slack.com/methods/chat.meMessage">https://api.slack.com/methods/chat.meMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.meMessage">https://docs.slack.dev/reference/methods/chat.meMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_postEphemeral"><code class="name flex">
-<span>def <span class="ident">chat_postEphemeral</span></span>(<span>self,<br>*,<br>channel: str,<br>user: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_postEphemeral</span></span>(<span>self,<br>*,<br>channel: str,<br>user: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9888,10 +9962,11 @@ Each authorization represents an app installation that the event is visible to.
     link_names: Optional[bool] = None,
     username: Optional[str] = None,
     parse: Optional[str] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sends an ephemeral message to a user in a channel.
-    https://api.slack.com/methods/chat.postEphemeral
+    https://docs.slack.dev/reference/methods/chat.postEphemeral
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9907,19 +9982,20 @@ Each authorization represents an app installation that the event is visible to.
             &#34;link_names&#34;: link_names,
             &#34;username&#34;: username,
             &#34;parse&#34;: parse,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.postEphemeral&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends an ephemeral message to a user in a channel.
-<a href="https://api.slack.com/methods/chat.postEphemeral">https://api.slack.com/methods/chat.postEphemeral</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.postEphemeral">https://docs.slack.dev/reference/methods/chat.postEphemeral</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_postMessage"><code class="name flex">
-<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9946,10 +10022,11 @@ Each authorization represents an app installation that the event is visible to.
     username: Optional[str] = None,
     parse: Optional[str] = None,  # none, full
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sends a message to a channel.
-    https://api.slack.com/methods/chat.postMessage
+    https://docs.slack.dev/reference/methods/chat.postMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9970,19 +10047,20 @@ Each authorization represents an app installation that the event is visible to.
             &#34;username&#34;: username,
             &#34;parse&#34;: parse,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postMessage&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.postMessage&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.postMessage&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends a message to a channel.
-<a href="https://api.slack.com/methods/chat.postMessage">https://api.slack.com/methods/chat.postMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.postMessage">https://docs.slack.dev/reference/methods/chat.postMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_scheduleMessage"><code class="name flex">
-<span>def <span class="ident">chat_scheduleMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>post_at: str | int,<br>text: str,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>link_names: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_scheduleMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>post_at: str | int,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>link_names: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9994,7 +10072,7 @@ Each authorization represents an app installation that the event is visible to.
     *,
     channel: str,
     post_at: Union[str, int],
-    text: str,
+    text: Optional[str] = None,
     as_user: Optional[bool] = None,
     attachments: Optional[Union[str, Sequence[Union[Dict, Attachment]]]] = None,
     blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
@@ -10005,10 +10083,11 @@ Each authorization represents an app installation that the event is visible to.
     unfurl_media: Optional[bool] = None,
     link_names: Optional[bool] = None,
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Schedules a message.
-    https://api.slack.com/methods/chat.scheduleMessage
+    https://docs.slack.dev/reference/methods/chat.scheduleMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10025,16 +10104,17 @@ Each authorization represents an app installation that the event is visible to.
             &#34;unfurl_media&#34;: unfurl_media,
             &#34;link_names&#34;: link_names,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.scheduleMessage&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Schedules a message.
-<a href="https://api.slack.com/methods/chat.scheduleMessage">https://api.slack.com/methods/chat.scheduleMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.scheduleMessage">https://docs.slack.dev/reference/methods/chat.scheduleMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_scheduledMessages_list"><code class="name flex">
 <span>def <span class="ident">chat_scheduledMessages_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>cursor: str | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10056,7 +10136,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all scheduled messages.
-    https://api.slack.com/methods/chat.scheduledMessages.list
+    https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10071,7 +10151,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all scheduled messages.
-<a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.scheduledMessages.list">https://docs.slack.dev/reference/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_unfurl"><code class="name flex">
 <span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10096,7 +10176,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Provide custom unfurl behavior for user-posted URLs.
-    https://api.slack.com/methods/chat.unfurl
+    https://docs.slack.dev/reference/methods/chat.unfurl
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10117,10 +10197,10 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.unfurl&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Provide custom unfurl behavior for user-posted URLs.
-<a href="https://api.slack.com/methods/chat.unfurl">https://api.slack.com/methods/chat.unfurl</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.unfurl">https://docs.slack.dev/reference/methods/chat.unfurl</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_update"><code class="name flex">
-<span>def <span class="ident">chat_update</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>text: str | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>as_user: bool | None = None,<br>file_ids: str | Sequence[str] | None = None,<br>link_names: bool | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_update</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>text: str | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>as_user: bool | None = None,<br>file_ids: str | Sequence[str] | None = None,<br>link_names: bool | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10141,10 +10221,11 @@ Each authorization represents an app installation that the event is visible to.
     parse: Optional[str] = None,  # none, full
     reply_broadcast: Optional[bool] = None,
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Updates a message in a channel.
-    https://api.slack.com/methods/chat.update
+    https://docs.slack.dev/reference/methods/chat.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10158,6 +10239,7 @@ Each authorization represents an app installation that the event is visible to.
             &#34;parse&#34;: parse,
             &#34;reply_broadcast&#34;: reply_broadcast,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     if isinstance(file_ids, (list, tuple)):
@@ -10166,12 +10248,12 @@ Each authorization represents an app installation that the event is visible to.
         kwargs.update({&#34;file_ids&#34;: file_ids})
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.update&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.update&#34;, kwargs)
     # NOTE: intentionally using json over params for API methods using blocks/attachments
     return self.api_call(&#34;chat.update&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Updates a message in a channel.
-<a href="https://api.slack.com/methods/chat.update">https://api.slack.com/methods/chat.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.update">https://docs.slack.dev/reference/methods/chat.update</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_acceptSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_acceptSharedInvite</span></span>(<span>self,<br>*,<br>channel_name: str,<br>channel_id: str | None = None,<br>invite_id: str | None = None,<br>free_trial_accepted: bool | None = None,<br>is_private: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10193,7 +10275,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Accepts an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.acceptSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
     &#34;&#34;&#34;
     if channel_id is None and invite_id is None:
         raise e.SlackRequestError(&#34;Either channel_id or invite_id must be provided.&#34;)
@@ -10210,7 +10292,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.acceptSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Accepts an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.acceptSharedInvite">https://api.slack.com/methods/conversations.acceptSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite">https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_approveSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_approveSharedInvite</span></span>(<span>self, *, invite_id: str, target_team: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10228,13 +10310,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Approves an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.approveSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
     return self.api_call(&#34;conversations.approveSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approves an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.approveSharedInvite">https://api.slack.com/methods/conversations.approveSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.approveSharedInvite">https://docs.slack.dev/reference/methods/conversations.approveSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_archive"><code class="name flex">
 <span>def <span class="ident">conversations_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10251,13 +10333,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Archives a conversation.
-    https://api.slack.com/methods/conversations.archive
+    https://docs.slack.dev/reference/methods/conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.archive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archives a conversation.
-<a href="https://api.slack.com/methods/conversations.archive">https://api.slack.com/methods/conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.archive">https://docs.slack.dev/reference/methods/conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_canvases_create"><code class="name flex">
 <span>def <span class="ident">conversations_canvases_create</span></span>(<span>self, *, channel_id: str, document_content: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10275,13 +10357,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a Channel Canvas for a channel
-    https://api.slack.com/methods/conversations.canvases.create
+    https://docs.slack.dev/reference/methods/conversations.canvases.create
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;document_content&#34;: document_content})
     return self.api_call(&#34;conversations.canvases.create&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Channel Canvas for a channel
-<a href="https://api.slack.com/methods/conversations.canvases.create">https://api.slack.com/methods/conversations.canvases.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.canvases.create">https://docs.slack.dev/reference/methods/conversations.canvases.create</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_close"><code class="name flex">
 <span>def <span class="ident">conversations_close</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10298,13 +10380,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Closes a direct message or multi-person direct message.
-    https://api.slack.com/methods/conversations.close
+    https://docs.slack.dev/reference/methods/conversations.close
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.close&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Closes a direct message or multi-person direct message.
-<a href="https://api.slack.com/methods/conversations.close">https://api.slack.com/methods/conversations.close</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.close">https://docs.slack.dev/reference/methods/conversations.close</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_create"><code class="name flex">
 <span>def <span class="ident">conversations_create</span></span>(<span>self,<br>*,<br>name: str,<br>is_private: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10323,13 +10405,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Initiates a public or private channel-based conversation
-    https://api.slack.com/methods/conversations.create
+    https://docs.slack.dev/reference/methods/conversations.create
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;is_private&#34;: is_private, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;conversations.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Initiates a public or private channel-based conversation
-<a href="https://api.slack.com/methods/conversations.create">https://api.slack.com/methods/conversations.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.create">https://docs.slack.dev/reference/methods/conversations.create</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_declineSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_declineSharedInvite</span></span>(<span>self, *, invite_id: str, target_team: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10347,13 +10429,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Declines a Slack Connect channel invite.
-    https://api.slack.com/methods/conversations.declineSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
     return self.api_call(&#34;conversations.declineSharedInvite&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Declines a Slack Connect channel invite.
-<a href="https://api.slack.com/methods/conversations.declineSharedInvite">https://api.slack.com/methods/conversations.declineSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.declineSharedInvite">https://docs.slack.dev/reference/methods/conversations.declineSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_externalInvitePermissions_set"><code class="name flex">
 <span>def <span class="ident">conversations_externalInvitePermissions_set</span></span>(<span>self, *, action: str, channel: str, target_team: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10367,7 +10449,7 @@ Each authorization represents an app installation that the event is visible to.
     self, *, action: str, channel: str, target_team: str, **kwargs
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-    https://api.slack.com/methods/conversations.externalInvitePermissions.set
+    https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10379,7 +10461,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.externalInvitePermissions.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-<a href="https://api.slack.com/methods/conversations.externalInvitePermissions.set">https://api.slack.com/methods/conversations.externalInvitePermissions.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set">https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_history"><code class="name flex">
 <span>def <span class="ident">conversations_history</span></span>(<span>self,<br>*,<br>channel: str,<br>cursor: str | None = None,<br>inclusive: bool | None = None,<br>include_all_metadata: bool | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10402,7 +10484,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Fetches a conversation&#39;s history of messages and events.
-    https://api.slack.com/methods/conversations.history
+    https://docs.slack.dev/reference/methods/conversations.history
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10418,7 +10500,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.history&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetches a conversation's history of messages and events.
-<a href="https://api.slack.com/methods/conversations.history">https://api.slack.com/methods/conversations.history</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.history">https://docs.slack.dev/reference/methods/conversations.history</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_info"><code class="name flex">
 <span>def <span class="ident">conversations_info</span></span>(<span>self,<br>*,<br>channel: str,<br>include_locale: bool | None = None,<br>include_num_members: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10437,7 +10519,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve information about a conversation.
-    https://api.slack.com/methods/conversations.info
+    https://docs.slack.dev/reference/methods/conversations.info
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10449,7 +10531,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a conversation.
-<a href="https://api.slack.com/methods/conversations.info">https://api.slack.com/methods/conversations.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.info">https://docs.slack.dev/reference/methods/conversations.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_invite"><code class="name flex">
 <span>def <span class="ident">conversations_invite</span></span>(<span>self,<br>*,<br>channel: str,<br>users: str | Sequence[str],<br>force: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10468,7 +10550,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invites users to a channel.
-    https://api.slack.com/methods/conversations.invite
+    https://docs.slack.dev/reference/methods/conversations.invite
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10483,7 +10565,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invites users to a channel.
-<a href="https://api.slack.com/methods/conversations.invite">https://api.slack.com/methods/conversations.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.invite">https://docs.slack.dev/reference/methods/conversations.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_inviteShared"><code class="name flex">
 <span>def <span class="ident">conversations_inviteShared</span></span>(<span>self,<br>*,<br>channel: str,<br>emails: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10502,7 +10584,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sends an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.inviteShared
+    https://docs.slack.dev/reference/methods/conversations.inviteShared
     &#34;&#34;&#34;
     if emails is None and user_ids is None:
         raise e.SlackRequestError(&#34;Either emails or user ids must be provided.&#34;)
@@ -10518,7 +10600,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.inviteShared&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.inviteShared">https://api.slack.com/methods/conversations.inviteShared</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.inviteShared">https://docs.slack.dev/reference/methods/conversations.inviteShared</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_join"><code class="name flex">
 <span>def <span class="ident">conversations_join</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10535,13 +10617,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Joins an existing conversation.
-    https://api.slack.com/methods/conversations.join
+    https://docs.slack.dev/reference/methods/conversations.join
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.join&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Joins an existing conversation.
-<a href="https://api.slack.com/methods/conversations.join">https://api.slack.com/methods/conversations.join</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.join">https://docs.slack.dev/reference/methods/conversations.join</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_kick"><code class="name flex">
 <span>def <span class="ident">conversations_kick</span></span>(<span>self, *, channel: str, user: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10559,13 +10641,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a user from a conversation.
-    https://api.slack.com/methods/conversations.kick
+    https://docs.slack.dev/reference/methods/conversations.kick
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;user&#34;: user})
     return self.api_call(&#34;conversations.kick&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a user from a conversation.
-<a href="https://api.slack.com/methods/conversations.kick">https://api.slack.com/methods/conversations.kick</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.kick">https://docs.slack.dev/reference/methods/conversations.kick</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_leave"><code class="name flex">
 <span>def <span class="ident">conversations_leave</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10582,13 +10664,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Leaves a conversation.
-    https://api.slack.com/methods/conversations.leave
+    https://docs.slack.dev/reference/methods/conversations.leave
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.leave&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Leaves a conversation.
-<a href="https://api.slack.com/methods/conversations.leave">https://api.slack.com/methods/conversations.leave</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.leave">https://docs.slack.dev/reference/methods/conversations.leave</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_list"><code class="name flex">
 <span>def <span class="ident">conversations_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>exclude_archived: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>types: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10609,7 +10691,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all channels in a Slack team.
-    https://api.slack.com/methods/conversations.list
+    https://docs.slack.dev/reference/methods/conversations.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10626,7 +10708,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all channels in a Slack team.
-<a href="https://api.slack.com/methods/conversations.list">https://api.slack.com/methods/conversations.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.list">https://docs.slack.dev/reference/methods/conversations.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_listConnectInvites"><code class="name flex">
 <span>def <span class="ident">conversations_listConnectInvites</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10646,14 +10728,14 @@ Each authorization represents an app installation that the event is visible to.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List shared channel invites that have been generated
     or received but have not yet been approved by all parties.
-    https://api.slack.com/methods/conversations.listConnectInvites
+    https://docs.slack.dev/reference/methods/conversations.listConnectInvites
     &#34;&#34;&#34;
     kwargs.update({&#34;count&#34;: count, &#34;cursor&#34;: cursor, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;conversations.listConnectInvites&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List shared channel invites that have been generated
 or received but have not yet been approved by all parties.
-<a href="https://api.slack.com/methods/conversations.listConnectInvites">https://api.slack.com/methods/conversations.listConnectInvites</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.listConnectInvites">https://docs.slack.dev/reference/methods/conversations.listConnectInvites</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_mark"><code class="name flex">
 <span>def <span class="ident">conversations_mark</span></span>(<span>self, *, channel: str, ts: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10671,13 +10753,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the read cursor in a channel.
-    https://api.slack.com/methods/conversations.mark
+    https://docs.slack.dev/reference/methods/conversations.mark
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts})
     return self.api_call(&#34;conversations.mark&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the read cursor in a channel.
-<a href="https://api.slack.com/methods/conversations.mark">https://api.slack.com/methods/conversations.mark</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.mark">https://docs.slack.dev/reference/methods/conversations.mark</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_members"><code class="name flex">
 <span>def <span class="ident">conversations_members</span></span>(<span>self, *, channel: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10696,13 +10778,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve members of a conversation.
-    https://api.slack.com/methods/conversations.members
+    https://docs.slack.dev/reference/methods/conversations.members
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;conversations.members&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve members of a conversation.
-<a href="https://api.slack.com/methods/conversations.members">https://api.slack.com/methods/conversations.members</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.members">https://docs.slack.dev/reference/methods/conversations.members</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_open"><code class="name flex">
 <span>def <span class="ident">conversations_open</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>return_im: bool | None = None,<br>users: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10721,7 +10803,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Opens or resumes a direct message or multi-person direct message.
-    https://api.slack.com/methods/conversations.open
+    https://docs.slack.dev/reference/methods/conversations.open
     &#34;&#34;&#34;
     if channel is None and users is None:
         raise e.SlackRequestError(&#34;Either channel or users must be provided.&#34;)
@@ -10733,7 +10815,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.open&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Opens or resumes a direct message or multi-person direct message.
-<a href="https://api.slack.com/methods/conversations.open">https://api.slack.com/methods/conversations.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.open">https://docs.slack.dev/reference/methods/conversations.open</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_rename"><code class="name flex">
 <span>def <span class="ident">conversations_rename</span></span>(<span>self, *, channel: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10751,13 +10833,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Renames a conversation.
-    https://api.slack.com/methods/conversations.rename
+    https://docs.slack.dev/reference/methods/conversations.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name})
     return self.api_call(&#34;conversations.rename&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Renames a conversation.
-<a href="https://api.slack.com/methods/conversations.rename">https://api.slack.com/methods/conversations.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.rename">https://docs.slack.dev/reference/methods/conversations.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_replies"><code class="name flex">
 <span>def <span class="ident">conversations_replies</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>cursor: str | None = None,<br>inclusive: bool | None = None,<br>include_all_metadata: bool | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10781,7 +10863,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a thread of messages posted to a conversation
-    https://api.slack.com/methods/conversations.replies
+    https://docs.slack.dev/reference/methods/conversations.replies
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10798,7 +10880,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.replies&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a thread of messages posted to a conversation
-<a href="https://api.slack.com/methods/conversations.replies">https://api.slack.com/methods/conversations.replies</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.replies">https://docs.slack.dev/reference/methods/conversations.replies</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_requestSharedInvite_approve"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_approve</span></span>(<span>self,<br>*,<br>invite_id: str,<br>channel_id: str | None = None,<br>is_external_limited: str | None = None,<br>message: Dict[str, Any] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10818,7 +10900,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-    https://api.slack.com/methods/conversations.requestSharedInvite.approve
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10832,7 +10914,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.requestSharedInvite.approve&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.approve">https://api.slack.com/methods/conversations.requestSharedInvite.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_requestSharedInvite_deny"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_deny</span></span>(<span>self, *, invite_id: str, message: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10850,13 +10932,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deny a request to invite an external user to a channel.
-    https://api.slack.com/methods/conversations.requestSharedInvite.deny
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;message&#34;: message})
     return self.api_call(&#34;conversations.requestSharedInvite.deny&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deny a request to invite an external user to a channel.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.deny">https://api.slack.com/methods/conversations.requestSharedInvite.deny</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_requestSharedInvite_list"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>include_approved: bool | None = None,<br>include_denied: bool | None = None,<br>include_expired: bool | None = None,<br>invite_ids: str | Sequence[str] | None = None,<br>limit: int | None = None,<br>user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10879,7 +10961,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists requests to add external users to channels with ability to filter.
-    https://api.slack.com/methods/conversations.requestSharedInvite.list
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10899,7 +10981,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.requestSharedInvite.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists requests to add external users to channels with ability to filter.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.list">https://api.slack.com/methods/conversations.requestSharedInvite.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_setPurpose"><code class="name flex">
 <span>def <span class="ident">conversations_setPurpose</span></span>(<span>self, *, channel: str, purpose: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10917,13 +10999,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the purpose for a conversation.
-    https://api.slack.com/methods/conversations.setPurpose
+    https://docs.slack.dev/reference/methods/conversations.setPurpose
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;purpose&#34;: purpose})
     return self.api_call(&#34;conversations.setPurpose&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the purpose for a conversation.
-<a href="https://api.slack.com/methods/conversations.setPurpose">https://api.slack.com/methods/conversations.setPurpose</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.setPurpose">https://docs.slack.dev/reference/methods/conversations.setPurpose</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_setTopic"><code class="name flex">
 <span>def <span class="ident">conversations_setTopic</span></span>(<span>self, *, channel: str, topic: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10941,13 +11023,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the topic for a conversation.
-    https://api.slack.com/methods/conversations.setTopic
+    https://docs.slack.dev/reference/methods/conversations.setTopic
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;topic&#34;: topic})
     return self.api_call(&#34;conversations.setTopic&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the topic for a conversation.
-<a href="https://api.slack.com/methods/conversations.setTopic">https://api.slack.com/methods/conversations.setTopic</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.setTopic">https://docs.slack.dev/reference/methods/conversations.setTopic</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.conversations_unarchive"><code class="name flex">
 <span>def <span class="ident">conversations_unarchive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10964,13 +11046,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Reverses conversation archival.
-    https://api.slack.com/methods/conversations.unarchive
+    https://docs.slack.dev/reference/methods/conversations.unarchive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.unarchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Reverses conversation archival.
-<a href="https://api.slack.com/methods/conversations.unarchive">https://api.slack.com/methods/conversations.unarchive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.unarchive">https://docs.slack.dev/reference/methods/conversations.unarchive</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.dialog_open"><code class="name flex">
 <span>def <span class="ident">dialog_open</span></span>(<span>self, *, dialog: Dict[str, Any], trigger_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10988,7 +11070,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Open a dialog with a user.
-    https://api.slack.com/methods/dialog.open
+    https://docs.slack.dev/reference/methods/dialog.open
     &#34;&#34;&#34;
     kwargs.update({&#34;dialog&#34;: dialog, &#34;trigger_id&#34;: trigger_id})
     kwargs = _remove_none_values(kwargs)
@@ -10996,7 +11078,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;dialog.open&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Open a dialog with a user.
-<a href="https://api.slack.com/methods/dialog.open">https://api.slack.com/methods/dialog.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dialog.open">https://docs.slack.dev/reference/methods/dialog.open</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.dnd_endDnd"><code class="name flex">
 <span>def <span class="ident">dnd_endDnd</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11011,12 +11093,12 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ends the current user&#39;s Do Not Disturb session immediately.
-    https://api.slack.com/methods/dnd.endDnd
+    https://docs.slack.dev/reference/methods/dnd.endDnd
     &#34;&#34;&#34;
     return self.api_call(&#34;dnd.endDnd&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends the current user's Do Not Disturb session immediately.
-<a href="https://api.slack.com/methods/dnd.endDnd">https://api.slack.com/methods/dnd.endDnd</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.endDnd">https://docs.slack.dev/reference/methods/dnd.endDnd</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.dnd_endSnooze"><code class="name flex">
 <span>def <span class="ident">dnd_endSnooze</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11031,12 +11113,12 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ends the current user&#39;s snooze mode immediately.
-    https://api.slack.com/methods/dnd.endSnooze
+    https://docs.slack.dev/reference/methods/dnd.endSnooze
     &#34;&#34;&#34;
     return self.api_call(&#34;dnd.endSnooze&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends the current user's snooze mode immediately.
-<a href="https://api.slack.com/methods/dnd.endSnooze">https://api.slack.com/methods/dnd.endSnooze</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.endSnooze">https://docs.slack.dev/reference/methods/dnd.endSnooze</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.dnd_info"><code class="name flex">
 <span>def <span class="ident">dnd_info</span></span>(<span>self, *, team_id: str | None = None, user: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11054,13 +11136,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieves a user&#39;s current Do Not Disturb status.
-    https://api.slack.com/methods/dnd.info
+    https://docs.slack.dev/reference/methods/dnd.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
     return self.api_call(&#34;dnd.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves a user's current Do Not Disturb status.
-<a href="https://api.slack.com/methods/dnd.info">https://api.slack.com/methods/dnd.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.info">https://docs.slack.dev/reference/methods/dnd.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.dnd_setSnooze"><code class="name flex">
 <span>def <span class="ident">dnd_setSnooze</span></span>(<span>self, *, num_minutes: str | int, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11077,13 +11159,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Turns on Do Not Disturb mode for the current user, or changes its duration.
-    https://api.slack.com/methods/dnd.setSnooze
+    https://docs.slack.dev/reference/methods/dnd.setSnooze
     &#34;&#34;&#34;
     kwargs.update({&#34;num_minutes&#34;: num_minutes})
     return self.api_call(&#34;dnd.setSnooze&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Turns on Do Not Disturb mode for the current user, or changes its duration.
-<a href="https://api.slack.com/methods/dnd.setSnooze">https://api.slack.com/methods/dnd.setSnooze</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.setSnooze">https://docs.slack.dev/reference/methods/dnd.setSnooze</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.dnd_teamInfo"><code class="name flex">
 <span>def <span class="ident">dnd_teamInfo</span></span>(<span>self, users: str | Sequence[str], team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11100,7 +11182,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieves the Do Not Disturb status for users on a team.
-    https://api.slack.com/methods/dnd.teamInfo
+    https://docs.slack.dev/reference/methods/dnd.teamInfo
     &#34;&#34;&#34;
     if isinstance(users, (list, tuple)):
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -11110,7 +11192,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;dnd.teamInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves the Do Not Disturb status for users on a team.
-<a href="https://api.slack.com/methods/dnd.teamInfo">https://api.slack.com/methods/dnd.teamInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.teamInfo">https://docs.slack.dev/reference/methods/dnd.teamInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.emoji_list"><code class="name flex">
 <span>def <span class="ident">emoji_list</span></span>(<span>self, include_categories: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11126,13 +11208,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists custom emoji for a team.
-    https://api.slack.com/methods/emoji.list
+    https://docs.slack.dev/reference/methods/emoji.list
     &#34;&#34;&#34;
     kwargs.update({&#34;include_categories&#34;: include_categories})
     return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists custom emoji for a team.
-<a href="https://api.slack.com/methods/emoji.list">https://api.slack.com/methods/emoji.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/emoji.list">https://docs.slack.dev/reference/methods/emoji.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_comments_delete"><code class="name flex">
 <span>def <span class="ident">files_comments_delete</span></span>(<span>self, *, file: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11150,13 +11232,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes an existing comment on a file.
-    https://api.slack.com/methods/files.comments.delete
+    https://docs.slack.dev/reference/methods/files.comments.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file, &#34;id&#34;: id})
     return self.api_call(&#34;files.comments.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes an existing comment on a file.
-<a href="https://api.slack.com/methods/files.comments.delete">https://api.slack.com/methods/files.comments.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.comments.delete">https://docs.slack.dev/reference/methods/files.comments.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_completeUploadExternal"><code class="name flex">
 <span>def <span class="ident">files_completeUploadExternal</span></span>(<span>self,<br>*,<br>files: List[Dict[str, str]],<br>channel_id: str | None = None,<br>channels: List[str] | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11177,7 +11259,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Finishes an upload started with files.getUploadURLExternal.
-    https://api.slack.com/methods/files.completeUploadExternal
+    https://docs.slack.dev/reference/methods/files.completeUploadExternal
     &#34;&#34;&#34;
     _files = [{k: v for k, v in f.items() if v is not None} for f in files]
     kwargs.update(
@@ -11193,7 +11275,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.completeUploadExternal&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Finishes an upload started with files.getUploadURLExternal.
-<a href="https://api.slack.com/methods/files.completeUploadExternal">https://api.slack.com/methods/files.completeUploadExternal</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.completeUploadExternal">https://docs.slack.dev/reference/methods/files.completeUploadExternal</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_delete"><code class="name flex">
 <span>def <span class="ident">files_delete</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11210,13 +11292,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a file.
-    https://api.slack.com/methods/files.delete
+    https://docs.slack.dev/reference/methods/files.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a file.
-<a href="https://api.slack.com/methods/files.delete">https://api.slack.com/methods/files.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.delete">https://docs.slack.dev/reference/methods/files.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_getUploadURLExternal"><code class="name flex">
 <span>def <span class="ident">files_getUploadURLExternal</span></span>(<span>self,<br>*,<br>filename: str,<br>length: int,<br>alt_txt: str | None = None,<br>snippet_type: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11236,7 +11318,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets a URL for an edge external upload.
-    https://api.slack.com/methods/files.getUploadURLExternal
+    https://docs.slack.dev/reference/methods/files.getUploadURLExternal
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11249,7 +11331,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.getUploadURLExternal&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets a URL for an edge external upload.
-<a href="https://api.slack.com/methods/files.getUploadURLExternal">https://api.slack.com/methods/files.getUploadURLExternal</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.getUploadURLExternal">https://docs.slack.dev/reference/methods/files.getUploadURLExternal</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_info"><code class="name flex">
 <span>def <span class="ident">files_info</span></span>(<span>self,<br>*,<br>file: str,<br>count: int | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11270,7 +11352,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a team file.
-    https://api.slack.com/methods/files.info
+    https://docs.slack.dev/reference/methods/files.info
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11284,7 +11366,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a team file.
-<a href="https://api.slack.com/methods/files.info">https://api.slack.com/methods/files.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.info">https://docs.slack.dev/reference/methods/files.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_list"><code class="name flex">
 <span>def <span class="ident">files_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>count: int | None = None,<br>page: int | None = None,<br>show_files_hidden_by_limit: bool | None = None,<br>team_id: str | None = None,<br>ts_from: str | None = None,<br>ts_to: str | None = None,<br>types: str | Sequence[str] | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11309,7 +11391,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists &amp; filters team files.
-    https://api.slack.com/methods/files.list
+    https://docs.slack.dev/reference/methods/files.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11330,7 +11412,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists &amp; filters team files.
-<a href="https://api.slack.com/methods/files.list">https://api.slack.com/methods/files.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.list">https://docs.slack.dev/reference/methods/files.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_remote_add"><code class="name flex">
 <span>def <span class="ident">files_remote_add</span></span>(<span>self,<br>*,<br>external_id: str,<br>external_url: str,<br>title: str,<br>filetype: str | None = None,<br>indexable_file_contents: str | bytes | io.IOBase | None = None,<br>preview_image: str | bytes | io.IOBase | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11352,7 +11434,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds a file from a remote service.
-    https://api.slack.com/methods/files.remote.add
+    https://docs.slack.dev/reference/methods/files.remote.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11379,7 +11461,7 @@ or received but have not yet been approved by all parties.
     )</code></pre>
 </details>
 <div class="desc"><p>Adds a file from a remote service.
-<a href="https://api.slack.com/methods/files.remote.add">https://api.slack.com/methods/files.remote.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.add">https://docs.slack.dev/reference/methods/files.remote.add</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_remote_info"><code class="name flex">
 <span>def <span class="ident">files_remote_info</span></span>(<span>self, *, external_id: str | None = None, file: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11397,13 +11479,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-    https://api.slack.com/methods/files.remote.info
+    https://docs.slack.dev/reference/methods/files.remote.info
     &#34;&#34;&#34;
     kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
     return self.api_call(&#34;files.remote.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a remote file added to Slack.
-<a href="https://api.slack.com/methods/files.remote.info">https://api.slack.com/methods/files.remote.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.info">https://docs.slack.dev/reference/methods/files.remote.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_remote_list"><code class="name flex">
 <span>def <span class="ident">files_remote_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>ts_from: str | None = None,<br>ts_to: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11424,7 +11506,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-    https://api.slack.com/methods/files.remote.list
+    https://docs.slack.dev/reference/methods/files.remote.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11438,7 +11520,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.remote.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a remote file added to Slack.
-<a href="https://api.slack.com/methods/files.remote.list">https://api.slack.com/methods/files.remote.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.list">https://docs.slack.dev/reference/methods/files.remote.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_remote_remove"><code class="name flex">
 <span>def <span class="ident">files_remote_remove</span></span>(<span>self, *, external_id: str | None = None, file: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11456,13 +11538,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a remote file.
-    https://api.slack.com/methods/files.remote.remove
+    https://docs.slack.dev/reference/methods/files.remote.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
     return self.api_call(&#34;files.remote.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a remote file.
-<a href="https://api.slack.com/methods/files.remote.remove">https://api.slack.com/methods/files.remote.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.remove">https://docs.slack.dev/reference/methods/files.remote.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_remote_share"><code class="name flex">
 <span>def <span class="ident">files_remote_share</span></span>(<span>self,<br>*,<br>channels: str | Sequence[str],<br>external_id: str | None = None,<br>file: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11481,7 +11563,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Share a remote file into a channel.
-    https://api.slack.com/methods/files.remote.share
+    https://docs.slack.dev/reference/methods/files.remote.share
     &#34;&#34;&#34;
     if external_id is None and file is None:
         raise e.SlackRequestError(&#34;Either external_id or file must be provided.&#34;)
@@ -11493,7 +11575,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.remote.share&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Share a remote file into a channel.
-<a href="https://api.slack.com/methods/files.remote.share">https://api.slack.com/methods/files.remote.share</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.share">https://docs.slack.dev/reference/methods/files.remote.share</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_remote_update"><code class="name flex">
 <span>def <span class="ident">files_remote_update</span></span>(<span>self,<br>*,<br>external_id: str | None = None,<br>external_url: str | None = None,<br>file: str | None = None,<br>title: str | None = None,<br>filetype: str | None = None,<br>indexable_file_contents: str | None = None,<br>preview_image: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11516,7 +11598,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Updates an existing remote file.
-    https://api.slack.com/methods/files.remote.update
+    https://docs.slack.dev/reference/methods/files.remote.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11544,7 +11626,7 @@ or received but have not yet been approved by all parties.
     )</code></pre>
 </details>
 <div class="desc"><p>Updates an existing remote file.
-<a href="https://api.slack.com/methods/files.remote.update">https://api.slack.com/methods/files.remote.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.update">https://docs.slack.dev/reference/methods/files.remote.update</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_revokePublicURL"><code class="name flex">
 <span>def <span class="ident">files_revokePublicURL</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11561,13 +11643,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes public/external sharing access for a file
-    https://api.slack.com/methods/files.revokePublicURL
+    https://docs.slack.dev/reference/methods/files.revokePublicURL
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.revokePublicURL&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes public/external sharing access for a file
-<a href="https://api.slack.com/methods/files.revokePublicURL">https://api.slack.com/methods/files.revokePublicURL</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.revokePublicURL">https://docs.slack.dev/reference/methods/files.revokePublicURL</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_sharedPublicURL"><code class="name flex">
 <span>def <span class="ident">files_sharedPublicURL</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11584,13 +11666,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Enables a file for public/external sharing.
-    https://api.slack.com/methods/files.sharedPublicURL
+    https://docs.slack.dev/reference/methods/files.sharedPublicURL
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.sharedPublicURL&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enables a file for public/external sharing.
-<a href="https://api.slack.com/methods/files.sharedPublicURL">https://api.slack.com/methods/files.sharedPublicURL</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.sharedPublicURL">https://docs.slack.dev/reference/methods/files.sharedPublicURL</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_upload"><code class="name flex">
 <span>def <span class="ident">files_upload</span></span>(<span>self,<br>*,<br>file: str | bytes | io.IOBase | None = None,<br>content: str | bytes | None = None,<br>filename: str | None = None,<br>filetype: str | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>title: str | None = None,<br>channels: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11614,7 +11696,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Uploads or creates a file.
-    https://api.slack.com/methods/files.upload
+    https://docs.slack.dev/reference/methods/files.upload
     &#34;&#34;&#34;
     _print_files_upload_v2_suggestion()
 
@@ -11647,7 +11729,7 @@ or received but have not yet been approved by all parties.
         return self.api_call(&#34;files.upload&#34;, data=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Uploads or creates a file.
-<a href="https://api.slack.com/methods/files.upload">https://api.slack.com/methods/files.upload</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.upload">https://docs.slack.dev/reference/methods/files.upload</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_upload_v2"><code class="name flex">
 <span>def <span class="ident">files_upload_v2</span></span>(<span>self,<br>*,<br>filename: str | None = None,<br>file: str | bytes | io.IOBase | os.PathLike | None = None,<br>content: str | bytes | None = None,<br>title: str | None = None,<br>alt_txt: str | None = None,<br>snippet_type: str | None = None,<br>file_uploads: List[Dict[str, Any]] | None = None,<br>channel: str | None = None,<br>channels: List[str] | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>request_file_info: bool = True,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11678,12 +11760,12 @@ or received but have not yet been approved by all parties.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;This wrapper method provides an easy way to upload files using the following endpoints:
 
-    - step1: https://api.slack.com/methods/files.getUploadURLExternal
+    - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
     - step2: &#34;https://files.slack.com/upload/v1/...&#34; URLs returned from files.getUploadURLExternal API
 
-    - step3: https://api.slack.com/methods/files.completeUploadExternal
-        and https://api.slack.com/methods/files.info
+    - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+        and https://docs.slack.dev/reference/methods/files.info
 
     &#34;&#34;&#34;
     if file is None and content is None and file_uploads is None:
@@ -11762,14 +11844,14 @@ or received but have not yet been approved by all parties.
 <div class="desc"><p>This wrapper method provides an easy way to upload files using the following endpoints:</p>
 <ul>
 <li>
-<p>step1: <a href="https://api.slack.com/methods/files.getUploadURLExternal">https://api.slack.com/methods/files.getUploadURLExternal</a></p>
+<p>step1: <a href="https://docs.slack.dev/reference/methods/files.getUploadURLExternal">https://docs.slack.dev/reference/methods/files.getUploadURLExternal</a></p>
 </li>
 <li>
 <p>step2: "https://files.slack.com/upload/v1/&hellip;" URLs returned from files.getUploadURLExternal API</p>
 </li>
 <li>
-<p>step3: <a href="https://api.slack.com/methods/files.completeUploadExternal">https://api.slack.com/methods/files.completeUploadExternal</a>
-and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/methods/files.info</a></p>
+<p>step3: <a href="https://docs.slack.dev/reference/methods/files.completeUploadExternal">https://docs.slack.dev/reference/methods/files.completeUploadExternal</a>
+and <a href="https://docs.slack.dev/reference/methods/files.info">https://docs.slack.dev/reference/methods/files.info</a></p>
 </li>
 </ul></div>
 </dd>
@@ -11789,13 +11871,13 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Signal the failure to execute a function
-    https://api.slack.com/methods/functions.completeError
+    https://docs.slack.dev/reference/methods/functions.completeError
     &#34;&#34;&#34;
     kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;error&#34;: error})
     return self.api_call(&#34;functions.completeError&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Signal the failure to execute a function
-<a href="https://api.slack.com/methods/functions.completeError">https://api.slack.com/methods/functions.completeError</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/functions.completeError">https://docs.slack.dev/reference/methods/functions.completeError</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.functions_completeSuccess"><code class="name flex">
 <span>def <span class="ident">functions_completeSuccess</span></span>(<span>self, *, function_execution_id: str, outputs: Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11813,13 +11895,13 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Signal the successful completion of a function
-    https://api.slack.com/methods/functions.completeSuccess
+    https://docs.slack.dev/reference/methods/functions.completeSuccess
     &#34;&#34;&#34;
     kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;outputs&#34;: json.dumps(outputs)})
     return self.api_call(&#34;functions.completeSuccess&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Signal the successful completion of a function
-<a href="https://api.slack.com/methods/functions.completeSuccess">https://api.slack.com/methods/functions.completeSuccess</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/functions.completeSuccess">https://docs.slack.dev/reference/methods/functions.completeSuccess</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.groups_archive"><code class="name flex">
 <span>def <span class="ident">groups_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12295,7 +12377,7 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;For Enterprise Grid workspaces, map local user IDs to global user IDs
-    https://api.slack.com/methods/migration.exchange
+    https://docs.slack.dev/reference/methods/migration.exchange
     &#34;&#34;&#34;
     if isinstance(users, (list, tuple)):
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -12305,7 +12387,7 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     return self.api_call(&#34;migration.exchange&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>For Enterprise Grid workspaces, map local user IDs to global user IDs
-<a href="https://api.slack.com/methods/migration.exchange">https://api.slack.com/methods/migration.exchange</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/migration.exchange">https://docs.slack.dev/reference/methods/migration.exchange</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.mpim_close"><code class="name flex">
 <span>def <span class="ident">mpim_close</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12452,7 +12534,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-    https://api.slack.com/methods/oauth.access
+    https://docs.slack.dev/reference/methods/oauth.access
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12464,7 +12546,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.
-<a href="https://api.slack.com/methods/oauth.access">https://api.slack.com/methods/oauth.access</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.access">https://docs.slack.dev/reference/methods/oauth.access</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.oauth_v2_access"><code class="name flex">
 <span>def <span class="ident">oauth_v2_access</span></span>(<span>self,<br>*,<br>client_id: str,<br>client_secret: str,<br>code: str | None = None,<br>redirect_uri: str | None = None,<br>grant_type: str | None = None,<br>refresh_token: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12490,7 +12572,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-    https://api.slack.com/methods/oauth.v2.access
+    https://docs.slack.dev/reference/methods/oauth.v2.access
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12507,7 +12589,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.
-<a href="https://api.slack.com/methods/oauth.v2.access">https://api.slack.com/methods/oauth.v2.access</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.v2.access">https://docs.slack.dev/reference/methods/oauth.v2.access</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.oauth_v2_exchange"><code class="name flex">
 <span>def <span class="ident">oauth_v2_exchange</span></span>(<span>self, *, token: str, client_id: str, client_secret: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12526,13 +12608,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
-    https://api.slack.com/methods/oauth.v2.exchange
+    https://docs.slack.dev/reference/methods/oauth.v2.exchange
     &#34;&#34;&#34;
     kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token})
     return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Exchanges a legacy access token for a new expiring access token and refresh token
-<a href="https://api.slack.com/methods/oauth.v2.exchange">https://api.slack.com/methods/oauth.v2.exchange</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.v2.exchange">https://docs.slack.dev/reference/methods/oauth.v2.exchange</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.openid_connect_token"><code class="name flex">
 <span>def <span class="ident">openid_connect_token</span></span>(<span>self,<br>client_id: str,<br>client_secret: str,<br>code: str | None = None,<br>redirect_uri: str | None = None,<br>grant_type: str | None = None,<br>refresh_token: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12553,7 +12635,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-    https://api.slack.com/methods/openid.connect.token
+    https://docs.slack.dev/reference/methods/openid.connect.token
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12570,7 +12652,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-<a href="https://api.slack.com/methods/openid.connect.token">https://api.slack.com/methods/openid.connect.token</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/openid.connect.token">https://docs.slack.dev/reference/methods/openid.connect.token</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.openid_connect_userInfo"><code class="name flex">
 <span>def <span class="ident">openid_connect_userInfo</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12585,12 +12667,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get the identity of a user who has authorized Sign in with Slack.
-    https://api.slack.com/methods/openid.connect.userInfo
+    https://docs.slack.dev/reference/methods/openid.connect.userInfo
     &#34;&#34;&#34;
     return self.api_call(&#34;openid.connect.userInfo&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get the identity of a user who has authorized Sign in with Slack.
-<a href="https://api.slack.com/methods/openid.connect.userInfo">https://api.slack.com/methods/openid.connect.userInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/openid.connect.userInfo">https://docs.slack.dev/reference/methods/openid.connect.userInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.pins_add"><code class="name flex">
 <span>def <span class="ident">pins_add</span></span>(<span>self, *, channel: str, timestamp: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12608,13 +12690,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Pins an item to a channel.
-    https://api.slack.com/methods/pins.add
+    https://docs.slack.dev/reference/methods/pins.add
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;pins.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Pins an item to a channel.
-<a href="https://api.slack.com/methods/pins.add">https://api.slack.com/methods/pins.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.add">https://docs.slack.dev/reference/methods/pins.add</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.pins_list"><code class="name flex">
 <span>def <span class="ident">pins_list</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12631,13 +12713,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists items pinned to a channel.
-    https://api.slack.com/methods/pins.list
+    https://docs.slack.dev/reference/methods/pins.list
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;pins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists items pinned to a channel.
-<a href="https://api.slack.com/methods/pins.list">https://api.slack.com/methods/pins.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.list">https://docs.slack.dev/reference/methods/pins.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.pins_remove"><code class="name flex">
 <span>def <span class="ident">pins_remove</span></span>(<span>self, *, channel: str, timestamp: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12655,13 +12737,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Un-pins an item from a channel.
-    https://api.slack.com/methods/pins.remove
+    https://docs.slack.dev/reference/methods/pins.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;pins.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Un-pins an item from a channel.
-<a href="https://api.slack.com/methods/pins.remove">https://api.slack.com/methods/pins.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.remove">https://docs.slack.dev/reference/methods/pins.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.reactions_add"><code class="name flex">
 <span>def <span class="ident">reactions_add</span></span>(<span>self, *, channel: str, name: str, timestamp: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12680,13 +12762,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds a reaction to an item.
-    https://api.slack.com/methods/reactions.add
+    https://docs.slack.dev/reference/methods/reactions.add
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;reactions.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds a reaction to an item.
-<a href="https://api.slack.com/methods/reactions.add">https://api.slack.com/methods/reactions.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.add">https://docs.slack.dev/reference/methods/reactions.add</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.reactions_get"><code class="name flex">
 <span>def <span class="ident">reactions_get</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>full: bool | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12707,7 +12789,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets reactions for an item.
-    https://api.slack.com/methods/reactions.get
+    https://docs.slack.dev/reference/methods/reactions.get
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12721,7 +12803,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets reactions for an item.
-<a href="https://api.slack.com/methods/reactions.get">https://api.slack.com/methods/reactions.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.get">https://docs.slack.dev/reference/methods/reactions.get</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.reactions_list"><code class="name flex">
 <span>def <span class="ident">reactions_list</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>full: bool | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>team_id: str | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12744,7 +12826,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists reactions made by a user.
-    https://api.slack.com/methods/reactions.list
+    https://docs.slack.dev/reference/methods/reactions.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12760,7 +12842,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists reactions made by a user.
-<a href="https://api.slack.com/methods/reactions.list">https://api.slack.com/methods/reactions.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.list">https://docs.slack.dev/reference/methods/reactions.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.reactions_remove"><code class="name flex">
 <span>def <span class="ident">reactions_remove</span></span>(<span>self,<br>*,<br>name: str,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12781,7 +12863,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a reaction from an item.
-    https://api.slack.com/methods/reactions.remove
+    https://docs.slack.dev/reference/methods/reactions.remove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12795,7 +12877,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a reaction from an item.
-<a href="https://api.slack.com/methods/reactions.remove">https://api.slack.com/methods/reactions.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.remove">https://docs.slack.dev/reference/methods/reactions.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.reminders_add"><code class="name flex">
 <span>def <span class="ident">reminders_add</span></span>(<span>self,<br>*,<br>text: str,<br>time: str,<br>team_id: str | None = None,<br>user: str | None = None,<br>recurrence: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12816,7 +12898,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Creates a reminder.
-    https://api.slack.com/methods/reminders.add
+    https://docs.slack.dev/reference/methods/reminders.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12830,7 +12912,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reminders.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Creates a reminder.
-<a href="https://api.slack.com/methods/reminders.add">https://api.slack.com/methods/reminders.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.add">https://docs.slack.dev/reference/methods/reminders.add</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.reminders_complete"><code class="name flex">
 <span>def <span class="ident">reminders_complete</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12848,13 +12930,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Marks a reminder as complete.
-    https://api.slack.com/methods/reminders.complete
+    https://docs.slack.dev/reference/methods/reminders.complete
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.complete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Marks a reminder as complete.
-<a href="https://api.slack.com/methods/reminders.complete">https://api.slack.com/methods/reminders.complete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.complete">https://docs.slack.dev/reference/methods/reminders.complete</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.reminders_delete"><code class="name flex">
 <span>def <span class="ident">reminders_delete</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12872,13 +12954,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a reminder.
-    https://api.slack.com/methods/reminders.delete
+    https://docs.slack.dev/reference/methods/reminders.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a reminder.
-<a href="https://api.slack.com/methods/reminders.delete">https://api.slack.com/methods/reminders.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.delete">https://docs.slack.dev/reference/methods/reminders.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.reminders_info"><code class="name flex">
 <span>def <span class="ident">reminders_info</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12896,13 +12978,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a reminder.
-    https://api.slack.com/methods/reminders.info
+    https://docs.slack.dev/reference/methods/reminders.info
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a reminder.
-<a href="https://api.slack.com/methods/reminders.info">https://api.slack.com/methods/reminders.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.info">https://docs.slack.dev/reference/methods/reminders.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.reminders_list"><code class="name flex">
 <span>def <span class="ident">reminders_list</span></span>(<span>self, *, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12919,13 +13001,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all reminders created by or for a given user.
-    https://api.slack.com/methods/reminders.list
+    https://docs.slack.dev/reference/methods/reminders.list
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all reminders created by or for a given user.
-<a href="https://api.slack.com/methods/reminders.list">https://api.slack.com/methods/reminders.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.list">https://docs.slack.dev/reference/methods/reminders.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.rtm_connect"><code class="name flex">
 <span>def <span class="ident">rtm_connect</span></span>(<span>self,<br>*,<br>batch_presence_aware: bool | None = None,<br>presence_sub: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12943,13 +13025,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Starts a Real Time Messaging session.
-    https://api.slack.com/methods/rtm.connect
+    https://docs.slack.dev/reference/methods/rtm.connect
     &#34;&#34;&#34;
     kwargs.update({&#34;batch_presence_aware&#34;: batch_presence_aware, &#34;presence_sub&#34;: presence_sub})
     return self.api_call(&#34;rtm.connect&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Starts a Real Time Messaging session.
-<a href="https://api.slack.com/methods/rtm.connect">https://api.slack.com/methods/rtm.connect</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/rtm.connect">https://docs.slack.dev/reference/methods/rtm.connect</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.rtm_start"><code class="name flex">
 <span>def <span class="ident">rtm_start</span></span>(<span>self,<br>*,<br>batch_presence_aware: bool | None = None,<br>include_locale: bool | None = None,<br>mpim_aware: bool | None = None,<br>no_latest: bool | None = None,<br>no_unreads: bool | None = None,<br>presence_sub: bool | None = None,<br>simple_latest: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12972,7 +13054,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Starts a Real Time Messaging session.
-    https://api.slack.com/methods/rtm.start
+    https://docs.slack.dev/reference/methods/rtm.start
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12988,7 +13070,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;rtm.start&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Starts a Real Time Messaging session.
-<a href="https://api.slack.com/methods/rtm.start">https://api.slack.com/methods/rtm.start</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/rtm.start">https://docs.slack.dev/reference/methods/rtm.start</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.search_all"><code class="name flex">
 <span>def <span class="ident">search_all</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13011,7 +13093,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Searches for messages and files matching a query.
-    https://api.slack.com/methods/search.all
+    https://docs.slack.dev/reference/methods/search.all
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13027,7 +13109,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.all&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for messages and files matching a query.
-<a href="https://api.slack.com/methods/search.all">https://api.slack.com/methods/search.all</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.all">https://docs.slack.dev/reference/methods/search.all</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.search_files"><code class="name flex">
 <span>def <span class="ident">search_files</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13050,7 +13132,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Searches for files matching a query.
-    https://api.slack.com/methods/search.files
+    https://docs.slack.dev/reference/methods/search.files
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13066,7 +13148,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.files&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for files matching a query.
-<a href="https://api.slack.com/methods/search.files">https://api.slack.com/methods/search.files</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.files">https://docs.slack.dev/reference/methods/search.files</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.search_messages"><code class="name flex">
 <span>def <span class="ident">search_messages</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>cursor: str | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13090,7 +13172,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Searches for messages matching a query.
-    https://api.slack.com/methods/search.messages
+    https://docs.slack.dev/reference/methods/search.messages
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13107,7 +13189,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.messages&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for messages matching a query.
-<a href="https://api.slack.com/methods/search.messages">https://api.slack.com/methods/search.messages</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.messages">https://docs.slack.dev/reference/methods/search.messages</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.stars_add"><code class="name flex">
 <span>def <span class="ident">stars_add</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13127,7 +13209,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds a star to an item.
-    https://api.slack.com/methods/stars.add
+    https://docs.slack.dev/reference/methods/stars.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13140,7 +13222,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds a star to an item.
-<a href="https://api.slack.com/methods/stars.add">https://api.slack.com/methods/stars.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.add">https://docs.slack.dev/reference/methods/stars.add</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.stars_list"><code class="name flex">
 <span>def <span class="ident">stars_list</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13161,7 +13243,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists stars for a user.
-    https://api.slack.com/methods/stars.list
+    https://docs.slack.dev/reference/methods/stars.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13175,7 +13257,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists stars for a user.
-<a href="https://api.slack.com/methods/stars.list">https://api.slack.com/methods/stars.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.list">https://docs.slack.dev/reference/methods/stars.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.stars_remove"><code class="name flex">
 <span>def <span class="ident">stars_remove</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13195,7 +13277,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a star from an item.
-    https://api.slack.com/methods/stars.remove
+    https://docs.slack.dev/reference/methods/stars.remove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13208,7 +13290,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a star from an item.
-<a href="https://api.slack.com/methods/stars.remove">https://api.slack.com/methods/stars.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.remove">https://docs.slack.dev/reference/methods/stars.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.team_accessLogs"><code class="name flex">
 <span>def <span class="ident">team_accessLogs</span></span>(<span>self,<br>*,<br>before: str | int | None = None,<br>count: str | int | None = None,<br>page: str | int | None = None,<br>team_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13230,7 +13312,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets the access logs for the current team.
-    https://api.slack.com/methods/team.accessLogs
+    https://docs.slack.dev/reference/methods/team.accessLogs
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13245,7 +13327,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.accessLogs&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets the access logs for the current team.
-<a href="https://api.slack.com/methods/team.accessLogs">https://api.slack.com/methods/team.accessLogs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.accessLogs">https://docs.slack.dev/reference/methods/team.accessLogs</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.team_billableInfo"><code class="name flex">
 <span>def <span class="ident">team_billableInfo</span></span>(<span>self, *, team_id: str | None = None, user: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13263,13 +13345,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets billable users information for the current team.
-    https://api.slack.com/methods/team.billableInfo
+    https://docs.slack.dev/reference/methods/team.billableInfo
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
     return self.api_call(&#34;team.billableInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets billable users information for the current team.
-<a href="https://api.slack.com/methods/team.billableInfo">https://api.slack.com/methods/team.billableInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.billableInfo">https://docs.slack.dev/reference/methods/team.billableInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.team_billing_info"><code class="name flex">
 <span>def <span class="ident">team_billing_info</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13284,12 +13366,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Reads a workspace&#39;s billing plan information.
-    https://api.slack.com/methods/team.billing.info
+    https://docs.slack.dev/reference/methods/team.billing.info
     &#34;&#34;&#34;
     return self.api_call(&#34;team.billing.info&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Reads a workspace's billing plan information.
-<a href="https://api.slack.com/methods/team.billing.info">https://api.slack.com/methods/team.billing.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.billing.info">https://docs.slack.dev/reference/methods/team.billing.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.team_externalTeams_disconnect"><code class="name flex">
 <span>def <span class="ident">team_externalTeams_disconnect</span></span>(<span>self, *, target_team: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13306,7 +13388,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Disconnects an external organization.
-    https://api.slack.com/methods/team.externalTeams.disconnect
+    https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13316,7 +13398,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.externalTeams.disconnect&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disconnects an external organization.
-<a href="https://api.slack.com/methods/team.externalTeams.disconnect">https://api.slack.com/methods/team.externalTeams.disconnect</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.externalTeams.disconnect">https://docs.slack.dev/reference/methods/team.externalTeams.disconnect</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.team_externalTeams_list"><code class="name flex">
 <span>def <span class="ident">team_externalTeams_list</span></span>(<span>self,<br>*,<br>connection_status_filter: str | None = None,<br>slack_connect_pref_filter: Sequence[str] | None = None,<br>sort_direction: str | None = None,<br>sort_field: str | None = None,<br>workspace_filter: Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13339,7 +13421,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
-    https://api.slack.com/methods/team.externalTeams.list
+    https://docs.slack.dev/reference/methods/team.externalTeams.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13363,7 +13445,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns a list of all the external teams connected and details about the connection.
-<a href="https://api.slack.com/methods/team.externalTeams.list">https://api.slack.com/methods/team.externalTeams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.externalTeams.list">https://docs.slack.dev/reference/methods/team.externalTeams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.team_info"><code class="name flex">
 <span>def <span class="ident">team_info</span></span>(<span>self, *, team: str | None = None, domain: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13381,13 +13463,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about the current team.
-    https://api.slack.com/methods/team.info
+    https://docs.slack.dev/reference/methods/team.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team&#34;: team, &#34;domain&#34;: domain})
     return self.api_call(&#34;team.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about the current team.
-<a href="https://api.slack.com/methods/team.info">https://api.slack.com/methods/team.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.info">https://docs.slack.dev/reference/methods/team.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.team_integrationLogs"><code class="name flex">
 <span>def <span class="ident">team_integrationLogs</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>change_type: str | None = None,<br>count: str | int | None = None,<br>page: str | int | None = None,<br>service_id: str | None = None,<br>team_id: str | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13410,7 +13492,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets the integration logs for the current team.
-    https://api.slack.com/methods/team.integrationLogs
+    https://docs.slack.dev/reference/methods/team.integrationLogs
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13426,7 +13508,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.integrationLogs&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets the integration logs for the current team.
-<a href="https://api.slack.com/methods/team.integrationLogs">https://api.slack.com/methods/team.integrationLogs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.integrationLogs">https://docs.slack.dev/reference/methods/team.integrationLogs</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.team_preferences_list"><code class="name flex">
 <span>def <span class="ident">team_preferences_list</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13441,12 +13523,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a list of a workspace&#39;s team preferences.
-    https://api.slack.com/methods/team.preferences.list
+    https://docs.slack.dev/reference/methods/team.preferences.list
     &#34;&#34;&#34;
     return self.api_call(&#34;team.preferences.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a list of a workspace's team preferences.
-<a href="https://api.slack.com/methods/team.preferences.list">https://api.slack.com/methods/team.preferences.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.preferences.list">https://docs.slack.dev/reference/methods/team.preferences.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.team_profile_get"><code class="name flex">
 <span>def <span class="ident">team_profile_get</span></span>(<span>self, *, visibility: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13463,13 +13545,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a team&#39;s profile.
-    https://api.slack.com/methods/team.profile.get
+    https://docs.slack.dev/reference/methods/team.profile.get
     &#34;&#34;&#34;
     kwargs.update({&#34;visibility&#34;: visibility})
     return self.api_call(&#34;team.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a team's profile.
-<a href="https://api.slack.com/methods/team.profile.get">https://api.slack.com/methods/team.profile.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.profile.get">https://docs.slack.dev/reference/methods/team.profile.get</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.tooling_tokens_rotate"><code class="name flex">
 <span>def <span class="ident">tooling_tokens_rotate</span></span>(<span>self, *, refresh_token: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13486,13 +13568,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a refresh token for a new app configuration token
-    https://api.slack.com/methods/tooling.tokens.rotate
+    https://docs.slack.dev/reference/methods/tooling.tokens.rotate
     &#34;&#34;&#34;
     kwargs.update({&#34;refresh_token&#34;: refresh_token})
     return self.api_call(&#34;tooling.tokens.rotate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Exchanges a refresh token for a new app configuration token
-<a href="https://api.slack.com/methods/tooling.tokens.rotate">https://api.slack.com/methods/tooling.tokens.rotate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/tooling.tokens.rotate">https://docs.slack.dev/reference/methods/tooling.tokens.rotate</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.usergroups_create"><code class="name flex">
 <span>def <span class="ident">usergroups_create</span></span>(<span>self,<br>*,<br>name: str,<br>channels: str | Sequence[str] | None = None,<br>description: str | None = None,<br>handle: str | None = None,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13514,7 +13596,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a User Group
-    https://api.slack.com/methods/usergroups.create
+    https://docs.slack.dev/reference/methods/usergroups.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13532,7 +13614,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a User Group
-<a href="https://api.slack.com/methods/usergroups.create">https://api.slack.com/methods/usergroups.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.create">https://docs.slack.dev/reference/methods/usergroups.create</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.usergroups_disable"><code class="name flex">
 <span>def <span class="ident">usergroups_disable</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13551,13 +13633,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Disable an existing User Group
-    https://api.slack.com/methods/usergroups.disable
+    https://docs.slack.dev/reference/methods/usergroups.disable
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;usergroups.disable&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disable an existing User Group
-<a href="https://api.slack.com/methods/usergroups.disable">https://api.slack.com/methods/usergroups.disable</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.disable">https://docs.slack.dev/reference/methods/usergroups.disable</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.usergroups_enable"><code class="name flex">
 <span>def <span class="ident">usergroups_enable</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13576,13 +13658,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Enable a User Group
-    https://api.slack.com/methods/usergroups.enable
+    https://docs.slack.dev/reference/methods/usergroups.enable
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;usergroups.enable&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enable a User Group
-<a href="https://api.slack.com/methods/usergroups.enable">https://api.slack.com/methods/usergroups.enable</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.enable">https://docs.slack.dev/reference/methods/usergroups.enable</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.usergroups_list"><code class="name flex">
 <span>def <span class="ident">usergroups_list</span></span>(<span>self,<br>*,<br>include_count: bool | None = None,<br>include_disabled: bool | None = None,<br>include_users: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13602,7 +13684,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all User Groups for a team
-    https://api.slack.com/methods/usergroups.list
+    https://docs.slack.dev/reference/methods/usergroups.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13615,7 +13697,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all User Groups for a team
-<a href="https://api.slack.com/methods/usergroups.list">https://api.slack.com/methods/usergroups.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.list">https://docs.slack.dev/reference/methods/usergroups.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.usergroups_update"><code class="name flex">
 <span>def <span class="ident">usergroups_update</span></span>(<span>self,<br>*,<br>usergroup: str,<br>channels: str | Sequence[str] | None = None,<br>description: str | None = None,<br>handle: str | None = None,<br>include_count: bool | None = None,<br>name: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13638,7 +13720,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an existing User Group
-    https://api.slack.com/methods/usergroups.update
+    https://docs.slack.dev/reference/methods/usergroups.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13657,7 +13739,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing User Group
-<a href="https://api.slack.com/methods/usergroups.update">https://api.slack.com/methods/usergroups.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.update">https://docs.slack.dev/reference/methods/usergroups.update</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.usergroups_users_list"><code class="name flex">
 <span>def <span class="ident">usergroups_users_list</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_disabled: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13676,7 +13758,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all users in a User Group
-    https://api.slack.com/methods/usergroups.users.list
+    https://docs.slack.dev/reference/methods/usergroups.users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13688,7 +13770,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.users.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all users in a User Group
-<a href="https://api.slack.com/methods/usergroups.users.list">https://api.slack.com/methods/usergroups.users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.users.list">https://docs.slack.dev/reference/methods/usergroups.users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.usergroups_users_update"><code class="name flex">
 <span>def <span class="ident">usergroups_users_update</span></span>(<span>self,<br>*,<br>usergroup: str,<br>users: str | Sequence[str],<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13708,7 +13790,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update the list of users for a User Group
-    https://api.slack.com/methods/usergroups.users.update
+    https://docs.slack.dev/reference/methods/usergroups.users.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13724,7 +13806,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update the list of users for a User Group
-<a href="https://api.slack.com/methods/usergroups.users.update">https://api.slack.com/methods/usergroups.users.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.users.update">https://docs.slack.dev/reference/methods/usergroups.users.update</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_conversations"><code class="name flex">
 <span>def <span class="ident">users_conversations</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>exclude_archived: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>types: str | Sequence[str] | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13746,7 +13828,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List conversations the calling user may access.
-    https://api.slack.com/methods/users.conversations
+    https://docs.slack.dev/reference/methods/users.conversations
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13764,7 +13846,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.conversations&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List conversations the calling user may access.
-<a href="https://api.slack.com/methods/users.conversations">https://api.slack.com/methods/users.conversations</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.conversations">https://docs.slack.dev/reference/methods/users.conversations</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_deletePhoto"><code class="name flex">
 <span>def <span class="ident">users_deletePhoto</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13779,12 +13861,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Delete the user profile photo
-    https://api.slack.com/methods/users.deletePhoto
+    https://docs.slack.dev/reference/methods/users.deletePhoto
     &#34;&#34;&#34;
     return self.api_call(&#34;users.deletePhoto&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete the user profile photo
-<a href="https://api.slack.com/methods/users.deletePhoto">https://api.slack.com/methods/users.deletePhoto</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.deletePhoto">https://docs.slack.dev/reference/methods/users.deletePhoto</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_discoverableContacts_lookup"><code class="name flex">
 <span>def <span class="ident">users_discoverableContacts_lookup</span></span>(<span>self, email: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13800,13 +13882,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lookup an email address to see if someone is on Slack
-    https://api.slack.com/methods/users.discoverableContacts.lookup
+    https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
     &#34;&#34;&#34;
     kwargs.update({&#34;email&#34;: email})
     return self.api_call(&#34;users.discoverableContacts.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lookup an email address to see if someone is on Slack
-<a href="https://api.slack.com/methods/users.discoverableContacts.lookup">https://api.slack.com/methods/users.discoverableContacts.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup">https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_getPresence"><code class="name flex">
 <span>def <span class="ident">users_getPresence</span></span>(<span>self, *, user: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13823,13 +13905,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets user presence information.
-    https://api.slack.com/methods/users.getPresence
+    https://docs.slack.dev/reference/methods/users.getPresence
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user})
     return self.api_call(&#34;users.getPresence&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets user presence information.
-<a href="https://api.slack.com/methods/users.getPresence">https://api.slack.com/methods/users.getPresence</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.getPresence">https://docs.slack.dev/reference/methods/users.getPresence</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_identity"><code class="name flex">
 <span>def <span class="ident">users_identity</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13844,12 +13926,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get a user&#39;s identity.
-    https://api.slack.com/methods/users.identity
+    https://docs.slack.dev/reference/methods/users.identity
     &#34;&#34;&#34;
     return self.api_call(&#34;users.identity&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a user's identity.
-<a href="https://api.slack.com/methods/users.identity">https://api.slack.com/methods/users.identity</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.identity">https://docs.slack.dev/reference/methods/users.identity</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_info"><code class="name flex">
 <span>def <span class="ident">users_info</span></span>(<span>self, *, user: str, include_locale: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13867,13 +13949,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a user.
-    https://api.slack.com/methods/users.info
+    https://docs.slack.dev/reference/methods/users.info
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user, &#34;include_locale&#34;: include_locale})
     return self.api_call(&#34;users.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a user.
-<a href="https://api.slack.com/methods/users.info">https://api.slack.com/methods/users.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.info">https://docs.slack.dev/reference/methods/users.info</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_list"><code class="name flex">
 <span>def <span class="ident">users_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>include_locale: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13893,7 +13975,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all users in a Slack team.
-    https://api.slack.com/methods/users.list
+    https://docs.slack.dev/reference/methods/users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13906,7 +13988,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all users in a Slack team.
-<a href="https://api.slack.com/methods/users.list">https://api.slack.com/methods/users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.list">https://docs.slack.dev/reference/methods/users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_lookupByEmail"><code class="name flex">
 <span>def <span class="ident">users_lookupByEmail</span></span>(<span>self, *, email: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13923,13 +14005,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Find a user with an email address.
-    https://api.slack.com/methods/users.lookupByEmail
+    https://docs.slack.dev/reference/methods/users.lookupByEmail
     &#34;&#34;&#34;
     kwargs.update({&#34;email&#34;: email})
     return self.api_call(&#34;users.lookupByEmail&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Find a user with an email address.
-<a href="https://api.slack.com/methods/users.lookupByEmail">https://api.slack.com/methods/users.lookupByEmail</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.lookupByEmail">https://docs.slack.dev/reference/methods/users.lookupByEmail</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_profile_get"><code class="name flex">
 <span>def <span class="ident">users_profile_get</span></span>(<span>self, *, user: str | None = None, include_labels: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13947,13 +14029,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieves a user&#39;s profile information.
-    https://api.slack.com/methods/users.profile.get
+    https://docs.slack.dev/reference/methods/users.profile.get
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user, &#34;include_labels&#34;: include_labels})
     return self.api_call(&#34;users.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves a user's profile information.
-<a href="https://api.slack.com/methods/users.profile.get">https://api.slack.com/methods/users.profile.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.profile.get">https://docs.slack.dev/reference/methods/users.profile.get</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_profile_set"><code class="name flex">
 <span>def <span class="ident">users_profile_set</span></span>(<span>self,<br>*,<br>name: str | None = None,<br>value: str | None = None,<br>user: str | None = None,<br>profile: Dict | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13973,7 +14055,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the profile information for a user.
-    https://api.slack.com/methods/users.profile.set
+    https://docs.slack.dev/reference/methods/users.profile.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13988,7 +14070,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.profile.set&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the profile information for a user.
-<a href="https://api.slack.com/methods/users.profile.set">https://api.slack.com/methods/users.profile.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.profile.set">https://docs.slack.dev/reference/methods/users.profile.set</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_setPhoto"><code class="name flex">
 <span>def <span class="ident">users_setPhoto</span></span>(<span>self,<br>*,<br>image: str | io.IOBase,<br>crop_w: str | int | None = None,<br>crop_x: str | int | None = None,<br>crop_y: str | int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14008,13 +14090,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the user profile photo
-    https://api.slack.com/methods/users.setPhoto
+    https://docs.slack.dev/reference/methods/users.setPhoto
     &#34;&#34;&#34;
     kwargs.update({&#34;crop_w&#34;: crop_w, &#34;crop_x&#34;: crop_x, &#34;crop_y&#34;: crop_y})
     return self.api_call(&#34;users.setPhoto&#34;, files={&#34;image&#34;: image}, data=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the user profile photo
-<a href="https://api.slack.com/methods/users.setPhoto">https://api.slack.com/methods/users.setPhoto</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.setPhoto">https://docs.slack.dev/reference/methods/users.setPhoto</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.users_setPresence"><code class="name flex">
 <span>def <span class="ident">users_setPresence</span></span>(<span>self, *, presence: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14031,13 +14113,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Manually sets user presence.
-    https://api.slack.com/methods/users.setPresence
+    https://docs.slack.dev/reference/methods/users.setPresence
     &#34;&#34;&#34;
     kwargs.update({&#34;presence&#34;: presence})
     return self.api_call(&#34;users.setPresence&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Manually sets user presence.
-<a href="https://api.slack.com/methods/users.setPresence">https://api.slack.com/methods/users.setPresence</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.setPresence">https://docs.slack.dev/reference/methods/users.setPresence</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.views_open"><code class="name flex">
 <span>def <span class="ident">views_open</span></span>(<span>self,<br>*,<br>trigger_id: str | None = None,<br>interactivity_pointer: str | None = None,<br>view: dict | <a title="slack_sdk.models.views.View" href="models/views/index.html#slack_sdk.models.views.View">View</a>,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14056,8 +14138,8 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Open a view for a user.
-    https://api.slack.com/methods/views.open
-    See https://api.slack.com/surfaces/modals for details.
+    https://docs.slack.dev/reference/methods/views.open
+    See https://docs.slack.dev/surfaces/modals/ for details.
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
     if isinstance(view, View):
@@ -14069,8 +14151,8 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;views.open&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Open a view for a user.
-<a href="https://api.slack.com/methods/views.open">https://api.slack.com/methods/views.open</a>
-See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a> for details.</p></div>
+<a href="https://docs.slack.dev/reference/methods/views.open">https://docs.slack.dev/reference/methods/views.open</a>
+See <a href="https://docs.slack.dev/surfaces/modals/">https://docs.slack.dev/surfaces/modals/</a> for details.</p></div>
 </dd>
 <dt id="slack_sdk.WebClient.views_publish"><code class="name flex">
 <span>def <span class="ident">views_publish</span></span>(<span>self,<br>*,<br>user_id: str,<br>view: dict | <a title="slack_sdk.models.views.View" href="models/views/index.html#slack_sdk.models.views.View">View</a>,<br>hash: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14090,8 +14172,8 @@ See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfac
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Publish a static view for a User.
     Create or update the view that comprises an
-    app&#39;s Home tab (https://api.slack.com/surfaces/tabs)
-    https://api.slack.com/methods/views.publish
+    app&#39;s Home tab (https://docs.slack.dev/surfaces/app-home/)
+    https://docs.slack.dev/reference/methods/views.publish
     &#34;&#34;&#34;
     kwargs.update({&#34;user_id&#34;: user_id, &#34;hash&#34;: hash})
     if isinstance(view, View):
@@ -14104,8 +14186,8 @@ See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfac
 </details>
 <div class="desc"><p>Publish a static view for a User.
 Create or update the view that comprises an
-app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.com/surfaces/tabs</a>)
-<a href="https://api.slack.com/methods/views.publish">https://api.slack.com/methods/views.publish</a></p></div>
+app's Home tab (<a href="https://docs.slack.dev/surfaces/app-home/">https://docs.slack.dev/surfaces/app-home/</a>)
+<a href="https://docs.slack.dev/reference/methods/views.publish">https://docs.slack.dev/reference/methods/views.publish</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.views_push"><code class="name flex">
 <span>def <span class="ident">views_push</span></span>(<span>self,<br>*,<br>trigger_id: str | None = None,<br>interactivity_pointer: str | None = None,<br>view: dict | <a title="slack_sdk.models.views.View" href="models/views/index.html#slack_sdk.models.views.View">View</a>,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14127,9 +14209,9 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
     Push a new view onto the existing view stack by passing a view
     payload and a valid trigger_id generated from an interaction
     within the existing modal.
-    Read the modals documentation (https://api.slack.com/surfaces/modals)
+    Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
     to learn more about the lifecycle and intricacies of views.
-    https://api.slack.com/methods/views.push
+    https://docs.slack.dev/reference/methods/views.push
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
     if isinstance(view, View):
@@ -14144,9 +14226,9 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
 Push a new view onto the existing view stack by passing a view
 payload and a valid trigger_id generated from an interaction
 within the existing modal.
-Read the modals documentation (<a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a>)
+Read the modals documentation (<a href="https://docs.slack.dev/surfaces/modals/">https://docs.slack.dev/surfaces/modals/</a>)
 to learn more about the lifecycle and intricacies of views.
-<a href="https://api.slack.com/methods/views.push">https://api.slack.com/methods/views.push</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/views.push">https://docs.slack.dev/reference/methods/views.push</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.views_update"><code class="name flex">
 <span>def <span class="ident">views_update</span></span>(<span>self,<br>*,<br>view: dict | <a title="slack_sdk.models.views.View" href="models/views/index.html#slack_sdk.models.views.View">View</a>,<br>external_id: str | None = None,<br>view_id: str | None = None,<br>hash: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14168,9 +14250,9 @@ to learn more about the lifecycle and intricacies of views.
     &#34;&#34;&#34;Update an existing view.
     Update a view by passing a new view definition along with the
     view_id returned in views.open or the external_id.
-    See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+    See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
     to learn more about updating views and avoiding race conditions with the hash argument.
-    https://api.slack.com/methods/views.update
+    https://docs.slack.dev/reference/methods/views.update
     &#34;&#34;&#34;
     if isinstance(view, View):
         kwargs.update({&#34;view&#34;: view.to_dict()})
@@ -14190,9 +14272,119 @@ to learn more about the lifecycle and intricacies of views.
 <div class="desc"><p>Update an existing view.
 Update a view by passing a new view definition along with the
 view_id returned in views.open or the external_id.
-See the modals documentation (<a href="https://api.slack.com/surfaces/modals#updating_views">https://api.slack.com/surfaces/modals#updating_views</a>)
+See the modals documentation (<a href="https://docs.slack.dev/surfaces/modals/#updating_views">https://docs.slack.dev/surfaces/modals/#updating_views</a>)
 to learn more about updating views and avoiding race conditions with the hash argument.
-<a href="https://api.slack.com/methods/views.update">https://api.slack.com/methods/views.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/views.update">https://docs.slack.dev/reference/methods/views.update</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.workflows_featured_add"><code class="name flex">
+<span>def <span class="ident">workflows_featured_add</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_add(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Add featured workflows to a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.add
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.add&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Add featured workflows to a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.add">https://docs.slack.dev/reference/methods/workflows.featured.add</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.workflows_featured_list"><code class="name flex">
+<span>def <span class="ident">workflows_featured_list</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_list(
+    self,
+    *,
+    channel_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;List the featured workflows for specified channels.
+    https://docs.slack.dev/reference/methods/workflows.featured.list
+    &#34;&#34;&#34;
+    if isinstance(channel_ids, (list, tuple)):
+        kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
+    else:
+        kwargs.update({&#34;channel_ids&#34;: channel_ids})
+    return self.api_call(&#34;workflows.featured.list&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>List the featured workflows for specified channels.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.list">https://docs.slack.dev/reference/methods/workflows.featured.list</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.workflows_featured_remove"><code class="name flex">
+<span>def <span class="ident">workflows_featured_remove</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_remove(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Remove featured workflows from a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.remove
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.remove&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Remove featured workflows from a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.remove">https://docs.slack.dev/reference/methods/workflows.featured.remove</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.workflows_featured_set"><code class="name flex">
+<span>def <span class="ident">workflows_featured_set</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_set(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Set featured workflows for a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.set
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.set&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Set featured workflows for a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.set">https://docs.slack.dev/reference/methods/workflows.featured.set</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.workflows_stepCompleted"><code class="name flex">
 <span>def <span class="ident">workflows_stepCompleted</span></span>(<span>self, *, workflow_step_execute_id: str, outputs: dict | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14210,7 +14402,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Indicate a successful outcome of a workflow step&#39;s execution.
-    https://api.slack.com/methods/workflows.stepCompleted
+    https://docs.slack.dev/reference/methods/workflows.stepCompleted
     &#34;&#34;&#34;
     kwargs.update({&#34;workflow_step_execute_id&#34;: workflow_step_execute_id})
     if outputs is not None:
@@ -14220,7 +14412,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.stepCompleted&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Indicate a successful outcome of a workflow step's execution.
-<a href="https://api.slack.com/methods/workflows.stepCompleted">https://api.slack.com/methods/workflows.stepCompleted</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.stepCompleted">https://docs.slack.dev/reference/methods/workflows.stepCompleted</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.workflows_stepFailed"><code class="name flex">
 <span>def <span class="ident">workflows_stepFailed</span></span>(<span>self, *, workflow_step_execute_id: str, error: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14238,7 +14430,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Indicate an unsuccessful outcome of a workflow step&#39;s execution.
-    https://api.slack.com/methods/workflows.stepFailed
+    https://docs.slack.dev/reference/methods/workflows.stepFailed
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -14251,7 +14443,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.stepFailed&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Indicate an unsuccessful outcome of a workflow step's execution.
-<a href="https://api.slack.com/methods/workflows.stepFailed">https://api.slack.com/methods/workflows.stepFailed</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.stepFailed">https://docs.slack.dev/reference/methods/workflows.stepFailed</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.workflows_updateStep"><code class="name flex">
 <span>def <span class="ident">workflows_updateStep</span></span>(<span>self,<br>*,<br>workflow_step_edit_id: str,<br>inputs: Dict[str, Any] | None = None,<br>outputs: List[Dict[str, str]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14270,7 +14462,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update the configuration for a workflow extension step.
-    https://api.slack.com/methods/workflows.updateStep
+    https://docs.slack.dev/reference/methods/workflows.updateStep
     &#34;&#34;&#34;
     kwargs.update({&#34;workflow_step_edit_id&#34;: workflow_step_edit_id})
     if inputs is not None:
@@ -14282,7 +14474,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.updateStep&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update the configuration for a workflow extension step.
-<a href="https://api.slack.com/methods/workflows.updateStep">https://api.slack.com/methods/workflows.updateStep</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.updateStep">https://docs.slack.dev/reference/methods/workflows.updateStep</a></p></div>
 </dd>
 </dl>
 <h3>Inherited members</h3>
@@ -14335,7 +14527,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     ):
         &#34;&#34;&#34;API client for Incoming Webhooks and `response_url`
 
-        https://api.slack.com/messaging/webhooks
+        https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/
 
         Args:
             url: Complete URL to send data (e.g., `https://hooks.slack.com/XXX`)
@@ -14554,19 +14746,19 @@ to learn more about updating views and avoiding race conditions with the hash ar
             http_resp = opener.open(req, timeout=self.timeout)
         else:
             http_resp = urlopen(req, context=self.ssl, timeout=self.timeout)
-        charset: str = http_resp.headers.get_content_charset() or &#34;utf-8&#34;  # type: ignore[union-attr]
-        response_body: str = http_resp.read().decode(charset)  # type: ignore[union-attr]
+        charset: str = http_resp.headers.get_content_charset() or &#34;utf-8&#34;
+        response_body: str = http_resp.read().decode(charset)
         resp = WebhookResponse(
             url=url,
-            status_code=http_resp.status,  # type: ignore[union-attr]
+            status_code=http_resp.status,
             body=response_body,
-            headers=http_resp.headers,  # type: ignore[arg-type, union-attr]
+            headers=http_resp.headers,  # type: ignore[arg-type]
         )
         _debug_log_response(self.logger, resp)
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for Incoming Webhooks and <code>response_url</code></p>
-<p><a href="https://api.slack.com/messaging/webhooks">https://api.slack.com/messaging/webhooks</a></p>
+<p><a href="https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/">https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>url</code></strong></dt>
@@ -15077,6 +15269,10 @@ if you give this argument, body_params and files will be skipped</dd>
 <li><code><a title="slack_sdk.WebClient.views_publish" href="#slack_sdk.WebClient.views_publish">views_publish</a></code></li>
 <li><code><a title="slack_sdk.WebClient.views_push" href="#slack_sdk.WebClient.views_push">views_push</a></code></li>
 <li><code><a title="slack_sdk.WebClient.views_update" href="#slack_sdk.WebClient.views_update">views_update</a></code></li>
+<li><code><a title="slack_sdk.WebClient.workflows_featured_add" href="#slack_sdk.WebClient.workflows_featured_add">workflows_featured_add</a></code></li>
+<li><code><a title="slack_sdk.WebClient.workflows_featured_list" href="#slack_sdk.WebClient.workflows_featured_list">workflows_featured_list</a></code></li>
+<li><code><a title="slack_sdk.WebClient.workflows_featured_remove" href="#slack_sdk.WebClient.workflows_featured_remove">workflows_featured_remove</a></code></li>
+<li><code><a title="slack_sdk.WebClient.workflows_featured_set" href="#slack_sdk.WebClient.workflows_featured_set">workflows_featured_set</a></code></li>
 <li><code><a title="slack_sdk.WebClient.workflows_stepCompleted" href="#slack_sdk.WebClient.workflows_stepCompleted">workflows_stepCompleted</a></code></li>
 <li><code><a title="slack_sdk.WebClient.workflows_stepFailed" href="#slack_sdk.WebClient.workflows_stepFailed">workflows_stepFailed</a></code></li>
 <li><code><a title="slack_sdk.WebClient.workflows_updateStep" href="#slack_sdk.WebClient.workflows_updateStep">workflows_updateStep</a></code></li>

--- a/docs/reference/models/attachments/index.html
+++ b/docs/reference/models/attachments/index.html
@@ -82,8 +82,8 @@ el.replaceWith(d);
         return json</code></pre>
 </details>
 <div class="desc"><p>Action in attachments
-<a href="https://api.slack.com/messaging/composing/layouts#attachments">https://api.slack.com/messaging/composing/layouts#attachments</a>
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields">https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields</a></p></div>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts">https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts</a>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.attachments.Action" href="#slack_sdk.models.attachments.Action">Action</a></li>
@@ -161,8 +161,8 @@ def data_source_valid(self):
 </summary>
 <pre><code class="python">class Action(JsonObject):
     &#34;&#34;&#34;Action in attachments
-    https://api.slack.com/messaging/composing/layouts#attachments
-    https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields
+    https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts
+    https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields
     &#34;&#34;&#34;
 
     attributes = {&#34;name&#34;, &#34;text&#34;, &#34;url&#34;}
@@ -190,8 +190,8 @@ def data_source_valid(self):
         return json</code></pre>
 </details>
 <div class="desc"><p>Action in attachments
-<a href="https://api.slack.com/messaging/composing/layouts#attachments">https://api.slack.com/messaging/composing/layouts#attachments</a>
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields">https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields</a></p></div>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts">https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts</a>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
@@ -265,7 +265,7 @@ def name_or_url_present(self):
     ):
         &#34;&#34;&#34;Simple button for use inside attachments
 
-        https://api.slack.com/legacy/message-buttons
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/
 
         Args:
             name: Name this specific action. The name will be returned to your
@@ -303,10 +303,10 @@ def name_or_url_present(self):
         return json</code></pre>
 </details>
 <div class="desc"><p>Action in attachments
-<a href="https://api.slack.com/messaging/composing/layouts#attachments">https://api.slack.com/messaging/composing/layouts#attachments</a>
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields">https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields</a></p>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts">https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts</a>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields</a></p>
 <p>Simple button for use inside attachments</p>
-<p><a href="https://api.slack.com/legacy/message-buttons">https://api.slack.com/legacy/message-buttons</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/">https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -416,7 +416,7 @@ def value_length(self):
         Automatically populate the selector with a list of public channels in the
         workspace.
 
-        https://api.slack.com/legacy/message-menus#let_users_choose_one_of_their_workspace_s_channels
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_channels
 
         Args:
             name: Name this specific action. The name will be returned to your
@@ -430,11 +430,11 @@ def value_length(self):
         super().__init__(name=name, text=text, selected_option=selected_channel)</code></pre>
 </details>
 <div class="desc"><p>Action in attachments
-<a href="https://api.slack.com/messaging/composing/layouts#attachments">https://api.slack.com/messaging/composing/layouts#attachments</a>
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields">https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields</a></p>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts">https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts</a>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields</a></p>
 <p>Automatically populate the selector with a list of public channels in the
 workspace.</p>
-<p><a href="https://api.slack.com/legacy/message-menus#let_users_choose_one_of_their_workspace_s_channels">https://api.slack.com/legacy/message-menus#let_users_choose_one_of_their_workspace_s_channels</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_channels">https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_channels</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -492,7 +492,7 @@ value.</dd>
         Automatically populate the selector with a list of conversations they have in
         the workspace.
 
-        https://api.slack.com/legacy/message-menus#let_users_choose_one_of_their_conversations
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_conversations
 
         Args:
             name: Name this specific action. The name will be returned to your
@@ -506,11 +506,11 @@ value.</dd>
         super().__init__(name=name, text=text, selected_option=selected_conversation)</code></pre>
 </details>
 <div class="desc"><p>Action in attachments
-<a href="https://api.slack.com/messaging/composing/layouts#attachments">https://api.slack.com/messaging/composing/layouts#attachments</a>
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields">https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields</a></p>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts">https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts</a>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields</a></p>
 <p>Automatically populate the selector with a list of conversations they have in
 the workspace.</p>
-<p><a href="https://api.slack.com/legacy/message-menus#let_users_choose_one_of_their_conversations">https://api.slack.com/legacy/message-menus#let_users_choose_one_of_their_conversations</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_conversations">https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_conversations</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -578,7 +578,7 @@ value.</dd>
         &#34;&#34;&#34;
         Populate a message select menu from your own application dynamically.
 
-        https://api.slack.com/legacy/message-menus#populate_message_menus_dynamically
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_dynamic
 
         Args:
             name: Name this specific action. The name will be returned to your
@@ -595,10 +595,10 @@ value.</dd>
         self.min_query_length = min_query_length</code></pre>
 </details>
 <div class="desc"><p>Action in attachments
-<a href="https://api.slack.com/messaging/composing/layouts#attachments">https://api.slack.com/messaging/composing/layouts#attachments</a>
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields">https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields</a></p>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts">https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts</a>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields</a></p>
 <p>Populate a message select menu from your own application dynamically.</p>
-<p><a href="https://api.slack.com/legacy/message-menus#populate_message_menus_dynamically">https://api.slack.com/legacy/message-menus#populate_message_menus_dynamically</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_dynamic">https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_dynamic</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -669,7 +669,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     def __init__(self, *, text: str, url: str):
         &#34;&#34;&#34;A simple interactive button that just opens a URL
 
-        https://api.slack.com/messaging/composing/layouts#attachments
+        https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts
 
         Args:
           text: text to display on the button, eg &#39;Click Me!&#34;
@@ -678,10 +678,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         super().__init__(text=text, url=url, subtype=&#34;button&#34;)</code></pre>
 </details>
 <div class="desc"><p>Action in attachments
-<a href="https://api.slack.com/messaging/composing/layouts#attachments">https://api.slack.com/messaging/composing/layouts#attachments</a>
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields">https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields</a></p>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts">https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts</a>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields</a></p>
 <p>A simple interactive button that just opens a URL</p>
-<p><a href="https://api.slack.com/messaging/composing/layouts#attachments">https://api.slack.com/messaging/composing/layouts#attachments</a></p>
+<p><a href="https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts">https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong></dt>
@@ -722,7 +722,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     def __init__(self, name: str, text: str, selected_user: Optional[Option] = None):
         &#34;&#34;&#34;Automatically populate the selector with a list of users in the workspace.
 
-        https://api.slack.com/legacy/message-menus#allow_users_to_select_from_a_list_of_members
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_team_members
 
         Args:
             name: Name this specific action. The name will be returned to your
@@ -736,10 +736,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         super().__init__(name=name, text=text, selected_option=selected_user)</code></pre>
 </details>
 <div class="desc"><p>Action in attachments
-<a href="https://api.slack.com/messaging/composing/layouts#attachments">https://api.slack.com/messaging/composing/layouts#attachments</a>
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields">https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields</a></p>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts">https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts</a>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields</a></p>
 <p>Automatically populate the selector with a list of users in the workspace.</p>
-<p><a href="https://api.slack.com/legacy/message-menus#allow_users_to_select_from_a_list_of_members">https://api.slack.com/legacy/message-menus#allow_users_to_select_from_a_list_of_members</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_team_members">https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_team_members</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -840,7 +840,7 @@ value.</dd>
         A supplemental object that will display after the rest of the message.
         Considered legacy - recommended replacement is to use message blocks instead.
 
-        https://api.slack.com/reference/messaging/attachments#fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields
 
         Args:
             text: The main body text of the attachment. It can be formatted as
@@ -956,7 +956,7 @@ value.</dd>
 <div class="desc"><p>The base class for JSON serializable class objects</p>
 <p>A supplemental object that will display after the rest of the message.
 Considered legacy - recommended replacement is to use message blocks instead.</p>
-<p><a href="https://api.slack.com/reference/messaging/attachments#fields">https://api.slack.com/reference/messaging/attachments#fields</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong></dt>
@@ -1247,7 +1247,7 @@ def ts_without_footer(self) -&gt; bool:
         A bridge between legacy attachments and Block Kit formatting - pass a list of
         Block objects directly to this attachment.
 
-        https://api.slack.com/reference/messaging/attachments#fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields
 
         Args:
             blocks: a sequence of Block objects
@@ -1272,7 +1272,7 @@ def ts_without_footer(self) -&gt; bool:
 <div class="desc"><p>The base class for JSON serializable class objects</p>
 <p>A bridge between legacy attachments and Block Kit formatting - pass a list of
 Block objects directly to this attachment.</p>
-<p><a href="https://api.slack.com/reference/messaging/attachments#fields">https://api.slack.com/reference/messaging/attachments#fields</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>blocks</code></strong></dt>
@@ -1386,8 +1386,8 @@ def fields_attribute_absent(self) -&gt; bool:
         An Attachment, but designed to contain interactive Actions
         Considered legacy - recommended replacement is to use message blocks instead.
 
-        https://api.slack.com/legacy/interactive-message-field-guide#attachment_fields
-        https://api.slack.com/reference/messaging/attachments#fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#attachment_fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields
 
         Args:
             actions: A collection of Action objects to include in the attachment.
@@ -1481,8 +1481,8 @@ def fields_attribute_absent(self) -&gt; bool:
 <div class="desc"><p>The base class for JSON serializable class objects</p>
 <p>An Attachment, but designed to contain interactive Actions
 Considered legacy - recommended replacement is to use message blocks instead.</p>
-<p><a href="https://api.slack.com/legacy/interactive-message-field-guide#attachment_fields">https://api.slack.com/legacy/interactive-message-field-guide#attachment_fields</a>
-<a href="https://api.slack.com/reference/messaging/attachments#fields">https://api.slack.com/reference/messaging/attachments#fields</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#attachment_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#attachment_fields</a>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>actions</code></strong></dt>

--- a/docs/reference/models/blocks/basic_components.html
+++ b/docs/reference/models/blocks/basic_components.html
@@ -56,7 +56,7 @@ el.replaceWith(d);
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class ConfirmObject(JsonObject):
-    attributes = {}  # type: ignore[assignment] # no attributes because to_dict has unique implementations
+    attributes: Set[str] = set()
 
     title_max_length = 100
     text_max_length = 300
@@ -88,7 +88,7 @@ el.replaceWith(d);
         An object that defines a dialog that provides a confirmation step to any
         interactive element. This dialog will ask the user to confirm their action by
         offering a confirm and deny button.
-        https://api.slack.com/reference/block-kit/composition-objects#confirm
+        https://docs.slack.dev/reference/block-kit/composition-objects/confirmation-dialog-object/
         &#34;&#34;&#34;
         self._title = TextObject.parse(title, default_type=PlainTextObject.type)
         self._text = TextObject.parse(text, default_type=MarkdownTextObject.type)
@@ -156,7 +156,7 @@ el.replaceWith(d);
 <p>An object that defines a dialog that provides a confirmation step to any
 interactive element. This dialog will ask the user to confirm their action by
 offering a confirm and deny button.
-<a href="https://api.slack.com/reference/block-kit/composition-objects#confirm">https://api.slack.com/reference/block-kit/composition-objects#confirm</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/confirmation-dialog-object/">https://docs.slack.dev/reference/block-kit/composition-objects/confirmation-dialog-object/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
@@ -164,7 +164,7 @@ offering a confirm and deny button.
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="slack_sdk.models.blocks.basic_components.ConfirmObject.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dt id="slack_sdk.models.blocks.basic_components.ConfirmObject.attributes"><code class="name">var <span class="ident">attributes</span> : Set[str]</code></dt>
 <dd>
 <div class="desc"><p>The type of the None singleton.</p></div>
 </dd>
@@ -295,7 +295,7 @@ def title_length(self) -&gt; bool:
     ):
         &#34;&#34;&#34;
         Determines when a plain-text input element will return a block_actions interaction payload.
-        https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config
+        https://docs.slack.dev/reference/block-kit/composition-objects/dispatch-action-configuration-object
         &#34;&#34;&#34;
         self._trigger_actions_on = trigger_actions_on or []
 
@@ -308,7 +308,7 @@ def title_length(self) -&gt; bool:
 </details>
 <div class="desc"><p>The base class for JSON serializable class objects</p>
 <p>Determines when a plain-text input element will return a block_actions interaction payload.
-<a href="https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config">https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/dispatch-action-configuration-object">https://docs.slack.dev/reference/block-kit/composition-objects/dispatch-action-configuration-object</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
@@ -362,7 +362,7 @@ def title_length(self) -&gt; bool:
     def __init__(self, *, text: str, verbatim: Optional[bool] = None):
         &#34;&#34;&#34;A Markdown text object, meaning markdown characters will be parsed as
         formatting information.
-        https://api.slack.com/reference/block-kit/composition-objects#text
+        https://docs.slack.dev/reference/block-kit/composition-objects/text-object
 
         Args:
             text (required): The text for the block. This field accepts any of the standard text formatting markup
@@ -406,7 +406,7 @@ def title_length(self) -&gt; bool:
 <div class="desc"><p>mrkdwn typed text object</p>
 <p>A Markdown text object, meaning markdown characters will be parsed as
 formatting information.
-<a href="https://api.slack.com/reference/block-kit/composition-objects#text">https://api.slack.com/reference/block-kit/composition-objects#text</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/text-object">https://docs.slack.dev/reference/block-kit/composition-objects/text-object</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
@@ -546,7 +546,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     different required formats in different situations
     &#34;&#34;&#34;
 
-    attributes = {}  # type: ignore[assignment] # no attributes because to_dict has unique implementations
+    attributes: Set[str] = set()
     logger = logging.getLogger(__name__)
 
     label_max_length = 75
@@ -568,13 +568,13 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         (StaticDialogSelectElement)
 
         Blocks:
-        https://api.slack.com/reference/block-kit/composition-objects#option
+        https://docs.slack.dev/reference/block-kit/composition-objects/option-object
 
         Dialogs:
-        https://api.slack.com/dialogs#select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
 
         Legacy interactive attachments:
-        https://api.slack.com/legacy/interactive-message-field-guide#option_fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_fields
 
         Args:
             label: A short, user-facing string to label this option to users.
@@ -693,11 +693,11 @@ different required formats in different situations</p>
 SelectElement, OverflowMenuElement) or dialog element
 (StaticDialogSelectElement)</p>
 <p>Blocks:
-<a href="https://api.slack.com/reference/block-kit/composition-objects#option">https://api.slack.com/reference/block-kit/composition-objects#option</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/option-object">https://docs.slack.dev/reference/block-kit/composition-objects/option-object</a></p>
 <p>Dialogs:
-<a href="https://api.slack.com/dialogs#select_elements">https://api.slack.com/dialogs#select_elements</a></p>
+<a href="https://docs.slack.dev/legacy/legacy-dialogs/#select_elements">https://docs.slack.dev/legacy/legacy-dialogs/#select_elements</a></p>
 <p>Legacy interactive attachments:
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#option_fields">https://api.slack.com/legacy/interactive-message-field-guide#option_fields</a></p>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_fields</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>label</code></strong></dt>
@@ -719,7 +719,7 @@ dialogs.</dd>
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="slack_sdk.models.blocks.basic_components.Option.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dt id="slack_sdk.models.blocks.basic_components.Option.attributes"><code class="name">var <span class="ident">attributes</span> : Set[str]</code></dt>
 <dd>
 <div class="desc"><p>The type of the None singleton.</p></div>
 </dd>
@@ -828,7 +828,7 @@ correct shape.</p></div>
     different required formats in different situations
     &#34;&#34;&#34;
 
-    attributes = {}  # type: ignore[assignment] # no attributes because to_dict has unique implementations
+    attributes: Set[str] = set()
     label_max_length = 75
     options_max_length = 100
     logger = logging.getLogger(__name__)
@@ -845,13 +845,13 @@ correct shape.</p></div>
         UI) and a list of Option objects.
 
         Blocks:
-        https://api.slack.com/reference/block-kit/composition-objects#option-group
+        https://docs.slack.dev/reference/block-kit/composition-objects/option-group-object
 
         Dialogs:
-        https://api.slack.com/dialogs#select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
 
         Legacy interactive attachments:
-        https://api.slack.com/legacy/interactive-message-field-guide#option_groups_to_place_within_message_menu_actions
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_groups
 
         Args:
             label: Text to display at the top of this group of options.
@@ -913,11 +913,11 @@ different required formats in different situations</p>
 <p>Create a group of Option objects - pass in a label (that will be part of the
 UI) and a list of Option objects.</p>
 <p>Blocks:
-<a href="https://api.slack.com/reference/block-kit/composition-objects#option-group">https://api.slack.com/reference/block-kit/composition-objects#option-group</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/option-group-object">https://docs.slack.dev/reference/block-kit/composition-objects/option-group-object</a></p>
 <p>Dialogs:
-<a href="https://api.slack.com/dialogs#select_elements">https://api.slack.com/dialogs#select_elements</a></p>
+<a href="https://docs.slack.dev/legacy/legacy-dialogs/#select_elements">https://docs.slack.dev/legacy/legacy-dialogs/#select_elements</a></p>
 <p>Legacy interactive attachments:
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#option_groups_to_place_within_message_menu_actions">https://api.slack.com/legacy/interactive-message-field-guide#option_groups_to_place_within_message_menu_actions</a></p>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_groups">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_groups</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>label</code></strong></dt>
@@ -932,7 +932,7 @@ UI) and a list of Option objects.</p>
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="slack_sdk.models.blocks.basic_components.OptionGroup.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dt id="slack_sdk.models.blocks.basic_components.OptionGroup.attributes"><code class="name">var <span class="ident">attributes</span> : Set[str]</code></dt>
 <dd>
 <div class="desc"><p>The type of the None singleton.</p></div>
 </dd>
@@ -990,7 +990,7 @@ UI) and a list of Option objects.</p>
     def __init__(self, *, text: str, emoji: Optional[bool] = None):
         &#34;&#34;&#34;A plain text object, meaning markdown characters will not be parsed as
         formatting information.
-        https://api.slack.com/reference/block-kit/composition-objects#text
+        https://docs.slack.dev/reference/block-kit/composition-objects/text-object
 
         Args:
             text (required): The text for the block. This field accepts any of the standard text formatting markup
@@ -1013,7 +1013,7 @@ UI) and a list of Option objects.</p>
 <div class="desc"><p>plain_text typed text object</p>
 <p>A plain text object, meaning markdown characters will not be parsed as
 formatting information.
-<a href="https://api.slack.com/reference/block-kit/composition-objects#text">https://api.slack.com/reference/block-kit/composition-objects#text</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/text-object">https://docs.slack.dev/reference/block-kit/composition-objects/text-object</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
@@ -1114,7 +1114,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         url: Optional[str] = None,
     ):
         &#34;&#34;&#34;An object containing Slack file information to be used in an image block or image element.
-        https://api.slack.com/reference/block-kit/composition-objects#slack_file
+        https://docs.slack.dev/reference/block-kit/composition-objects/slack-file-object
 
         Args:
             id: Slack ID of the file.
@@ -1134,7 +1134,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>The base class for JSON serializable class objects</p>
 <p>An object containing Slack file information to be used in an image block or image element.
-<a href="https://api.slack.com/reference/block-kit/composition-objects#slack_file">https://api.slack.com/reference/block-kit/composition-objects#slack_file</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/slack-file-object">https://docs.slack.dev/reference/block-kit/composition-objects/slack-file-object</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>id</code></strong></dt>

--- a/docs/reference/models/blocks/block_elements.html
+++ b/docs/reference/models/blocks/block_elements.html
@@ -57,7 +57,7 @@ el.replaceWith(d);
 </summary>
 <pre><code class="python">class BlockElement(JsonObject, metaclass=ABCMeta):
     &#34;&#34;&#34;Block Elements are things that exists inside of your Blocks.
-    https://api.slack.com/reference/block-kit/block-elements
+    https://docs.slack.dev/reference/block-kit/block-elements/
     &#34;&#34;&#34;
 
     attributes = {&#34;type&#34;}
@@ -119,7 +119,7 @@ el.replaceWith(d);
             yield from subclass._get_sub_block_elements()</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
@@ -216,7 +216,7 @@ def subtype(self) -&gt; Optional[str]:
     ):
         &#34;&#34;&#34;An interactive element that inserts a button. The button can be a trigger for
         anything from opening a simple link to starting a complex workflow.
-        https://api.slack.com/reference/block-kit/block-elements#button
+        https://docs.slack.dev/reference/block-kit/block-elements/button-element/
 
         Args:
             text (required): A text object that defines the button&#39;s text.
@@ -275,10 +275,10 @@ def subtype(self) -&gt; Optional[str]:
         return self.accessibility_label is None or len(self.accessibility_label) &lt;= self.text_max_length</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An interactive element that inserts a button. The button can be a trigger for
 anything from opening a simple link to starting a complex workflow.
-<a href="https://api.slack.com/reference/block-kit/block-elements#button">https://api.slack.com/reference/block-kit/block-elements#button</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/button-element/">https://docs.slack.dev/reference/block-kit/block-elements/button-element/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
@@ -386,7 +386,7 @@ Maximum length for this field is 75 characters.</dd>
         &#34;&#34;&#34;
         This multi-select menu will populate its options with a list of public channels visible
         to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#channel_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#channel_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -417,10 +417,10 @@ Maximum length for this field is 75 characters.</dd>
         self.max_selected_items = max_selected_items</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This multi-select menu will populate its options with a list of public channels visible
 to the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#channel_multi_select">https://api.slack.com/reference/block-kit/block-elements#channel_multi_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#channel_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#channel_multi_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -518,7 +518,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will populate its options with a list of public channels
         visible to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#channel_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#channels_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -550,10 +550,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.response_url_enabled = response_url_enabled</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will populate its options with a list of public channels
 visible to the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#channel_select">https://api.slack.com/reference/block-kit/block-elements#channel_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#channels_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#channels_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -649,7 +649,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A checkbox group that allows a user to choose multiple items from a list of possible options.
-        https://api.slack.com/reference/block-kit/block-elements#checkboxes
+        https://docs.slack.dev/reference/block-kit/block-elements/checkboxes-element/
 
         Args:
             action_id (required): An identifier for the action triggered when the checkbox group is changed.
@@ -676,9 +676,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.initial_options = Option.parse_all(initial_options)</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>A checkbox group that allows a user to choose multiple items from a list of possible options.
-<a href="https://api.slack.com/reference/block-kit/block-elements#checkboxes">https://api.slack.com/reference/block-kit/block-elements#checkboxes</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/checkboxes-element/">https://docs.slack.dev/reference/block-kit/block-elements/checkboxes-element/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -764,7 +764,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     ):
         &#34;&#34;&#34;Provides a way to filter the list of options in a conversations select menu
         or conversations multi-select menu.
-        https://api.slack.com/reference/block-kit/composition-objects#filter_conversations
+        https://docs.slack.dev/reference/block-kit/composition-objects/conversation-filter-object
 
         Args:
             include: Indicates which type of conversations should be included in the list.
@@ -795,7 +795,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <div class="desc"><p>The base class for JSON serializable class objects</p>
 <p>Provides a way to filter the list of options in a conversations select menu
 or conversations multi-select menu.
-<a href="https://api.slack.com/reference/block-kit/composition-objects#filter_conversations">https://api.slack.com/reference/block-kit/composition-objects#filter_conversations</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/conversation-filter-object">https://docs.slack.dev/reference/block-kit/composition-objects/conversation-filter-object</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>include</code></strong></dt>
@@ -884,7 +884,7 @@ from conversation lists. Defaults to false.</dd>
         &#34;&#34;&#34;
         This multi-select menu will populate its options with a list of public and private channels,
         DMs, and MPIMs visible to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element/#conversation_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -921,10 +921,10 @@ from conversation lists. Defaults to false.</dd>
         self.filter = ConversationFilter.parse(filter)  # type: ignore[arg-type]</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This multi-select menu will populate its options with a list of public and private channels,
 DMs, and MPIMs visible to the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select">https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element/#conversation_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element/#conversation_multi_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -1044,7 +1044,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will populate its options with a list of public and private
         channels, DMs, and MPIMs visible to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#conversation_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#conversations_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -1082,10 +1082,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.filter = filter</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will populate its options with a list of public and private
 channels, DMs, and MPIMs visible to the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#conversation_select">https://api.slack.com/reference/block-kit/block-elements#conversation_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#conversations_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#conversations_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -1196,7 +1196,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         An element which lets users easily select a date from a calendar style UI.
         Date picker elements can be used inside of SectionBlocks and ActionsBlocks.
-        https://api.slack.com/reference/block-kit/block-elements#datepicker
+        https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -1231,10 +1231,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         )</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An element which lets users easily select a date from a calendar style UI.
 Date picker elements can be used inside of SectionBlocks and ActionsBlocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements#datepicker">https://api.slack.com/reference/block-kit/block-elements#datepicker</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element">https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -1330,7 +1330,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         date picker will take the form of a dropdown calendar. Both options will have free-text
         entry for precise choices. On mobile clients, the time picker and date
         picker will use native UIs.
-        https://api.slack.com/reference/block-kit/block-elements#datetimepicker
+        https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element/
 
         Args:
             action_id (required): An identifier for the action triggered when a time is selected. You can use this
@@ -1360,13 +1360,13 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return self.initial_date_time is None or (0 &lt;= self.initial_date_time &lt;= 9999999999)</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An element that allows the selection of a time of day formatted as a UNIX timestamp.
 On desktop clients, this time picker will take the form of a dropdown list and the
 date picker will take the form of a dropdown calendar. Both options will have free-text
 entry for precise choices. On mobile clients, the time picker and date
 picker will use native UIs.
-<a href="https://api.slack.com/reference/block-kit/block-elements#datetimepicker">https://api.slack.com/reference/block-kit/block-elements#datetimepicker</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element/">https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -1461,7 +1461,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;
-        https://api.slack.com/reference/block-kit/block-elements#email
+        https://docs.slack.dev/reference/block-kit/block-elements/email-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -1488,8 +1488,8 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.dispatch_action_config = dispatch_action_config</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
-<p><a href="https://api.slack.com/reference/block-kit/block-elements#email">https://api.slack.com/reference/block-kit/block-elements#email</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
+<p><a href="https://docs.slack.dev/reference/block-kit/block-elements/email-input-element">https://docs.slack.dev/reference/block-kit/block-elements/email-input-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -1589,7 +1589,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will load its options from an external data source, allowing
         for a dynamic list of options.
-        https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -1626,10 +1626,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.max_selected_items = max_selected_items</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will load its options from an external data source, allowing
 for a dynamic list of options.
-<a href="https://api.slack.com/reference/block-kit/block-elements#external_multi_select">https://api.slack.com/reference/block-kit/block-elements#external_multi_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -1733,7 +1733,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will load its options from an external data source, allowing
         for a dynamic list of options.
-        https://api.slack.com/reference/block-kit/block-elements#external_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -1768,10 +1768,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.initial_option = initial_option</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will load its options from an external data source, allowing
 for a dynamic list of options.
-<a href="https://api.slack.com/reference/block-kit/block-elements#external_select">https://api.slack.com/reference/block-kit/block-elements#external_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -1873,7 +1873,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;
-        https://api.slack.com/reference/block-kit/block-elements#file_input
+        https://docs.slack.dev/reference/block-kit/block-elements/file-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -1896,8 +1896,8 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.max_files = max_files</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
-<p><a href="https://api.slack.com/reference/block-kit/block-elements#file_input">https://api.slack.com/reference/block-kit/block-elements#file_input</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
+<p><a href="https://docs.slack.dev/reference/block-kit/block-elements/file-input-element">https://docs.slack.dev/reference/block-kit/block-elements/file-input-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -1991,7 +1991,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;An element to insert an image - this element can be used in section and
         context blocks only. If you want a block with only an image in it,
         you&#39;re looking for the image block.
-        https://api.slack.com/reference/block-kit/block-elements#image
+        https://docs.slack.dev/reference/block-kit/block-elements/image-element
 
         Args:
             alt_text (required): A plain-text summary of the image. This should not contain any markup.
@@ -2014,11 +2014,11 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return len(self.alt_text) &lt;= self.alt_text_max_length  # type: ignore[arg-type]</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An element to insert an image - this element can be used in section and
 context blocks only. If you want a block with only an image in it,
 you're looking for the image block.
-<a href="https://api.slack.com/reference/block-kit/block-elements#image">https://api.slack.com/reference/block-kit/block-elements#image</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/image-element">https://docs.slack.dev/reference/block-kit/block-elements/image-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>alt_text</code></strong> :&ensp;<code>required</code></dt>
@@ -2130,7 +2130,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         )</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>InteractiveElement that is usable in input blocks</p>
 <p>We generally recommend using the concrete subclasses for better supports of available properties.</p></div>
 <h3>Ancestors</h3>
@@ -2247,7 +2247,7 @@ def subtype(self) -&gt; Optional[str]:
         return self.action_id is None or len(self.action_id) &lt;= self.action_id_max_length</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An interactive block element.</p>
 <p>We generally recommend using the concrete subclasses for better supports of available properties.</p></div>
 <h3>Ancestors</h3>
@@ -2319,7 +2319,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;A simple button that simply opens a given URL. You will still receive an
         interaction payload and will need to send an acknowledgement response.
         This is a helper class that makes creating links simpler.
-        https://api.slack.com/reference/block-kit/block-elements#button
+        https://docs.slack.dev/reference/block-kit/block-elements/button-element/
 
         Args:
             text (required): A text object that defines the button&#39;s text.
@@ -2351,11 +2351,11 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         show_unknown_key_warning(self, others)</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>A simple button that simply opens a given URL. You will still receive an
 interaction payload and will need to send an acknowledgement response.
 This is a helper class that makes creating links simpler.
-<a href="https://api.slack.com/reference/block-kit/block-elements#button">https://api.slack.com/reference/block-kit/block-elements#button</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/button-element/">https://docs.slack.dev/reference/block-kit/block-elements/button-element/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
@@ -2444,7 +2444,7 @@ If you don't include this field, the default button style will be used.</dd>
         **others: dict,
     ):
         &#34;&#34;&#34;
-        https://api.slack.com/reference/block-kit/block-elements#number
+        https://docs.slack.dev/reference/block-kit/block-elements/number-input-element/
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -2478,8 +2478,8 @@ If you don't include this field, the default button style will be used.</dd>
         self.dispatch_action_config = dispatch_action_config</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
-<p><a href="https://api.slack.com/reference/block-kit/block-elements#number">https://api.slack.com/reference/block-kit/block-elements#number</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
+<p><a href="https://docs.slack.dev/reference/block-kit/block-elements/number-input-element/">https://docs.slack.dev/reference/block-kit/block-elements/number-input-element/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -2595,7 +2595,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         buttons. You can also specify simple URL links as overflow menu options,
         instead of actions.
 
-        https://api.slack.com/reference/block-kit/block-elements#overflow
+        https://docs.slack.dev/reference/block-kit/block-elements/overflow-menu-element
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -2618,7 +2618,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return self.options_min_length &lt;= len(self.options) &lt;= self.options_max_length</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This is like a cross between a button and a select menu - when a user clicks
 on this overflow button, they will be presented with a list of options to
 choose from. Unlike the select menu, there is no typeahead field, and the
@@ -2627,7 +2627,7 @@ button always appears with an ellipsis ("…") rather than customisable text.</p
 menu, or to supply a list of less visually important actions after a row of
 buttons. You can also specify simple URL links as overflow menu options,
 instead of actions.</p>
-<p><a href="https://api.slack.com/reference/block-kit/block-elements#overflow">https://api.slack.com/reference/block-kit/block-elements#overflow</a></p>
+<p><a href="https://docs.slack.dev/reference/block-kit/block-elements/overflow-menu-element">https://docs.slack.dev/reference/block-kit/block-elements/overflow-menu-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -2720,7 +2720,7 @@ after a menu item is selected.</dd>
         where a user can enter freeform data. It can appear as a single-line
         field or a larger textarea using the multiline flag. Plain-text input
         elements can be used inside of SectionBlocks and ActionsBlocks.
-        https://api.slack.com/reference/block-kit/block-elements#input
+        https://docs.slack.dev/reference/block-kit/block-elements/plain-text-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -2756,12 +2756,12 @@ after a menu item is selected.</dd>
         self.dispatch_action_config = dispatch_action_config</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>A plain-text input, similar to the HTML <input> tag, creates a field
 where a user can enter freeform data. It can appear as a single-line
 field or a larger textarea using the multiline flag. Plain-text input
 elements can be used inside of SectionBlocks and ActionsBlocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements#input">https://api.slack.com/reference/block-kit/block-elements#input</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/plain-text-input-element">https://docs.slack.dev/reference/block-kit/block-elements/plain-text-input-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -2869,7 +2869,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A radio button group that allows a user to choose one item from a list of possible options.
-        https://api.slack.com/reference/block-kit/block-elements#radio
+        https://docs.slack.dev/reference/block-kit/block-elements/radio-button-group-element
 
         Args:
             action_id (required): An identifier for the action triggered when the radio button group is changed.
@@ -2896,9 +2896,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.initial_option = initial_option</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>A radio button group that allows a user to choose one item from a list of possible options.
-<a href="https://api.slack.com/reference/block-kit/block-elements#radio">https://api.slack.com/reference/block-kit/block-elements#radio</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/radio-button-group-element">https://docs.slack.dev/reference/block-kit/block-elements/radio-button-group-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -2975,7 +2975,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     pass</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.block_elements.BlockElement" href="#slack_sdk.models.blocks.block_elements.BlockElement">BlockElement</a></li>
@@ -3246,42 +3246,42 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.Broadcast"><code class="name">var <span class="ident">Broadcast</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.Channel"><code class="name">var <span class="ident">Channel</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.Color"><code class="name">var <span class="ident">Color</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.Date"><code class="name">var <span class="ident">Date</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.Emoji"><code class="name">var <span class="ident">Emoji</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.Link"><code class="name">var <span class="ident">Link</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.Team"><code class="name">var <span class="ident">Team</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.Text"><code class="name">var <span class="ident">Text</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.TextStyle"><code class="name">var <span class="ident">TextStyle</span></code></dt>
 <dd>
@@ -3290,12 +3290,12 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.User"><code class="name">var <span class="ident">User</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.block_elements.RichTextElementParts.UserGroup"><code class="name">var <span class="ident">UserGroup</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 </dl>
 </dd>
@@ -3343,7 +3343,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.dispatch_action_config = dispatch_action_config</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>InteractiveElement that is usable in input blocks</p>
 <p>We generally recommend using the concrete subclasses for better supports of available properties.</p></div>
 <h3>Ancestors</h3>
@@ -3430,7 +3430,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.border = border</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.block_elements.RichTextElement" href="#slack_sdk.models.blocks.block_elements.RichTextElement">RichTextElement</a></li>
@@ -3501,7 +3501,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.border = border</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.block_elements.RichTextElement" href="#slack_sdk.models.blocks.block_elements.RichTextElement">RichTextElement</a></li>
@@ -3570,7 +3570,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.elements = BlockElement.parse_all(elements)</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.block_elements.RichTextElement" href="#slack_sdk.models.blocks.block_elements.RichTextElement">RichTextElement</a></li>
@@ -3639,7 +3639,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.elements = BlockElement.parse_all(elements)</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.block_elements.RichTextElement" href="#slack_sdk.models.blocks.block_elements.RichTextElement">RichTextElement</a></li>
@@ -3712,7 +3712,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;This is the simplest form of select menu, with a static list of options passed in when defining the element.
-        https://api.slack.com/reference/block-kit/block-elements#static_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -3764,9 +3764,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return self.options is not None or self.option_groups is not None</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This is the simplest form of select menu, with a static list of options passed in when defining the element.
-<a href="https://api.slack.com/reference/block-kit/block-elements#static_select">https://api.slack.com/reference/block-kit/block-elements#static_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -3880,7 +3880,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     ):
         &#34;&#34;&#34;
         This is the simplest form of select menu, with a static list of options passed in when defining the element.
-        https://api.slack.com/reference/block-kit/block-elements#static_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#static_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -3935,9 +3935,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return self.options is not None or self.option_groups is not None</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This is the simplest form of select menu, with a static list of options passed in when defining the element.
-<a href="https://api.slack.com/reference/block-kit/block-elements#static_multi_select">https://api.slack.com/reference/block-kit/block-elements#static_multi_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#static_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#static_multi_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -4052,7 +4052,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;This is the simplest form of select menu, with a static list of options passed in when defining the element.
-        https://api.slack.com/reference/block-kit/block-elements#static_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -4104,9 +4104,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return self.options is not None or self.option_groups is not None</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This is the simplest form of select menu, with a static list of options passed in when defining the element.
-<a href="https://api.slack.com/reference/block-kit/block-elements#static_select">https://api.slack.com/reference/block-kit/block-elements#static_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -4219,7 +4219,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         On desktop clients, this time picker will take the form of a dropdown list
         with free-text entry for precise choices.
         On mobile clients, the time picker will use native time picker UIs.
-        https://api.slack.com/reference/block-kit/block-elements#timepicker
+        https://docs.slack.dev/reference/block-kit/block-elements/time-picker-element
 
         Args:
             action_id (required): An identifier for the action triggered when a time is selected.
@@ -4254,12 +4254,12 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return self.initial_time is None or re.match(r&#34;([0-1][0-9]|2[0-3]):([0-5][0-9])&#34;, self.initial_time) is not None</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An element which allows selection of a time of day.
 On desktop clients, this time picker will take the form of a dropdown list
 with free-text entry for precise choices.
 On mobile clients, the time picker will use native time picker UIs.
-<a href="https://api.slack.com/reference/block-kit/block-elements#timepicker">https://api.slack.com/reference/block-kit/block-elements#timepicker</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/time-picker-element">https://docs.slack.dev/reference/block-kit/block-elements/time-picker-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -4361,7 +4361,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         A URL input element, similar to the Plain-text input element,
         creates a single line field where a user can enter URL-encoded data.
-        https://api.slack.com/reference/block-kit/block-elements#url
+        https://docs.slack.dev/reference/block-kit/block-elements/url-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -4388,10 +4388,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.dispatch_action_config = dispatch_action_config</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>A URL input element, similar to the Plain-text input element,
 creates a single line field where a user can enter URL-encoded data.
-<a href="https://api.slack.com/reference/block-kit/block-elements#url">https://api.slack.com/reference/block-kit/block-elements#url</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/url-input-element">https://docs.slack.dev/reference/block-kit/block-elements/url-input-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -4490,7 +4490,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will populate its options with a list of Slack users visible to
         the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#users_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#users_multi_select
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -4520,10 +4520,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.max_selected_items = max_selected_items</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will populate its options with a list of Slack users visible to
 the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#users_multi_select">https://api.slack.com/reference/block-kit/block-elements#users_multi_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#users_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#users_multi_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -4619,7 +4619,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will populate its options with a list of Slack users visible to
         the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#users_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#users_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -4646,10 +4646,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.initial_user = initial_user</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will populate its options with a list of Slack users visible to
 the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#users_select">https://api.slack.com/reference/block-kit/block-elements#users_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#users_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#users_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -4742,7 +4742,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;Allows users to run a link trigger with customizable inputs
         Interactive component - but interactions with workflow button elements will not send block_actions events,
         since these are used to start new workflow runs.
-        https://api.slack.com/reference/block-kit/block-elements#workflow_button
+        https://docs.slack.dev/reference/block-kit/block-elements/workflow-button-element
 
         Args:
             text (required): A text object that defines the button&#39;s text.
@@ -4774,11 +4774,11 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.accessibility_label = accessibility_label</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>Allows users to run a link trigger with customizable inputs
 Interactive component - but interactions with workflow button elements will not send block_actions events,
 since these are used to start new workflow runs.
-<a href="https://api.slack.com/reference/block-kit/block-elements#workflow_button">https://api.slack.com/reference/block-kit/block-elements#workflow_button</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/workflow-button-element">https://docs.slack.dev/reference/block-kit/block-elements/workflow-button-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>

--- a/docs/reference/models/blocks/blocks.html
+++ b/docs/reference/models/blocks/blocks.html
@@ -71,7 +71,7 @@ el.replaceWith(d);
         **others: dict,
     ):
         &#34;&#34;&#34;A block that is used to hold interactive elements.
-        https://api.slack.com/reference/block-kit/blocks#actions
+        https://docs.slack.dev/reference/block-kit/blocks/actions-block
 
         Args:
             elements (required): An array of interactive element objects - buttons, select menus, overflow menus,
@@ -94,9 +94,9 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A block that is used to hold interactive elements.
-<a href="https://api.slack.com/reference/block-kit/blocks#actions">https://api.slack.com/reference/block-kit/blocks#actions</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/actions-block">https://docs.slack.dev/reference/block-kit/blocks/actions-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>elements</code></strong> :&ensp;<code>required</code></dt>
@@ -167,7 +167,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <pre><code class="python">class Block(JsonObject):
     &#34;&#34;&#34;Blocks are a series of components that can be combined
     to create visually rich and compellingly interactive messages.
-    https://api.slack.com/reference/block-kit/blocks
+    https://docs.slack.dev/reference/block-kit/blocks
     &#34;&#34;&#34;
 
     attributes = {&#34;block_id&#34;, &#34;type&#34;}
@@ -228,6 +228,8 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
                     return CallBlock(**block)
                 elif type == HeaderBlock.type:
                     return HeaderBlock(**block)
+                elif type == MarkdownBlock.type:
+                    return MarkdownBlock(**block)
                 elif type == VideoBlock.type:
                     return VideoBlock(**block)
                 elif type == RichTextBlock.type:
@@ -245,7 +247,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
@@ -261,6 +263,7 @@ to create visually rich and compellingly interactive messages.
 <li><a title="slack_sdk.models.blocks.blocks.HeaderBlock" href="#slack_sdk.models.blocks.blocks.HeaderBlock">HeaderBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.ImageBlock" href="#slack_sdk.models.blocks.blocks.ImageBlock">ImageBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.InputBlock" href="#slack_sdk.models.blocks.blocks.InputBlock">InputBlock</a></li>
+<li><a title="slack_sdk.models.blocks.blocks.MarkdownBlock" href="#slack_sdk.models.blocks.blocks.MarkdownBlock">MarkdownBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.SectionBlock" href="#slack_sdk.models.blocks.blocks.SectionBlock">SectionBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.VideoBlock" href="#slack_sdk.models.blocks.blocks.VideoBlock">VideoBlock</a></li>
@@ -347,7 +350,7 @@ def subtype(self) -&gt; Optional[str]:
         **others: dict,
     ):
         &#34;&#34;&#34;Displays a call information
-        https://api.slack.com/reference/block-kit/blocks#call
+        https://docs.slack.dev/reference/block-kit/blocks#call
         &#34;&#34;&#34;
         super().__init__(type=self.type, block_id=block_id)
         show_unknown_key_warning(self, others)
@@ -358,9 +361,9 @@ def subtype(self) -&gt; Optional[str]:
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>Displays a call information
-<a href="https://api.slack.com/reference/block-kit/blocks#call">https://api.slack.com/reference/block-kit/blocks#call</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/blocks#call">https://docs.slack.dev/reference/block-kit/blocks#call</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.blocks.Block" href="#slack_sdk.models.blocks.blocks.Block">Block</a></li>
@@ -427,7 +430,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;Displays message context, which can include both images and text.
-        https://api.slack.com/reference/block-kit/blocks#context
+        https://docs.slack.dev/reference/block-kit/blocks/context-block
 
         Args:
             elements (required): An array of image elements and text objects. Maximum number of items is 10.
@@ -447,9 +450,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>Displays message context, which can include both images and text.
-<a href="https://api.slack.com/reference/block-kit/blocks#context">https://api.slack.com/reference/block-kit/blocks#context</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/context-block">https://docs.slack.dev/reference/block-kit/blocks/context-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>elements</code></strong> :&ensp;<code>required</code></dt>
@@ -524,7 +527,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A content divider, like an &lt;hr&gt;, to split up different blocks inside of a message.
-        https://api.slack.com/reference/block-kit/blocks#divider
+        https://docs.slack.dev/reference/block-kit/blocks/divider-block
 
         Args:
             block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
@@ -538,9 +541,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A content divider, like an <hr>, to split up different blocks inside of a message.
-<a href="https://api.slack.com/reference/block-kit/blocks#divider">https://api.slack.com/reference/block-kit/blocks#divider</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/divider-block">https://docs.slack.dev/reference/block-kit/blocks/divider-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>block_id</code></strong></dt>
@@ -602,7 +605,7 @@ If a message is updated, use a new block_id.</dd>
         **others: dict,
     ):
         &#34;&#34;&#34;Displays a remote file.
-        https://api.slack.com/reference/block-kit/blocks#file
+        https://docs.slack.dev/reference/block-kit/blocks/file-block
 
         Args:
             external_id (required): The external unique ID for this file.
@@ -620,9 +623,9 @@ If a message is updated, use a new block_id.</dd>
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>Displays a remote file.
-<a href="https://api.slack.com/reference/block-kit/blocks#file">https://api.slack.com/reference/block-kit/blocks#file</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/file-block">https://docs.slack.dev/reference/block-kit/blocks/file-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>external_id</code></strong> :&ensp;<code>required</code></dt>
@@ -701,7 +704,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A header is a plain-text block that displays in a larger, bold font.
-        https://api.slack.com/reference/block-kit/blocks#header
+        https://docs.slack.dev/reference/block-kit/blocks/header-block
 
         Args:
             block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
@@ -726,9 +729,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A header is a plain-text block that displays in a larger, bold font.
-<a href="https://api.slack.com/reference/block-kit/blocks#header">https://api.slack.com/reference/block-kit/blocks#header</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/header-block">https://docs.slack.dev/reference/block-kit/blocks/header-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>block_id</code></strong></dt>
@@ -816,7 +819,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A simple image block, designed to make those cat photos really pop.
-        https://api.slack.com/reference/block-kit/blocks#image
+        https://docs.slack.dev/reference/block-kit/blocks/image-block
 
         Args:
             alt_text (required): A plain-text summary of the image. This should not contain any markup.
@@ -868,9 +871,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A simple image block, designed to make those cat photos really pop.
-<a href="https://api.slack.com/reference/block-kit/blocks#image">https://api.slack.com/reference/block-kit/blocks#image</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/image-block">https://docs.slack.dev/reference/block-kit/blocks/image-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>alt_text</code></strong> :&ensp;<code>required</code></dt>
@@ -974,7 +977,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     ):
         &#34;&#34;&#34;A block that collects information from users - it can hold a plain-text input element,
         a select menu element, a multi-select menu element, or a datepicker.
-        https://api.slack.com/reference/block-kit/blocks#input
+        https://docs.slack.dev/reference/block-kit/blocks/input-block
 
         Args:
             label (required): A label that appears above an input element in the form of a text object
@@ -1021,10 +1024,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A block that collects information from users - it can hold a plain-text input element,
 a select menu element, a multi-select menu element, or a datepicker.
-<a href="https://api.slack.com/reference/block-kit/blocks#input">https://api.slack.com/reference/block-kit/blocks#input</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/input-block">https://docs.slack.dev/reference/block-kit/blocks/input-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>label</code></strong> :&ensp;<code>required</code></dt>
@@ -1098,6 +1101,113 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </li>
 </ul>
 </dd>
+<dt id="slack_sdk.models.blocks.blocks.MarkdownBlock"><code class="flex name class">
+<span>class <span class="ident">MarkdownBlock</span></span>
+<span>(</span><span>*, text: str, block_id: str | None = None, **others: dict)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MarkdownBlock(Block):
+    type = &#34;markdown&#34;
+    text_max_length = 12000
+
+    @property
+    def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+        return super().attributes.union({&#34;text&#34;})
+
+    def __init__(
+        self,
+        *,
+        text: str,
+        block_id: Optional[str] = None,
+        **others: dict,
+    ):
+        &#34;&#34;&#34;Displays formatted markdown.
+        https://docs.slack.dev/reference/block-kit/blocks/markdown-block/
+
+        Args:
+            block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
+                Maximum length for this field is 255 characters.
+                block_id should be unique for each message and each iteration of a message.
+                If a message is updated, use a new block_id.
+            text (required): The standard markdown-formatted text. Limit 12,000 characters max.
+        &#34;&#34;&#34;
+        super().__init__(type=self.type, block_id=block_id)
+        show_unknown_key_warning(self, others)
+
+        self.text = text
+
+    @JsonValidator(&#34;text attribute must be specified&#34;)
+    def _validate_text(self):
+        return self.text != &#34;&#34;
+
+    @JsonValidator(f&#34;text attribute cannot exceed {text_max_length} characters&#34;)
+    def _validate_alt_text_length(self):
+        return len(self.text) &lt;= self.text_max_length</code></pre>
+</details>
+<div class="desc"><p>Blocks are a series of components that can be combined
+to create visually rich and compellingly interactive messages.
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
+<p>Displays formatted markdown.
+<a href="https://docs.slack.dev/reference/block-kit/blocks/markdown-block/">https://docs.slack.dev/reference/block-kit/blocks/markdown-block/</a></p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>block_id</code></strong></dt>
+<dd>A string acting as a unique identifier for a block. If not specified, one will be generated.
+Maximum length for this field is 255 characters.
+block_id should be unique for each message and each iteration of a message.
+If a message is updated, use a new block_id.</dd>
+<dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
+<dd>The standard markdown-formatted text. Limit 12,000 characters max.</dd>
+</dl></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.blocks.blocks.Block" href="#slack_sdk.models.blocks.blocks.Block">Block</a></li>
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.blocks.MarkdownBlock.text_max_length"><code class="name">var <span class="ident">text_max_length</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+<dt id="slack_sdk.models.blocks.blocks.MarkdownBlock.type"><code class="name">var <span class="ident">type</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.blocks.MarkdownBlock.attributes"><code class="name">prop <span class="ident">attributes</span> : Set[str]</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+    return super().attributes.union({&#34;text&#34;})</code></pre>
+</details>
+<div class="desc"><p>Build an unordered collection of unique elements.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.blocks.blocks.Block" href="#slack_sdk.models.blocks.blocks.Block">Block</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.block_id_max_length" href="#slack_sdk.models.blocks.blocks.Block.block_id_max_length">block_id_max_length</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.logger" href="#slack_sdk.models.blocks.blocks.Block.logger">logger</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
 <dt id="slack_sdk.models.blocks.blocks.RichTextBlock"><code class="flex name class">
 <span>class <span class="ident">RichTextBlock</span></span>
 <span>(</span><span>*,<br>elements: Sequence[dict | <a title="slack_sdk.models.blocks.block_elements.RichTextElement" href="block_elements.html#slack_sdk.models.blocks.block_elements.RichTextElement">RichTextElement</a>],<br>block_id: str | None = None,<br>**others: dict)</span>
@@ -1122,7 +1232,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A block that is used to hold interactive elements.
-        https://api.slack.com/reference/block-kit/blocks#rich_text
+        https://docs.slack.dev/reference/block-kit/blocks/rich-text-block
 
         Args:
             elements (required): An array of rich text objects -
@@ -1139,9 +1249,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A block that is used to hold interactive elements.
-<a href="https://api.slack.com/reference/block-kit/blocks#rich_text">https://api.slack.com/reference/block-kit/blocks#rich_text</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/rich-text-block">https://docs.slack.dev/reference/block-kit/blocks/rich-text-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>elements</code></strong> :&ensp;<code>required</code></dt>
@@ -1223,7 +1333,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A section is one of the most flexible blocks available.
-        https://api.slack.com/reference/block-kit/blocks#section
+        https://docs.slack.dev/reference/block-kit/blocks/section-block
 
         Args:
             block_id (required): A string acting as a unique identifier for a block.
@@ -1282,9 +1392,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A section is one of the most flexible blocks available.
-<a href="https://api.slack.com/reference/block-kit/blocks#section">https://api.slack.com/reference/block-kit/blocks#section</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/section-block">https://docs.slack.dev/reference/block-kit/blocks/section-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>block_id</code></strong> :&ensp;<code>required</code></dt>
@@ -1409,7 +1519,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         (e.g. link unfurls, messages, modals, App Home) —
         anywhere you can put blocks! To use the video block within your app,
         you must have the links.embed:write scope.
-        https://api.slack.com/reference/block-kit/blocks#video
+        https://docs.slack.dev/reference/block-kit/blocks/video-block
 
         Args:
             block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
@@ -1467,12 +1577,12 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A video block is designed to embed videos in all app surfaces
 (e.g. link unfurls, messages, modals, App Home) —
 anywhere you can put blocks! To use the video block within your app,
 you must have the links.embed:write scope.
-<a href="https://api.slack.com/reference/block-kit/blocks#video">https://api.slack.com/reference/block-kit/blocks#video</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/video-block">https://docs.slack.dev/reference/block-kit/blocks/video-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>block_id</code></strong></dt>
@@ -1649,6 +1759,14 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <li><code><a title="slack_sdk.models.blocks.blocks.InputBlock.hint_max_length" href="#slack_sdk.models.blocks.blocks.InputBlock.hint_max_length">hint_max_length</a></code></li>
 <li><code><a title="slack_sdk.models.blocks.blocks.InputBlock.label_max_length" href="#slack_sdk.models.blocks.blocks.InputBlock.label_max_length">label_max_length</a></code></li>
 <li><code><a title="slack_sdk.models.blocks.blocks.InputBlock.type" href="#slack_sdk.models.blocks.blocks.InputBlock.type">type</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.blocks.blocks.MarkdownBlock" href="#slack_sdk.models.blocks.blocks.MarkdownBlock">MarkdownBlock</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.blocks.blocks.MarkdownBlock.attributes" href="#slack_sdk.models.blocks.blocks.MarkdownBlock.attributes">attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.MarkdownBlock.text_max_length" href="#slack_sdk.models.blocks.blocks.MarkdownBlock.text_max_length">text_max_length</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.MarkdownBlock.type" href="#slack_sdk.models.blocks.blocks.MarkdownBlock.type">type</a></code></li>
 </ul>
 </li>
 <li>

--- a/docs/reference/models/blocks/index.html
+++ b/docs/reference/models/blocks/index.html
@@ -39,8 +39,8 @@ el.replaceWith(d);
 <p>Block Kit data model objects</p>
 <p>To learn more about Block Kit, please check the following resources and tools:</p>
 <ul>
-<li><a href="https://api.slack.com/block-kit">https://api.slack.com/block-kit</a></li>
-<li><a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></li>
+<li><a href="https://docs.slack.dev/block-kit/">https://docs.slack.dev/block-kit/</a></li>
+<li><a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></li>
 <li><a href="https://app.slack.com/block-kit-builder">https://app.slack.com/block-kit-builder</a></li>
 </ul>
 </section>
@@ -93,7 +93,7 @@ el.replaceWith(d);
         **others: dict,
     ):
         &#34;&#34;&#34;A block that is used to hold interactive elements.
-        https://api.slack.com/reference/block-kit/blocks#actions
+        https://docs.slack.dev/reference/block-kit/blocks/actions-block
 
         Args:
             elements (required): An array of interactive element objects - buttons, select menus, overflow menus,
@@ -116,9 +116,9 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A block that is used to hold interactive elements.
-<a href="https://api.slack.com/reference/block-kit/blocks#actions">https://api.slack.com/reference/block-kit/blocks#actions</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/actions-block">https://docs.slack.dev/reference/block-kit/blocks/actions-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>elements</code></strong> :&ensp;<code>required</code></dt>
@@ -189,7 +189,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <pre><code class="python">class Block(JsonObject):
     &#34;&#34;&#34;Blocks are a series of components that can be combined
     to create visually rich and compellingly interactive messages.
-    https://api.slack.com/reference/block-kit/blocks
+    https://docs.slack.dev/reference/block-kit/blocks
     &#34;&#34;&#34;
 
     attributes = {&#34;block_id&#34;, &#34;type&#34;}
@@ -250,6 +250,8 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
                     return CallBlock(**block)
                 elif type == HeaderBlock.type:
                     return HeaderBlock(**block)
+                elif type == MarkdownBlock.type:
+                    return MarkdownBlock(**block)
                 elif type == VideoBlock.type:
                     return VideoBlock(**block)
                 elif type == RichTextBlock.type:
@@ -267,7 +269,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
@@ -283,6 +285,7 @@ to create visually rich and compellingly interactive messages.
 <li><a title="slack_sdk.models.blocks.blocks.HeaderBlock" href="blocks.html#slack_sdk.models.blocks.blocks.HeaderBlock">HeaderBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.ImageBlock" href="blocks.html#slack_sdk.models.blocks.blocks.ImageBlock">ImageBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.InputBlock" href="blocks.html#slack_sdk.models.blocks.blocks.InputBlock">InputBlock</a></li>
+<li><a title="slack_sdk.models.blocks.blocks.MarkdownBlock" href="blocks.html#slack_sdk.models.blocks.blocks.MarkdownBlock">MarkdownBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.SectionBlock" href="blocks.html#slack_sdk.models.blocks.blocks.SectionBlock">SectionBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.VideoBlock" href="blocks.html#slack_sdk.models.blocks.blocks.VideoBlock">VideoBlock</a></li>
@@ -354,7 +357,7 @@ def subtype(self) -&gt; Optional[str]:
 </summary>
 <pre><code class="python">class BlockElement(JsonObject, metaclass=ABCMeta):
     &#34;&#34;&#34;Block Elements are things that exists inside of your Blocks.
-    https://api.slack.com/reference/block-kit/block-elements
+    https://docs.slack.dev/reference/block-kit/block-elements/
     &#34;&#34;&#34;
 
     attributes = {&#34;type&#34;}
@@ -416,7 +419,7 @@ def subtype(self) -&gt; Optional[str]:
             yield from subclass._get_sub_block_elements()</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
@@ -513,7 +516,7 @@ def subtype(self) -&gt; Optional[str]:
     ):
         &#34;&#34;&#34;An interactive element that inserts a button. The button can be a trigger for
         anything from opening a simple link to starting a complex workflow.
-        https://api.slack.com/reference/block-kit/block-elements#button
+        https://docs.slack.dev/reference/block-kit/block-elements/button-element/
 
         Args:
             text (required): A text object that defines the button&#39;s text.
@@ -572,10 +575,10 @@ def subtype(self) -&gt; Optional[str]:
         return self.accessibility_label is None or len(self.accessibility_label) &lt;= self.text_max_length</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An interactive element that inserts a button. The button can be a trigger for
 anything from opening a simple link to starting a complex workflow.
-<a href="https://api.slack.com/reference/block-kit/block-elements#button">https://api.slack.com/reference/block-kit/block-elements#button</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/button-element/">https://docs.slack.dev/reference/block-kit/block-elements/button-element/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
@@ -679,7 +682,7 @@ Maximum length for this field is 75 characters.</dd>
         **others: dict,
     ):
         &#34;&#34;&#34;Displays a call information
-        https://api.slack.com/reference/block-kit/blocks#call
+        https://docs.slack.dev/reference/block-kit/blocks#call
         &#34;&#34;&#34;
         super().__init__(type=self.type, block_id=block_id)
         show_unknown_key_warning(self, others)
@@ -690,9 +693,9 @@ Maximum length for this field is 75 characters.</dd>
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>Displays a call information
-<a href="https://api.slack.com/reference/block-kit/blocks#call">https://api.slack.com/reference/block-kit/blocks#call</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/blocks#call">https://docs.slack.dev/reference/block-kit/blocks#call</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.blocks.Block" href="blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a></li>
@@ -764,7 +767,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This multi-select menu will populate its options with a list of public channels visible
         to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#channel_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#channel_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -795,10 +798,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.max_selected_items = max_selected_items</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This multi-select menu will populate its options with a list of public channels visible
 to the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#channel_multi_select">https://api.slack.com/reference/block-kit/block-elements#channel_multi_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#channel_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#channel_multi_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -896,7 +899,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will populate its options with a list of public channels
         visible to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#channel_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#channels_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -928,10 +931,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.response_url_enabled = response_url_enabled</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will populate its options with a list of public channels
 visible to the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#channel_select">https://api.slack.com/reference/block-kit/block-elements#channel_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#channels_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#channels_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -1027,7 +1030,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A checkbox group that allows a user to choose multiple items from a list of possible options.
-        https://api.slack.com/reference/block-kit/block-elements#checkboxes
+        https://docs.slack.dev/reference/block-kit/block-elements/checkboxes-element/
 
         Args:
             action_id (required): An identifier for the action triggered when the checkbox group is changed.
@@ -1054,9 +1057,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.initial_options = Option.parse_all(initial_options)</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>A checkbox group that allows a user to choose multiple items from a list of possible options.
-<a href="https://api.slack.com/reference/block-kit/block-elements#checkboxes">https://api.slack.com/reference/block-kit/block-elements#checkboxes</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/checkboxes-element/">https://docs.slack.dev/reference/block-kit/block-elements/checkboxes-element/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -1130,7 +1133,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class ConfirmObject(JsonObject):
-    attributes = {}  # type: ignore[assignment] # no attributes because to_dict has unique implementations
+    attributes: Set[str] = set()
 
     title_max_length = 100
     text_max_length = 300
@@ -1162,7 +1165,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         An object that defines a dialog that provides a confirmation step to any
         interactive element. This dialog will ask the user to confirm their action by
         offering a confirm and deny button.
-        https://api.slack.com/reference/block-kit/composition-objects#confirm
+        https://docs.slack.dev/reference/block-kit/composition-objects/confirmation-dialog-object/
         &#34;&#34;&#34;
         self._title = TextObject.parse(title, default_type=PlainTextObject.type)
         self._text = TextObject.parse(text, default_type=MarkdownTextObject.type)
@@ -1230,7 +1233,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <p>An object that defines a dialog that provides a confirmation step to any
 interactive element. This dialog will ask the user to confirm their action by
 offering a confirm and deny button.
-<a href="https://api.slack.com/reference/block-kit/composition-objects#confirm">https://api.slack.com/reference/block-kit/composition-objects#confirm</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/confirmation-dialog-object/">https://docs.slack.dev/reference/block-kit/composition-objects/confirmation-dialog-object/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
@@ -1238,7 +1241,7 @@ offering a confirm and deny button.
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="slack_sdk.models.blocks.ConfirmObject.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dt id="slack_sdk.models.blocks.ConfirmObject.attributes"><code class="name">var <span class="ident">attributes</span> : Set[str]</code></dt>
 <dd>
 <div class="desc"><p>The type of the None singleton.</p></div>
 </dd>
@@ -1363,7 +1366,7 @@ def title_length(self) -&gt; bool:
         **others: dict,
     ):
         &#34;&#34;&#34;Displays message context, which can include both images and text.
-        https://api.slack.com/reference/block-kit/blocks#context
+        https://docs.slack.dev/reference/block-kit/blocks/context-block
 
         Args:
             elements (required): An array of image elements and text objects. Maximum number of items is 10.
@@ -1383,9 +1386,9 @@ def title_length(self) -&gt; bool:
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>Displays message context, which can include both images and text.
-<a href="https://api.slack.com/reference/block-kit/blocks#context">https://api.slack.com/reference/block-kit/blocks#context</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/context-block">https://docs.slack.dev/reference/block-kit/blocks/context-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>elements</code></strong> :&ensp;<code>required</code></dt>
@@ -1463,7 +1466,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     ):
         &#34;&#34;&#34;Provides a way to filter the list of options in a conversations select menu
         or conversations multi-select menu.
-        https://api.slack.com/reference/block-kit/composition-objects#filter_conversations
+        https://docs.slack.dev/reference/block-kit/composition-objects/conversation-filter-object
 
         Args:
             include: Indicates which type of conversations should be included in the list.
@@ -1494,7 +1497,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <div class="desc"><p>The base class for JSON serializable class objects</p>
 <p>Provides a way to filter the list of options in a conversations select menu
 or conversations multi-select menu.
-<a href="https://api.slack.com/reference/block-kit/composition-objects#filter_conversations">https://api.slack.com/reference/block-kit/composition-objects#filter_conversations</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/conversation-filter-object">https://docs.slack.dev/reference/block-kit/composition-objects/conversation-filter-object</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>include</code></strong></dt>
@@ -1583,7 +1586,7 @@ from conversation lists. Defaults to false.</dd>
         &#34;&#34;&#34;
         This multi-select menu will populate its options with a list of public and private channels,
         DMs, and MPIMs visible to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element/#conversation_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -1620,10 +1623,10 @@ from conversation lists. Defaults to false.</dd>
         self.filter = ConversationFilter.parse(filter)  # type: ignore[arg-type]</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This multi-select menu will populate its options with a list of public and private channels,
 DMs, and MPIMs visible to the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select">https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element/#conversation_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element/#conversation_multi_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -1743,7 +1746,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will populate its options with a list of public and private
         channels, DMs, and MPIMs visible to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#conversation_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#conversations_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -1781,10 +1784,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.filter = filter</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will populate its options with a list of public and private
 channels, DMs, and MPIMs visible to the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#conversation_select">https://api.slack.com/reference/block-kit/block-elements#conversation_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#conversations_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#conversations_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -1895,7 +1898,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         An element which lets users easily select a date from a calendar style UI.
         Date picker elements can be used inside of SectionBlocks and ActionsBlocks.
-        https://api.slack.com/reference/block-kit/block-elements#datepicker
+        https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -1930,10 +1933,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         )</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An element which lets users easily select a date from a calendar style UI.
 Date picker elements can be used inside of SectionBlocks and ActionsBlocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements#datepicker">https://api.slack.com/reference/block-kit/block-elements#datepicker</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element">https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -2029,7 +2032,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         date picker will take the form of a dropdown calendar. Both options will have free-text
         entry for precise choices. On mobile clients, the time picker and date
         picker will use native UIs.
-        https://api.slack.com/reference/block-kit/block-elements#datetimepicker
+        https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element/
 
         Args:
             action_id (required): An identifier for the action triggered when a time is selected. You can use this
@@ -2059,13 +2062,13 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return self.initial_date_time is None or (0 &lt;= self.initial_date_time &lt;= 9999999999)</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An element that allows the selection of a time of day formatted as a UNIX timestamp.
 On desktop clients, this time picker will take the form of a dropdown list and the
 date picker will take the form of a dropdown calendar. Both options will have free-text
 entry for precise choices. On mobile clients, the time picker and date
 picker will use native UIs.
-<a href="https://api.slack.com/reference/block-kit/block-elements#datetimepicker">https://api.slack.com/reference/block-kit/block-elements#datetimepicker</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element/">https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -2147,7 +2150,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A content divider, like an &lt;hr&gt;, to split up different blocks inside of a message.
-        https://api.slack.com/reference/block-kit/blocks#divider
+        https://docs.slack.dev/reference/block-kit/blocks/divider-block
 
         Args:
             block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
@@ -2161,9 +2164,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A content divider, like an <hr>, to split up different blocks inside of a message.
-<a href="https://api.slack.com/reference/block-kit/blocks#divider">https://api.slack.com/reference/block-kit/blocks#divider</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/divider-block">https://docs.slack.dev/reference/block-kit/blocks/divider-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>block_id</code></strong></dt>
@@ -2232,7 +2235,7 @@ If a message is updated, use a new block_id.</dd>
         **others: dict,
     ):
         &#34;&#34;&#34;
-        https://api.slack.com/reference/block-kit/block-elements#email
+        https://docs.slack.dev/reference/block-kit/block-elements/email-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -2259,8 +2262,8 @@ If a message is updated, use a new block_id.</dd>
         self.dispatch_action_config = dispatch_action_config</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
-<p><a href="https://api.slack.com/reference/block-kit/block-elements#email">https://api.slack.com/reference/block-kit/block-elements#email</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
+<p><a href="https://docs.slack.dev/reference/block-kit/block-elements/email-input-element">https://docs.slack.dev/reference/block-kit/block-elements/email-input-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -2360,7 +2363,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will load its options from an external data source, allowing
         for a dynamic list of options.
-        https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -2397,10 +2400,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.max_selected_items = max_selected_items</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will load its options from an external data source, allowing
 for a dynamic list of options.
-<a href="https://api.slack.com/reference/block-kit/block-elements#external_multi_select">https://api.slack.com/reference/block-kit/block-elements#external_multi_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -2504,7 +2507,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will load its options from an external data source, allowing
         for a dynamic list of options.
-        https://api.slack.com/reference/block-kit/block-elements#external_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -2539,10 +2542,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.initial_option = initial_option</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will load its options from an external data source, allowing
 for a dynamic list of options.
-<a href="https://api.slack.com/reference/block-kit/block-elements#external_select">https://api.slack.com/reference/block-kit/block-elements#external_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -2639,7 +2642,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;Displays a remote file.
-        https://api.slack.com/reference/block-kit/blocks#file
+        https://docs.slack.dev/reference/block-kit/blocks/file-block
 
         Args:
             external_id (required): The external unique ID for this file.
@@ -2657,9 +2660,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>Displays a remote file.
-<a href="https://api.slack.com/reference/block-kit/blocks#file">https://api.slack.com/reference/block-kit/blocks#file</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/file-block">https://docs.slack.dev/reference/block-kit/blocks/file-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>external_id</code></strong> :&ensp;<code>required</code></dt>
@@ -2738,7 +2741,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A header is a plain-text block that displays in a larger, bold font.
-        https://api.slack.com/reference/block-kit/blocks#header
+        https://docs.slack.dev/reference/block-kit/blocks/header-block
 
         Args:
             block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
@@ -2763,9 +2766,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A header is a plain-text block that displays in a larger, bold font.
-<a href="https://api.slack.com/reference/block-kit/blocks#header">https://api.slack.com/reference/block-kit/blocks#header</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/header-block">https://docs.slack.dev/reference/block-kit/blocks/header-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>block_id</code></strong></dt>
@@ -2853,7 +2856,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A simple image block, designed to make those cat photos really pop.
-        https://api.slack.com/reference/block-kit/blocks#image
+        https://docs.slack.dev/reference/block-kit/blocks/image-block
 
         Args:
             alt_text (required): A plain-text summary of the image. This should not contain any markup.
@@ -2905,9 +2908,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A simple image block, designed to make those cat photos really pop.
-<a href="https://api.slack.com/reference/block-kit/blocks#image">https://api.slack.com/reference/block-kit/blocks#image</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/image-block">https://docs.slack.dev/reference/block-kit/blocks/image-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>alt_text</code></strong> :&ensp;<code>required</code></dt>
@@ -3009,7 +3012,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;An element to insert an image - this element can be used in section and
         context blocks only. If you want a block with only an image in it,
         you&#39;re looking for the image block.
-        https://api.slack.com/reference/block-kit/block-elements#image
+        https://docs.slack.dev/reference/block-kit/block-elements/image-element
 
         Args:
             alt_text (required): A plain-text summary of the image. This should not contain any markup.
@@ -3032,11 +3035,11 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return len(self.alt_text) &lt;= self.alt_text_max_length  # type: ignore[arg-type]</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An element to insert an image - this element can be used in section and
 context blocks only. If you want a block with only an image in it,
 you're looking for the image block.
-<a href="https://api.slack.com/reference/block-kit/block-elements#image">https://api.slack.com/reference/block-kit/block-elements#image</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/image-element">https://docs.slack.dev/reference/block-kit/block-elements/image-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>alt_text</code></strong> :&ensp;<code>required</code></dt>
@@ -3125,7 +3128,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     ):
         &#34;&#34;&#34;A block that collects information from users - it can hold a plain-text input element,
         a select menu element, a multi-select menu element, or a datepicker.
-        https://api.slack.com/reference/block-kit/blocks#input
+        https://docs.slack.dev/reference/block-kit/blocks/input-block
 
         Args:
             label (required): A label that appears above an input element in the form of a text object
@@ -3172,10 +3175,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A block that collects information from users - it can hold a plain-text input element,
 a select menu element, a multi-select menu element, or a datepicker.
-<a href="https://api.slack.com/reference/block-kit/blocks#input">https://api.slack.com/reference/block-kit/blocks#input</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/input-block">https://docs.slack.dev/reference/block-kit/blocks/input-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>label</code></strong> :&ensp;<code>required</code></dt>
@@ -3303,7 +3306,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         )</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>InteractiveElement that is usable in input blocks</p>
 <p>We generally recommend using the concrete subclasses for better supports of available properties.</p></div>
 <h3>Ancestors</h3>
@@ -3420,7 +3423,7 @@ def subtype(self) -&gt; Optional[str]:
         return self.action_id is None or len(self.action_id) &lt;= self.action_id_max_length</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An interactive block element.</p>
 <p>We generally recommend using the concrete subclasses for better supports of available properties.</p></div>
 <h3>Ancestors</h3>
@@ -3492,7 +3495,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;A simple button that simply opens a given URL. You will still receive an
         interaction payload and will need to send an acknowledgement response.
         This is a helper class that makes creating links simpler.
-        https://api.slack.com/reference/block-kit/block-elements#button
+        https://docs.slack.dev/reference/block-kit/block-elements/button-element/
 
         Args:
             text (required): A text object that defines the button&#39;s text.
@@ -3524,11 +3527,11 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         show_unknown_key_warning(self, others)</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>A simple button that simply opens a given URL. You will still receive an
 interaction payload and will need to send an acknowledgement response.
 This is a helper class that makes creating links simpler.
-<a href="https://api.slack.com/reference/block-kit/block-elements#button">https://api.slack.com/reference/block-kit/block-elements#button</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/button-element/">https://docs.slack.dev/reference/block-kit/block-elements/button-element/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
@@ -3579,6 +3582,113 @@ If you don't include this field, the default button style will be used.</dd>
 </li>
 </ul>
 </dd>
+<dt id="slack_sdk.models.blocks.MarkdownBlock"><code class="flex name class">
+<span>class <span class="ident">MarkdownBlock</span></span>
+<span>(</span><span>*, text: str, block_id: str | None = None, **others: dict)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class MarkdownBlock(Block):
+    type = &#34;markdown&#34;
+    text_max_length = 12000
+
+    @property
+    def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+        return super().attributes.union({&#34;text&#34;})
+
+    def __init__(
+        self,
+        *,
+        text: str,
+        block_id: Optional[str] = None,
+        **others: dict,
+    ):
+        &#34;&#34;&#34;Displays formatted markdown.
+        https://docs.slack.dev/reference/block-kit/blocks/markdown-block/
+
+        Args:
+            block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
+                Maximum length for this field is 255 characters.
+                block_id should be unique for each message and each iteration of a message.
+                If a message is updated, use a new block_id.
+            text (required): The standard markdown-formatted text. Limit 12,000 characters max.
+        &#34;&#34;&#34;
+        super().__init__(type=self.type, block_id=block_id)
+        show_unknown_key_warning(self, others)
+
+        self.text = text
+
+    @JsonValidator(&#34;text attribute must be specified&#34;)
+    def _validate_text(self):
+        return self.text != &#34;&#34;
+
+    @JsonValidator(f&#34;text attribute cannot exceed {text_max_length} characters&#34;)
+    def _validate_alt_text_length(self):
+        return len(self.text) &lt;= self.text_max_length</code></pre>
+</details>
+<div class="desc"><p>Blocks are a series of components that can be combined
+to create visually rich and compellingly interactive messages.
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
+<p>Displays formatted markdown.
+<a href="https://docs.slack.dev/reference/block-kit/blocks/markdown-block/">https://docs.slack.dev/reference/block-kit/blocks/markdown-block/</a></p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>block_id</code></strong></dt>
+<dd>A string acting as a unique identifier for a block. If not specified, one will be generated.
+Maximum length for this field is 255 characters.
+block_id should be unique for each message and each iteration of a message.
+If a message is updated, use a new block_id.</dd>
+<dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
+<dd>The standard markdown-formatted text. Limit 12,000 characters max.</dd>
+</dl></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.blocks.blocks.Block" href="blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a></li>
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.MarkdownBlock.text_max_length"><code class="name">var <span class="ident">text_max_length</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+<dt id="slack_sdk.models.blocks.MarkdownBlock.type"><code class="name">var <span class="ident">type</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.MarkdownBlock.attributes"><code class="name">prop <span class="ident">attributes</span> : Set[str]</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+    return super().attributes.union({&#34;text&#34;})</code></pre>
+</details>
+<div class="desc"><p>Build an unordered collection of unique elements.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.blocks.blocks.Block" href="blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.block_id_max_length" href="blocks.html#slack_sdk.models.blocks.blocks.Block.block_id_max_length">block_id_max_length</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.logger" href="blocks.html#slack_sdk.models.blocks.blocks.Block.logger">logger</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
 <dt id="slack_sdk.models.blocks.MarkdownTextObject"><code class="flex name class">
 <span>class <span class="ident">MarkdownTextObject</span></span>
 <span>(</span><span>*, text: str, verbatim: bool | None = None)</span>
@@ -3600,7 +3710,7 @@ If you don't include this field, the default button style will be used.</dd>
     def __init__(self, *, text: str, verbatim: Optional[bool] = None):
         &#34;&#34;&#34;A Markdown text object, meaning markdown characters will be parsed as
         formatting information.
-        https://api.slack.com/reference/block-kit/composition-objects#text
+        https://docs.slack.dev/reference/block-kit/composition-objects/text-object
 
         Args:
             text (required): The text for the block. This field accepts any of the standard text formatting markup
@@ -3644,7 +3754,7 @@ If you don't include this field, the default button style will be used.</dd>
 <div class="desc"><p>mrkdwn typed text object</p>
 <p>A Markdown text object, meaning markdown characters will be parsed as
 formatting information.
-<a href="https://api.slack.com/reference/block-kit/composition-objects#text">https://api.slack.com/reference/block-kit/composition-objects#text</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/text-object">https://docs.slack.dev/reference/block-kit/composition-objects/text-object</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
@@ -3807,7 +3917,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;
-        https://api.slack.com/reference/block-kit/block-elements#number
+        https://docs.slack.dev/reference/block-kit/block-elements/number-input-element/
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -3841,8 +3951,8 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.dispatch_action_config = dispatch_action_config</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
-<p><a href="https://api.slack.com/reference/block-kit/block-elements#number">https://api.slack.com/reference/block-kit/block-elements#number</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
+<p><a href="https://docs.slack.dev/reference/block-kit/block-elements/number-input-element/">https://docs.slack.dev/reference/block-kit/block-elements/number-input-element/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -3936,7 +4046,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     different required formats in different situations
     &#34;&#34;&#34;
 
-    attributes = {}  # type: ignore[assignment] # no attributes because to_dict has unique implementations
+    attributes: Set[str] = set()
     logger = logging.getLogger(__name__)
 
     label_max_length = 75
@@ -3958,13 +4068,13 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         (StaticDialogSelectElement)
 
         Blocks:
-        https://api.slack.com/reference/block-kit/composition-objects#option
+        https://docs.slack.dev/reference/block-kit/composition-objects/option-object
 
         Dialogs:
-        https://api.slack.com/dialogs#select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
 
         Legacy interactive attachments:
-        https://api.slack.com/legacy/interactive-message-field-guide#option_fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_fields
 
         Args:
             label: A short, user-facing string to label this option to users.
@@ -4083,11 +4193,11 @@ different required formats in different situations</p>
 SelectElement, OverflowMenuElement) or dialog element
 (StaticDialogSelectElement)</p>
 <p>Blocks:
-<a href="https://api.slack.com/reference/block-kit/composition-objects#option">https://api.slack.com/reference/block-kit/composition-objects#option</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/option-object">https://docs.slack.dev/reference/block-kit/composition-objects/option-object</a></p>
 <p>Dialogs:
-<a href="https://api.slack.com/dialogs#select_elements">https://api.slack.com/dialogs#select_elements</a></p>
+<a href="https://docs.slack.dev/legacy/legacy-dialogs/#select_elements">https://docs.slack.dev/legacy/legacy-dialogs/#select_elements</a></p>
 <p>Legacy interactive attachments:
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#option_fields">https://api.slack.com/legacy/interactive-message-field-guide#option_fields</a></p>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_fields">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_fields</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>label</code></strong></dt>
@@ -4109,7 +4219,7 @@ dialogs.</dd>
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="slack_sdk.models.blocks.Option.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dt id="slack_sdk.models.blocks.Option.attributes"><code class="name">var <span class="ident">attributes</span> : Set[str]</code></dt>
 <dd>
 <div class="desc"><p>The type of the None singleton.</p></div>
 </dd>
@@ -4218,7 +4328,7 @@ correct shape.</p></div>
     different required formats in different situations
     &#34;&#34;&#34;
 
-    attributes = {}  # type: ignore[assignment] # no attributes because to_dict has unique implementations
+    attributes: Set[str] = set()
     label_max_length = 75
     options_max_length = 100
     logger = logging.getLogger(__name__)
@@ -4235,13 +4345,13 @@ correct shape.</p></div>
         UI) and a list of Option objects.
 
         Blocks:
-        https://api.slack.com/reference/block-kit/composition-objects#option-group
+        https://docs.slack.dev/reference/block-kit/composition-objects/option-group-object
 
         Dialogs:
-        https://api.slack.com/dialogs#select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
 
         Legacy interactive attachments:
-        https://api.slack.com/legacy/interactive-message-field-guide#option_groups_to_place_within_message_menu_actions
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_groups
 
         Args:
             label: Text to display at the top of this group of options.
@@ -4303,11 +4413,11 @@ different required formats in different situations</p>
 <p>Create a group of Option objects - pass in a label (that will be part of the
 UI) and a list of Option objects.</p>
 <p>Blocks:
-<a href="https://api.slack.com/reference/block-kit/composition-objects#option-group">https://api.slack.com/reference/block-kit/composition-objects#option-group</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/option-group-object">https://docs.slack.dev/reference/block-kit/composition-objects/option-group-object</a></p>
 <p>Dialogs:
-<a href="https://api.slack.com/dialogs#select_elements">https://api.slack.com/dialogs#select_elements</a></p>
+<a href="https://docs.slack.dev/legacy/legacy-dialogs/#select_elements">https://docs.slack.dev/legacy/legacy-dialogs/#select_elements</a></p>
 <p>Legacy interactive attachments:
-<a href="https://api.slack.com/legacy/interactive-message-field-guide#option_groups_to_place_within_message_menu_actions">https://api.slack.com/legacy/interactive-message-field-guide#option_groups_to_place_within_message_menu_actions</a></p>
+<a href="https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_groups">https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_groups</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>label</code></strong></dt>
@@ -4322,7 +4432,7 @@ UI) and a list of Option objects.</p>
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="slack_sdk.models.blocks.OptionGroup.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dt id="slack_sdk.models.blocks.OptionGroup.attributes"><code class="name">var <span class="ident">attributes</span> : Set[str]</code></dt>
 <dd>
 <div class="desc"><p>The type of the None singleton.</p></div>
 </dd>
@@ -4396,7 +4506,7 @@ UI) and a list of Option objects.</p>
         buttons. You can also specify simple URL links as overflow menu options,
         instead of actions.
 
-        https://api.slack.com/reference/block-kit/block-elements#overflow
+        https://docs.slack.dev/reference/block-kit/block-elements/overflow-menu-element
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -4419,7 +4529,7 @@ UI) and a list of Option objects.</p>
         return self.options_min_length &lt;= len(self.options) &lt;= self.options_max_length</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This is like a cross between a button and a select menu - when a user clicks
 on this overflow button, they will be presented with a list of options to
 choose from. Unlike the select menu, there is no typeahead field, and the
@@ -4428,7 +4538,7 @@ button always appears with an ellipsis ("…") rather than customisable text.</p
 menu, or to supply a list of less visually important actions after a row of
 buttons. You can also specify simple URL links as overflow menu options,
 instead of actions.</p>
-<p><a href="https://api.slack.com/reference/block-kit/block-elements#overflow">https://api.slack.com/reference/block-kit/block-elements#overflow</a></p>
+<p><a href="https://docs.slack.dev/reference/block-kit/block-elements/overflow-menu-element">https://docs.slack.dev/reference/block-kit/block-elements/overflow-menu-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -4521,7 +4631,7 @@ after a menu item is selected.</dd>
         where a user can enter freeform data. It can appear as a single-line
         field or a larger textarea using the multiline flag. Plain-text input
         elements can be used inside of SectionBlocks and ActionsBlocks.
-        https://api.slack.com/reference/block-kit/block-elements#input
+        https://docs.slack.dev/reference/block-kit/block-elements/plain-text-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -4557,12 +4667,12 @@ after a menu item is selected.</dd>
         self.dispatch_action_config = dispatch_action_config</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>A plain-text input, similar to the HTML <input> tag, creates a field
 where a user can enter freeform data. It can appear as a single-line
 field or a larger textarea using the multiline flag. Plain-text input
 elements can be used inside of SectionBlocks and ActionsBlocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements#input">https://api.slack.com/reference/block-kit/block-elements#input</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/plain-text-input-element">https://docs.slack.dev/reference/block-kit/block-elements/plain-text-input-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -4664,7 +4774,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     def __init__(self, *, text: str, emoji: Optional[bool] = None):
         &#34;&#34;&#34;A plain text object, meaning markdown characters will not be parsed as
         formatting information.
-        https://api.slack.com/reference/block-kit/composition-objects#text
+        https://docs.slack.dev/reference/block-kit/composition-objects/text-object
 
         Args:
             text (required): The text for the block. This field accepts any of the standard text formatting markup
@@ -4687,7 +4797,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <div class="desc"><p>plain_text typed text object</p>
 <p>A plain text object, meaning markdown characters will not be parsed as
 formatting information.
-<a href="https://api.slack.com/reference/block-kit/composition-objects#text">https://api.slack.com/reference/block-kit/composition-objects#text</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/text-object">https://docs.slack.dev/reference/block-kit/composition-objects/text-object</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
@@ -4796,7 +4906,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A radio button group that allows a user to choose one item from a list of possible options.
-        https://api.slack.com/reference/block-kit/block-elements#radio
+        https://docs.slack.dev/reference/block-kit/block-elements/radio-button-group-element
 
         Args:
             action_id (required): An identifier for the action triggered when the radio button group is changed.
@@ -4823,9 +4933,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.initial_option = initial_option</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>A radio button group that allows a user to choose one item from a list of possible options.
-<a href="https://api.slack.com/reference/block-kit/block-elements#radio">https://api.slack.com/reference/block-kit/block-elements#radio</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/radio-button-group-element">https://docs.slack.dev/reference/block-kit/block-elements/radio-button-group-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -4913,7 +5023,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A block that is used to hold interactive elements.
-        https://api.slack.com/reference/block-kit/blocks#rich_text
+        https://docs.slack.dev/reference/block-kit/blocks/rich-text-block
 
         Args:
             elements (required): An array of rich text objects -
@@ -4930,9 +5040,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A block that is used to hold interactive elements.
-<a href="https://api.slack.com/reference/block-kit/blocks#rich_text">https://api.slack.com/reference/block-kit/blocks#rich_text</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/rich-text-block">https://docs.slack.dev/reference/block-kit/blocks/rich-text-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>elements</code></strong> :&ensp;<code>required</code></dt>
@@ -4998,7 +5108,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     pass</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.block_elements.BlockElement" href="block_elements.html#slack_sdk.models.blocks.block_elements.BlockElement">BlockElement</a></li>
@@ -5269,42 +5379,42 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <dt id="slack_sdk.models.blocks.RichTextElementParts.Broadcast"><code class="name">var <span class="ident">Broadcast</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.RichTextElementParts.Channel"><code class="name">var <span class="ident">Channel</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.RichTextElementParts.Color"><code class="name">var <span class="ident">Color</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.RichTextElementParts.Date"><code class="name">var <span class="ident">Date</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.RichTextElementParts.Emoji"><code class="name">var <span class="ident">Emoji</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.RichTextElementParts.Link"><code class="name">var <span class="ident">Link</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.RichTextElementParts.Team"><code class="name">var <span class="ident">Team</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.RichTextElementParts.Text"><code class="name">var <span class="ident">Text</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.RichTextElementParts.TextStyle"><code class="name">var <span class="ident">TextStyle</span></code></dt>
 <dd>
@@ -5313,12 +5423,12 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <dt id="slack_sdk.models.blocks.RichTextElementParts.User"><code class="name">var <span class="ident">User</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 <dt id="slack_sdk.models.blocks.RichTextElementParts.UserGroup"><code class="name">var <span class="ident">UserGroup</span></code></dt>
 <dd>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 </dd>
 </dl>
 </dd>
@@ -5366,7 +5476,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.dispatch_action_config = dispatch_action_config</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>InteractiveElement that is usable in input blocks</p>
 <p>We generally recommend using the concrete subclasses for better supports of available properties.</p></div>
 <h3>Ancestors</h3>
@@ -5453,7 +5563,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.border = border</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.block_elements.RichTextElement" href="block_elements.html#slack_sdk.models.blocks.block_elements.RichTextElement">RichTextElement</a></li>
@@ -5524,7 +5634,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.border = border</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.block_elements.RichTextElement" href="block_elements.html#slack_sdk.models.blocks.block_elements.RichTextElement">RichTextElement</a></li>
@@ -5593,7 +5703,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.elements = BlockElement.parse_all(elements)</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.block_elements.RichTextElement" href="block_elements.html#slack_sdk.models.blocks.block_elements.RichTextElement">RichTextElement</a></li>
@@ -5662,7 +5772,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.elements = BlockElement.parse_all(elements)</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p></div>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.block_elements.RichTextElement" href="block_elements.html#slack_sdk.models.blocks.block_elements.RichTextElement">RichTextElement</a></li>
@@ -5733,7 +5843,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;A section is one of the most flexible blocks available.
-        https://api.slack.com/reference/block-kit/blocks#section
+        https://docs.slack.dev/reference/block-kit/blocks/section-block
 
         Args:
             block_id (required): A string acting as a unique identifier for a block.
@@ -5792,9 +5902,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A section is one of the most flexible blocks available.
-<a href="https://api.slack.com/reference/block-kit/blocks#section">https://api.slack.com/reference/block-kit/blocks#section</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/section-block">https://docs.slack.dev/reference/block-kit/blocks/section-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>block_id</code></strong> :&ensp;<code>required</code></dt>
@@ -5901,7 +6011,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;This is the simplest form of select menu, with a static list of options passed in when defining the element.
-        https://api.slack.com/reference/block-kit/block-elements#static_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -5953,9 +6063,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return self.options is not None or self.option_groups is not None</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This is the simplest form of select menu, with a static list of options passed in when defining the element.
-<a href="https://api.slack.com/reference/block-kit/block-elements#static_select">https://api.slack.com/reference/block-kit/block-elements#static_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -6069,7 +6179,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     ):
         &#34;&#34;&#34;
         This is the simplest form of select menu, with a static list of options passed in when defining the element.
-        https://api.slack.com/reference/block-kit/block-elements#static_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#static_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -6124,9 +6234,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return self.options is not None or self.option_groups is not None</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This is the simplest form of select menu, with a static list of options passed in when defining the element.
-<a href="https://api.slack.com/reference/block-kit/block-elements#static_multi_select">https://api.slack.com/reference/block-kit/block-elements#static_multi_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#static_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#static_multi_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -6241,7 +6351,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         **others: dict,
     ):
         &#34;&#34;&#34;This is the simplest form of select menu, with a static list of options passed in when defining the element.
-        https://api.slack.com/reference/block-kit/block-elements#static_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -6293,9 +6403,9 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         return self.options is not None or self.option_groups is not None</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This is the simplest form of select menu, with a static list of options passed in when defining the element.
-<a href="https://api.slack.com/reference/block-kit/block-elements#static_select">https://api.slack.com/reference/block-kit/block-elements#static_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -6533,7 +6643,7 @@ def subtype(self) -&gt; Optional[str]:
         On desktop clients, this time picker will take the form of a dropdown list
         with free-text entry for precise choices.
         On mobile clients, the time picker will use native time picker UIs.
-        https://api.slack.com/reference/block-kit/block-elements#timepicker
+        https://docs.slack.dev/reference/block-kit/block-elements/time-picker-element
 
         Args:
             action_id (required): An identifier for the action triggered when a time is selected.
@@ -6568,12 +6678,12 @@ def subtype(self) -&gt; Optional[str]:
         return self.initial_time is None or re.match(r&#34;([0-1][0-9]|2[0-3]):([0-5][0-9])&#34;, self.initial_time) is not None</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>An element which allows selection of a time of day.
 On desktop clients, this time picker will take the form of a dropdown list
 with free-text entry for precise choices.
 On mobile clients, the time picker will use native time picker UIs.
-<a href="https://api.slack.com/reference/block-kit/block-elements#timepicker">https://api.slack.com/reference/block-kit/block-elements#timepicker</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/time-picker-element">https://docs.slack.dev/reference/block-kit/block-elements/time-picker-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -6675,7 +6785,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         A URL input element, similar to the Plain-text input element,
         creates a single line field where a user can enter URL-encoded data.
-        https://api.slack.com/reference/block-kit/block-elements#url
+        https://docs.slack.dev/reference/block-kit/block-elements/url-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -6702,10 +6812,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.dispatch_action_config = dispatch_action_config</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>A URL input element, similar to the Plain-text input element,
 creates a single line field where a user can enter URL-encoded data.
-<a href="https://api.slack.com/reference/block-kit/block-elements#url">https://api.slack.com/reference/block-kit/block-elements#url</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/url-input-element">https://docs.slack.dev/reference/block-kit/block-elements/url-input-element</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -6804,7 +6914,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will populate its options with a list of Slack users visible to
         the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#users_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#users_multi_select
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -6834,10 +6944,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.max_selected_items = max_selected_items</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will populate its options with a list of Slack users visible to
 the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#users_multi_select">https://api.slack.com/reference/block-kit/block-elements#users_multi_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#users_multi_select">https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#users_multi_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>action_id</code></strong> :&ensp;<code>required</code></dt>
@@ -6933,7 +7043,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         &#34;&#34;&#34;
         This select menu will populate its options with a list of Slack users visible to
         the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#users_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#users_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -6960,10 +7070,10 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         self.initial_user = initial_user</code></pre>
 </details>
 <div class="desc"><p>Block Elements are things that exists inside of your Blocks.
-<a href="https://api.slack.com/reference/block-kit/block-elements">https://api.slack.com/reference/block-kit/block-elements</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/">https://docs.slack.dev/reference/block-kit/block-elements/</a></p>
 <p>This select menu will populate its options with a list of Slack users visible to
 the current user in the active workspace.
-<a href="https://api.slack.com/reference/block-kit/block-elements#users_select">https://api.slack.com/reference/block-kit/block-elements#users_select</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#users_select">https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#users_select</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>placeholder</code></strong> :&ensp;<code>required</code></dt>
@@ -7076,7 +7186,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         (e.g. link unfurls, messages, modals, App Home) —
         anywhere you can put blocks! To use the video block within your app,
         you must have the links.embed:write scope.
-        https://api.slack.com/reference/block-kit/blocks#video
+        https://docs.slack.dev/reference/block-kit/blocks/video-block
 
         Args:
             block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
@@ -7134,12 +7244,12 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </details>
 <div class="desc"><p>Blocks are a series of components that can be combined
 to create visually rich and compellingly interactive messages.
-<a href="https://api.slack.com/reference/block-kit/blocks">https://api.slack.com/reference/block-kit/blocks</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
 <p>A video block is designed to embed videos in all app surfaces
 (e.g. link unfurls, messages, modals, App Home) —
 anywhere you can put blocks! To use the video block within your app,
 you must have the links.embed:write scope.
-<a href="https://api.slack.com/reference/block-kit/blocks#video">https://api.slack.com/reference/block-kit/blocks#video</a></p>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/video-block">https://docs.slack.dev/reference/block-kit/blocks/video-block</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>block_id</code></strong></dt>
@@ -7463,6 +7573,14 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </li>
 <li>
 <h4><code><a title="slack_sdk.models.blocks.LinkButtonElement" href="#slack_sdk.models.blocks.LinkButtonElement">LinkButtonElement</a></code></h4>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.blocks.MarkdownBlock" href="#slack_sdk.models.blocks.MarkdownBlock">MarkdownBlock</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.blocks.MarkdownBlock.attributes" href="#slack_sdk.models.blocks.MarkdownBlock.attributes">attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.MarkdownBlock.text_max_length" href="#slack_sdk.models.blocks.MarkdownBlock.text_max_length">text_max_length</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.MarkdownBlock.type" href="#slack_sdk.models.blocks.MarkdownBlock.type">type</a></code></li>
+</ul>
 </li>
 <li>
 <h4><code><a title="slack_sdk.models.blocks.MarkdownTextObject" href="#slack_sdk.models.blocks.MarkdownTextObject">MarkdownTextObject</a></code></h4>

--- a/docs/reference/models/dialoags.html
+++ b/docs/reference/models/dialoags.html
@@ -247,7 +247,7 @@ def placeholder_length(self) -&gt; bool:
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class DialogBuilder(JsonObject):
-    attributes = {}  # type: ignore[assignment] # no attributes because to_dict has unique implementation
+    attributes: Set[str] = set()
 
     _callback_id: Optional[str]
     _elements: List[Union[DialogTextComponent, AbstractDialogSelector]]
@@ -348,7 +348,7 @@ def placeholder_length(self) -&gt; bool:
         &#34;&#34;&#34;
         Text elements are single-line plain text fields.
 
-        https://api.slack.com/dialogs#attributes_text_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_text_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -403,7 +403,7 @@ def placeholder_length(self) -&gt; bool:
         character count to the max_length you have set or the default,
         3000.
 
-        https://api.slack.com/dialogs#attributes_textarea_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_textarea_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -456,7 +456,7 @@ def placeholder_length(self) -&gt; bool:
         A select element may contain up to 100 selections, provided as a list of
         Option or OptionGroup objects
 
-        https://api.slack.com/dialogs#attributes_select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -499,7 +499,7 @@ def placeholder_length(self) -&gt; bool:
         A list of options can be loaded from an external URL and used in your dialog
         menus.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_external
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -542,7 +542,7 @@ def placeholder_length(self) -&gt; bool:
         assignee. Slack pre-populates the user list in client-side, so your app
         doesn&#39;t need access to a related OAuth scope.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_users
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -577,7 +577,7 @@ def placeholder_length(self) -&gt; bool:
         You can also provide a select menu with a list of channels. Specify your
         data_source as channels to limit only to public channels
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -613,7 +613,7 @@ def placeholder_length(self) -&gt; bool:
         private channels, direct messages, MPIMs, and whatever else we consider a
         conversation-like thing.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -687,7 +687,7 @@ dialog to Slack</p></div>
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="slack_sdk.models.dialoags.DialogBuilder.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dt id="slack_sdk.models.dialoags.DialogBuilder.attributes"><code class="name">var <span class="ident">attributes</span> : Set[str]</code></dt>
 <dd>
 <div class="desc"><p>The type of the None singleton.</p></div>
 </dd>
@@ -772,7 +772,7 @@ def callback_id_present(self) -&gt; bool:
     You can also provide a select menu with a list of channels. Specify your
     data_source as channels to limit only to public channels
 
-    https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+    https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -796,7 +796,7 @@ def callback_id_present(self) -&gt; bool:
 </details>
 <div class="desc"><p>You can also provide a select menu with a list of channels. Specify your
 data_source as channels to limit only to public channels</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations">https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -835,7 +835,7 @@ completing the element. 150 character maximum.</dd>
     private channels, direct messages, MPIMs, and whatever else we consider a
     conversation-like thing.
 
-    https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+    https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -860,7 +860,7 @@ completing the element. 150 character maximum.</dd>
 <div class="desc"><p>You can also provide a select menu with a list of conversations - including
 private channels, direct messages, MPIMs, and whatever else we consider a
 conversation-like thing.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations">https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -917,7 +917,7 @@ def elements_length(self) -&gt; bool:
     A list of options can be loaded from an external URL and used in your dialog
     menus.
 
-    https://api.slack.com/dialogs#dynamic_select_elements_external
+    https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -950,7 +950,7 @@ a single item from a list. True to web roots, this selection is displayed as
 a dropdown menu.</p>
 <p>A list of options can be loaded from an external URL and used in your dialog
 menus.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_external">https://api.slack.com/dialogs#dynamic_select_elements_external</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1074,7 +1074,7 @@ def state_length(self) -&gt; bool:
     A select element may contain up to 100 selections, provided as a list of
     Option or OptionGroup objects
 
-    https://api.slack.com/dialogs#attributes_select_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -1104,7 +1104,7 @@ a single item from a list. True to web roots, this selection is displayed as
 a dropdown menu.</p>
 <p>A select element may contain up to 100 selections, provided as a list of
 Option or OptionGroup objects</p>
-<p><a href="https://api.slack.com/dialogs#attributes_select_elements">https://api.slack.com/dialogs#attributes_select_elements</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements">https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1209,7 +1209,7 @@ def submit_label_valid(self) -&gt; bool:
     character count to the max_length you have set or the default,
     3000.
 
-    https://api.slack.com/dialogs#attributes_textarea_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#attributes_textarea_elements
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -1249,7 +1249,7 @@ encountered these on the world wide web. Use this element if you want a
 relatively long answer from users. The element UI provides a remaining
 character count to the max_length you have set or the default,
 3000.</p>
-<p><a href="https://api.slack.com/dialogs#attributes_textarea_elements">https://api.slack.com/dialogs#attributes_textarea_elements</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#attributes_textarea_elements">https://docs.slack.dev/legacy/legacy-dialogs/#attributes_textarea_elements</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1303,7 +1303,7 @@ subtype.</dd>
     &#34;&#34;&#34;
     Text elements are single-line plain text fields.
 
-    https://api.slack.com/dialogs#attributes_text_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#attributes_text_elements
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -1339,7 +1339,7 @@ subtype.</dd>
     return self</code></pre>
 </details>
 <div class="desc"><p>Text elements are single-line plain text fields.</p>
-<p><a href="https://api.slack.com/dialogs#attributes_text_elements">https://api.slack.com/dialogs#attributes_text_elements</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#attributes_text_elements">https://docs.slack.dev/legacy/legacy-dialogs/#attributes_text_elements</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1445,7 +1445,7 @@ def title_present(self) -&gt; bool:
     assignee. Slack pre-populates the user list in client-side, so your app
     doesn&#39;t need access to a related OAuth scope.
 
-    https://api.slack.com/dialogs#dynamic_select_elements_users
+    https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -1471,7 +1471,7 @@ def title_present(self) -&gt; bool:
 when you are creating a bug tracking app, you want to include a field for an
 assignee. Slack pre-populates the user list in client-side, so your app
 doesn't need access to a related OAuth scope.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_users">https://api.slack.com/dialogs#dynamic_select_elements_users</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1525,7 +1525,7 @@ completing the element. 150 character maximum.</dd>
         You can also provide a select menu with a list of channels. Specify your
         data_source as channels to limit only to public channels
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -1547,7 +1547,7 @@ completing the element. 150 character maximum.</dd>
 <div class="desc"><p>The base class for JSON serializable class objects</p>
 <p>You can also provide a select menu with a list of channels. Specify your
 data_source as channels to limit only to public channels</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations">https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1618,7 +1618,7 @@ completing the element. 150 character maximum.</dd>
         private channels, direct messages, MPIMs, and whatever else we consider a
         conversation-like thing.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -1641,7 +1641,7 @@ completing the element. 150 character maximum.</dd>
 <p>You can also provide a select menu with a list of conversations - including
 private channels, direct messages, MPIMs, and whatever else we consider a
 conversation-like thing.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations">https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1720,7 +1720,7 @@ completing the element. 150 character maximum.</dd>
         A list of options can be loaded from an external URL and used in your dialog
         menus.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_external
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -1750,7 +1750,7 @@ a single item from a list. True to web roots, this selection is displayed as
 a dropdown menu.</p>
 <p>A list of options can be loaded from an external URL and used in your dialog
 menus.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_external">https://api.slack.com/dialogs#dynamic_select_elements_external</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1829,7 +1829,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     single item from a list. True to web roots, this selection is displayed as a
     dropdown menu.
 
-    https://api.slack.com/dialogs#select_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
     &#34;&#34;&#34;
 
     data_source = &#34;static&#34;
@@ -1854,7 +1854,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         A select element may contain up to 100 selections, provided as a list of
         Option or OptionGroup objects
 
-        https://api.slack.com/dialogs#attributes_select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -1891,13 +1891,13 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <div class="desc"><p>Use the select element for multiple choice selections allowing users to pick a
 single item from a list. True to web roots, this selection is displayed as a
 dropdown menu.</p>
-<p><a href="https://api.slack.com/dialogs#select_elements">https://api.slack.com/dialogs#select_elements</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#select_elements">https://docs.slack.dev/legacy/legacy-dialogs/#select_elements</a></p>
 <p>Use the select element for multiple choice selections allowing users to pick
 a single item from a list. True to web roots, this selection is displayed as
 a dropdown menu.</p>
 <p>A select element may contain up to 100 selections, provided as a list of
 Option or OptionGroup objects</p>
-<p><a href="https://api.slack.com/dialogs#attributes_select_elements">https://api.slack.com/dialogs#attributes_select_elements</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements">https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1982,7 +1982,7 @@ def options_length(self) -&gt; bool:
     answer from users. The element UI provides a remaining character count to the
     max_length you have set or the default, 3000.
 
-    https://api.slack.com/dialogs#textarea_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#textarea_elements
     &#34;&#34;&#34;
 
     type = &#34;textarea&#34;
@@ -1992,7 +1992,7 @@ def options_length(self) -&gt; bool:
 these on the world wide web. Use this element if you want a relatively long
 answer from users. The element UI provides a remaining character count to the
 max_length you have set or the default, 3000.</p>
-<p><a href="https://api.slack.com/dialogs#textarea_elements">https://api.slack.com/dialogs#textarea_elements</a></p></div>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#textarea_elements">https://docs.slack.dev/legacy/legacy-dialogs/#textarea_elements</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.dialogs.DialogTextComponent" href="dialogs/index.html#slack_sdk.models.dialogs.DialogTextComponent">DialogTextComponent</a></li>
@@ -2375,14 +2375,14 @@ def value_length(self) -&gt; bool:
     &#34;&#34;&#34;
     Text elements are single-line plain text fields.
 
-    https://api.slack.com/dialogs#text_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#text_elements
     &#34;&#34;&#34;
 
     type = &#34;text&#34;
     max_value_length = 150</code></pre>
 </details>
 <div class="desc"><p>Text elements are single-line plain text fields.</p>
-<p><a href="https://api.slack.com/dialogs#text_elements">https://api.slack.com/dialogs#text_elements</a></p></div>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#text_elements">https://docs.slack.dev/legacy/legacy-dialogs/#text_elements</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.dialogs.DialogTextComponent" href="dialogs/index.html#slack_sdk.models.dialogs.DialogTextComponent">DialogTextComponent</a></li>
@@ -2443,7 +2443,7 @@ def value_length(self) -&gt; bool:
         assignee. Slack pre-populates the user list in client-side, so your app
         doesn&#39;t need access to a related OAuth scope.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_users
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -2467,7 +2467,7 @@ def value_length(self) -&gt; bool:
 when you are creating a bug tracking app, you want to include a field for an
 assignee. Slack pre-populates the user list in client-side, so your app
 doesn't need access to a related OAuth scope.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_users">https://api.slack.com/dialogs#dynamic_select_elements_users</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>

--- a/docs/reference/models/dialogs/index.html
+++ b/docs/reference/models/dialogs/index.html
@@ -247,7 +247,7 @@ def placeholder_length(self) -&gt; bool:
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class DialogBuilder(JsonObject):
-    attributes = {}  # type: ignore[assignment] # no attributes because to_dict has unique implementation
+    attributes: Set[str] = set()
 
     _callback_id: Optional[str]
     _elements: List[Union[DialogTextComponent, AbstractDialogSelector]]
@@ -348,7 +348,7 @@ def placeholder_length(self) -&gt; bool:
         &#34;&#34;&#34;
         Text elements are single-line plain text fields.
 
-        https://api.slack.com/dialogs#attributes_text_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_text_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -403,7 +403,7 @@ def placeholder_length(self) -&gt; bool:
         character count to the max_length you have set or the default,
         3000.
 
-        https://api.slack.com/dialogs#attributes_textarea_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_textarea_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -456,7 +456,7 @@ def placeholder_length(self) -&gt; bool:
         A select element may contain up to 100 selections, provided as a list of
         Option or OptionGroup objects
 
-        https://api.slack.com/dialogs#attributes_select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -499,7 +499,7 @@ def placeholder_length(self) -&gt; bool:
         A list of options can be loaded from an external URL and used in your dialog
         menus.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_external
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -542,7 +542,7 @@ def placeholder_length(self) -&gt; bool:
         assignee. Slack pre-populates the user list in client-side, so your app
         doesn&#39;t need access to a related OAuth scope.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_users
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -577,7 +577,7 @@ def placeholder_length(self) -&gt; bool:
         You can also provide a select menu with a list of channels. Specify your
         data_source as channels to limit only to public channels
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -613,7 +613,7 @@ def placeholder_length(self) -&gt; bool:
         private channels, direct messages, MPIMs, and whatever else we consider a
         conversation-like thing.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -687,7 +687,7 @@ dialog to Slack</p></div>
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="slack_sdk.models.dialogs.DialogBuilder.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dt id="slack_sdk.models.dialogs.DialogBuilder.attributes"><code class="name">var <span class="ident">attributes</span> : Set[str]</code></dt>
 <dd>
 <div class="desc"><p>The type of the None singleton.</p></div>
 </dd>
@@ -772,7 +772,7 @@ def callback_id_present(self) -&gt; bool:
     You can also provide a select menu with a list of channels. Specify your
     data_source as channels to limit only to public channels
 
-    https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+    https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -796,7 +796,7 @@ def callback_id_present(self) -&gt; bool:
 </details>
 <div class="desc"><p>You can also provide a select menu with a list of channels. Specify your
 data_source as channels to limit only to public channels</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations">https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -835,7 +835,7 @@ completing the element. 150 character maximum.</dd>
     private channels, direct messages, MPIMs, and whatever else we consider a
     conversation-like thing.
 
-    https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+    https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -860,7 +860,7 @@ completing the element. 150 character maximum.</dd>
 <div class="desc"><p>You can also provide a select menu with a list of conversations - including
 private channels, direct messages, MPIMs, and whatever else we consider a
 conversation-like thing.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations">https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -917,7 +917,7 @@ def elements_length(self) -&gt; bool:
     A list of options can be loaded from an external URL and used in your dialog
     menus.
 
-    https://api.slack.com/dialogs#dynamic_select_elements_external
+    https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -950,7 +950,7 @@ a single item from a list. True to web roots, this selection is displayed as
 a dropdown menu.</p>
 <p>A list of options can be loaded from an external URL and used in your dialog
 menus.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_external">https://api.slack.com/dialogs#dynamic_select_elements_external</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1074,7 +1074,7 @@ def state_length(self) -&gt; bool:
     A select element may contain up to 100 selections, provided as a list of
     Option or OptionGroup objects
 
-    https://api.slack.com/dialogs#attributes_select_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -1104,7 +1104,7 @@ a single item from a list. True to web roots, this selection is displayed as
 a dropdown menu.</p>
 <p>A select element may contain up to 100 selections, provided as a list of
 Option or OptionGroup objects</p>
-<p><a href="https://api.slack.com/dialogs#attributes_select_elements">https://api.slack.com/dialogs#attributes_select_elements</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements">https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1209,7 +1209,7 @@ def submit_label_valid(self) -&gt; bool:
     character count to the max_length you have set or the default,
     3000.
 
-    https://api.slack.com/dialogs#attributes_textarea_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#attributes_textarea_elements
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -1249,7 +1249,7 @@ encountered these on the world wide web. Use this element if you want a
 relatively long answer from users. The element UI provides a remaining
 character count to the max_length you have set or the default,
 3000.</p>
-<p><a href="https://api.slack.com/dialogs#attributes_textarea_elements">https://api.slack.com/dialogs#attributes_textarea_elements</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#attributes_textarea_elements">https://docs.slack.dev/legacy/legacy-dialogs/#attributes_textarea_elements</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1303,7 +1303,7 @@ subtype.</dd>
     &#34;&#34;&#34;
     Text elements are single-line plain text fields.
 
-    https://api.slack.com/dialogs#attributes_text_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#attributes_text_elements
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -1339,7 +1339,7 @@ subtype.</dd>
     return self</code></pre>
 </details>
 <div class="desc"><p>Text elements are single-line plain text fields.</p>
-<p><a href="https://api.slack.com/dialogs#attributes_text_elements">https://api.slack.com/dialogs#attributes_text_elements</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#attributes_text_elements">https://docs.slack.dev/legacy/legacy-dialogs/#attributes_text_elements</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1445,7 +1445,7 @@ def title_present(self) -&gt; bool:
     assignee. Slack pre-populates the user list in client-side, so your app
     doesn&#39;t need access to a related OAuth scope.
 
-    https://api.slack.com/dialogs#dynamic_select_elements_users
+    https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users
 
     Args:
         name: Name of form element. Required. No more than 300 characters.
@@ -1471,7 +1471,7 @@ def title_present(self) -&gt; bool:
 when you are creating a bug tracking app, you want to include a field for an
 assignee. Slack pre-populates the user list in client-side, so your app
 doesn't need access to a related OAuth scope.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_users">https://api.slack.com/dialogs#dynamic_select_elements_users</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1525,7 +1525,7 @@ completing the element. 150 character maximum.</dd>
         You can also provide a select menu with a list of channels. Specify your
         data_source as channels to limit only to public channels
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -1547,7 +1547,7 @@ completing the element. 150 character maximum.</dd>
 <div class="desc"><p>The base class for JSON serializable class objects</p>
 <p>You can also provide a select menu with a list of channels. Specify your
 data_source as channels to limit only to public channels</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations">https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1618,7 +1618,7 @@ completing the element. 150 character maximum.</dd>
         private channels, direct messages, MPIMs, and whatever else we consider a
         conversation-like thing.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -1641,7 +1641,7 @@ completing the element. 150 character maximum.</dd>
 <p>You can also provide a select menu with a list of conversations - including
 private channels, direct messages, MPIMs, and whatever else we consider a
 conversation-like thing.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations">https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1720,7 +1720,7 @@ completing the element. 150 character maximum.</dd>
         A list of options can be loaded from an external URL and used in your dialog
         menus.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_external
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -1750,7 +1750,7 @@ a single item from a list. True to web roots, this selection is displayed as
 a dropdown menu.</p>
 <p>A list of options can be loaded from an external URL and used in your dialog
 menus.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_external">https://api.slack.com/dialogs#dynamic_select_elements_external</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1829,7 +1829,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
     single item from a list. True to web roots, this selection is displayed as a
     dropdown menu.
 
-    https://api.slack.com/dialogs#select_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
     &#34;&#34;&#34;
 
     data_source = &#34;static&#34;
@@ -1854,7 +1854,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
         A select element may contain up to 100 selections, provided as a list of
         Option or OptionGroup objects
 
-        https://api.slack.com/dialogs#attributes_select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -1891,13 +1891,13 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <div class="desc"><p>Use the select element for multiple choice selections allowing users to pick a
 single item from a list. True to web roots, this selection is displayed as a
 dropdown menu.</p>
-<p><a href="https://api.slack.com/dialogs#select_elements">https://api.slack.com/dialogs#select_elements</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#select_elements">https://docs.slack.dev/legacy/legacy-dialogs/#select_elements</a></p>
 <p>Use the select element for multiple choice selections allowing users to pick
 a single item from a list. True to web roots, this selection is displayed as
 a dropdown menu.</p>
 <p>A select element may contain up to 100 selections, provided as a list of
 Option or OptionGroup objects</p>
-<p><a href="https://api.slack.com/dialogs#attributes_select_elements">https://api.slack.com/dialogs#attributes_select_elements</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements">https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>
@@ -1982,7 +1982,7 @@ def options_length(self) -&gt; bool:
     answer from users. The element UI provides a remaining character count to the
     max_length you have set or the default, 3000.
 
-    https://api.slack.com/dialogs#textarea_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#textarea_elements
     &#34;&#34;&#34;
 
     type = &#34;textarea&#34;
@@ -1992,7 +1992,7 @@ def options_length(self) -&gt; bool:
 these on the world wide web. Use this element if you want a relatively long
 answer from users. The element UI provides a remaining character count to the
 max_length you have set or the default, 3000.</p>
-<p><a href="https://api.slack.com/dialogs#textarea_elements">https://api.slack.com/dialogs#textarea_elements</a></p></div>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#textarea_elements">https://docs.slack.dev/legacy/legacy-dialogs/#textarea_elements</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.dialogs.DialogTextComponent" href="#slack_sdk.models.dialogs.DialogTextComponent">DialogTextComponent</a></li>
@@ -2375,14 +2375,14 @@ def value_length(self) -&gt; bool:
     &#34;&#34;&#34;
     Text elements are single-line plain text fields.
 
-    https://api.slack.com/dialogs#text_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#text_elements
     &#34;&#34;&#34;
 
     type = &#34;text&#34;
     max_value_length = 150</code></pre>
 </details>
 <div class="desc"><p>Text elements are single-line plain text fields.</p>
-<p><a href="https://api.slack.com/dialogs#text_elements">https://api.slack.com/dialogs#text_elements</a></p></div>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#text_elements">https://docs.slack.dev/legacy/legacy-dialogs/#text_elements</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.dialogs.DialogTextComponent" href="#slack_sdk.models.dialogs.DialogTextComponent">DialogTextComponent</a></li>
@@ -2443,7 +2443,7 @@ def value_length(self) -&gt; bool:
         assignee. Slack pre-populates the user list in client-side, so your app
         doesn&#39;t need access to a related OAuth scope.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_users
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -2467,7 +2467,7 @@ def value_length(self) -&gt; bool:
 when you are creating a bug tracking app, you want to include a field for an
 assignee. Slack pre-populates the user list in client-side, so your app
 doesn't need access to a related OAuth scope.</p>
-<p><a href="https://api.slack.com/dialogs#dynamic_select_elements_users">https://api.slack.com/dialogs#dynamic_select_elements_users</a></p>
+<p><a href="https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users">https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>name</code></strong></dt>

--- a/docs/reference/models/messages/index.html
+++ b/docs/reference/models/messages/index.html
@@ -64,13 +64,13 @@ el.replaceWith(d);
 <pre><code class="python">class ChannelLink(Link):
     def __init__(self):
         &#34;&#34;&#34;Represents an @channel link, which notifies everyone present in this channel.
-        https://api.slack.com/reference/surfaces/formatting
+        https://docs.slack.dev/messaging/formatting-message-text/
         &#34;&#34;&#34;
         super().__init__(url=&#34;!channel&#34;, text=&#34;channel&#34;)</code></pre>
 </details>
 <div class="desc"><p>The base class for all model objects in this module</p>
 <p>Represents an @channel link, which notifies everyone present in this channel.
-<a href="https://api.slack.com/reference/surfaces/formatting">https://api.slack.com/reference/surfaces/formatting</a></p></div>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/">https://docs.slack.dev/messaging/formatting-message-text/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.messages.Link" href="#slack_sdk.models.messages.Link">Link</a></li>
@@ -96,7 +96,7 @@ el.replaceWith(d);
         link: Optional[str] = None,
     ):
         &#34;&#34;&#34;Text containing a date or time should display that date in the local timezone of the person seeing the text.
-        https://api.slack.com/reference/surfaces/formatting#date-formatting
+        https://docs.slack.dev/messaging/formatting-message-text/#date-formatting
         &#34;&#34;&#34;
         if isinstance(date, datetime):
             epoch = int(date.timestamp())
@@ -110,7 +110,7 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>The base class for all model objects in this module</p>
 <p>Text containing a date or time should display that date in the local timezone of the person seeing the text.
-<a href="https://api.slack.com/reference/surfaces/formatting#date-formatting">https://api.slack.com/reference/surfaces/formatting#date-formatting</a></p></div>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#date-formatting">https://docs.slack.dev/messaging/formatting-message-text/#date-formatting</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.messages.Link" href="#slack_sdk.models.messages.Link">Link</a></li>
@@ -128,13 +128,13 @@ el.replaceWith(d);
 <pre><code class="python">class EveryoneLink(Link):
     def __init__(self):
         &#34;&#34;&#34;Represents an @everyone link, which notifies all users of this workspace.
-        https://api.slack.com/reference/surfaces/formatting
+        https://docs.slack.dev/messaging/formatting-message-text/
         &#34;&#34;&#34;
         super().__init__(url=&#34;!everyone&#34;, text=&#34;everyone&#34;)</code></pre>
 </details>
 <div class="desc"><p>The base class for all model objects in this module</p>
 <p>Represents an @everyone link, which notifies all users of this workspace.
-<a href="https://api.slack.com/reference/surfaces/formatting">https://api.slack.com/reference/surfaces/formatting</a></p></div>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/">https://docs.slack.dev/messaging/formatting-message-text/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.messages.Link" href="#slack_sdk.models.messages.Link">Link</a></li>
@@ -152,13 +152,13 @@ el.replaceWith(d);
 <pre><code class="python">class HereLink(Link):
     def __init__(self):
         &#34;&#34;&#34;Represents an @here link, which notifies all online users of this channel.
-        https://api.slack.com/reference/surfaces/formatting
+        https://docs.slack.dev/messaging/formatting-message-text/
         &#34;&#34;&#34;
         super().__init__(url=&#34;!here&#34;, text=&#34;here&#34;)</code></pre>
 </details>
 <div class="desc"><p>The base class for all model objects in this module</p>
 <p>Represents an @here link, which notifies all online users of this channel.
-<a href="https://api.slack.com/reference/surfaces/formatting">https://api.slack.com/reference/surfaces/formatting</a></p></div>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/">https://docs.slack.dev/messaging/formatting-message-text/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.messages.Link" href="#slack_sdk.models.messages.Link">Link</a></li>
@@ -177,7 +177,7 @@ el.replaceWith(d);
 <pre><code class="python">class Link(BaseObject):
     def __init__(self, *, url: str, text: str):
         &#34;&#34;&#34;Base class used to generate links in Slack&#39;s not-quite Markdown, not quite HTML syntax
-        https://api.slack.com/reference/surfaces/formatting#linking_to_urls
+        https://docs.slack.dev/messaging/formatting-message-text/#linking_to_urls
         &#34;&#34;&#34;
         self.url = url
         self.text = text
@@ -191,7 +191,7 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>The base class for all model objects in this module</p>
 <p>Base class used to generate links in Slack's not-quite Markdown, not quite HTML syntax
-<a href="https://api.slack.com/reference/surfaces/formatting#linking_to_urls">https://api.slack.com/reference/surfaces/formatting#linking_to_urls</a></p></div>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#linking_to_urls">https://docs.slack.dev/messaging/formatting-message-text/#linking_to_urls</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
@@ -226,14 +226,14 @@ el.replaceWith(d);
 
     def __init__(self, *, object_id: str, text: str = &#34;&#34;):
         &#34;&#34;&#34;Convenience class to create links to specific object types
-        https://api.slack.com/reference/surfaces/formatting#linking-channels
+        https://docs.slack.dev/messaging/formatting-message-text/#linking-channels
         &#34;&#34;&#34;
         prefix = self.prefix_mapping.get(object_id[0].upper(), &#34;@&#34;)
         super().__init__(url=f&#34;{prefix}{object_id}&#34;, text=text)</code></pre>
 </details>
 <div class="desc"><p>The base class for all model objects in this module</p>
 <p>Convenience class to create links to specific object types
-<a href="https://api.slack.com/reference/surfaces/formatting#linking-channels">https://api.slack.com/reference/surfaces/formatting#linking-channels</a></p></div>
+<a href="https://docs.slack.dev/messaging/formatting-message-text/#linking-channels">https://docs.slack.dev/messaging/formatting-message-text/#linking-channels</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.messages.Link" href="#slack_sdk.models.messages.Link">Link</a></li>

--- a/docs/reference/models/messages/message.html
+++ b/docs/reference/models/messages/message.html
@@ -71,7 +71,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         Create a message.
 
-        https://api.slack.com/messaging/composing#message-structure
+        https://docs.slack.dev/messaging/#message-structure
 
         Args:
             text: Plain or Slack Markdown-like text to display in the message.
@@ -114,7 +114,7 @@ el.replaceWith(d);
 </details>
 <div class="desc"><p>The base class for JSON serializable class objects</p>
 <p>Create a message.</p>
-<p><a href="https://api.slack.com/messaging/composing#message-structure">https://api.slack.com/messaging/composing#message-structure</a></p>
+<p><a href="https://docs.slack.dev/messaging/#message-structure">https://docs.slack.dev/messaging/#message-structure</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>text</code></strong></dt>

--- a/docs/reference/models/metadata/index.html
+++ b/docs/reference/models/metadata/index.html
@@ -58,7 +58,7 @@ el.replaceWith(d);
 <pre><code class="python">class Metadata(JsonObject):
     &#34;&#34;&#34;Message metadata
 
-    https://api.slack.com/metadata
+    https://docs.slack.dev/messaging/message-metadata/
     &#34;&#34;&#34;
 
     attributes = {
@@ -83,7 +83,7 @@ el.replaceWith(d);
         return self.__str__()</code></pre>
 </details>
 <div class="desc"><p>Message metadata</p>
-<p><a href="https://api.slack.com/metadata">https://api.slack.com/metadata</a></p></div>
+<p><a href="https://docs.slack.dev/messaging/message-metadata/">https://docs.slack.dev/messaging/message-metadata/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>

--- a/docs/reference/models/views/index.html
+++ b/docs/reference/models/views/index.html
@@ -58,7 +58,7 @@ el.replaceWith(d);
 <pre><code class="python">class View(JsonObject):
     &#34;&#34;&#34;View object for modals and Home tabs.
 
-    https://api.slack.com/reference/surfaces/views
+    https://docs.slack.dev/reference/views/
     &#34;&#34;&#34;
 
     types = [&#34;modal&#34;, &#34;home&#34;, &#34;workflow_step&#34;]
@@ -175,7 +175,7 @@ el.replaceWith(d);
         return self.__str__()</code></pre>
 </details>
 <div class="desc"><p>View object for modals and Home tabs.</p>
-<p><a href="https://api.slack.com/reference/surfaces/views">https://api.slack.com/reference/surfaces/views</a></p></div>
+<p><a href="https://docs.slack.dev/reference/views/">https://docs.slack.dev/reference/views/</a></p></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>

--- a/docs/reference/oauth/index.html
+++ b/docs/reference/oauth/index.html
@@ -37,7 +37,7 @@ el.replaceWith(d);
 </header>
 <section id="section-intro">
 <p>Modules for implementing the Slack OAuth flow</p>
-<p><a href="https://slack.dev/python-slack-sdk/oauth/">https://slack.dev/python-slack-sdk/oauth/</a></p>
+<p><a href="https://docs.slack.dev/tools/python-slack-sdk/oauth">https://docs.slack.dev/tools/python-slack-sdk/oauth</a></p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/oauth/installation_store/async_cacheable_installation_store.html
+++ b/docs/reference/oauth/installation_store/async_cacheable_installation_store.html
@@ -74,7 +74,7 @@ el.replaceWith(d);
     def logger(self) -&gt; Logger:
         return self.underlying.logger
 
-    async def async_save(self, installation: Installation):  # type: ignore[explicit-override]
+    async def async_save(self, installation: Installation):
         # Invalidate cache data for update operations
         key = f&#34;{installation.enterprise_id or &#39;&#39;}-{installation.team_id or &#39;&#39;}&#34;
         if key in self.cached_bots:
@@ -84,14 +84,14 @@ el.replaceWith(d);
             self.cached_installations.pop(key)
         return await self.underlying.async_save(installation)
 
-    async def async_save_bot(self, bot: Bot):  # type: ignore[explicit-override]
+    async def async_save_bot(self, bot: Bot):
         # Invalidate cache data for update operations
         key = f&#34;{bot.enterprise_id or &#39;&#39;}-{bot.team_id or &#39;&#39;}&#34;
         if key in self.cached_bots:
             self.cached_bots.pop(key)
         return await self.underlying.async_save_bot(bot)
 
-    async def async_find_bot(  # type: ignore[explicit-override]
+    async def async_find_bot(
         self,
         *,
         enterprise_id: Optional[str],
@@ -112,7 +112,7 @@ el.replaceWith(d);
             self.cached_bots[key] = bot
         return bot
 
-    async def async_find_installation(  # type: ignore[explicit-override]
+    async def async_find_installation(
         self,
         *,
         enterprise_id: Optional[str],

--- a/docs/reference/oauth/installation_store/cacheable_installation_store.html
+++ b/docs/reference/oauth/installation_store/cacheable_installation_store.html
@@ -74,7 +74,7 @@ el.replaceWith(d);
     def logger(self) -&gt; Logger:
         return self.underlying.logger
 
-    def save(self, installation: Installation):  # type: ignore[explicit-override]
+    def save(self, installation: Installation):
         # Invalidate cache data for update operations
         key = f&#34;{installation.enterprise_id or &#39;&#39;}-{installation.team_id or &#39;&#39;}&#34;
         if key in self.cached_bots:
@@ -85,14 +85,14 @@ el.replaceWith(d);
 
         return self.underlying.save(installation)
 
-    def save_bot(self, bot: Bot):  # type: ignore[explicit-override]
+    def save_bot(self, bot: Bot):
         # Invalidate cache data for update operations
         key = f&#34;{bot.enterprise_id or &#39;&#39;}-{bot.team_id or &#39;&#39;}&#34;
         if key in self.cached_bots:
             self.cached_bots.pop(key)
         return self.underlying.save_bot(bot)
 
-    def find_bot(  # type: ignore[explicit-override]
+    def find_bot(
         self,
         *,
         enterprise_id: Optional[str],
@@ -113,7 +113,7 @@ el.replaceWith(d);
             self.cached_bots[key] = bot
         return bot
 
-    def find_installation(  # type: ignore[explicit-override]
+    def find_installation(
         self,
         *,
         enterprise_id: Optional[str],

--- a/docs/reference/oauth/installation_store/installation_store.html
+++ b/docs/reference/oauth/installation_store/installation_store.html
@@ -37,7 +37,7 @@ el.replaceWith(d);
 </header>
 <section id="section-intro">
 <p>Slack installation data store</p>
-<p>Refer to <a href="https://slack.dev/python-slack-sdk/oauth/">https://slack.dev/python-slack-sdk/oauth/</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/python-slack-sdk/oauth">https://docs.slack.dev/tools/python-slack-sdk/oauth</a> for details.</p>
 </section>
 <section>
 </section>

--- a/docs/reference/oauth/state_store/index.html
+++ b/docs/reference/oauth/state_store/index.html
@@ -37,7 +37,7 @@ el.replaceWith(d);
 </header>
 <section id="section-intro">
 <p>OAuth state parameter data store</p>
-<p>Refer to <a href="https://slack.dev/python-slack-sdk/oauth/">https://slack.dev/python-slack-sdk/oauth/</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/python-slack-sdk/oauth">https://docs.slack.dev/tools/python-slack-sdk/oauth</a> for details.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/scim/async_client.html
+++ b/docs/reference/scim/async_client.html
@@ -87,7 +87,7 @@ el.replaceWith(d);
         retry_handlers: Optional[List[AsyncRetryHandler]] = None,
     ):
         &#34;&#34;&#34;API client for SCIM API
-        See https://api.slack.com/scim for more details
+        See https://docs.slack.dev/admins/scim-api/ for more details
 
         Args:
             token: An admin user&#39;s token, which starts with `xoxp-`
@@ -416,7 +416,7 @@ el.replaceWith(d);
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for SCIM API
-See <a href="https://api.slack.com/scim">https://api.slack.com/scim</a> for more details</p>
+See <a href="https://docs.slack.dev/admins/scim-api/">https://docs.slack.dev/admins/scim-api/</a> for more details</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>token</code></strong></dt>

--- a/docs/reference/scim/index.html
+++ b/docs/reference/scim/index.html
@@ -40,7 +40,7 @@ el.replaceWith(d);
 <p>SCIM API is a set of APIs for provisioning and managing user accounts and groups.
 SCIM is used by Single Sign-On (SSO) services and identity providers to manage people across a variety of tools,
 including Slack.</p>
-<p>Refer to <a href="https://slack.dev/python-slack-sdk/scim/">https://slack.dev/python-slack-sdk/scim/</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/python-slack-sdk/scim">https://docs.slack.dev/tools/python-slack-sdk/scim</a> for details.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>
@@ -301,7 +301,7 @@ def user(self) -&gt; User:
         retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         &#34;&#34;&#34;API client for SCIM API
-        See https://api.slack.com/scim for more details
+        See https://docs.slack.dev/admins/scim-api/ for more details
 
         Args:
             token: An admin user&#39;s token, which starts with `xoxp-`
@@ -646,7 +646,7 @@ def user(self) -&gt; User:
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for SCIM API
-See <a href="https://api.slack.com/scim">https://api.slack.com/scim</a> for more details</p>
+See <a href="https://docs.slack.dev/admins/scim-api/">https://docs.slack.dev/admins/scim-api/</a> for more details</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>token</code></strong></dt>

--- a/docs/reference/scim/v1/async_client.html
+++ b/docs/reference/scim/v1/async_client.html
@@ -87,7 +87,7 @@ el.replaceWith(d);
         retry_handlers: Optional[List[AsyncRetryHandler]] = None,
     ):
         &#34;&#34;&#34;API client for SCIM API
-        See https://api.slack.com/scim for more details
+        See https://docs.slack.dev/admins/scim-api/ for more details
 
         Args:
             token: An admin user&#39;s token, which starts with `xoxp-`
@@ -416,7 +416,7 @@ el.replaceWith(d);
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for SCIM API
-See <a href="https://api.slack.com/scim">https://api.slack.com/scim</a> for more details</p>
+See <a href="https://docs.slack.dev/admins/scim-api/">https://docs.slack.dev/admins/scim-api/</a> for more details</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>token</code></strong></dt>

--- a/docs/reference/scim/v1/client.html
+++ b/docs/reference/scim/v1/client.html
@@ -40,7 +40,7 @@ el.replaceWith(d);
 <p>SCIM API is a set of APIs for provisioning and managing user accounts and groups.
 SCIM is used by Single Sign-On (SSO) services and identity providers to manage people across a variety of tools,
 including Slack.</p>
-<p>Refer to <a href="https://slack.dev/python-slack-sdk/scim/">https://slack.dev/python-slack-sdk/scim/</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/python-slack-sdk/scim/">https://docs.slack.dev/tools/python-slack-sdk/scim/</a> for details.</p>
 </section>
 <section>
 </section>
@@ -86,7 +86,7 @@ including Slack.</p>
         retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         &#34;&#34;&#34;API client for SCIM API
-        See https://api.slack.com/scim for more details
+        See https://docs.slack.dev/admins/scim-api/ for more details
 
         Args:
             token: An admin user&#39;s token, which starts with `xoxp-`
@@ -431,7 +431,7 @@ including Slack.</p>
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for SCIM API
-See <a href="https://api.slack.com/scim">https://api.slack.com/scim</a> for more details</p>
+See <a href="https://docs.slack.dev/admins/scim-api/">https://docs.slack.dev/admins/scim-api/</a> for more details</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>token</code></strong></dt>

--- a/docs/reference/scim/v1/index.html
+++ b/docs/reference/scim/v1/index.html
@@ -40,7 +40,7 @@ el.replaceWith(d);
 <p>SCIM API is a set of APIs for provisioning and managing user accounts and groups.
 SCIM is used by Single Sign-On (SSO) services and identity providers to manage people across a variety of tools,
 including Slack.</p>
-<p>Refer to <a href="https://slack.dev/python-slack-sdk/scim/">https://slack.dev/python-slack-sdk/scim/</a> for details.</p>
+<p>Refer to <a href="https://docs.slack.dev/tools/python-slack-sdk/scim">https://docs.slack.dev/tools/python-slack-sdk/scim</a> for details.</p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/signature/index.html
+++ b/docs/reference/signature/index.html
@@ -93,7 +93,7 @@ el.replaceWith(d);
         Slack signs its requests using a secret that&#39;s unique to your app.
         With the help of signing secrets, your app can more confidently verify
         whether requests from us are authentic.
-        https://api.slack.com/authentication/verifying-requests-from-slack
+        https://docs.slack.dev/authentication/verifying-requests-from-slack/
         &#34;&#34;&#34;
         self.signing_secret = signing_secret
         self.clock = clock
@@ -150,7 +150,7 @@ el.replaceWith(d);
 <p>Slack signs its requests using a secret that's unique to your app.
 With the help of signing secrets, your app can more confidently verify
 whether requests from us are authentic.
-<a href="https://api.slack.com/authentication/verifying-requests-from-slack">https://api.slack.com/authentication/verifying-requests-from-slack</a></p></div>
+<a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/">https://docs.slack.dev/authentication/verifying-requests-from-slack/</a></p></div>
 <h3>Methods</h3>
 <dl>
 <dt id="slack_sdk.signature.SignatureVerifier.generate_signature"><code class="name flex">

--- a/docs/reference/socket_mode/aiohttp/index.html
+++ b/docs/reference/socket_mode/aiohttp/index.html
@@ -38,8 +38,8 @@ el.replaceWith(d);
 <section id="section-intro">
 <p>aiohttp based Socket Mode client</p>
 <ul>
-<li><a href="https://api.slack.com/apis/connections/socket">https://api.slack.com/apis/connections/socket</a></li>
-<li><a href="https://slack.dev/python-slack-sdk/socket-mode/">https://slack.dev/python-slack-sdk/socket-mode/</a></li>
+<li><a href="https://docs.slack.dev/apis/events-api/using-socket-mode/">https://docs.slack.dev/apis/events-api/using-socket-mode/</a></li>
+<li><a href="https://docs.slack.dev/tools/python-slack-sdk/socket-mode/">https://docs.slack.dev/tools/python-slack-sdk/socket-mode/</a></li>
 <li><a href="https://pypi.org/project/aiohttp/">https://pypi.org/project/aiohttp/</a></li>
 </ul>
 </section>

--- a/docs/reference/socket_mode/builtin/client.html
+++ b/docs/reference/socket_mode/builtin/client.html
@@ -38,8 +38,8 @@ el.replaceWith(d);
 <section id="section-intro">
 <p>The built-in Socket Mode client</p>
 <ul>
-<li><a href="https://api.slack.com/apis/connections/socket">https://api.slack.com/apis/connections/socket</a></li>
-<li><a href="https://slack.dev/python-slack-sdk/socket-mode/">https://slack.dev/python-slack-sdk/socket-mode/</a></li>
+<li><a href="https://docs.slack.dev/apis/events-api/using-socket-mode/">https://docs.slack.dev/apis/events-api/using-socket-mode/</a></li>
+<li><a href="https://docs.slack.dev/tools/python-slack-sdk/socket-mode/">https://docs.slack.dev/tools/python-slack-sdk/socket-mode/</a></li>
 </ul>
 </section>
 <section>

--- a/docs/reference/socket_mode/client.html
+++ b/docs/reference/socket_mode/client.html
@@ -167,7 +167,7 @@ el.replaceWith(d);
 
             for listener in self.message_listeners:
                 try:
-                    listener(self, message, raw_message)  # type: ignore[call-arg, arg-type]
+                    listener(self, message, raw_message)  # type: ignore[call-arg, arg-type, misc]
                 except Exception as e:
                     self.logger.exception(f&#34;Failed to run a message listener: {e}&#34;)
 
@@ -431,7 +431,7 @@ el.replaceWith(d);
 
         for listener in self.message_listeners:
             try:
-                listener(self, message, raw_message)  # type: ignore[call-arg, arg-type]
+                listener(self, message, raw_message)  # type: ignore[call-arg, arg-type, misc]
             except Exception as e:
                 self.logger.exception(f&#34;Failed to run a message listener: {e}&#34;)
 

--- a/docs/reference/socket_mode/index.html
+++ b/docs/reference/socket_mode/index.html
@@ -40,7 +40,7 @@ el.replaceWith(d);
 <p>Socket Mode is a method of connecting your app to Slack’s APIs using WebSockets instead of HTTP.
 You can use slack_sdk.socket_mode.SocketModeClient for managing Socket Mode connections
 and performing interactions with Slack.</p>
-<p><a href="https://api.slack.com/apis/connections/socket">https://api.slack.com/apis/connections/socket</a></p>
+<p><a href="https://docs.slack.dev/apis/events-api/using-socket-mode/">https://docs.slack.dev/apis/events-api/using-socket-mode/</a></p>
 </section>
 <section>
 <h2 class="section-title" id="header-submodules">Sub-modules</h2>

--- a/docs/reference/socket_mode/websocket_client/index.html
+++ b/docs/reference/socket_mode/websocket_client/index.html
@@ -38,8 +38,8 @@ el.replaceWith(d);
 <section id="section-intro">
 <p>websocket-client bassd Socket Mode client</p>
 <ul>
-<li><a href="https://api.slack.com/apis/connections/socket">https://api.slack.com/apis/connections/socket</a></li>
-<li><a href="https://slack.dev/python-slack-sdk/socket-mode/">https://slack.dev/python-slack-sdk/socket-mode/</a></li>
+<li><a href="https://docs.slack.dev/apis/events-api/using-socket-mode/">https://docs.slack.dev/apis/events-api/using-socket-mode/</a></li>
+<li><a href="https://docs.slack.dev/tools/python-slack-sdk/socket-mode/">https://docs.slack.dev/tools/python-slack-sdk/socket-mode/</a></li>
 <li><a href="https://pypi.org/project/websocket-client/">https://pypi.org/project/websocket-client/</a></li>
 </ul>
 </section>
@@ -91,7 +91,7 @@ el.replaceWith(d);
     auto_reconnect_enabled: bool
     default_auto_reconnect_enabled: bool
 
-    close: bool  # type: ignore[assignment]
+    closed: bool
     connect_operation_lock: Lock
 
     on_open_listeners: List[Callable[[WebSocketApp], None]]
@@ -258,7 +258,7 @@ el.replaceWith(d);
                     )
                     raise e
 
-    def close(self) -&gt; None:  # type: ignore[explicit-override, no-redef]
+    def close(self) -&gt; None:
         self.closed = True
         self.auto_reconnect_enabled = False
         self.disconnect()
@@ -384,7 +384,7 @@ el.replaceWith(d);
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def close(self) -&gt; None:  # type: ignore[explicit-override, no-redef]
+<pre><code class="python">def close(self) -&gt; None:
     self.closed = True
     self.auto_reconnect_enabled = False
     self.disconnect()

--- a/docs/reference/socket_mode/websockets/index.html
+++ b/docs/reference/socket_mode/websockets/index.html
@@ -38,8 +38,8 @@ el.replaceWith(d);
 <section id="section-intro">
 <p>websockets bassd Socket Mode client</p>
 <ul>
-<li><a href="https://api.slack.com/apis/connections/socket">https://api.slack.com/apis/connections/socket</a></li>
-<li><a href="https://slack.dev/python-slack-sdk/socket-mode/">https://slack.dev/python-slack-sdk/socket-mode/</a></li>
+<li><a href="https://docs.slack.dev/apis/events-api/using-socket-mode/">https://docs.slack.dev/apis/events-api/using-socket-mode/</a></li>
+<li><a href="https://docs.slack.dev/tools/python-slack-sdk/socket-mode/">https://docs.slack.dev/tools/python-slack-sdk/socket-mode/</a></li>
 <li><a href="https://pypi.org/project/websockets/">https://pypi.org/project/websockets/</a></li>
 </ul>
 </section>

--- a/docs/reference/web/async_client.html
+++ b/docs/reference/web/async_client.html
@@ -59,7 +59,7 @@ el.replaceWith(d);
 <pre><code class="python">class AsyncWebClient(AsyncBaseClient):
     &#34;&#34;&#34;A WebClient allows apps to communicate with the Slack Platform&#39;s Web API.
 
-    https://api.slack.com/methods
+    https://docs.slack.dev/reference/methods
 
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
@@ -130,7 +130,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieve analytics data for a given date, presented as a compressed JSON file
-        https://api.slack.com/methods/admin.analytics.getFile
+        https://docs.slack.dev/reference/methods/admin.analytics.getFile
         &#34;&#34;&#34;
         kwargs.update({&#34;type&#34;: type})
         if date is not None:
@@ -152,7 +152,7 @@ el.replaceWith(d);
         Either app_id or request_id is required.
         These IDs can be obtained either directly via the app_requested event,
         or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.approve
+        https://docs.slack.dev/reference/methods/admin.apps.approve
         &#34;&#34;&#34;
         if app_id:
             kwargs.update({&#34;app_id&#34;: app_id})
@@ -179,7 +179,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List approved apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.approved.list
+        https://docs.slack.dev/reference/methods/admin.apps.approved.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -200,7 +200,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Clear an app resolution
-        https://api.slack.com/methods/admin.apps.clearResolution
+        https://docs.slack.dev/reference/methods/admin.apps.clearResolution
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -220,7 +220,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.cancel
+        https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -240,7 +240,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.list
+        https://docs.slack.dev/reference/methods/admin.apps.requests.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -264,7 +264,7 @@ el.replaceWith(d);
         Exactly one of the team_id or enterprise_id arguments is required, not both.
         Either app_id or request_id is required. These IDs can be obtained either directly
         via the app_requested event, or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.restrict
+        https://docs.slack.dev/reference/methods/admin.apps.restrict
         &#34;&#34;&#34;
         if app_id:
             kwargs.update({&#34;app_id&#34;: app_id})
@@ -291,7 +291,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List restricted apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.restricted.list
+        https://docs.slack.dev/reference/methods/admin.apps.restricted.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -313,7 +313,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Uninstall an app from one or many workspaces, or an entire enterprise organization.
         With an org-level token, enterprise_id or team_ids is required.
-        https://api.slack.com/methods/admin.apps.uninstall
+        https://docs.slack.dev/reference/methods/admin.apps.uninstall
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         if enterprise_id is not None:
@@ -344,7 +344,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Get logs for a specified team/org
-        https://api.slack.com/methods/admin.apps.activities.list
+        https://docs.slack.dev/reference/methods/admin.apps.activities.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -372,7 +372,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Look up the app config for connectors by their IDs
-        https://api.slack.com/methods/admin.apps.config.lookup
+        https://docs.slack.dev/reference/methods/admin.apps.config.lookup
         &#34;&#34;&#34;
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -389,7 +389,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set the app config for a connector
-        https://api.slack.com/methods/admin.apps.config.set
+        https://docs.slack.dev/reference/methods/admin.apps.config.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -411,7 +411,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.
-        https://api.slack.com/methods/admin.auth.policy.getEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
         &#34;&#34;&#34;
         kwargs.update({&#34;policy_name&#34;: policy_name})
         if cursor is not None:
@@ -431,7 +431,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Assign entities to a particular authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.assignEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
         &#34;&#34;&#34;
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -450,7 +450,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Remove specified entities from a specified authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.removeEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
         &#34;&#34;&#34;
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -469,7 +469,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Create a Salesforce channel for the corresponding object provided.
-        https://api.slack.com/methods/admin.conversations.createForObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
         &#34;&#34;&#34;
         kwargs.update(
             {&#34;object_id&#34;: object_id, &#34;salesforce_org_id&#34;: salesforce_org_id, &#34;invite_object_team&#34;: invite_object_team}
@@ -485,7 +485,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Link a Salesforce record to a channel.
-        https://api.slack.com/methods/admin.conversations.linkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -504,7 +504,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Unlink a Salesforce record from a channel.
-        https://api.slack.com/methods/admin.conversations.unlinkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -523,7 +523,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Create an Information Barrier
-        https://api.slack.com/methods/admin.barriers.create
+        https://docs.slack.dev/reference/methods/admin.barriers.create
         &#34;&#34;&#34;
         kwargs.update({&#34;primary_usergroup_id&#34;: primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -543,7 +543,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Delete an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.delete
+        https://docs.slack.dev/reference/methods/admin.barriers.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;barrier_id&#34;: barrier_id})
         return await self.api_call(&#34;admin.barriers.delete&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -558,7 +558,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Update an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.update
+        https://docs.slack.dev/reference/methods/admin.barriers.update
         &#34;&#34;&#34;
         kwargs.update({&#34;barrier_id&#34;: barrier_id, &#34;primary_usergroup_id&#34;: primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -579,7 +579,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Get all Information Barriers for your organization
-        https://api.slack.com/methods/admin.barriers.list&#34;&#34;&#34;
+        https://docs.slack.dev/reference/methods/admin.barriers.list&#34;&#34;&#34;
         kwargs.update(
             {
                 &#34;cursor&#34;: cursor,
@@ -599,7 +599,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Create a public or private channel-based conversation.
-        https://api.slack.com/methods/admin.conversations.create
+        https://docs.slack.dev/reference/methods/admin.conversations.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -619,7 +619,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Delete a public or private channel.
-        https://api.slack.com/methods/admin.conversations.delete
+        https://docs.slack.dev/reference/methods/admin.conversations.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return await self.api_call(&#34;admin.conversations.delete&#34;, params=kwargs)
@@ -632,7 +632,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Invite a user to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.invite
+        https://docs.slack.dev/reference/methods/admin.conversations.invite
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(user_ids, (list, tuple)):
@@ -649,7 +649,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Archive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return await self.api_call(&#34;admin.conversations.archive&#34;, params=kwargs)
@@ -661,7 +661,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Unarchive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return await self.api_call(&#34;admin.conversations.unarchive&#34;, params=kwargs)
@@ -674,7 +674,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Rename a public or private channel.
-        https://api.slack.com/methods/admin.conversations.rename
+        https://docs.slack.dev/reference/methods/admin.conversations.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;name&#34;: name})
         return await self.api_call(&#34;admin.conversations.rename&#34;, params=kwargs)
@@ -692,7 +692,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.
-        https://api.slack.com/methods/admin.conversations.search
+        https://docs.slack.dev/reference/methods/admin.conversations.search
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -723,7 +723,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Convert a public channel to a private channel.
-        https://api.slack.com/methods/admin.conversations.convertToPrivate
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return await self.api_call(&#34;admin.conversations.convertToPrivate&#34;, params=kwargs)
@@ -735,7 +735,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Convert a privte channel to a public channel.
-        https://api.slack.com/methods/admin.conversations.convertToPublic
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return await self.api_call(&#34;admin.conversations.convertToPublic&#34;, params=kwargs)
@@ -748,7 +748,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set the posting permissions for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(prefs, dict):
@@ -764,7 +764,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Get conversation preferences for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.getConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return await self.api_call(&#34;admin.conversations.getConversationPrefs&#34;, params=kwargs)
@@ -777,7 +777,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Disconnect a connected channel from one or more workspaces.
-        https://api.slack.com/methods/admin.conversations.disconnectShared
+        https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(leaving_team_ids, (list, tuple)):
@@ -797,7 +797,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Returns channels on the given team using the filters.
-        https://api.slack.com/methods/admin.conversations.lookup
+        https://docs.slack.dev/reference/methods/admin.conversations.lookup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -825,7 +825,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;List all disconnected channels—i.e.,
         channels that were once connected to other workspaces and then disconnected—and
         the corresponding original channel IDs for key revocation with EKM.
-        https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+        https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -852,7 +852,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add an allowlist of IDP groups for accessing a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -875,7 +875,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all IDP Groups linked to a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -898,7 +898,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Remove a linked IDP group linked from a private channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -923,7 +923,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.setTeams
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -947,7 +947,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a channel.
-        https://api.slack.com/methods/admin.conversations.getTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.getTeams
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -965,7 +965,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Get a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.getCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return await self.api_call(&#34;admin.conversations.getCustomRetention&#34;, params=kwargs)
@@ -977,7 +977,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Remove a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.removeCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return await self.api_call(&#34;admin.conversations.removeCustomRetention&#34;, params=kwargs)
@@ -990,7 +990,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.setCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;duration_days&#34;: duration_days})
         return await self.api_call(&#34;admin.conversations.setCustomRetention&#34;, params=kwargs)
@@ -1002,7 +1002,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Archive public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkArchive
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
         return await self.api_call(&#34;admin.conversations.bulkArchive&#34;, params=kwargs)
@@ -1027,7 +1027,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Move public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkMove
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1045,7 +1045,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add an emoji.
-        https://api.slack.com/methods/admin.emoji.add
+        https://docs.slack.dev/reference/methods/admin.emoji.add
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;url&#34;: url})
         return await self.api_call(&#34;admin.emoji.add&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1058,7 +1058,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add an emoji alias.
-        https://api.slack.com/methods/admin.emoji.addAlias
+        https://docs.slack.dev/reference/methods/admin.emoji.addAlias
         &#34;&#34;&#34;
         kwargs.update({&#34;alias_for&#34;: alias_for, &#34;name&#34;: name})
         return await self.api_call(&#34;admin.emoji.addAlias&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1071,7 +1071,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List emoji for an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.list
+        https://docs.slack.dev/reference/methods/admin.emoji.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return await self.api_call(&#34;admin.emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1083,7 +1083,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Remove an emoji across an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.remove
+        https://docs.slack.dev/reference/methods/admin.emoji.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name})
         return await self.api_call(&#34;admin.emoji.remove&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1096,7 +1096,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Rename an emoji.
-        https://api.slack.com/methods/admin.emoji.rename
+        https://docs.slack.dev/reference/methods/admin.emoji.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;new_name&#34;: new_name})
         return await self.api_call(&#34;admin.emoji.rename&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1111,7 +1111,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Look up functions by a set of apps
-        https://api.slack.com/methods/admin.functions.list
+        https://docs.slack.dev/reference/methods/admin.functions.list
         &#34;&#34;&#34;
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -1134,7 +1134,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lookup the visibility of multiple Slack functions
         and include the users if it is limited to particular named entities.
-        https://api.slack.com/methods/admin.functions.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
         &#34;&#34;&#34;
         if isinstance(function_ids, (list, tuple)):
             kwargs.update({&#34;function_ids&#34;: &#34;,&#34;.join(function_ids)})
@@ -1152,7 +1152,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set the visibility of a Slack function
         and define the users or workspaces if it is set to named_entities
-        https://api.slack.com/methods/admin.functions.permissions.set
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1176,7 +1176,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Adds members to the specified role with the specified scopes
-        https://api.slack.com/methods/admin.roles.addAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.addAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;role_id&#34;: role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1201,7 +1201,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists assignments for all roles across entities.
             Options to scope results by any combination of roles or entities
-        https://api.slack.com/methods/admin.roles.listAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.listAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;sort_dir&#34;: sort_dir})
         if isinstance(entity_ids, (list, tuple)):
@@ -1223,7 +1223,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Removes a set of users from a role for the given scopes and entities
-        https://api.slack.com/methods/admin.roles.removeAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;role_id&#34;: role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1245,7 +1245,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Wipes all valid sessions on all devices for a given user.
-        https://api.slack.com/methods/admin.users.session.reset
+        https://docs.slack.dev/reference/methods/admin.users.session.reset
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1265,7 +1265,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-        https://api.slack.com/methods/admin.users.session.resetBulk
+        https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1287,7 +1287,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Invalidate a single session for a user by session_id.
-        https://api.slack.com/methods/admin.users.session.invalidate
+        https://docs.slack.dev/reference/methods/admin.users.session.invalidate
         &#34;&#34;&#34;
         kwargs.update({&#34;session_id&#34;: session_id, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;admin.users.session.invalidate&#34;, params=kwargs)
@@ -1302,7 +1302,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists all active user sessions for an organization
-        https://api.slack.com/methods/admin.users.session.list
+        https://docs.slack.dev/reference/methods/admin.users.session.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1322,7 +1322,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set the default channels of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1339,7 +1339,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Get user-specific session settings—the session duration
         and what happens when the client closes—given a list of users.
-        https://api.slack.com/methods/admin.users.session.getSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.getSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1357,7 +1357,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Configure the user-level session settings—the session duration
         and what happens when the client closes—for one or more users.
-        https://api.slack.com/methods/admin.users.session.setSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.setSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1379,7 +1379,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Clear user-specific session settings—the session duration
         and what happens when the client closes—for a list of users.
-        https://api.slack.com/methods/admin.users.session.clearSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1396,7 +1396,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Ask Slackbot to send you an export listing all workspace members using unsupported software,
         presented as a zipped CSV file.
-        https://api.slack.com/methods/admin.users.unsupportedVersions.export
+        https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1414,7 +1414,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Approve a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.approve
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;admin.inviteRequests.approve&#34;, params=kwargs)
@@ -1428,7 +1428,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all approved workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.approved.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1448,7 +1448,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all denied workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.denied.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1467,7 +1467,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Deny a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.deny
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;admin.inviteRequests.deny&#34;, params=kwargs)
@@ -1488,7 +1488,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.inviteRequests.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1509,7 +1509,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Create an Enterprise team.
-        https://api.slack.com/methods/admin.teams.create
+        https://docs.slack.dev/reference/methods/admin.teams.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1529,7 +1529,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all teams on an Enterprise organization.
-        https://api.slack.com/methods/admin.teams.list
+        https://docs.slack.dev/reference/methods/admin.teams.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return await self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
@@ -1543,7 +1543,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.teams.owners.list
+        https://docs.slack.dev/reference/methods/admin.teams.owners.list
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return await self.api_call(&#34;admin.teams.owners.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1555,7 +1555,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Fetch information about settings in a workspace
-        https://api.slack.com/methods/admin.teams.settings.info
+        https://docs.slack.dev/reference/methods/admin.teams.settings.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         return await self.api_call(&#34;admin.teams.settings.info&#34;, params=kwargs)
@@ -1568,7 +1568,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set the description of a given workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDescription
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;description&#34;: description})
         return await self.api_call(&#34;admin.teams.settings.setDescription&#34;, params=kwargs)
@@ -1581,7 +1581,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;discoverability&#34;: discoverability})
         return await self.api_call(&#34;admin.teams.settings.setDiscoverability&#34;, params=kwargs)
@@ -1594,7 +1594,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setIcon
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;image_url&#34;: image_url})
         return await self.api_call(&#34;admin.teams.settings.setIcon&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1607,7 +1607,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setName
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setName
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;name&#34;: name})
         return await self.api_call(&#34;admin.teams.settings.setName&#34;, params=kwargs)
@@ -1621,7 +1621,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.addChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;usergroup_id&#34;: usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1639,7 +1639,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Associate one or more default workspaces with an organization-wide IDP group.
-        https://api.slack.com/methods/admin.usergroups.addTeams
+        https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup_id&#34;: usergroup_id, &#34;auto_provision&#34;: auto_provision})
         if isinstance(team_ids, (list, tuple)):
@@ -1657,7 +1657,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.listChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1676,7 +1676,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.removeChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup_id&#34;: usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1696,7 +1696,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add an Enterprise user to a workspace.
-        https://api.slack.com/methods/admin.users.assign
+        https://docs.slack.dev/reference/methods/admin.users.assign
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1728,7 +1728,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Invite a user to a workspace.
-        https://api.slack.com/methods/admin.users.invite
+        https://docs.slack.dev/reference/methods/admin.users.invite
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1752,7 +1752,7 @@ el.replaceWith(d);
     async def admin_users_list(
         self,
         *,
-        team_id: str,
+        team_id: Optional[str] = None,
         include_deactivated_user_workspaces: Optional[bool] = None,
         is_active: Optional[bool] = None,
         cursor: Optional[str] = None,
@@ -1760,7 +1760,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List users on a workspace
-        https://api.slack.com/methods/admin.users.list
+        https://docs.slack.dev/reference/methods/admin.users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1781,7 +1781,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Remove a user from a workspace.
-        https://api.slack.com/methods/admin.users.remove
+        https://docs.slack.dev/reference/methods/admin.users.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return await self.api_call(&#34;admin.users.remove&#34;, params=kwargs)
@@ -1794,7 +1794,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set an existing guest, regular user, or owner to be an admin user.
-        https://api.slack.com/methods/admin.users.setAdmin
+        https://docs.slack.dev/reference/methods/admin.users.setAdmin
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return await self.api_call(&#34;admin.users.setAdmin&#34;, params=kwargs)
@@ -1808,7 +1808,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set an expiration for a guest user.
-        https://api.slack.com/methods/admin.users.setExpiration
+        https://docs.slack.dev/reference/methods/admin.users.setExpiration
         &#34;&#34;&#34;
         kwargs.update({&#34;expiration_ts&#34;: expiration_ts, &#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return await self.api_call(&#34;admin.users.setExpiration&#34;, params=kwargs)
@@ -1821,7 +1821,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set an existing guest, regular user, or admin user to be a workspace owner.
-        https://api.slack.com/methods/admin.users.setOwner
+        https://docs.slack.dev/reference/methods/admin.users.setOwner
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return await self.api_call(&#34;admin.users.setOwner&#34;, params=kwargs)
@@ -1834,7 +1834,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set an existing guest user, admin user, or owner to be a regular user.
-        https://api.slack.com/methods/admin.users.setRegular
+        https://docs.slack.dev/reference/methods/admin.users.setRegular
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return await self.api_call(&#34;admin.users.setRegular&#34;, params=kwargs)
@@ -1855,7 +1855,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Search workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.search
+        https://docs.slack.dev/reference/methods/admin.workflows.search
         &#34;&#34;&#34;
         if collaborator_ids is not None:
             if isinstance(collaborator_ids, (list, tuple)):
@@ -1885,7 +1885,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Look up the permissions for a set of workflows
-        https://api.slack.com/methods/admin.workflows.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
         &#34;&#34;&#34;
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -1906,7 +1906,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add collaborators to workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.add
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
         &#34;&#34;&#34;
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -1926,7 +1926,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Remove collaborators from workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.remove
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
         &#34;&#34;&#34;
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -1945,7 +1945,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Unpublish workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.unpublish
+        https://docs.slack.dev/reference/methods/admin.workflows.unpublish
         &#34;&#34;&#34;
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -1960,7 +1960,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Checks API calling code.
-        https://api.slack.com/methods/api.test
+        https://docs.slack.dev/reference/methods/api.test
         &#34;&#34;&#34;
         kwargs.update({&#34;error&#34;: error})
         return await self.api_call(&#34;api.test&#34;, params=kwargs)
@@ -1973,7 +1973,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Generate a temporary Socket Mode WebSocket URL that your app can connect to
         in order to receive events and interactive payloads
-        https://api.slack.com/methods/apps.connections.open
+        https://docs.slack.dev/reference/methods/apps.connections.open
         &#34;&#34;&#34;
         kwargs.update({&#34;token&#34;: app_token})
         return await self.api_call(&#34;apps.connections.open&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -1988,7 +1988,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Get a list of authorizations for the given event context.
         Each authorization represents an app installation that the event is visible to.
-        https://api.slack.com/methods/apps.event.authorizations.list
+        https://docs.slack.dev/reference/methods/apps.event.authorizations.list
         &#34;&#34;&#34;
         kwargs.update({&#34;event_context&#34;: event_context, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return await self.api_call(&#34;apps.event.authorizations.list&#34;, params=kwargs)
@@ -2001,7 +2001,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Uninstalls your app from a workspace.
-        https://api.slack.com/methods/apps.uninstall
+        https://docs.slack.dev/reference/methods/apps.uninstall
         &#34;&#34;&#34;
         kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret})
         return await self.api_call(&#34;apps.uninstall&#34;, params=kwargs)
@@ -2013,7 +2013,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Create an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.create
+        https://docs.slack.dev/reference/methods/apps.manifest.create
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2028,7 +2028,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Permanently deletes an app created through app manifests
-        https://api.slack.com/methods/apps.manifest.delete
+        https://docs.slack.dev/reference/methods/apps.manifest.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         return await self.api_call(&#34;apps.manifest.delete&#34;, params=kwargs)
@@ -2040,7 +2040,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Export an app manifest from an existing app
-        https://api.slack.com/methods/apps.manifest.export
+        https://docs.slack.dev/reference/methods/apps.manifest.export
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         return await self.api_call(&#34;apps.manifest.export&#34;, params=kwargs)
@@ -2053,7 +2053,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Update an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.update
+        https://docs.slack.dev/reference/methods/apps.manifest.update
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2070,7 +2070,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Validate an app manifest
-        https://api.slack.com/methods/apps.manifest.validate
+        https://docs.slack.dev/reference/methods/apps.manifest.validate
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2086,7 +2086,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Exchanges a refresh token for a new app configuration token
-        https://api.slack.com/methods/tooling.tokens.rotate
+        https://docs.slack.dev/reference/methods/tooling.tokens.rotate
         &#34;&#34;&#34;
         kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return await self.api_call(&#34;tooling.tokens.rotate&#34;, params=kwargs)
@@ -2100,7 +2100,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setStatus
+        https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status})
         return await self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)
@@ -2114,7 +2114,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setTitle
+        https://docs.slack.dev/reference/methods/assistant.threads.setTitle
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;title&#34;: title})
         return await self.api_call(&#34;assistant.threads.setTitle&#34;, params=kwargs)
@@ -2129,7 +2129,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+        https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
         if title is not None:
@@ -2143,7 +2143,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/auth.revoke
+        https://docs.slack.dev/reference/methods/auth.revoke
         &#34;&#34;&#34;
         kwargs.update({&#34;test&#34;: test})
         return await self.api_call(&#34;auth.revoke&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2153,7 +2153,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Checks authentication &amp; identity.
-        https://api.slack.com/methods/auth.test
+        https://docs.slack.dev/reference/methods/auth.test
         &#34;&#34;&#34;
         return await self.api_call(&#34;auth.test&#34;, params=kwargs)
 
@@ -2165,7 +2165,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List the workspaces a token can access.
-        https://api.slack.com/methods/auth.teams.list
+        https://docs.slack.dev/reference/methods/auth.teams.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;include_icon&#34;: include_icon})
         return await self.api_call(&#34;auth.teams.list&#34;, params=kwargs)
@@ -2183,7 +2183,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Add bookmark to a channel.
-        https://api.slack.com/methods/bookmarks.add
+        https://docs.slack.dev/reference/methods/bookmarks.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2209,7 +2209,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Edit bookmark.
-        https://api.slack.com/methods/bookmarks.edit
+        https://docs.slack.dev/reference/methods/bookmarks.edit
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2229,7 +2229,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List bookmark for the channel.
-        https://api.slack.com/methods/bookmarks.list
+        https://docs.slack.dev/reference/methods/bookmarks.list
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return await self.api_call(&#34;bookmarks.list&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2242,7 +2242,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Remove bookmark from the channel.
-        https://api.slack.com/methods/bookmarks.remove
+        https://docs.slack.dev/reference/methods/bookmarks.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;bookmark_id&#34;: bookmark_id, &#34;channel_id&#34;: channel_id})
         return await self.api_call(&#34;bookmarks.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2255,7 +2255,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets information about a bot user.
-        https://api.slack.com/methods/bots.info
+        https://docs.slack.dev/reference/methods/bots.info
         &#34;&#34;&#34;
         kwargs.update({&#34;bot&#34;: bot, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;bots.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2274,7 +2274,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Registers a new Call.
-        https://api.slack.com/methods/calls.add
+        https://docs.slack.dev/reference/methods/calls.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2301,7 +2301,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Ends a Call.
-        https://api.slack.com/methods/calls.end
+        https://docs.slack.dev/reference/methods/calls.end
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id, &#34;duration&#34;: duration})
         return await self.api_call(&#34;calls.end&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2313,7 +2313,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Returns information about a Call.
-        https://api.slack.com/methods/calls.info
+        https://docs.slack.dev/reference/methods/calls.info
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         return await self.api_call(&#34;calls.info&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2326,7 +2326,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Registers new participants added to a Call.
-        https://api.slack.com/methods/calls.participants.add
+        https://docs.slack.dev/reference/methods/calls.participants.add
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         _update_call_participants(kwargs, users)
@@ -2340,7 +2340,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Registers participants removed from a Call.
-        https://api.slack.com/methods/calls.participants.remove
+        https://docs.slack.dev/reference/methods/calls.participants.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         _update_call_participants(kwargs, users)
@@ -2356,7 +2356,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Updates information about a Call.
-        https://api.slack.com/methods/calls.update
+        https://docs.slack.dev/reference/methods/calls.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2376,7 +2376,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Create Canvas for a user
-        https://api.slack.com/methods/canvases.create
+        https://docs.slack.dev/reference/methods/canvases.create
         &#34;&#34;&#34;
         kwargs.update({&#34;title&#34;: title, &#34;document_content&#34;: document_content})
         return await self.api_call(&#34;canvases.create&#34;, json=kwargs)
@@ -2389,7 +2389,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Update an existing canvas
-        https://api.slack.com/methods/canvases.edit
+        https://docs.slack.dev/reference/methods/canvases.edit
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;changes&#34;: changes})
         return await self.api_call(&#34;canvases.edit&#34;, json=kwargs)
@@ -2401,7 +2401,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Deletes a canvas
-        https://api.slack.com/methods/canvases.delete
+        https://docs.slack.dev/reference/methods/canvases.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id})
         return await self.api_call(&#34;canvases.delete&#34;, params=kwargs)
@@ -2416,7 +2416,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sets the access level to a canvas for specified entities
-        https://api.slack.com/methods/canvases.access.set
+        https://docs.slack.dev/reference/methods/canvases.access.set
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;access_level&#34;: access_level})
         if channel_ids is not None:
@@ -2441,7 +2441,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Create a Channel Canvas for a channel
-        https://api.slack.com/methods/canvases.access.delete
+        https://docs.slack.dev/reference/methods/canvases.access.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id})
         if channel_ids is not None:
@@ -2464,7 +2464,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Find sections matching the provided criteria
-        https://api.slack.com/methods/canvases.sections.lookup
+        https://docs.slack.dev/reference/methods/canvases.sections.lookup
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;criteria&#34;: json.dumps(criteria)})
         return await self.api_call(&#34;canvases.sections.lookup&#34;, params=kwargs)
@@ -2472,7 +2472,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: channels.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     async def channels_archive(
@@ -2651,7 +2651,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Deletes a message.
-        https://api.slack.com/methods/chat.delete
+        https://docs.slack.dev/reference/methods/chat.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts, &#34;as_user&#34;: as_user})
         return await self.api_call(&#34;chat.delete&#34;, params=kwargs)
@@ -2665,7 +2665,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Deletes a scheduled message.
-        https://api.slack.com/methods/chat.deleteScheduledMessage
+        https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2684,7 +2684,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieve a permalink URL for a specific extant message
-        https://api.slack.com/methods/chat.getPermalink
+        https://docs.slack.dev/reference/methods/chat.getPermalink
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;message_ts&#34;: message_ts})
         return await self.api_call(&#34;chat.getPermalink&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2697,7 +2697,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Share a me message into a channel.
-        https://api.slack.com/methods/chat.meMessage
+        https://docs.slack.dev/reference/methods/chat.meMessage
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;text&#34;: text})
         return await self.api_call(&#34;chat.meMessage&#34;, params=kwargs)
@@ -2717,10 +2717,11 @@ el.replaceWith(d);
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sends an ephemeral message to a user in a channel.
-        https://api.slack.com/methods/chat.postEphemeral
+        https://docs.slack.dev/reference/methods/chat.postEphemeral
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2736,11 +2737,12 @@ el.replaceWith(d);
                 &#34;link_names&#34;: link_names,
                 &#34;username&#34;: username,
                 &#34;parse&#34;: parse,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return await self.api_call(&#34;chat.postEphemeral&#34;, json=kwargs)
 
@@ -2764,10 +2766,11 @@ el.replaceWith(d);
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sends a message to a channel.
-        https://api.slack.com/methods/chat.postMessage
+        https://docs.slack.dev/reference/methods/chat.postMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2788,11 +2791,12 @@ el.replaceWith(d);
                 &#34;username&#34;: username,
                 &#34;parse&#34;: parse,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postMessage&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.postMessage&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return await self.api_call(&#34;chat.postMessage&#34;, json=kwargs)
 
@@ -2801,7 +2805,7 @@ el.replaceWith(d);
         *,
         channel: str,
         post_at: Union[str, int],
-        text: str,
+        text: Optional[str] = None,
         as_user: Optional[bool] = None,
         attachments: Optional[Union[str, Sequence[Union[Dict, Attachment]]]] = None,
         blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
@@ -2812,10 +2816,11 @@ el.replaceWith(d);
         unfurl_media: Optional[bool] = None,
         link_names: Optional[bool] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Schedules a message.
-        https://api.slack.com/methods/chat.scheduleMessage
+        https://docs.slack.dev/reference/methods/chat.scheduleMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2832,11 +2837,12 @@ el.replaceWith(d);
                 &#34;unfurl_media&#34;: unfurl_media,
                 &#34;link_names&#34;: link_names,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return await self.api_call(&#34;chat.scheduleMessage&#34;, json=kwargs)
 
@@ -2855,7 +2861,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Provide custom unfurl behavior for user-posted URLs.
-        https://api.slack.com/methods/chat.unfurl
+        https://docs.slack.dev/reference/methods/chat.unfurl
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2889,10 +2895,11 @@ el.replaceWith(d);
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Updates a message in a channel.
-        https://api.slack.com/methods/chat.update
+        https://docs.slack.dev/reference/methods/chat.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2906,6 +2913,7 @@ el.replaceWith(d);
                 &#34;parse&#34;: parse,
                 &#34;reply_broadcast&#34;: reply_broadcast,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         if isinstance(file_ids, (list, tuple)):
@@ -2914,7 +2922,7 @@ el.replaceWith(d);
             kwargs.update({&#34;file_ids&#34;: file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.update&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.update&#34;, kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return await self.api_call(&#34;chat.update&#34;, json=kwargs)
 
@@ -2930,7 +2938,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists all scheduled messages.
-        https://api.slack.com/methods/chat.scheduledMessages.list
+        https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2956,7 +2964,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Accepts an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.acceptSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
         &#34;&#34;&#34;
         if channel_id is None and invite_id is None:
             raise e.SlackRequestError(&#34;Either channel_id or invite_id must be provided.&#34;)
@@ -2980,7 +2988,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Approves an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.approveSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
         return await self.api_call(&#34;conversations.approveSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2992,7 +3000,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Archives a conversation.
-        https://api.slack.com/methods/conversations.archive
+        https://docs.slack.dev/reference/methods/conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return await self.api_call(&#34;conversations.archive&#34;, params=kwargs)
@@ -3004,7 +3012,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Closes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.close
+        https://docs.slack.dev/reference/methods/conversations.close
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return await self.api_call(&#34;conversations.close&#34;, params=kwargs)
@@ -3018,7 +3026,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Initiates a public or private channel-based conversation
-        https://api.slack.com/methods/conversations.create
+        https://docs.slack.dev/reference/methods/conversations.create
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;is_private&#34;: is_private, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;conversations.create&#34;, params=kwargs)
@@ -3031,7 +3039,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Declines a Slack Connect channel invite.
-        https://api.slack.com/methods/conversations.declineSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
         return await self.api_call(&#34;conversations.declineSharedInvite&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3040,7 +3048,7 @@ el.replaceWith(d);
         self, *, action: str, channel: str, target_team: str, **kwargs
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-        https://api.slack.com/methods/conversations.externalInvitePermissions.set
+        https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3064,7 +3072,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Fetches a conversation&#39;s history of messages and events.
-        https://api.slack.com/methods/conversations.history
+        https://docs.slack.dev/reference/methods/conversations.history
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3088,7 +3096,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieve information about a conversation.
-        https://api.slack.com/methods/conversations.info
+        https://docs.slack.dev/reference/methods/conversations.info
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3108,7 +3116,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Invites users to a channel.
-        https://api.slack.com/methods/conversations.invite
+        https://docs.slack.dev/reference/methods/conversations.invite
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3131,7 +3139,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sends an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.inviteShared
+        https://docs.slack.dev/reference/methods/conversations.inviteShared
         &#34;&#34;&#34;
         if emails is None and user_ids is None:
             raise e.SlackRequestError(&#34;Either emails or user ids must be provided.&#34;)
@@ -3153,7 +3161,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Joins an existing conversation.
-        https://api.slack.com/methods/conversations.join
+        https://docs.slack.dev/reference/methods/conversations.join
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return await self.api_call(&#34;conversations.join&#34;, params=kwargs)
@@ -3166,7 +3174,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Removes a user from a conversation.
-        https://api.slack.com/methods/conversations.kick
+        https://docs.slack.dev/reference/methods/conversations.kick
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;user&#34;: user})
         return await self.api_call(&#34;conversations.kick&#34;, params=kwargs)
@@ -3178,7 +3186,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Leaves a conversation.
-        https://api.slack.com/methods/conversations.leave
+        https://docs.slack.dev/reference/methods/conversations.leave
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return await self.api_call(&#34;conversations.leave&#34;, params=kwargs)
@@ -3194,7 +3202,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists all channels in a Slack team.
-        https://api.slack.com/methods/conversations.list
+        https://docs.slack.dev/reference/methods/conversations.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3220,7 +3228,7 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List shared channel invites that have been generated
         or received but have not yet been approved by all parties.
-        https://api.slack.com/methods/conversations.listConnectInvites
+        https://docs.slack.dev/reference/methods/conversations.listConnectInvites
         &#34;&#34;&#34;
         kwargs.update({&#34;count&#34;: count, &#34;cursor&#34;: cursor, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;conversations.listConnectInvites&#34;, params=kwargs)
@@ -3233,7 +3241,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sets the read cursor in a channel.
-        https://api.slack.com/methods/conversations.mark
+        https://docs.slack.dev/reference/methods/conversations.mark
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts})
         return await self.api_call(&#34;conversations.mark&#34;, params=kwargs)
@@ -3247,7 +3255,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieve members of a conversation.
-        https://api.slack.com/methods/conversations.members
+        https://docs.slack.dev/reference/methods/conversations.members
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return await self.api_call(&#34;conversations.members&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3261,7 +3269,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Opens or resumes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.open
+        https://docs.slack.dev/reference/methods/conversations.open
         &#34;&#34;&#34;
         if channel is None and users is None:
             raise e.SlackRequestError(&#34;Either channel or users must be provided.&#34;)
@@ -3280,7 +3288,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Renames a conversation.
-        https://api.slack.com/methods/conversations.rename
+        https://docs.slack.dev/reference/methods/conversations.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name})
         return await self.api_call(&#34;conversations.rename&#34;, params=kwargs)
@@ -3299,7 +3307,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieve a thread of messages posted to a conversation
-        https://api.slack.com/methods/conversations.replies
+        https://docs.slack.dev/reference/methods/conversations.replies
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3325,7 +3333,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-        https://api.slack.com/methods/conversations.requestSharedInvite.approve
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3346,7 +3354,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Deny a request to invite an external user to a channel.
-        https://api.slack.com/methods/conversations.requestSharedInvite.deny
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;message&#34;: message})
         return await self.api_call(&#34;conversations.requestSharedInvite.deny&#34;, params=kwargs)
@@ -3364,7 +3372,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists requests to add external users to channels with ability to filter.
-        https://api.slack.com/methods/conversations.requestSharedInvite.list
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3391,7 +3399,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sets the purpose for a conversation.
-        https://api.slack.com/methods/conversations.setPurpose
+        https://docs.slack.dev/reference/methods/conversations.setPurpose
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;purpose&#34;: purpose})
         return await self.api_call(&#34;conversations.setPurpose&#34;, params=kwargs)
@@ -3404,7 +3412,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Sets the topic for a conversation.
-        https://api.slack.com/methods/conversations.setTopic
+        https://docs.slack.dev/reference/methods/conversations.setTopic
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;topic&#34;: topic})
         return await self.api_call(&#34;conversations.setTopic&#34;, params=kwargs)
@@ -3416,7 +3424,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Reverses conversation archival.
-        https://api.slack.com/methods/conversations.unarchive
+        https://docs.slack.dev/reference/methods/conversations.unarchive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return await self.api_call(&#34;conversations.unarchive&#34;, params=kwargs)
@@ -3429,7 +3437,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Create a Channel Canvas for a channel
-        https://api.slack.com/methods/conversations.canvases.create
+        https://docs.slack.dev/reference/methods/conversations.canvases.create
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;document_content&#34;: document_content})
         return await self.api_call(&#34;conversations.canvases.create&#34;, json=kwargs)
@@ -3442,7 +3450,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Open a dialog with a user.
-        https://api.slack.com/methods/dialog.open
+        https://docs.slack.dev/reference/methods/dialog.open
         &#34;&#34;&#34;
         kwargs.update({&#34;dialog&#34;: dialog, &#34;trigger_id&#34;: trigger_id})
         kwargs = _remove_none_values(kwargs)
@@ -3454,7 +3462,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Ends the current user&#39;s Do Not Disturb session immediately.
-        https://api.slack.com/methods/dnd.endDnd
+        https://docs.slack.dev/reference/methods/dnd.endDnd
         &#34;&#34;&#34;
         return await self.api_call(&#34;dnd.endDnd&#34;, params=kwargs)
 
@@ -3463,7 +3471,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Ends the current user&#39;s snooze mode immediately.
-        https://api.slack.com/methods/dnd.endSnooze
+        https://docs.slack.dev/reference/methods/dnd.endSnooze
         &#34;&#34;&#34;
         return await self.api_call(&#34;dnd.endSnooze&#34;, params=kwargs)
 
@@ -3475,7 +3483,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieves a user&#39;s current Do Not Disturb status.
-        https://api.slack.com/methods/dnd.info
+        https://docs.slack.dev/reference/methods/dnd.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
         return await self.api_call(&#34;dnd.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3487,7 +3495,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Turns on Do Not Disturb mode for the current user, or changes its duration.
-        https://api.slack.com/methods/dnd.setSnooze
+        https://docs.slack.dev/reference/methods/dnd.setSnooze
         &#34;&#34;&#34;
         kwargs.update({&#34;num_minutes&#34;: num_minutes})
         return await self.api_call(&#34;dnd.setSnooze&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3499,7 +3507,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieves the Do Not Disturb status for users on a team.
-        https://api.slack.com/methods/dnd.teamInfo
+        https://docs.slack.dev/reference/methods/dnd.teamInfo
         &#34;&#34;&#34;
         if isinstance(users, (list, tuple)):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -3514,7 +3522,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists custom emoji for a team.
-        https://api.slack.com/methods/emoji.list
+        https://docs.slack.dev/reference/methods/emoji.list
         &#34;&#34;&#34;
         kwargs.update({&#34;include_categories&#34;: include_categories})
         return await self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3527,7 +3535,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Deletes an existing comment on a file.
-        https://api.slack.com/methods/files.comments.delete
+        https://docs.slack.dev/reference/methods/files.comments.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file, &#34;id&#34;: id})
         return await self.api_call(&#34;files.comments.delete&#34;, params=kwargs)
@@ -3539,7 +3547,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Deletes a file.
-        https://api.slack.com/methods/files.delete
+        https://docs.slack.dev/reference/methods/files.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return await self.api_call(&#34;files.delete&#34;, params=kwargs)
@@ -3555,7 +3563,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets information about a team file.
-        https://api.slack.com/methods/files.info
+        https://docs.slack.dev/reference/methods/files.info
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3583,7 +3591,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists &amp; filters team files.
-        https://api.slack.com/methods/files.list
+        https://docs.slack.dev/reference/methods/files.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3611,7 +3619,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.info
+        https://docs.slack.dev/reference/methods/files.remote.info
         &#34;&#34;&#34;
         kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
         return await self.api_call(&#34;files.remote.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3627,7 +3635,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.list
+        https://docs.slack.dev/reference/methods/files.remote.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3652,7 +3660,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Adds a file from a remote service.
-        https://api.slack.com/methods/files.remote.add
+        https://docs.slack.dev/reference/methods/files.remote.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3691,7 +3699,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Updates an existing remote file.
-        https://api.slack.com/methods/files.remote.update
+        https://docs.slack.dev/reference/methods/files.remote.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3726,7 +3734,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Remove a remote file.
-        https://api.slack.com/methods/files.remote.remove
+        https://docs.slack.dev/reference/methods/files.remote.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
         return await self.api_call(&#34;files.remote.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -3740,7 +3748,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Share a remote file into a channel.
-        https://api.slack.com/methods/files.remote.share
+        https://docs.slack.dev/reference/methods/files.remote.share
         &#34;&#34;&#34;
         if external_id is None and file is None:
             raise e.SlackRequestError(&#34;Either external_id or file must be provided.&#34;)
@@ -3758,7 +3766,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Revokes public/external sharing access for a file
-        https://api.slack.com/methods/files.revokePublicURL
+        https://docs.slack.dev/reference/methods/files.revokePublicURL
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return await self.api_call(&#34;files.revokePublicURL&#34;, params=kwargs)
@@ -3770,7 +3778,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Enables a file for public/external sharing.
-        https://api.slack.com/methods/files.sharedPublicURL
+        https://docs.slack.dev/reference/methods/files.sharedPublicURL
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return await self.api_call(&#34;files.sharedPublicURL&#34;, params=kwargs)
@@ -3789,7 +3797,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Uploads or creates a file.
-        https://api.slack.com/methods/files.upload
+        https://docs.slack.dev/reference/methods/files.upload
         &#34;&#34;&#34;
         _print_files_upload_v2_suggestion()
 
@@ -3842,12 +3850,12 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;This wrapper method provides an easy way to upload files using the following endpoints:
 
-        - step1: https://api.slack.com/methods/files.getUploadURLExternal
+        - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
         - step2: &#34;https://files.slack.com/upload/v1/...&#34; URLs returned from files.getUploadURLExternal API
 
-        - step3: https://api.slack.com/methods/files.completeUploadExternal
-            and https://api.slack.com/methods/files.info
+        - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+            and https://docs.slack.dev/reference/methods/files.info
 
         &#34;&#34;&#34;
         if file is None and content is None and file_uploads is None:
@@ -3933,7 +3941,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets a URL for an edge external upload.
-        https://api.slack.com/methods/files.getUploadURLExternal
+        https://docs.slack.dev/reference/methods/files.getUploadURLExternal
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3956,7 +3964,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Finishes an upload started with files.getUploadURLExternal.
-        https://api.slack.com/methods/files.completeUploadExternal
+        https://docs.slack.dev/reference/methods/files.completeUploadExternal
         &#34;&#34;&#34;
         _files = [{k: v for k, v in f.items() if v is not None} for f in files]
         kwargs.update(
@@ -3979,7 +3987,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Signal the successful completion of a function
-        https://api.slack.com/methods/functions.completeSuccess
+        https://docs.slack.dev/reference/methods/functions.completeSuccess
         &#34;&#34;&#34;
         kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;outputs&#34;: json.dumps(outputs)})
         return await self.api_call(&#34;functions.completeSuccess&#34;, params=kwargs)
@@ -3992,7 +4000,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Signal the failure to execute a function
-        https://api.slack.com/methods/functions.completeError
+        https://docs.slack.dev/reference/methods/functions.completeError
         &#34;&#34;&#34;
         kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;error&#34;: error})
         return await self.api_call(&#34;functions.completeError&#34;, params=kwargs)
@@ -4000,7 +4008,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     async def groups_archive(
@@ -4181,7 +4189,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: im.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     async def im_close(
@@ -4257,7 +4265,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;For Enterprise Grid workspaces, map local user IDs to global user IDs
-        https://api.slack.com/methods/migration.exchange
+        https://docs.slack.dev/reference/methods/migration.exchange
         &#34;&#34;&#34;
         if isinstance(users, (list, tuple)):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -4269,7 +4277,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: mpim.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     async def mpim_close(
@@ -4356,7 +4364,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.v2.access
+        https://docs.slack.dev/reference/methods/oauth.v2.access
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4382,7 +4390,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.access
+        https://docs.slack.dev/reference/methods/oauth.access
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4402,7 +4410,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
-        https://api.slack.com/methods/oauth.v2.exchange
+        https://docs.slack.dev/reference/methods/oauth.v2.exchange
         &#34;&#34;&#34;
         kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token})
         return await self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
@@ -4418,7 +4426,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.token
+        https://docs.slack.dev/reference/methods/openid.connect.token
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4439,7 +4447,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Get the identity of a user who has authorized Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.userInfo
+        https://docs.slack.dev/reference/methods/openid.connect.userInfo
         &#34;&#34;&#34;
         return await self.api_call(&#34;openid.connect.userInfo&#34;, params=kwargs)
 
@@ -4451,7 +4459,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Pins an item to a channel.
-        https://api.slack.com/methods/pins.add
+        https://docs.slack.dev/reference/methods/pins.add
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
         return await self.api_call(&#34;pins.add&#34;, params=kwargs)
@@ -4463,7 +4471,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists items pinned to a channel.
-        https://api.slack.com/methods/pins.list
+        https://docs.slack.dev/reference/methods/pins.list
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return await self.api_call(&#34;pins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4476,7 +4484,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Un-pins an item from a channel.
-        https://api.slack.com/methods/pins.remove
+        https://docs.slack.dev/reference/methods/pins.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
         return await self.api_call(&#34;pins.remove&#34;, params=kwargs)
@@ -4490,7 +4498,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Adds a reaction to an item.
-        https://api.slack.com/methods/reactions.add
+        https://docs.slack.dev/reference/methods/reactions.add
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name, &#34;timestamp&#34;: timestamp})
         return await self.api_call(&#34;reactions.add&#34;, params=kwargs)
@@ -4506,7 +4514,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets reactions for an item.
-        https://api.slack.com/methods/reactions.get
+        https://docs.slack.dev/reference/methods/reactions.get
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4532,7 +4540,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists reactions made by a user.
-        https://api.slack.com/methods/reactions.list
+        https://docs.slack.dev/reference/methods/reactions.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4558,7 +4566,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Removes a reaction from an item.
-        https://api.slack.com/methods/reactions.remove
+        https://docs.slack.dev/reference/methods/reactions.remove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4582,7 +4590,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Creates a reminder.
-        https://api.slack.com/methods/reminders.add
+        https://docs.slack.dev/reference/methods/reminders.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4603,7 +4611,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Marks a reminder as complete.
-        https://api.slack.com/methods/reminders.complete
+        https://docs.slack.dev/reference/methods/reminders.complete
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;reminders.complete&#34;, params=kwargs)
@@ -4616,7 +4624,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Deletes a reminder.
-        https://api.slack.com/methods/reminders.delete
+        https://docs.slack.dev/reference/methods/reminders.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;reminders.delete&#34;, params=kwargs)
@@ -4629,7 +4637,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets information about a reminder.
-        https://api.slack.com/methods/reminders.info
+        https://docs.slack.dev/reference/methods/reminders.info
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;reminders.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4641,7 +4649,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists all reminders created by or for a given user.
-        https://api.slack.com/methods/reminders.list
+        https://docs.slack.dev/reference/methods/reminders.list
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         return await self.api_call(&#34;reminders.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4654,7 +4662,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.connect
+        https://docs.slack.dev/reference/methods/rtm.connect
         &#34;&#34;&#34;
         kwargs.update({&#34;batch_presence_aware&#34;: batch_presence_aware, &#34;presence_sub&#34;: presence_sub})
         return await self.api_call(&#34;rtm.connect&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4672,7 +4680,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.start
+        https://docs.slack.dev/reference/methods/rtm.start
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4700,7 +4708,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Searches for messages and files matching a query.
-        https://api.slack.com/methods/search.all
+        https://docs.slack.dev/reference/methods/search.all
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4728,7 +4736,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Searches for files matching a query.
-        https://api.slack.com/methods/search.files
+        https://docs.slack.dev/reference/methods/search.files
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4757,7 +4765,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Searches for messages matching a query.
-        https://api.slack.com/methods/search.messages
+        https://docs.slack.dev/reference/methods/search.messages
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4783,7 +4791,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Adds a star to an item.
-        https://api.slack.com/methods/stars.add
+        https://docs.slack.dev/reference/methods/stars.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4806,7 +4814,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists stars for a user.
-        https://api.slack.com/methods/stars.list
+        https://docs.slack.dev/reference/methods/stars.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4829,7 +4837,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Removes a star from an item.
-        https://api.slack.com/methods/stars.remove
+        https://docs.slack.dev/reference/methods/stars.remove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4853,7 +4861,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets the access logs for the current team.
-        https://api.slack.com/methods/team.accessLogs
+        https://docs.slack.dev/reference/methods/team.accessLogs
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4875,7 +4883,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets billable users information for the current team.
-        https://api.slack.com/methods/team.billableInfo
+        https://docs.slack.dev/reference/methods/team.billableInfo
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
         return await self.api_call(&#34;team.billableInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4885,7 +4893,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Reads a workspace&#39;s billing plan information.
-        https://api.slack.com/methods/team.billing.info
+        https://docs.slack.dev/reference/methods/team.billing.info
         &#34;&#34;&#34;
         return await self.api_call(&#34;team.billing.info&#34;, params=kwargs)
 
@@ -4896,7 +4904,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Disconnects an external organization.
-        https://api.slack.com/methods/team.externalTeams.disconnect
+        https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4918,7 +4926,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
-        https://api.slack.com/methods/team.externalTeams.list
+        https://docs.slack.dev/reference/methods/team.externalTeams.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4949,7 +4957,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets information about the current team.
-        https://api.slack.com/methods/team.info
+        https://docs.slack.dev/reference/methods/team.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team&#34;: team, &#34;domain&#34;: domain})
         return await self.api_call(&#34;team.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4967,7 +4975,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets the integration logs for the current team.
-        https://api.slack.com/methods/team.integrationLogs
+        https://docs.slack.dev/reference/methods/team.integrationLogs
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4989,7 +4997,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieve a team&#39;s profile.
-        https://api.slack.com/methods/team.profile.get
+        https://docs.slack.dev/reference/methods/team.profile.get
         &#34;&#34;&#34;
         kwargs.update({&#34;visibility&#34;: visibility})
         return await self.api_call(&#34;team.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4999,7 +5007,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieve a list of a workspace&#39;s team preferences.
-        https://api.slack.com/methods/team.preferences.list
+        https://docs.slack.dev/reference/methods/team.preferences.list
         &#34;&#34;&#34;
         return await self.api_call(&#34;team.preferences.list&#34;, params=kwargs)
 
@@ -5015,7 +5023,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Create a User Group
-        https://api.slack.com/methods/usergroups.create
+        https://docs.slack.dev/reference/methods/usergroups.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5041,7 +5049,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Disable an existing User Group
-        https://api.slack.com/methods/usergroups.disable
+        https://docs.slack.dev/reference/methods/usergroups.disable
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;usergroups.disable&#34;, params=kwargs)
@@ -5055,7 +5063,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Enable a User Group
-        https://api.slack.com/methods/usergroups.enable
+        https://docs.slack.dev/reference/methods/usergroups.enable
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
         return await self.api_call(&#34;usergroups.enable&#34;, params=kwargs)
@@ -5070,7 +5078,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all User Groups for a team
-        https://api.slack.com/methods/usergroups.list
+        https://docs.slack.dev/reference/methods/usergroups.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5095,7 +5103,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Update an existing User Group
-        https://api.slack.com/methods/usergroups.update
+        https://docs.slack.dev/reference/methods/usergroups.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5122,7 +5130,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List all users in a User Group
-        https://api.slack.com/methods/usergroups.users.list
+        https://docs.slack.dev/reference/methods/usergroups.users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5143,7 +5151,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Update the list of users for a User Group
-        https://api.slack.com/methods/usergroups.users.update
+        https://docs.slack.dev/reference/methods/usergroups.users.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5170,7 +5178,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;List conversations the calling user may access.
-        https://api.slack.com/methods/users.conversations
+        https://docs.slack.dev/reference/methods/users.conversations
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5192,7 +5200,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Delete the user profile photo
-        https://api.slack.com/methods/users.deletePhoto
+        https://docs.slack.dev/reference/methods/users.deletePhoto
         &#34;&#34;&#34;
         return await self.api_call(&#34;users.deletePhoto&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
@@ -5203,7 +5211,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets user presence information.
-        https://api.slack.com/methods/users.getPresence
+        https://docs.slack.dev/reference/methods/users.getPresence
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user})
         return await self.api_call(&#34;users.getPresence&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5213,7 +5221,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Get a user&#39;s identity.
-        https://api.slack.com/methods/users.identity
+        https://docs.slack.dev/reference/methods/users.identity
         &#34;&#34;&#34;
         return await self.api_call(&#34;users.identity&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
@@ -5225,7 +5233,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Gets information about a user.
-        https://api.slack.com/methods/users.info
+        https://docs.slack.dev/reference/methods/users.info
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user, &#34;include_locale&#34;: include_locale})
         return await self.api_call(&#34;users.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5240,7 +5248,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lists all users in a Slack team.
-        https://api.slack.com/methods/users.list
+        https://docs.slack.dev/reference/methods/users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5259,7 +5267,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Find a user with an email address.
-        https://api.slack.com/methods/users.lookupByEmail
+        https://docs.slack.dev/reference/methods/users.lookupByEmail
         &#34;&#34;&#34;
         kwargs.update({&#34;email&#34;: email})
         return await self.api_call(&#34;users.lookupByEmail&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5274,7 +5282,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set the user profile photo
-        https://api.slack.com/methods/users.setPhoto
+        https://docs.slack.dev/reference/methods/users.setPhoto
         &#34;&#34;&#34;
         kwargs.update({&#34;crop_w&#34;: crop_w, &#34;crop_x&#34;: crop_x, &#34;crop_y&#34;: crop_y})
         return await self.api_call(&#34;users.setPhoto&#34;, files={&#34;image&#34;: image}, data=kwargs)
@@ -5286,7 +5294,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Manually sets user presence.
-        https://api.slack.com/methods/users.setPresence
+        https://docs.slack.dev/reference/methods/users.setPresence
         &#34;&#34;&#34;
         kwargs.update({&#34;presence&#34;: presence})
         return await self.api_call(&#34;users.setPresence&#34;, params=kwargs)
@@ -5297,7 +5305,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Lookup an email address to see if someone is on Slack
-        https://api.slack.com/methods/users.discoverableContacts.lookup
+        https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
         &#34;&#34;&#34;
         kwargs.update({&#34;email&#34;: email})
         return await self.api_call(&#34;users.discoverableContacts.lookup&#34;, params=kwargs)
@@ -5310,7 +5318,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Retrieves a user&#39;s profile information.
-        https://api.slack.com/methods/users.profile.get
+        https://docs.slack.dev/reference/methods/users.profile.get
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user, &#34;include_labels&#34;: include_labels})
         return await self.api_call(&#34;users.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5325,7 +5333,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Set the profile information for a user.
-        https://api.slack.com/methods/users.profile.set
+        https://docs.slack.dev/reference/methods/users.profile.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5348,8 +5356,8 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Open a view for a user.
-        https://api.slack.com/methods/views.open
-        See https://api.slack.com/surfaces/modals for details.
+        https://docs.slack.dev/reference/methods/views.open
+        See https://docs.slack.dev/surfaces/modals/ for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
         if isinstance(view, View):
@@ -5372,9 +5380,9 @@ el.replaceWith(d);
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/surfaces/modals)
+        Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
         to learn more about the lifecycle and intricacies of views.
-        https://api.slack.com/methods/views.push
+        https://docs.slack.dev/reference/methods/views.push
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
         if isinstance(view, View):
@@ -5397,9 +5405,9 @@ el.replaceWith(d);
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+        See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
-        https://api.slack.com/methods/views.update
+        https://docs.slack.dev/reference/methods/views.update
         &#34;&#34;&#34;
         if isinstance(view, View):
             kwargs.update({&#34;view&#34;: view.to_dict()})
@@ -5426,8 +5434,8 @@ el.replaceWith(d);
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Publish a static view for a User.
         Create or update the view that comprises an
-        app&#39;s Home tab (https://api.slack.com/surfaces/tabs)
-        https://api.slack.com/methods/views.publish
+        app&#39;s Home tab (https://docs.slack.dev/surfaces/app-home/)
+        https://docs.slack.dev/reference/methods/views.publish
         &#34;&#34;&#34;
         kwargs.update({&#34;user_id&#34;: user_id, &#34;hash&#34;: hash})
         if isinstance(view, View):
@@ -5438,6 +5446,72 @@ el.replaceWith(d);
         # NOTE: Intentionally using json for the &#34;view&#34; parameter
         return await self.api_call(&#34;views.publish&#34;, json=kwargs)
 
+    async def workflows_featured_add(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Add featured workflows to a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.add
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return await self.api_call(&#34;workflows.featured.add&#34;, params=kwargs)
+
+    async def workflows_featured_list(
+        self,
+        *,
+        channel_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;List the featured workflows for specified channels.
+        https://docs.slack.dev/reference/methods/workflows.featured.list
+        &#34;&#34;&#34;
+        if isinstance(channel_ids, (list, tuple)):
+            kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
+        else:
+            kwargs.update({&#34;channel_ids&#34;: channel_ids})
+        return await self.api_call(&#34;workflows.featured.list&#34;, params=kwargs)
+
+    async def workflows_featured_remove(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Remove featured workflows from a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.remove
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return await self.api_call(&#34;workflows.featured.remove&#34;, params=kwargs)
+
+    async def workflows_featured_set(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Set featured workflows for a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.set
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return await self.api_call(&#34;workflows.featured.set&#34;, params=kwargs)
+
     async def workflows_stepCompleted(
         self,
         *,
@@ -5446,7 +5520,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Indicate a successful outcome of a workflow step&#39;s execution.
-        https://api.slack.com/methods/workflows.stepCompleted
+        https://docs.slack.dev/reference/methods/workflows.stepCompleted
         &#34;&#34;&#34;
         kwargs.update({&#34;workflow_step_execute_id&#34;: workflow_step_execute_id})
         if outputs is not None:
@@ -5463,7 +5537,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Indicate an unsuccessful outcome of a workflow step&#39;s execution.
-        https://api.slack.com/methods/workflows.stepFailed
+        https://docs.slack.dev/reference/methods/workflows.stepFailed
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5484,7 +5558,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; AsyncSlackResponse:
         &#34;&#34;&#34;Update the configuration for a workflow extension step.
-        https://api.slack.com/methods/workflows.updateStep
+        https://docs.slack.dev/reference/methods/workflows.updateStep
         &#34;&#34;&#34;
         kwargs.update({&#34;workflow_step_edit_id&#34;: workflow_step_edit_id})
         if inputs is not None:
@@ -5496,7 +5570,7 @@ el.replaceWith(d);
         return await self.api_call(&#34;workflows.updateStep&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>A WebClient allows apps to communicate with the Slack Platform's Web API.</p>
-<p><a href="https://api.slack.com/methods">https://api.slack.com/methods</a></p>
+<p><a href="https://docs.slack.dev/reference/methods">https://docs.slack.dev/reference/methods</a></p>
 <p>The Slack Web API is an interface for querying information from
 and enacting change in a Slack workspace.</p>
 <p>This client handles constructing and sending HTTP requests to Slack
@@ -5576,7 +5650,7 @@ removed at anytime.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieve analytics data for a given date, presented as a compressed JSON file
-    https://api.slack.com/methods/admin.analytics.getFile
+    https://docs.slack.dev/reference/methods/admin.analytics.getFile
     &#34;&#34;&#34;
     kwargs.update({&#34;type&#34;: type})
     if date is not None:
@@ -5586,7 +5660,7 @@ removed at anytime.</p></div>
     return await self.api_call(&#34;admin.analytics.getFile&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve analytics data for a given date, presented as a compressed JSON file
-<a href="https://api.slack.com/methods/admin.analytics.getFile">https://api.slack.com/methods/admin.analytics.getFile</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.analytics.getFile">https://docs.slack.dev/reference/methods/admin.analytics.getFile</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_activities_list"><code class="name flex">
 <span>async def <span class="ident">admin_apps_activities_list</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>component_id: str | None = None,<br>component_type: str | None = None,<br>log_event_type: str | None = None,<br>max_date_created: int | None = None,<br>min_date_created: int | None = None,<br>min_log_level: str | None = None,<br>sort_direction: str | None = None,<br>source: str | None = None,<br>team_id: str | None = None,<br>trace_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5615,7 +5689,7 @@ removed at anytime.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Get logs for a specified team/org
-    https://api.slack.com/methods/admin.apps.activities.list
+    https://docs.slack.dev/reference/methods/admin.apps.activities.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5637,7 +5711,7 @@ removed at anytime.</p></div>
     return await self.api_call(&#34;admin.apps.activities.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get logs for a specified team/org
-<a href="https://api.slack.com/methods/admin.apps.activities.list">https://api.slack.com/methods/admin.apps.activities.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.activities.list">https://docs.slack.dev/reference/methods/admin.apps.activities.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_approve"><code class="name flex">
 <span>async def <span class="ident">admin_apps_approve</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>request_id: str | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5660,7 +5734,7 @@ removed at anytime.</p></div>
     Either app_id or request_id is required.
     These IDs can be obtained either directly via the app_requested event,
     or by the admin.apps.requests.list method.
-    https://api.slack.com/methods/admin.apps.approve
+    https://docs.slack.dev/reference/methods/admin.apps.approve
     &#34;&#34;&#34;
     if app_id:
         kwargs.update({&#34;app_id&#34;: app_id})
@@ -5681,7 +5755,7 @@ removed at anytime.</p></div>
 Either app_id or request_id is required.
 These IDs can be obtained either directly via the app_requested event,
 or by the admin.apps.requests.list method.
-<a href="https://api.slack.com/methods/admin.apps.approve">https://api.slack.com/methods/admin.apps.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.approve">https://docs.slack.dev/reference/methods/admin.apps.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_approved_list"><code class="name flex">
 <span>async def <span class="ident">admin_apps_approved_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5701,7 +5775,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List approved apps for an org or workspace.
-    https://api.slack.com/methods/admin.apps.approved.list
+    https://docs.slack.dev/reference/methods/admin.apps.approved.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5714,7 +5788,7 @@ or by the admin.apps.requests.list method.
     return await self.api_call(&#34;admin.apps.approved.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List approved apps for an org or workspace.
-<a href="https://api.slack.com/methods/admin.apps.approved.list">https://api.slack.com/methods/admin.apps.approved.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.approved.list">https://docs.slack.dev/reference/methods/admin.apps.approved.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_clearResolution"><code class="name flex">
 <span>async def <span class="ident">admin_apps_clearResolution</span></span>(<span>self,<br>*,<br>app_id: str,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5733,7 +5807,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Clear an app resolution
-    https://api.slack.com/methods/admin.apps.clearResolution
+    https://docs.slack.dev/reference/methods/admin.apps.clearResolution
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5745,7 +5819,7 @@ or by the admin.apps.requests.list method.
     return await self.api_call(&#34;admin.apps.clearResolution&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Clear an app resolution
-<a href="https://api.slack.com/methods/admin.apps.clearResolution">https://api.slack.com/methods/admin.apps.clearResolution</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.clearResolution">https://docs.slack.dev/reference/methods/admin.apps.clearResolution</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_config_lookup"><code class="name flex">
 <span>async def <span class="ident">admin_apps_config_lookup</span></span>(<span>self, *, app_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5762,7 +5836,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Look up the app config for connectors by their IDs
-    https://api.slack.com/methods/admin.apps.config.lookup
+    https://docs.slack.dev/reference/methods/admin.apps.config.lookup
     &#34;&#34;&#34;
     if isinstance(app_ids, (list, tuple)):
         kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -5771,7 +5845,7 @@ or by the admin.apps.requests.list method.
     return await self.api_call(&#34;admin.apps.config.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up the app config for connectors by their IDs
-<a href="https://api.slack.com/methods/admin.apps.config.lookup">https://api.slack.com/methods/admin.apps.config.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.config.lookup">https://docs.slack.dev/reference/methods/admin.apps.config.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_config_set"><code class="name flex">
 <span>async def <span class="ident">admin_apps_config_set</span></span>(<span>self,<br>*,<br>app_id: str,<br>domain_restrictions: Dict[str, Any] | None = None,<br>workflow_auth_strategy: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5790,7 +5864,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set the app config for a connector
-    https://api.slack.com/methods/admin.apps.config.set
+    https://docs.slack.dev/reference/methods/admin.apps.config.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5803,7 +5877,7 @@ or by the admin.apps.requests.list method.
     return await self.api_call(&#34;admin.apps.config.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the app config for a connector
-<a href="https://api.slack.com/methods/admin.apps.config.set">https://api.slack.com/methods/admin.apps.config.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.config.set">https://docs.slack.dev/reference/methods/admin.apps.config.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_requests_cancel"><code class="name flex">
 <span>async def <span class="ident">admin_apps_requests_cancel</span></span>(<span>self,<br>*,<br>request_id: str,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5822,7 +5896,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List app requests for a team/workspace.
-    https://api.slack.com/methods/admin.apps.requests.cancel
+    https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5834,7 +5908,7 @@ or by the admin.apps.requests.list method.
     return await self.api_call(&#34;admin.apps.requests.cancel&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List app requests for a team/workspace.
-<a href="https://api.slack.com/methods/admin.apps.requests.cancel">https://api.slack.com/methods/admin.apps.requests.cancel</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.requests.cancel">https://docs.slack.dev/reference/methods/admin.apps.requests.cancel</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_requests_list"><code class="name flex">
 <span>async def <span class="ident">admin_apps_requests_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5853,7 +5927,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List app requests for a team/workspace.
-    https://api.slack.com/methods/admin.apps.requests.list
+    https://docs.slack.dev/reference/methods/admin.apps.requests.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5865,7 +5939,7 @@ or by the admin.apps.requests.list method.
     return await self.api_call(&#34;admin.apps.requests.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List app requests for a team/workspace.
-<a href="https://api.slack.com/methods/admin.apps.requests.list">https://api.slack.com/methods/admin.apps.requests.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.requests.list">https://docs.slack.dev/reference/methods/admin.apps.requests.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_restrict"><code class="name flex">
 <span>async def <span class="ident">admin_apps_restrict</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>request_id: str | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5888,7 +5962,7 @@ or by the admin.apps.requests.list method.
     Exactly one of the team_id or enterprise_id arguments is required, not both.
     Either app_id or request_id is required. These IDs can be obtained either directly
     via the app_requested event, or by the admin.apps.requests.list method.
-    https://api.slack.com/methods/admin.apps.restrict
+    https://docs.slack.dev/reference/methods/admin.apps.restrict
     &#34;&#34;&#34;
     if app_id:
         kwargs.update({&#34;app_id&#34;: app_id})
@@ -5909,7 +5983,7 @@ or by the admin.apps.requests.list method.
 Exactly one of the team_id or enterprise_id arguments is required, not both.
 Either app_id or request_id is required. These IDs can be obtained either directly
 via the app_requested event, or by the admin.apps.requests.list method.
-<a href="https://api.slack.com/methods/admin.apps.restrict">https://api.slack.com/methods/admin.apps.restrict</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.restrict">https://docs.slack.dev/reference/methods/admin.apps.restrict</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_restricted_list"><code class="name flex">
 <span>async def <span class="ident">admin_apps_restricted_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5929,7 +6003,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List restricted apps for an org or workspace.
-    https://api.slack.com/methods/admin.apps.restricted.list
+    https://docs.slack.dev/reference/methods/admin.apps.restricted.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5942,7 +6016,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
     return await self.api_call(&#34;admin.apps.restricted.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List restricted apps for an org or workspace.
-<a href="https://api.slack.com/methods/admin.apps.restricted.list">https://api.slack.com/methods/admin.apps.restricted.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.restricted.list">https://docs.slack.dev/reference/methods/admin.apps.restricted.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_apps_uninstall"><code class="name flex">
 <span>async def <span class="ident">admin_apps_uninstall</span></span>(<span>self,<br>*,<br>app_id: str,<br>enterprise_id: str | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5962,7 +6036,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Uninstall an app from one or many workspaces, or an entire enterprise organization.
     With an org-level token, enterprise_id or team_ids is required.
-    https://api.slack.com/methods/admin.apps.uninstall
+    https://docs.slack.dev/reference/methods/admin.apps.uninstall
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     if enterprise_id is not None:
@@ -5976,7 +6050,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
 </details>
 <div class="desc"><p>Uninstall an app from one or many workspaces, or an entire enterprise organization.
 With an org-level token, enterprise_id or team_ids is required.
-<a href="https://api.slack.com/methods/admin.apps.uninstall">https://api.slack.com/methods/admin.apps.uninstall</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.uninstall">https://docs.slack.dev/reference/methods/admin.apps.uninstall</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_assignEntities"><code class="name flex">
 <span>async def <span class="ident">admin_auth_policy_assignEntities</span></span>(<span>self,<br>*,<br>entity_ids: str | Sequence[str],<br>policy_name: str,<br>entity_type: str,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -5995,7 +6069,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Assign entities to a particular authentication policy.
-    https://api.slack.com/methods/admin.auth.policy.assignEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
     &#34;&#34;&#34;
     if isinstance(entity_ids, (list, tuple)):
         kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -6006,7 +6080,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return await self.api_call(&#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Assign entities to a particular authentication policy.
-<a href="https://api.slack.com/methods/admin.auth.policy.assignEntities">https://api.slack.com/methods/admin.auth.policy.assignEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_getEntities"><code class="name flex">
 <span>async def <span class="ident">admin_auth_policy_getEntities</span></span>(<span>self,<br>*,<br>policy_name: str,<br>cursor: str | None = None,<br>entity_type: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6026,7 +6100,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.
-    https://api.slack.com/methods/admin.auth.policy.getEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
     &#34;&#34;&#34;
     kwargs.update({&#34;policy_name&#34;: policy_name})
     if cursor is not None:
@@ -6038,7 +6112,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return await self.api_call(&#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetch all the entities assigned to a particular authentication policy by name.
-<a href="https://api.slack.com/methods/admin.auth.policy.getEntities">https://api.slack.com/methods/admin.auth.policy.getEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_auth_policy_removeEntities"><code class="name flex">
 <span>async def <span class="ident">admin_auth_policy_removeEntities</span></span>(<span>self,<br>*,<br>entity_ids: str | Sequence[str],<br>policy_name: str,<br>entity_type: str,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6057,7 +6131,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Remove specified entities from a specified authentication policy.
-    https://api.slack.com/methods/admin.auth.policy.removeEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
     &#34;&#34;&#34;
     if isinstance(entity_ids, (list, tuple)):
         kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -6068,7 +6142,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return await self.api_call(&#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove specified entities from a specified authentication policy.
-<a href="https://api.slack.com/methods/admin.auth.policy.removeEntities">https://api.slack.com/methods/admin.auth.policy.removeEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_barriers_create"><code class="name flex">
 <span>async def <span class="ident">admin_barriers_create</span></span>(<span>self,<br>*,<br>barriered_from_usergroup_ids: str | Sequence[str],<br>primary_usergroup_id: str,<br>restricted_subjects: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6087,7 +6161,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Create an Information Barrier
-    https://api.slack.com/methods/admin.barriers.create
+    https://docs.slack.dev/reference/methods/admin.barriers.create
     &#34;&#34;&#34;
     kwargs.update({&#34;primary_usergroup_id&#34;: primary_usergroup_id})
     if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -6101,7 +6175,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return await self.api_call(&#34;admin.barriers.create&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.create">https://api.slack.com/methods/admin.barriers.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.create">https://docs.slack.dev/reference/methods/admin.barriers.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_barriers_delete"><code class="name flex">
 <span>async def <span class="ident">admin_barriers_delete</span></span>(<span>self, *, barrier_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6118,13 +6192,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Delete an existing Information Barrier
-    https://api.slack.com/methods/admin.barriers.delete
+    https://docs.slack.dev/reference/methods/admin.barriers.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;barrier_id&#34;: barrier_id})
     return await self.api_call(&#34;admin.barriers.delete&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete an existing Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.delete">https://api.slack.com/methods/admin.barriers.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.delete">https://docs.slack.dev/reference/methods/admin.barriers.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_barriers_list"><code class="name flex">
 <span>async def <span class="ident">admin_barriers_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6142,7 +6216,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Get all Information Barriers for your organization
-    https://api.slack.com/methods/admin.barriers.list&#34;&#34;&#34;
+    https://docs.slack.dev/reference/methods/admin.barriers.list&#34;&#34;&#34;
     kwargs.update(
         {
             &#34;cursor&#34;: cursor,
@@ -6152,7 +6226,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return await self.api_call(&#34;admin.barriers.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get all Information Barriers for your organization
-<a href="https://api.slack.com/methods/admin.barriers.list">https://api.slack.com/methods/admin.barriers.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.list">https://docs.slack.dev/reference/methods/admin.barriers.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_barriers_update"><code class="name flex">
 <span>async def <span class="ident">admin_barriers_update</span></span>(<span>self,<br>*,<br>barrier_id: str,<br>barriered_from_usergroup_ids: str | Sequence[str],<br>primary_usergroup_id: str,<br>restricted_subjects: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6172,7 +6246,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Update an existing Information Barrier
-    https://api.slack.com/methods/admin.barriers.update
+    https://docs.slack.dev/reference/methods/admin.barriers.update
     &#34;&#34;&#34;
     kwargs.update({&#34;barrier_id&#34;: barrier_id, &#34;primary_usergroup_id&#34;: primary_usergroup_id})
     if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -6186,7 +6260,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return await self.api_call(&#34;admin.barriers.update&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.update">https://api.slack.com/methods/admin.barriers.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.update">https://docs.slack.dev/reference/methods/admin.barriers.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_archive"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_archive</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6203,13 +6277,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Archive a public or private channel.
-    https://api.slack.com/methods/admin.conversations.archive
+    https://docs.slack.dev/reference/methods/admin.conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return await self.api_call(&#34;admin.conversations.archive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archive a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.archive">https://api.slack.com/methods/admin.conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.archive">https://docs.slack.dev/reference/methods/admin.conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_bulkArchive"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_bulkArchive</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6226,13 +6300,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Archive public or private channels in bulk.
-    https://api.slack.com/methods/admin.conversations.bulkArchive
+    https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
     return await self.api_call(&#34;admin.conversations.bulkArchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archive public or private channels in bulk.
-<a href="https://api.slack.com/methods/admin.conversations.bulkArchive">https://api.slack.com/methods/admin.conversations.bulkArchive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive">https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_bulkDelete"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_bulkDelete</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6273,7 +6347,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Move public or private channels in bulk.
-    https://api.slack.com/methods/admin.conversations.bulkMove
+    https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6284,7 +6358,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return await self.api_call(&#34;admin.conversations.bulkMove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Move public or private channels in bulk.
-<a href="https://api.slack.com/methods/admin.conversations.bulkMove">https://api.slack.com/methods/admin.conversations.bulkMove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.bulkMove">https://docs.slack.dev/reference/methods/admin.conversations.bulkMove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_convertToPrivate"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_convertToPrivate</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6301,13 +6375,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Convert a public channel to a private channel.
-    https://api.slack.com/methods/admin.conversations.convertToPrivate
+    https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return await self.api_call(&#34;admin.conversations.convertToPrivate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Convert a public channel to a private channel.
-<a href="https://api.slack.com/methods/admin.conversations.convertToPrivate">https://api.slack.com/methods/admin.conversations.convertToPrivate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate">https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_convertToPublic"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_convertToPublic</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6324,13 +6398,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Convert a privte channel to a public channel.
-    https://api.slack.com/methods/admin.conversations.convertToPublic
+    https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return await self.api_call(&#34;admin.conversations.convertToPublic&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Convert a privte channel to a public channel.
-<a href="https://api.slack.com/methods/admin.conversations.convertToPublic">https://api.slack.com/methods/admin.conversations.convertToPublic</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic">https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_create"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_create</span></span>(<span>self,<br>*,<br>is_private: bool,<br>name: str,<br>description: str | None = None,<br>org_wide: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6351,7 +6425,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Create a public or private channel-based conversation.
-    https://api.slack.com/methods/admin.conversations.create
+    https://docs.slack.dev/reference/methods/admin.conversations.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6365,7 +6439,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return await self.api_call(&#34;admin.conversations.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a public or private channel-based conversation.
-<a href="https://api.slack.com/methods/admin.conversations.create">https://api.slack.com/methods/admin.conversations.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.create">https://docs.slack.dev/reference/methods/admin.conversations.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_createForObjects"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_createForObjects</span></span>(<span>self,<br>*,<br>object_id: str,<br>salesforce_org_id: str,<br>invite_object_team: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6384,7 +6458,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Create a Salesforce channel for the corresponding object provided.
-    https://api.slack.com/methods/admin.conversations.createForObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
     &#34;&#34;&#34;
     kwargs.update(
         {&#34;object_id&#34;: object_id, &#34;salesforce_org_id&#34;: salesforce_org_id, &#34;invite_object_team&#34;: invite_object_team}
@@ -6392,7 +6466,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return await self.api_call(&#34;admin.conversations.createForObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Salesforce channel for the corresponding object provided.
-<a href="https://api.slack.com/methods/admin.conversations.createForObjects">https://api.slack.com/methods/admin.conversations.createForObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.createForObjects">https://docs.slack.dev/reference/methods/admin.conversations.createForObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_delete"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_delete</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6409,13 +6483,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Delete a public or private channel.
-    https://api.slack.com/methods/admin.conversations.delete
+    https://docs.slack.dev/reference/methods/admin.conversations.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return await self.api_call(&#34;admin.conversations.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.delete">https://api.slack.com/methods/admin.conversations.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.delete">https://docs.slack.dev/reference/methods/admin.conversations.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_disconnectShared"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_disconnectShared</span></span>(<span>self,<br>*,<br>channel_id: str,<br>leaving_team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6433,7 +6507,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Disconnect a connected channel from one or more workspaces.
-    https://api.slack.com/methods/admin.conversations.disconnectShared
+    https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(leaving_team_ids, (list, tuple)):
@@ -6443,7 +6517,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return await self.api_call(&#34;admin.conversations.disconnectShared&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disconnect a connected channel from one or more workspaces.
-<a href="https://api.slack.com/methods/admin.conversations.disconnectShared">https://api.slack.com/methods/admin.conversations.disconnectShared</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared">https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_ekm_listOriginalConnectedChannelInfo"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_ekm_listOriginalConnectedChannelInfo</span></span>(<span>self,<br>*,<br>channel_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6465,7 +6539,7 @@ With an org-level token, enterprise_id or team_ids is required.
     &#34;&#34;&#34;List all disconnected channels—i.e.,
     channels that were once connected to other workspaces and then disconnected—and
     the corresponding original channel IDs for key revocation with EKM.
-    https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+    https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6486,7 +6560,7 @@ With an org-level token, enterprise_id or team_ids is required.
 <div class="desc"><p>List all disconnected channels—i.e.,
 channels that were once connected to other workspaces and then disconnected—and
 the corresponding original channel IDs for key revocation with EKM.
-<a href="https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo">https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo">https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_getConversationPrefs"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_getConversationPrefs</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6503,13 +6577,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Get conversation preferences for a public or private channel.
-    https://api.slack.com/methods/admin.conversations.getConversationPrefs
+    https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return await self.api_call(&#34;admin.conversations.getConversationPrefs&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get conversation preferences for a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.getConversationPrefs">https://api.slack.com/methods/admin.conversations.getConversationPrefs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs">https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_getCustomRetention"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_getCustomRetention</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6526,13 +6600,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Get a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.getCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return await self.api_call(&#34;admin.conversations.getCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.getCustomRetention">https://api.slack.com/methods/admin.conversations.getCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_getTeams"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_getTeams</span></span>(<span>self,<br>*,<br>channel_id: str,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6551,7 +6625,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a channel.
-    https://api.slack.com/methods/admin.conversations.getTeams
+    https://docs.slack.dev/reference/methods/admin.conversations.getTeams
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6563,7 +6637,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return await self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the workspaces in an Enterprise grid org that connect to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.getTeams">https://api.slack.com/methods/admin.conversations.getTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getTeams">https://docs.slack.dev/reference/methods/admin.conversations.getTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_invite"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_invite</span></span>(<span>self, *, channel_id: str, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6581,7 +6655,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Invite a user to a public or private channel.
-    https://api.slack.com/methods/admin.conversations.invite
+    https://docs.slack.dev/reference/methods/admin.conversations.invite
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(user_ids, (list, tuple)):
@@ -6592,7 +6666,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return await self.api_call(&#34;admin.conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invite a user to a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.invite">https://api.slack.com/methods/admin.conversations.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.invite">https://docs.slack.dev/reference/methods/admin.conversations.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_linkObjects"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_linkObjects</span></span>(<span>self, *, channel: str, record_id: str, salesforce_org_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6611,7 +6685,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Link a Salesforce record to a channel.
-    https://api.slack.com/methods/admin.conversations.linkObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6623,7 +6697,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return await self.api_call(&#34;admin.conversations.linkObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Link a Salesforce record to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.linkObjects">https://api.slack.com/methods/admin.conversations.linkObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.linkObjects">https://docs.slack.dev/reference/methods/admin.conversations.linkObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_lookup"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_lookup</span></span>(<span>self,<br>*,<br>last_message_activity_before: int,<br>team_ids: str | Sequence[str],<br>cursor: str | None = None,<br>limit: int | None = None,<br>max_member_count: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6644,7 +6718,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Returns channels on the given team using the filters.
-    https://api.slack.com/methods/admin.conversations.lookup
+    https://docs.slack.dev/reference/methods/admin.conversations.lookup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6661,7 +6735,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return await self.api_call(&#34;admin.conversations.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns channels on the given team using the filters.
-<a href="https://api.slack.com/methods/admin.conversations.lookup">https://api.slack.com/methods/admin.conversations.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.lookup">https://docs.slack.dev/reference/methods/admin.conversations.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_removeCustomRetention"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_removeCustomRetention</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6678,13 +6752,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Remove a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.removeCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return await self.api_call(&#34;admin.conversations.removeCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.removeCustomRetention">https://api.slack.com/methods/admin.conversations.removeCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_rename"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_rename</span></span>(<span>self, *, channel_id: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6702,13 +6776,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Rename a public or private channel.
-    https://api.slack.com/methods/admin.conversations.rename
+    https://docs.slack.dev/reference/methods/admin.conversations.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;name&#34;: name})
     return await self.api_call(&#34;admin.conversations.rename&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Rename a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.rename">https://api.slack.com/methods/admin.conversations.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.rename">https://docs.slack.dev/reference/methods/admin.conversations.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_restrictAccess_addGroup"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_restrictAccess_addGroup</span></span>(<span>self, *, channel_id: str, group_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6727,7 +6801,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Add an allowlist of IDP groups for accessing a channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6743,7 +6817,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>Add an allowlist of IDP groups for accessing a channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup">https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_restrictAccess_listGroups"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_restrictAccess_listGroups</span></span>(<span>self, *, channel_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6761,7 +6835,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all IDP Groups linked to a channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6776,7 +6850,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>List all IDP Groups linked to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups">https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_restrictAccess_removeGroup"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_restrictAccess_removeGroup</span></span>(<span>self, *, channel_id: str, group_id: str, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6795,7 +6869,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Remove a linked IDP group linked from a private channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6811,7 +6885,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>Remove a linked IDP group linked from a private channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup">https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_search"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_search</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>query: str | None = None,<br>search_channel_types: str | Sequence[str] | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6834,7 +6908,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.
-    https://api.slack.com/methods/admin.conversations.search
+    https://docs.slack.dev/reference/methods/admin.conversations.search
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6859,7 +6933,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return await self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Search for public or private channels in an Enterprise organization.
-<a href="https://api.slack.com/methods/admin.conversations.search">https://api.slack.com/methods/admin.conversations.search</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.search">https://docs.slack.dev/reference/methods/admin.conversations.search</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_setConversationPrefs"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_setConversationPrefs</span></span>(<span>self, *, channel_id: str, prefs: str | Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6877,7 +6951,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set the posting permissions for a public or private channel.
-    https://api.slack.com/methods/admin.conversations.setConversationPrefs
+    https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(prefs, dict):
@@ -6887,7 +6961,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return await self.api_call(&#34;admin.conversations.setConversationPrefs&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the posting permissions for a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.setConversationPrefs">https://api.slack.com/methods/admin.conversations.setConversationPrefs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs">https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_setCustomRetention"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_setCustomRetention</span></span>(<span>self, *, channel_id: str, duration_days: int, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6905,13 +6979,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.setCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;duration_days&#34;: duration_days})
     return await self.api_call(&#34;admin.conversations.setCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.setCustomRetention">https://api.slack.com/methods/admin.conversations.setCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_setTeams"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_setTeams</span></span>(<span>self,<br>*,<br>channel_id: str,<br>org_channel: bool | None = None,<br>target_team_ids: str | Sequence[str] | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6931,7 +7005,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-    https://api.slack.com/methods/admin.conversations.setTeams
+    https://docs.slack.dev/reference/methods/admin.conversations.setTeams
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6947,7 +7021,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return await self.api_call(&#34;admin.conversations.setTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.setTeams">https://api.slack.com/methods/admin.conversations.setTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setTeams">https://docs.slack.dev/reference/methods/admin.conversations.setTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_unarchive"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_unarchive</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6964,13 +7038,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Unarchive a public or private channel.
-    https://api.slack.com/methods/admin.conversations.archive
+    https://docs.slack.dev/reference/methods/admin.conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return await self.api_call(&#34;admin.conversations.unarchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unarchive a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.archive">https://api.slack.com/methods/admin.conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.archive">https://docs.slack.dev/reference/methods/admin.conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_conversations_unlinkObjects"><code class="name flex">
 <span>async def <span class="ident">admin_conversations_unlinkObjects</span></span>(<span>self, *, channel: str, new_name: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -6988,7 +7062,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Unlink a Salesforce record from a channel.
-    https://api.slack.com/methods/admin.conversations.unlinkObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6999,7 +7073,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return await self.api_call(&#34;admin.conversations.unlinkObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unlink a Salesforce record from a channel.
-<a href="https://api.slack.com/methods/admin.conversations.unlinkObjects">https://api.slack.com/methods/admin.conversations.unlinkObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects">https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_emoji_add"><code class="name flex">
 <span>async def <span class="ident">admin_emoji_add</span></span>(<span>self, *, name: str, url: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7017,13 +7091,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Add an emoji.
-    https://api.slack.com/methods/admin.emoji.add
+    https://docs.slack.dev/reference/methods/admin.emoji.add
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;url&#34;: url})
     return await self.api_call(&#34;admin.emoji.add&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an emoji.
-<a href="https://api.slack.com/methods/admin.emoji.add">https://api.slack.com/methods/admin.emoji.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.add">https://docs.slack.dev/reference/methods/admin.emoji.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_emoji_addAlias"><code class="name flex">
 <span>async def <span class="ident">admin_emoji_addAlias</span></span>(<span>self, *, alias_for: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7041,13 +7115,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Add an emoji alias.
-    https://api.slack.com/methods/admin.emoji.addAlias
+    https://docs.slack.dev/reference/methods/admin.emoji.addAlias
     &#34;&#34;&#34;
     kwargs.update({&#34;alias_for&#34;: alias_for, &#34;name&#34;: name})
     return await self.api_call(&#34;admin.emoji.addAlias&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an emoji alias.
-<a href="https://api.slack.com/methods/admin.emoji.addAlias">https://api.slack.com/methods/admin.emoji.addAlias</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.addAlias">https://docs.slack.dev/reference/methods/admin.emoji.addAlias</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_emoji_list"><code class="name flex">
 <span>async def <span class="ident">admin_emoji_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7065,13 +7139,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List emoji for an Enterprise Grid organization.
-    https://api.slack.com/methods/admin.emoji.list
+    https://docs.slack.dev/reference/methods/admin.emoji.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return await self.api_call(&#34;admin.emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List emoji for an Enterprise Grid organization.
-<a href="https://api.slack.com/methods/admin.emoji.list">https://api.slack.com/methods/admin.emoji.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.list">https://docs.slack.dev/reference/methods/admin.emoji.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_emoji_remove"><code class="name flex">
 <span>async def <span class="ident">admin_emoji_remove</span></span>(<span>self, *, name: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7088,13 +7162,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Remove an emoji across an Enterprise Grid organization.
-    https://api.slack.com/methods/admin.emoji.remove
+    https://docs.slack.dev/reference/methods/admin.emoji.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name})
     return await self.api_call(&#34;admin.emoji.remove&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove an emoji across an Enterprise Grid organization.
-<a href="https://api.slack.com/methods/admin.emoji.remove">https://api.slack.com/methods/admin.emoji.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.remove">https://docs.slack.dev/reference/methods/admin.emoji.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_emoji_rename"><code class="name flex">
 <span>async def <span class="ident">admin_emoji_rename</span></span>(<span>self, *, name: str, new_name: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7112,13 +7186,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Rename an emoji.
-    https://api.slack.com/methods/admin.emoji.rename
+    https://docs.slack.dev/reference/methods/admin.emoji.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;new_name&#34;: new_name})
     return await self.api_call(&#34;admin.emoji.rename&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Rename an emoji.
-<a href="https://api.slack.com/methods/admin.emoji.rename">https://api.slack.com/methods/admin.emoji.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.rename">https://docs.slack.dev/reference/methods/admin.emoji.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_functions_list"><code class="name flex">
 <span>async def <span class="ident">admin_functions_list</span></span>(<span>self,<br>*,<br>app_ids: str | Sequence[str],<br>team_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7138,7 +7212,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Look up functions by a set of apps
-    https://api.slack.com/methods/admin.functions.list
+    https://docs.slack.dev/reference/methods/admin.functions.list
     &#34;&#34;&#34;
     if isinstance(app_ids, (list, tuple)):
         kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -7154,7 +7228,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return await self.api_call(&#34;admin.functions.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up functions by a set of apps
-<a href="https://api.slack.com/methods/admin.functions.list">https://api.slack.com/methods/admin.functions.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.list">https://docs.slack.dev/reference/methods/admin.functions.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_functions_permissions_lookup"><code class="name flex">
 <span>async def <span class="ident">admin_functions_permissions_lookup</span></span>(<span>self, *, function_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7172,7 +7246,7 @@ the corresponding original channel IDs for key revocation with EKM.
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lookup the visibility of multiple Slack functions
     and include the users if it is limited to particular named entities.
-    https://api.slack.com/methods/admin.functions.permissions.lookup
+    https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
     &#34;&#34;&#34;
     if isinstance(function_ids, (list, tuple)):
         kwargs.update({&#34;function_ids&#34;: &#34;,&#34;.join(function_ids)})
@@ -7182,7 +7256,7 @@ the corresponding original channel IDs for key revocation with EKM.
 </details>
 <div class="desc"><p>Lookup the visibility of multiple Slack functions
 and include the users if it is limited to particular named entities.
-<a href="https://api.slack.com/methods/admin.functions.permissions.lookup">https://api.slack.com/methods/admin.functions.permissions.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup">https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_functions_permissions_set"><code class="name flex">
 <span>async def <span class="ident">admin_functions_permissions_set</span></span>(<span>self,<br>*,<br>function_id: str,<br>visibility: str,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7202,7 +7276,7 @@ and include the users if it is limited to particular named entities.
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set the visibility of a Slack function
     and define the users or workspaces if it is set to named_entities
-    https://api.slack.com/methods/admin.functions.permissions.set
+    https://docs.slack.dev/reference/methods/admin.functions.permissions.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7219,7 +7293,7 @@ and include the users if it is limited to particular named entities.
 </details>
 <div class="desc"><p>Set the visibility of a Slack function
 and define the users or workspaces if it is set to named_entities
-<a href="https://api.slack.com/methods/admin.functions.permissions.set">https://api.slack.com/methods/admin.functions.permissions.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.permissions.set">https://docs.slack.dev/reference/methods/admin.functions.permissions.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_inviteRequests_approve"><code class="name flex">
 <span>async def <span class="ident">admin_inviteRequests_approve</span></span>(<span>self, *, invite_request_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7237,13 +7311,13 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Approve a workspace invite request.
-    https://api.slack.com/methods/admin.inviteRequests.approve
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;admin.inviteRequests.approve&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approve a workspace invite request.
-<a href="https://api.slack.com/methods/admin.inviteRequests.approve">https://api.slack.com/methods/admin.inviteRequests.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.approve">https://docs.slack.dev/reference/methods/admin.inviteRequests.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_inviteRequests_approved_list"><code class="name flex">
 <span>async def <span class="ident">admin_inviteRequests_approved_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7262,7 +7336,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all approved workspace invite requests.
-    https://api.slack.com/methods/admin.inviteRequests.approved.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7274,7 +7348,7 @@ and define the users or workspaces if it is set to named_entities
     return await self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all approved workspace invite requests.
-<a href="https://api.slack.com/methods/admin.inviteRequests.approved.list">https://api.slack.com/methods/admin.inviteRequests.approved.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_inviteRequests_denied_list"><code class="name flex">
 <span>async def <span class="ident">admin_inviteRequests_denied_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7293,7 +7367,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all denied workspace invite requests.
-    https://api.slack.com/methods/admin.inviteRequests.denied.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7305,7 +7379,7 @@ and define the users or workspaces if it is set to named_entities
     return await self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all denied workspace invite requests.
-<a href="https://api.slack.com/methods/admin.inviteRequests.denied.list">https://api.slack.com/methods/admin.inviteRequests.denied.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_inviteRequests_deny"><code class="name flex">
 <span>async def <span class="ident">admin_inviteRequests_deny</span></span>(<span>self, *, invite_request_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7323,13 +7397,13 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Deny a workspace invite request.
-    https://api.slack.com/methods/admin.inviteRequests.deny
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;admin.inviteRequests.deny&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deny a workspace invite request.
-<a href="https://api.slack.com/methods/admin.inviteRequests.deny">https://api.slack.com/methods/admin.inviteRequests.deny</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.deny">https://docs.slack.dev/reference/methods/admin.inviteRequests.deny</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_inviteRequests_list"><code class="name flex">
 <span>async def <span class="ident">admin_inviteRequests_list</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7365,7 +7439,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Adds members to the specified role with the specified scopes
-    https://api.slack.com/methods/admin.roles.addAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.addAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;role_id&#34;: role_id})
     if isinstance(entity_ids, (list, tuple)):
@@ -7379,7 +7453,7 @@ and define the users or workspaces if it is set to named_entities
     return await self.api_call(&#34;admin.roles.addAssignments&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds members to the specified role with the specified scopes
-<a href="https://api.slack.com/methods/admin.roles.addAssignments">https://api.slack.com/methods/admin.roles.addAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.addAssignments">https://docs.slack.dev/reference/methods/admin.roles.addAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_roles_listAssignments"><code class="name flex">
 <span>async def <span class="ident">admin_roles_listAssignments</span></span>(<span>self,<br>*,<br>role_ids: str | Sequence[str] | None = None,<br>entity_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: str | int | None = None,<br>sort_dir: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7401,7 +7475,7 @@ and define the users or workspaces if it is set to named_entities
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists assignments for all roles across entities.
         Options to scope results by any combination of roles or entities
-    https://api.slack.com/methods/admin.roles.listAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.listAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;sort_dir&#34;: sort_dir})
     if isinstance(entity_ids, (list, tuple)):
@@ -7416,7 +7490,7 @@ and define the users or workspaces if it is set to named_entities
 </details>
 <div class="desc"><p>Lists assignments for all roles across entities.
 Options to scope results by any combination of roles or entities
-<a href="https://api.slack.com/methods/admin.roles.listAssignments">https://api.slack.com/methods/admin.roles.listAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.listAssignments">https://docs.slack.dev/reference/methods/admin.roles.listAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_roles_removeAssignments"><code class="name flex">
 <span>async def <span class="ident">admin_roles_removeAssignments</span></span>(<span>self,<br>*,<br>role_id: str,<br>entity_ids: str | Sequence[str],<br>user_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7435,7 +7509,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Removes a set of users from a role for the given scopes and entities
-    https://api.slack.com/methods/admin.roles.removeAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;role_id&#34;: role_id})
     if isinstance(entity_ids, (list, tuple)):
@@ -7449,7 +7523,7 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.roles.removeAssignments&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a set of users from a role for the given scopes and entities
-<a href="https://api.slack.com/methods/admin.roles.removeAssignments">https://api.slack.com/methods/admin.roles.removeAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.removeAssignments">https://docs.slack.dev/reference/methods/admin.roles.removeAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_admins_list"><code class="name flex">
 <span>async def <span class="ident">admin_teams_admins_list</span></span>(<span>self, *, team_id: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7468,7 +7542,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all of the admins on a given workspace.
-    https://api.slack.com/methods/admin.inviteRequests.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7480,7 +7554,7 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.teams.admins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all of the admins on a given workspace.
-<a href="https://api.slack.com/methods/admin.inviteRequests.list">https://api.slack.com/methods/admin.inviteRequests.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_create"><code class="name flex">
 <span>async def <span class="ident">admin_teams_create</span></span>(<span>self,<br>*,<br>team_domain: str,<br>team_name: str,<br>team_description: str | None = None,<br>team_discoverability: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7500,7 +7574,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Create an Enterprise team.
-    https://api.slack.com/methods/admin.teams.create
+    https://docs.slack.dev/reference/methods/admin.teams.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7513,7 +7587,7 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.teams.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an Enterprise team.
-<a href="https://api.slack.com/methods/admin.teams.create">https://api.slack.com/methods/admin.teams.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.create">https://docs.slack.dev/reference/methods/admin.teams.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_list"><code class="name flex">
 <span>async def <span class="ident">admin_teams_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7531,13 +7605,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all teams on an Enterprise organization.
-    https://api.slack.com/methods/admin.teams.list
+    https://docs.slack.dev/reference/methods/admin.teams.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return await self.api_call(&#34;admin.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all teams on an Enterprise organization.
-<a href="https://api.slack.com/methods/admin.teams.list">https://api.slack.com/methods/admin.teams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.list">https://docs.slack.dev/reference/methods/admin.teams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_owners_list"><code class="name flex">
 <span>async def <span class="ident">admin_teams_owners_list</span></span>(<span>self, *, team_id: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7556,13 +7630,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all of the admins on a given workspace.
-    https://api.slack.com/methods/admin.teams.owners.list
+    https://docs.slack.dev/reference/methods/admin.teams.owners.list
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return await self.api_call(&#34;admin.teams.owners.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all of the admins on a given workspace.
-<a href="https://api.slack.com/methods/admin.teams.owners.list">https://api.slack.com/methods/admin.teams.owners.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.owners.list">https://docs.slack.dev/reference/methods/admin.teams.owners.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_settings_info"><code class="name flex">
 <span>async def <span class="ident">admin_teams_settings_info</span></span>(<span>self, *, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7579,13 +7653,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Fetch information about settings in a workspace
-    https://api.slack.com/methods/admin.teams.settings.info
+    https://docs.slack.dev/reference/methods/admin.teams.settings.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     return await self.api_call(&#34;admin.teams.settings.info&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetch information about settings in a workspace
-<a href="https://api.slack.com/methods/admin.teams.settings.info">https://api.slack.com/methods/admin.teams.settings.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.info">https://docs.slack.dev/reference/methods/admin.teams.settings.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_settings_setDefaultChannels"><code class="name flex">
 <span>async def <span class="ident">admin_teams_settings_setDefaultChannels</span></span>(<span>self, *, team_id: str, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7603,7 +7677,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set the default channels of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7613,7 +7687,7 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.teams.settings.setDefaultChannels&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the default channels of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDefaultChannels">https://api.slack.com/methods/admin.teams.settings.setDefaultChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels">https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_settings_setDescription"><code class="name flex">
 <span>async def <span class="ident">admin_teams_settings_setDescription</span></span>(<span>self, *, team_id: str, description: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7631,13 +7705,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set the description of a given workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDescription
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;description&#34;: description})
     return await self.api_call(&#34;admin.teams.settings.setDescription&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the description of a given workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDescription">https://api.slack.com/methods/admin.teams.settings.setDescription</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription">https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_settings_setDiscoverability"><code class="name flex">
 <span>async def <span class="ident">admin_teams_settings_setDiscoverability</span></span>(<span>self, *, team_id: str, discoverability: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7655,13 +7729,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;discoverability&#34;: discoverability})
     return await self.api_call(&#34;admin.teams.settings.setDiscoverability&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDiscoverability">https://api.slack.com/methods/admin.teams.settings.setDiscoverability</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability">https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_settings_setIcon"><code class="name flex">
 <span>async def <span class="ident">admin_teams_settings_setIcon</span></span>(<span>self, *, team_id: str, image_url: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7679,13 +7753,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setIcon
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;image_url&#34;: image_url})
     return await self.api_call(&#34;admin.teams.settings.setIcon&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setIcon">https://api.slack.com/methods/admin.teams.settings.setIcon</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon">https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_teams_settings_setName"><code class="name flex">
 <span>async def <span class="ident">admin_teams_settings_setName</span></span>(<span>self, *, team_id: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7703,13 +7777,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setName
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setName
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;name&#34;: name})
     return await self.api_call(&#34;admin.teams.settings.setName&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setName">https://api.slack.com/methods/admin.teams.settings.setName</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setName">https://docs.slack.dev/reference/methods/admin.teams.settings.setName</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_usergroups_addChannels"><code class="name flex">
 <span>async def <span class="ident">admin_usergroups_addChannels</span></span>(<span>self,<br>*,<br>channel_ids: str | Sequence[str],<br>usergroup_id: str,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7728,7 +7802,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.addChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;usergroup_id&#34;: usergroup_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7738,7 +7812,7 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.addChannels">https://api.slack.com/methods/admin.usergroups.addChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.addChannels">https://docs.slack.dev/reference/methods/admin.usergroups.addChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_usergroups_addTeams"><code class="name flex">
 <span>async def <span class="ident">admin_usergroups_addTeams</span></span>(<span>self,<br>*,<br>usergroup_id: str,<br>team_ids: str | Sequence[str],<br>auto_provision: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7757,7 +7831,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Associate one or more default workspaces with an organization-wide IDP group.
-    https://api.slack.com/methods/admin.usergroups.addTeams
+    https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup_id&#34;: usergroup_id, &#34;auto_provision&#34;: auto_provision})
     if isinstance(team_ids, (list, tuple)):
@@ -7767,7 +7841,7 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Associate one or more default workspaces with an organization-wide IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.addTeams">https://api.slack.com/methods/admin.usergroups.addTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.addTeams">https://docs.slack.dev/reference/methods/admin.usergroups.addTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_usergroups_listChannels"><code class="name flex">
 <span>async def <span class="ident">admin_usergroups_listChannels</span></span>(<span>self,<br>*,<br>usergroup_id: str,<br>include_num_members: bool | None = None,<br>team_id: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7786,7 +7860,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.listChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7798,7 +7872,7 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.usergroups.listChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.listChannels">https://api.slack.com/methods/admin.usergroups.listChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.listChannels">https://docs.slack.dev/reference/methods/admin.usergroups.listChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_usergroups_removeChannels"><code class="name flex">
 <span>async def <span class="ident">admin_usergroups_removeChannels</span></span>(<span>self, *, usergroup_id: str, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7816,7 +7890,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.removeChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup_id&#34;: usergroup_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7826,7 +7900,7 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.removeChannels">https://api.slack.com/methods/admin.usergroups.removeChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels">https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_assign"><code class="name flex">
 <span>async def <span class="ident">admin_users_assign</span></span>(<span>self,<br>*,<br>team_id: str,<br>user_id: str,<br>channel_ids: str | Sequence[str] | None = None,<br>is_restricted: bool | None = None,<br>is_ultra_restricted: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7847,7 +7921,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Add an Enterprise user to a workspace.
-    https://api.slack.com/methods/admin.users.assign
+    https://docs.slack.dev/reference/methods/admin.users.assign
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7864,7 +7938,7 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.users.assign&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an Enterprise user to a workspace.
-<a href="https://api.slack.com/methods/admin.users.assign">https://api.slack.com/methods/admin.users.assign</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.assign">https://docs.slack.dev/reference/methods/admin.users.assign</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_invite"><code class="name flex">
 <span>async def <span class="ident">admin_users_invite</span></span>(<span>self,<br>*,<br>team_id: str,<br>email: str,<br>channel_ids: str | Sequence[str],<br>custom_message: str | None = None,<br>email_password_policy_enabled: bool | None = None,<br>guest_expiration_ts: str | float | None = None,<br>is_restricted: bool | None = None,<br>is_ultra_restricted: bool | None = None,<br>real_name: str | None = None,<br>resend: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7890,7 +7964,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Invite a user to a workspace.
-    https://api.slack.com/methods/admin.users.invite
+    https://docs.slack.dev/reference/methods/admin.users.invite
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7912,10 +7986,10 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.users.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invite a user to a workspace.
-<a href="https://api.slack.com/methods/admin.users.invite">https://api.slack.com/methods/admin.users.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.invite">https://docs.slack.dev/reference/methods/admin.users.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_list"><code class="name flex">
-<span>async def <span class="ident">admin_users_list</span></span>(<span>self,<br>*,<br>team_id: str,<br>include_deactivated_user_workspaces: bool | None = None,<br>is_active: bool | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">admin_users_list</span></span>(<span>self,<br>*,<br>team_id: str | None = None,<br>include_deactivated_user_workspaces: bool | None = None,<br>is_active: bool | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -7925,7 +7999,7 @@ Options to scope results by any combination of roles or entities
 <pre><code class="python">async def admin_users_list(
     self,
     *,
-    team_id: str,
+    team_id: Optional[str] = None,
     include_deactivated_user_workspaces: Optional[bool] = None,
     is_active: Optional[bool] = None,
     cursor: Optional[str] = None,
@@ -7933,7 +8007,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List users on a workspace
-    https://api.slack.com/methods/admin.users.list
+    https://docs.slack.dev/reference/methods/admin.users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7947,7 +8021,7 @@ Options to scope results by any combination of roles or entities
     return await self.api_call(&#34;admin.users.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List users on a workspace
-<a href="https://api.slack.com/methods/admin.users.list">https://api.slack.com/methods/admin.users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.list">https://docs.slack.dev/reference/methods/admin.users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_remove"><code class="name flex">
 <span>async def <span class="ident">admin_users_remove</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7965,13 +8039,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Remove a user from a workspace.
-    https://api.slack.com/methods/admin.users.remove
+    https://docs.slack.dev/reference/methods/admin.users.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return await self.api_call(&#34;admin.users.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a user from a workspace.
-<a href="https://api.slack.com/methods/admin.users.remove">https://api.slack.com/methods/admin.users.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.remove">https://docs.slack.dev/reference/methods/admin.users.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_session_clearSettings"><code class="name flex">
 <span>async def <span class="ident">admin_users_session_clearSettings</span></span>(<span>self, *, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -7989,7 +8063,7 @@ Options to scope results by any combination of roles or entities
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Clear user-specific session settings—the session duration
     and what happens when the client closes—for a list of users.
-    https://api.slack.com/methods/admin.users.session.clearSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -7999,7 +8073,7 @@ Options to scope results by any combination of roles or entities
 </details>
 <div class="desc"><p>Clear user-specific session settings—the session duration
 and what happens when the client closes—for a list of users.
-<a href="https://api.slack.com/methods/admin.users.session.clearSettings">https://api.slack.com/methods/admin.users.session.clearSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.clearSettings">https://docs.slack.dev/reference/methods/admin.users.session.clearSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_session_getSettings"><code class="name flex">
 <span>async def <span class="ident">admin_users_session_getSettings</span></span>(<span>self, *, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8017,7 +8091,7 @@ and what happens when the client closes—for a list of users.
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Get user-specific session settings—the session duration
     and what happens when the client closes—given a list of users.
-    https://api.slack.com/methods/admin.users.session.getSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.getSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8027,7 +8101,7 @@ and what happens when the client closes—for a list of users.
 </details>
 <div class="desc"><p>Get user-specific session settings—the session duration
 and what happens when the client closes—given a list of users.
-<a href="https://api.slack.com/methods/admin.users.session.getSettings">https://api.slack.com/methods/admin.users.session.getSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.getSettings">https://docs.slack.dev/reference/methods/admin.users.session.getSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_session_invalidate"><code class="name flex">
 <span>async def <span class="ident">admin_users_session_invalidate</span></span>(<span>self, *, session_id: str, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8045,13 +8119,13 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Invalidate a single session for a user by session_id.
-    https://api.slack.com/methods/admin.users.session.invalidate
+    https://docs.slack.dev/reference/methods/admin.users.session.invalidate
     &#34;&#34;&#34;
     kwargs.update({&#34;session_id&#34;: session_id, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;admin.users.session.invalidate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invalidate a single session for a user by session_id.
-<a href="https://api.slack.com/methods/admin.users.session.invalidate">https://api.slack.com/methods/admin.users.session.invalidate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.invalidate">https://docs.slack.dev/reference/methods/admin.users.session.invalidate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_session_list"><code class="name flex">
 <span>async def <span class="ident">admin_users_session_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8071,7 +8145,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists all active user sessions for an organization
-    https://api.slack.com/methods/admin.users.session.list
+    https://docs.slack.dev/reference/methods/admin.users.session.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8084,7 +8158,7 @@ and what happens when the client closes—given a list of users.
     return await self.api_call(&#34;admin.users.session.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all active user sessions for an organization
-<a href="https://api.slack.com/methods/admin.users.session.list">https://api.slack.com/methods/admin.users.session.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.list">https://docs.slack.dev/reference/methods/admin.users.session.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_session_reset"><code class="name flex">
 <span>async def <span class="ident">admin_users_session_reset</span></span>(<span>self,<br>*,<br>user_id: str,<br>mobile_only: bool | None = None,<br>web_only: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8103,7 +8177,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Wipes all valid sessions on all devices for a given user.
-    https://api.slack.com/methods/admin.users.session.reset
+    https://docs.slack.dev/reference/methods/admin.users.session.reset
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8115,7 +8189,7 @@ and what happens when the client closes—given a list of users.
     return await self.api_call(&#34;admin.users.session.reset&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Wipes all valid sessions on all devices for a given user.
-<a href="https://api.slack.com/methods/admin.users.session.reset">https://api.slack.com/methods/admin.users.session.reset</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.reset">https://docs.slack.dev/reference/methods/admin.users.session.reset</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_session_resetBulk"><code class="name flex">
 <span>async def <span class="ident">admin_users_session_resetBulk</span></span>(<span>self,<br>*,<br>user_ids: str | Sequence[str],<br>mobile_only: bool | None = None,<br>web_only: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8134,7 +8208,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-    https://api.slack.com/methods/admin.users.session.resetBulk
+    https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8149,7 +8223,7 @@ and what happens when the client closes—given a list of users.
     return await self.api_call(&#34;admin.users.session.resetBulk&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-<a href="https://api.slack.com/methods/admin.users.session.resetBulk">https://api.slack.com/methods/admin.users.session.resetBulk</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.resetBulk">https://docs.slack.dev/reference/methods/admin.users.session.resetBulk</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_session_setSettings"><code class="name flex">
 <span>async def <span class="ident">admin_users_session_setSettings</span></span>(<span>self,<br>*,<br>user_ids: str | Sequence[str],<br>desktop_app_browser_quit: bool | None = None,<br>duration: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8169,7 +8243,7 @@ and what happens when the client closes—given a list of users.
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Configure the user-level session settings—the session duration
     and what happens when the client closes—for one or more users.
-    https://api.slack.com/methods/admin.users.session.setSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.setSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8185,7 +8259,7 @@ and what happens when the client closes—given a list of users.
 </details>
 <div class="desc"><p>Configure the user-level session settings—the session duration
 and what happens when the client closes—for one or more users.
-<a href="https://api.slack.com/methods/admin.users.session.setSettings">https://api.slack.com/methods/admin.users.session.setSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.setSettings">https://docs.slack.dev/reference/methods/admin.users.session.setSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_setAdmin"><code class="name flex">
 <span>async def <span class="ident">admin_users_setAdmin</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8203,13 +8277,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set an existing guest, regular user, or owner to be an admin user.
-    https://api.slack.com/methods/admin.users.setAdmin
+    https://docs.slack.dev/reference/methods/admin.users.setAdmin
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return await self.api_call(&#34;admin.users.setAdmin&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest, regular user, or owner to be an admin user.
-<a href="https://api.slack.com/methods/admin.users.setAdmin">https://api.slack.com/methods/admin.users.setAdmin</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setAdmin">https://docs.slack.dev/reference/methods/admin.users.setAdmin</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_setExpiration"><code class="name flex">
 <span>async def <span class="ident">admin_users_setExpiration</span></span>(<span>self, *, expiration_ts: int, user_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8228,13 +8302,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set an expiration for a guest user.
-    https://api.slack.com/methods/admin.users.setExpiration
+    https://docs.slack.dev/reference/methods/admin.users.setExpiration
     &#34;&#34;&#34;
     kwargs.update({&#34;expiration_ts&#34;: expiration_ts, &#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return await self.api_call(&#34;admin.users.setExpiration&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an expiration for a guest user.
-<a href="https://api.slack.com/methods/admin.users.setExpiration">https://api.slack.com/methods/admin.users.setExpiration</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setExpiration">https://docs.slack.dev/reference/methods/admin.users.setExpiration</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_setOwner"><code class="name flex">
 <span>async def <span class="ident">admin_users_setOwner</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8252,13 +8326,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set an existing guest, regular user, or admin user to be a workspace owner.
-    https://api.slack.com/methods/admin.users.setOwner
+    https://docs.slack.dev/reference/methods/admin.users.setOwner
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return await self.api_call(&#34;admin.users.setOwner&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest, regular user, or admin user to be a workspace owner.
-<a href="https://api.slack.com/methods/admin.users.setOwner">https://api.slack.com/methods/admin.users.setOwner</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setOwner">https://docs.slack.dev/reference/methods/admin.users.setOwner</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_setRegular"><code class="name flex">
 <span>async def <span class="ident">admin_users_setRegular</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8276,13 +8350,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set an existing guest user, admin user, or owner to be a regular user.
-    https://api.slack.com/methods/admin.users.setRegular
+    https://docs.slack.dev/reference/methods/admin.users.setRegular
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return await self.api_call(&#34;admin.users.setRegular&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest user, admin user, or owner to be a regular user.
-<a href="https://api.slack.com/methods/admin.users.setRegular">https://api.slack.com/methods/admin.users.setRegular</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setRegular">https://docs.slack.dev/reference/methods/admin.users.setRegular</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_users_unsupportedVersions_export"><code class="name flex">
 <span>async def <span class="ident">admin_users_unsupportedVersions_export</span></span>(<span>self,<br>*,<br>date_end_of_support: str | int | None = None,<br>date_sessions_started: str | int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8301,7 +8375,7 @@ and what happens when the client closes—for one or more users.
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Ask Slackbot to send you an export listing all workspace members using unsupported software,
     presented as a zipped CSV file.
-    https://api.slack.com/methods/admin.users.unsupportedVersions.export
+    https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8313,7 +8387,7 @@ and what happens when the client closes—for one or more users.
 </details>
 <div class="desc"><p>Ask Slackbot to send you an export listing all workspace members using unsupported software,
 presented as a zipped CSV file.
-<a href="https://api.slack.com/methods/admin.users.unsupportedVersions.export">https://api.slack.com/methods/admin.users.unsupportedVersions.export</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export">https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_workflows_collaborators_add"><code class="name flex">
 <span>async def <span class="ident">admin_workflows_collaborators_add</span></span>(<span>self,<br>*,<br>collaborator_ids: str | Sequence[str],<br>workflow_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8331,7 +8405,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Add collaborators to workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.collaborators.add
+    https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
     &#34;&#34;&#34;
     if isinstance(collaborator_ids, (list, tuple)):
         kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -8344,7 +8418,7 @@ presented as a zipped CSV file.
     return await self.api_call(&#34;admin.workflows.collaborators.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add collaborators to workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.collaborators.add">https://api.slack.com/methods/admin.workflows.collaborators.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add">https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_workflows_collaborators_remove"><code class="name flex">
 <span>async def <span class="ident">admin_workflows_collaborators_remove</span></span>(<span>self,<br>*,<br>collaborator_ids: str | Sequence[str],<br>workflow_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8362,7 +8436,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Remove collaborators from workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.collaborators.remove
+    https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
     &#34;&#34;&#34;
     if isinstance(collaborator_ids, (list, tuple)):
         kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -8375,7 +8449,7 @@ presented as a zipped CSV file.
     return await self.api_call(&#34;admin.workflows.collaborators.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove collaborators from workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.collaborators.remove">https://api.slack.com/methods/admin.workflows.collaborators.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove">https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_workflows_permissions_lookup"><code class="name flex">
 <span>async def <span class="ident">admin_workflows_permissions_lookup</span></span>(<span>self,<br>*,<br>workflow_ids: str | Sequence[str],<br>max_workflow_triggers: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8393,7 +8467,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Look up the permissions for a set of workflows
-    https://api.slack.com/methods/admin.workflows.permissions.lookup
+    https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
     &#34;&#34;&#34;
     if isinstance(workflow_ids, (list, tuple)):
         kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -8407,7 +8481,7 @@ presented as a zipped CSV file.
     return await self.api_call(&#34;admin.workflows.permissions.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up the permissions for a set of workflows
-<a href="https://api.slack.com/methods/admin.workflows.permissions.lookup">https://api.slack.com/methods/admin.workflows.permissions.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup">https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_workflows_search"><code class="name flex">
 <span>async def <span class="ident">admin_workflows_search</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>collaborator_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>no_collaborators: bool | None = None,<br>num_trigger_ids: int | None = None,<br>query: str | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>source: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8433,7 +8507,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Search workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.search
+    https://docs.slack.dev/reference/methods/admin.workflows.search
     &#34;&#34;&#34;
     if collaborator_ids is not None:
         if isinstance(collaborator_ids, (list, tuple)):
@@ -8456,7 +8530,7 @@ presented as a zipped CSV file.
     return await self.api_call(&#34;admin.workflows.search&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Search workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.search">https://api.slack.com/methods/admin.workflows.search</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.search">https://docs.slack.dev/reference/methods/admin.workflows.search</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.admin_workflows_unpublish"><code class="name flex">
 <span>async def <span class="ident">admin_workflows_unpublish</span></span>(<span>self, *, workflow_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8473,7 +8547,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Unpublish workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.unpublish
+    https://docs.slack.dev/reference/methods/admin.workflows.unpublish
     &#34;&#34;&#34;
     if isinstance(workflow_ids, (list, tuple)):
         kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -8482,7 +8556,7 @@ presented as a zipped CSV file.
     return await self.api_call(&#34;admin.workflows.unpublish&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unpublish workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.unpublish">https://api.slack.com/methods/admin.workflows.unpublish</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.unpublish">https://docs.slack.dev/reference/methods/admin.workflows.unpublish</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.api_test"><code class="name flex">
 <span>async def <span class="ident">api_test</span></span>(<span>self, *, error: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8499,13 +8573,13 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Checks API calling code.
-    https://api.slack.com/methods/api.test
+    https://docs.slack.dev/reference/methods/api.test
     &#34;&#34;&#34;
     kwargs.update({&#34;error&#34;: error})
     return await self.api_call(&#34;api.test&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Checks API calling code.
-<a href="https://api.slack.com/methods/api.test">https://api.slack.com/methods/api.test</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/api.test">https://docs.slack.dev/reference/methods/api.test</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.apps_connections_open"><code class="name flex">
 <span>async def <span class="ident">apps_connections_open</span></span>(<span>self, *, app_token: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8523,14 +8597,14 @@ presented as a zipped CSV file.
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Generate a temporary Socket Mode WebSocket URL that your app can connect to
     in order to receive events and interactive payloads
-    https://api.slack.com/methods/apps.connections.open
+    https://docs.slack.dev/reference/methods/apps.connections.open
     &#34;&#34;&#34;
     kwargs.update({&#34;token&#34;: app_token})
     return await self.api_call(&#34;apps.connections.open&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Generate a temporary Socket Mode WebSocket URL that your app can connect to
 in order to receive events and interactive payloads
-<a href="https://api.slack.com/methods/apps.connections.open">https://api.slack.com/methods/apps.connections.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.connections.open">https://docs.slack.dev/reference/methods/apps.connections.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.apps_event_authorizations_list"><code class="name flex">
 <span>async def <span class="ident">apps_event_authorizations_list</span></span>(<span>self,<br>*,<br>event_context: str,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8550,14 +8624,14 @@ in order to receive events and interactive payloads
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Get a list of authorizations for the given event context.
     Each authorization represents an app installation that the event is visible to.
-    https://api.slack.com/methods/apps.event.authorizations.list
+    https://docs.slack.dev/reference/methods/apps.event.authorizations.list
     &#34;&#34;&#34;
     kwargs.update({&#34;event_context&#34;: event_context, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return await self.api_call(&#34;apps.event.authorizations.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a list of authorizations for the given event context.
 Each authorization represents an app installation that the event is visible to.
-<a href="https://api.slack.com/methods/apps.event.authorizations.list">https://api.slack.com/methods/apps.event.authorizations.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.event.authorizations.list">https://docs.slack.dev/reference/methods/apps.event.authorizations.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.apps_manifest_create"><code class="name flex">
 <span>async def <span class="ident">apps_manifest_create</span></span>(<span>self, *, manifest: str | Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8574,7 +8648,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Create an app from an app manifest
-    https://api.slack.com/methods/apps.manifest.create
+    https://docs.slack.dev/reference/methods/apps.manifest.create
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8583,7 +8657,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;apps.manifest.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an app from an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.create">https://api.slack.com/methods/apps.manifest.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.create">https://docs.slack.dev/reference/methods/apps.manifest.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.apps_manifest_delete"><code class="name flex">
 <span>async def <span class="ident">apps_manifest_delete</span></span>(<span>self, *, app_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8600,13 +8674,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Permanently deletes an app created through app manifests
-    https://api.slack.com/methods/apps.manifest.delete
+    https://docs.slack.dev/reference/methods/apps.manifest.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     return await self.api_call(&#34;apps.manifest.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Permanently deletes an app created through app manifests
-<a href="https://api.slack.com/methods/apps.manifest.delete">https://api.slack.com/methods/apps.manifest.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.delete">https://docs.slack.dev/reference/methods/apps.manifest.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.apps_manifest_export"><code class="name flex">
 <span>async def <span class="ident">apps_manifest_export</span></span>(<span>self, *, app_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8623,13 +8697,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Export an app manifest from an existing app
-    https://api.slack.com/methods/apps.manifest.export
+    https://docs.slack.dev/reference/methods/apps.manifest.export
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     return await self.api_call(&#34;apps.manifest.export&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Export an app manifest from an existing app
-<a href="https://api.slack.com/methods/apps.manifest.export">https://api.slack.com/methods/apps.manifest.export</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.export">https://docs.slack.dev/reference/methods/apps.manifest.export</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.apps_manifest_update"><code class="name flex">
 <span>async def <span class="ident">apps_manifest_update</span></span>(<span>self, *, app_id: str, manifest: str | Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8647,7 +8721,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Update an app from an app manifest
-    https://api.slack.com/methods/apps.manifest.update
+    https://docs.slack.dev/reference/methods/apps.manifest.update
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8657,7 +8731,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;apps.manifest.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an app from an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.update">https://api.slack.com/methods/apps.manifest.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.update">https://docs.slack.dev/reference/methods/apps.manifest.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.apps_manifest_validate"><code class="name flex">
 <span>async def <span class="ident">apps_manifest_validate</span></span>(<span>self, *, manifest: str | Dict[str, Any], app_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8675,7 +8749,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Validate an app manifest
-    https://api.slack.com/methods/apps.manifest.validate
+    https://docs.slack.dev/reference/methods/apps.manifest.validate
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8685,7 +8759,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;apps.manifest.validate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Validate an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.validate">https://api.slack.com/methods/apps.manifest.validate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.validate">https://docs.slack.dev/reference/methods/apps.manifest.validate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.apps_uninstall"><code class="name flex">
 <span>async def <span class="ident">apps_uninstall</span></span>(<span>self, *, client_id: str, client_secret: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8703,13 +8777,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Uninstalls your app from a workspace.
-    https://api.slack.com/methods/apps.uninstall
+    https://docs.slack.dev/reference/methods/apps.uninstall
     &#34;&#34;&#34;
     kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret})
     return await self.api_call(&#34;apps.uninstall&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Uninstalls your app from a workspace.
-<a href="https://api.slack.com/methods/apps.uninstall">https://api.slack.com/methods/apps.uninstall</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.uninstall">https://docs.slack.dev/reference/methods/apps.uninstall</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.assistant_threads_setStatus"><code class="name flex">
 <span>async def <span class="ident">assistant_threads_setStatus</span></span>(<span>self, *, channel_id: str, thread_ts: str, status: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8728,13 +8802,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setStatus
+    https://docs.slack.dev/reference/methods/assistant.threads.setStatus
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status})
     return await self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setStatus">https://api.slack.com/methods/assistant.threads.setStatus</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setStatus">https://docs.slack.dev/reference/methods/assistant.threads.setStatus</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.assistant_threads_setSuggestedPrompts"><code class="name flex">
 <span>async def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8754,7 +8828,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+    https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
     if title is not None:
@@ -8762,7 +8836,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setSuggestedPrompts">https://api.slack.com/methods/assistant.threads.setSuggestedPrompts</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts">https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.assistant_threads_setTitle"><code class="name flex">
 <span>async def <span class="ident">assistant_threads_setTitle</span></span>(<span>self, *, channel_id: str, thread_ts: str, title: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8781,13 +8855,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setTitle
+    https://docs.slack.dev/reference/methods/assistant.threads.setTitle
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;title&#34;: title})
     return await self.api_call(&#34;assistant.threads.setTitle&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setTitle">https://api.slack.com/methods/assistant.threads.setTitle</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setTitle">https://docs.slack.dev/reference/methods/assistant.threads.setTitle</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.auth_revoke"><code class="name flex">
 <span>async def <span class="ident">auth_revoke</span></span>(<span>self, *, test: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8804,13 +8878,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/auth.revoke
+    https://docs.slack.dev/reference/methods/auth.revoke
     &#34;&#34;&#34;
     kwargs.update({&#34;test&#34;: test})
     return await self.api_call(&#34;auth.revoke&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/auth.revoke">https://api.slack.com/methods/auth.revoke</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.revoke">https://docs.slack.dev/reference/methods/auth.revoke</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.auth_teams_list"><code class="name flex">
 <span>async def <span class="ident">auth_teams_list</span></span>(<span>self,<br>cursor: str | None = None,<br>limit: int | None = None,<br>include_icon: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8828,13 +8902,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List the workspaces a token can access.
-    https://api.slack.com/methods/auth.teams.list
+    https://docs.slack.dev/reference/methods/auth.teams.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;include_icon&#34;: include_icon})
     return await self.api_call(&#34;auth.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List the workspaces a token can access.
-<a href="https://api.slack.com/methods/auth.teams.list">https://api.slack.com/methods/auth.teams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.teams.list">https://docs.slack.dev/reference/methods/auth.teams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.auth_test"><code class="name flex">
 <span>async def <span class="ident">auth_test</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8849,12 +8923,12 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Checks authentication &amp; identity.
-    https://api.slack.com/methods/auth.test
+    https://docs.slack.dev/reference/methods/auth.test
     &#34;&#34;&#34;
     return await self.api_call(&#34;auth.test&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Checks authentication &amp; identity.
-<a href="https://api.slack.com/methods/auth.test">https://api.slack.com/methods/auth.test</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.test">https://docs.slack.dev/reference/methods/auth.test</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.bookmarks_add"><code class="name flex">
 <span>async def <span class="ident">bookmarks_add</span></span>(<span>self,<br>*,<br>channel_id: str,<br>title: str,<br>type: str,<br>emoji: str | None = None,<br>entity_id: str | None = None,<br>link: str | None = None,<br>parent_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8877,7 +8951,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Add bookmark to a channel.
-    https://api.slack.com/methods/bookmarks.add
+    https://docs.slack.dev/reference/methods/bookmarks.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8893,7 +8967,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;bookmarks.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add bookmark to a channel.
-<a href="https://api.slack.com/methods/bookmarks.add">https://api.slack.com/methods/bookmarks.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.add">https://docs.slack.dev/reference/methods/bookmarks.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.bookmarks_edit"><code class="name flex">
 <span>async def <span class="ident">bookmarks_edit</span></span>(<span>self,<br>*,<br>bookmark_id: str,<br>channel_id: str,<br>emoji: str | None = None,<br>link: str | None = None,<br>title: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8914,7 +8988,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Edit bookmark.
-    https://api.slack.com/methods/bookmarks.edit
+    https://docs.slack.dev/reference/methods/bookmarks.edit
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8928,7 +9002,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;bookmarks.edit&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Edit bookmark.
-<a href="https://api.slack.com/methods/bookmarks.edit">https://api.slack.com/methods/bookmarks.edit</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.edit">https://docs.slack.dev/reference/methods/bookmarks.edit</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.bookmarks_list"><code class="name flex">
 <span>async def <span class="ident">bookmarks_list</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8945,13 +9019,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List bookmark for the channel.
-    https://api.slack.com/methods/bookmarks.list
+    https://docs.slack.dev/reference/methods/bookmarks.list
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return await self.api_call(&#34;bookmarks.list&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List bookmark for the channel.
-<a href="https://api.slack.com/methods/bookmarks.list">https://api.slack.com/methods/bookmarks.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.list">https://docs.slack.dev/reference/methods/bookmarks.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.bookmarks_remove"><code class="name flex">
 <span>async def <span class="ident">bookmarks_remove</span></span>(<span>self, *, bookmark_id: str, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8969,13 +9043,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Remove bookmark from the channel.
-    https://api.slack.com/methods/bookmarks.remove
+    https://docs.slack.dev/reference/methods/bookmarks.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;bookmark_id&#34;: bookmark_id, &#34;channel_id&#34;: channel_id})
     return await self.api_call(&#34;bookmarks.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove bookmark from the channel.
-<a href="https://api.slack.com/methods/bookmarks.remove">https://api.slack.com/methods/bookmarks.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.remove">https://docs.slack.dev/reference/methods/bookmarks.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.bots_info"><code class="name flex">
 <span>async def <span class="ident">bots_info</span></span>(<span>self, *, bot: str | None = None, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -8993,13 +9067,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets information about a bot user.
-    https://api.slack.com/methods/bots.info
+    https://docs.slack.dev/reference/methods/bots.info
     &#34;&#34;&#34;
     kwargs.update({&#34;bot&#34;: bot, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;bots.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a bot user.
-<a href="https://api.slack.com/methods/bots.info">https://api.slack.com/methods/bots.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bots.info">https://docs.slack.dev/reference/methods/bots.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.calls_add"><code class="name flex">
 <span>async def <span class="ident">calls_add</span></span>(<span>self,<br>*,<br>external_unique_id: str,<br>join_url: str,<br>created_by: str | None = None,<br>date_start: int | None = None,<br>desktop_app_join_url: str | None = None,<br>external_display_id: str | None = None,<br>title: str | None = None,<br>users: str | Sequence[Dict[str, str]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9023,7 +9097,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Registers a new Call.
-    https://api.slack.com/methods/calls.add
+    https://docs.slack.dev/reference/methods/calls.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9043,7 +9117,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;calls.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers a new Call.
-<a href="https://api.slack.com/methods/calls.add">https://api.slack.com/methods/calls.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.add">https://docs.slack.dev/reference/methods/calls.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.calls_end"><code class="name flex">
 <span>async def <span class="ident">calls_end</span></span>(<span>self, *, id: str, duration: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9061,13 +9135,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Ends a Call.
-    https://api.slack.com/methods/calls.end
+    https://docs.slack.dev/reference/methods/calls.end
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id, &#34;duration&#34;: duration})
     return await self.api_call(&#34;calls.end&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends a Call.
-<a href="https://api.slack.com/methods/calls.end">https://api.slack.com/methods/calls.end</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.end">https://docs.slack.dev/reference/methods/calls.end</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.calls_info"><code class="name flex">
 <span>async def <span class="ident">calls_info</span></span>(<span>self, *, id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9084,13 +9158,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Returns information about a Call.
-    https://api.slack.com/methods/calls.info
+    https://docs.slack.dev/reference/methods/calls.info
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     return await self.api_call(&#34;calls.info&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns information about a Call.
-<a href="https://api.slack.com/methods/calls.info">https://api.slack.com/methods/calls.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.info">https://docs.slack.dev/reference/methods/calls.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.calls_participants_add"><code class="name flex">
 <span>async def <span class="ident">calls_participants_add</span></span>(<span>self, *, id: str, users: str | Sequence[Dict[str, str]], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9108,14 +9182,14 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Registers new participants added to a Call.
-    https://api.slack.com/methods/calls.participants.add
+    https://docs.slack.dev/reference/methods/calls.participants.add
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     _update_call_participants(kwargs, users)
     return await self.api_call(&#34;calls.participants.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers new participants added to a Call.
-<a href="https://api.slack.com/methods/calls.participants.add">https://api.slack.com/methods/calls.participants.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.participants.add">https://docs.slack.dev/reference/methods/calls.participants.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.calls_participants_remove"><code class="name flex">
 <span>async def <span class="ident">calls_participants_remove</span></span>(<span>self, *, id: str, users: str | Sequence[Dict[str, str]], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9133,14 +9207,14 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Registers participants removed from a Call.
-    https://api.slack.com/methods/calls.participants.remove
+    https://docs.slack.dev/reference/methods/calls.participants.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     _update_call_participants(kwargs, users)
     return await self.api_call(&#34;calls.participants.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers participants removed from a Call.
-<a href="https://api.slack.com/methods/calls.participants.remove">https://api.slack.com/methods/calls.participants.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.participants.remove">https://docs.slack.dev/reference/methods/calls.participants.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.calls_update"><code class="name flex">
 <span>async def <span class="ident">calls_update</span></span>(<span>self,<br>*,<br>id: str,<br>desktop_app_join_url: str | None = None,<br>join_url: str | None = None,<br>title: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9160,7 +9234,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Updates information about a Call.
-    https://api.slack.com/methods/calls.update
+    https://docs.slack.dev/reference/methods/calls.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9173,7 +9247,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;calls.update&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Updates information about a Call.
-<a href="https://api.slack.com/methods/calls.update">https://api.slack.com/methods/calls.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.update">https://docs.slack.dev/reference/methods/calls.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.canvases_access_delete"><code class="name flex">
 <span>async def <span class="ident">canvases_access_delete</span></span>(<span>self,<br>*,<br>canvas_id: str,<br>channel_ids: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9192,7 +9266,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Create a Channel Canvas for a channel
-    https://api.slack.com/methods/canvases.access.delete
+    https://docs.slack.dev/reference/methods/canvases.access.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id})
     if channel_ids is not None:
@@ -9208,7 +9282,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;canvases.access.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Channel Canvas for a channel
-<a href="https://api.slack.com/methods/canvases.access.delete">https://api.slack.com/methods/canvases.access.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.access.delete">https://docs.slack.dev/reference/methods/canvases.access.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.canvases_access_set"><code class="name flex">
 <span>async def <span class="ident">canvases_access_set</span></span>(<span>self,<br>*,<br>canvas_id: str,<br>access_level: str,<br>channel_ids: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9228,7 +9302,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sets the access level to a canvas for specified entities
-    https://api.slack.com/methods/canvases.access.set
+    https://docs.slack.dev/reference/methods/canvases.access.set
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;access_level&#34;: access_level})
     if channel_ids is not None:
@@ -9245,7 +9319,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;canvases.access.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the access level to a canvas for specified entities
-<a href="https://api.slack.com/methods/canvases.access.set">https://api.slack.com/methods/canvases.access.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.access.set">https://docs.slack.dev/reference/methods/canvases.access.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.canvases_create"><code class="name flex">
 <span>async def <span class="ident">canvases_create</span></span>(<span>self, *, title: str | None = None, document_content: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9263,13 +9337,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Create Canvas for a user
-    https://api.slack.com/methods/canvases.create
+    https://docs.slack.dev/reference/methods/canvases.create
     &#34;&#34;&#34;
     kwargs.update({&#34;title&#34;: title, &#34;document_content&#34;: document_content})
     return await self.api_call(&#34;canvases.create&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create Canvas for a user
-<a href="https://api.slack.com/methods/canvases.create">https://api.slack.com/methods/canvases.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.create">https://docs.slack.dev/reference/methods/canvases.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.canvases_delete"><code class="name flex">
 <span>async def <span class="ident">canvases_delete</span></span>(<span>self, *, canvas_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9286,13 +9360,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Deletes a canvas
-    https://api.slack.com/methods/canvases.delete
+    https://docs.slack.dev/reference/methods/canvases.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id})
     return await self.api_call(&#34;canvases.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a canvas
-<a href="https://api.slack.com/methods/canvases.delete">https://api.slack.com/methods/canvases.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.delete">https://docs.slack.dev/reference/methods/canvases.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.canvases_edit"><code class="name flex">
 <span>async def <span class="ident">canvases_edit</span></span>(<span>self, *, canvas_id: str, changes: Sequence[Dict[str, Any]], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9310,13 +9384,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Update an existing canvas
-    https://api.slack.com/methods/canvases.edit
+    https://docs.slack.dev/reference/methods/canvases.edit
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;changes&#34;: changes})
     return await self.api_call(&#34;canvases.edit&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing canvas
-<a href="https://api.slack.com/methods/canvases.edit">https://api.slack.com/methods/canvases.edit</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.edit">https://docs.slack.dev/reference/methods/canvases.edit</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.canvases_sections_lookup"><code class="name flex">
 <span>async def <span class="ident">canvases_sections_lookup</span></span>(<span>self, *, canvas_id: str, criteria: Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9334,13 +9408,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Find sections matching the provided criteria
-    https://api.slack.com/methods/canvases.sections.lookup
+    https://docs.slack.dev/reference/methods/canvases.sections.lookup
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;criteria&#34;: json.dumps(criteria)})
     return await self.api_call(&#34;canvases.sections.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Find sections matching the provided criteria
-<a href="https://api.slack.com/methods/canvases.sections.lookup">https://api.slack.com/methods/canvases.sections.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.sections.lookup">https://docs.slack.dev/reference/methods/canvases.sections.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.channels_archive"><code class="name flex">
 <span>async def <span class="ident">channels_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9674,13 +9748,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Deletes a message.
-    https://api.slack.com/methods/chat.delete
+    https://docs.slack.dev/reference/methods/chat.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts, &#34;as_user&#34;: as_user})
     return await self.api_call(&#34;chat.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a message.
-<a href="https://api.slack.com/methods/chat.delete">https://api.slack.com/methods/chat.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.delete">https://docs.slack.dev/reference/methods/chat.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_deleteScheduledMessage"><code class="name flex">
 <span>async def <span class="ident">chat_deleteScheduledMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>scheduled_message_id: str,<br>as_user: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9699,7 +9773,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Deletes a scheduled message.
-    https://api.slack.com/methods/chat.deleteScheduledMessage
+    https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9711,7 +9785,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;chat.deleteScheduledMessage&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a scheduled message.
-<a href="https://api.slack.com/methods/chat.deleteScheduledMessage">https://api.slack.com/methods/chat.deleteScheduledMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage">https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_getPermalink"><code class="name flex">
 <span>async def <span class="ident">chat_getPermalink</span></span>(<span>self, *, channel: str, message_ts: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9729,13 +9803,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieve a permalink URL for a specific extant message
-    https://api.slack.com/methods/chat.getPermalink
+    https://docs.slack.dev/reference/methods/chat.getPermalink
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;message_ts&#34;: message_ts})
     return await self.api_call(&#34;chat.getPermalink&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a permalink URL for a specific extant message
-<a href="https://api.slack.com/methods/chat.getPermalink">https://api.slack.com/methods/chat.getPermalink</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.getPermalink">https://docs.slack.dev/reference/methods/chat.getPermalink</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_meMessage"><code class="name flex">
 <span>async def <span class="ident">chat_meMessage</span></span>(<span>self, *, channel: str, text: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9753,16 +9827,16 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Share a me message into a channel.
-    https://api.slack.com/methods/chat.meMessage
+    https://docs.slack.dev/reference/methods/chat.meMessage
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;text&#34;: text})
     return await self.api_call(&#34;chat.meMessage&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Share a me message into a channel.
-<a href="https://api.slack.com/methods/chat.meMessage">https://api.slack.com/methods/chat.meMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.meMessage">https://docs.slack.dev/reference/methods/chat.meMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_postEphemeral"><code class="name flex">
-<span>async def <span class="ident">chat_postEphemeral</span></span>(<span>self,<br>*,<br>channel: str,<br>user: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">chat_postEphemeral</span></span>(<span>self,<br>*,<br>channel: str,<br>user: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9784,10 +9858,11 @@ Each authorization represents an app installation that the event is visible to.
     link_names: Optional[bool] = None,
     username: Optional[str] = None,
     parse: Optional[str] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sends an ephemeral message to a user in a channel.
-    https://api.slack.com/methods/chat.postEphemeral
+    https://docs.slack.dev/reference/methods/chat.postEphemeral
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9803,19 +9878,20 @@ Each authorization represents an app installation that the event is visible to.
             &#34;link_names&#34;: link_names,
             &#34;username&#34;: username,
             &#34;parse&#34;: parse,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return await self.api_call(&#34;chat.postEphemeral&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends an ephemeral message to a user in a channel.
-<a href="https://api.slack.com/methods/chat.postEphemeral">https://api.slack.com/methods/chat.postEphemeral</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.postEphemeral">https://docs.slack.dev/reference/methods/chat.postEphemeral</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_postMessage"><code class="name flex">
-<span>async def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9842,10 +9918,11 @@ Each authorization represents an app installation that the event is visible to.
     username: Optional[str] = None,
     parse: Optional[str] = None,  # none, full
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sends a message to a channel.
-    https://api.slack.com/methods/chat.postMessage
+    https://docs.slack.dev/reference/methods/chat.postMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9866,19 +9943,20 @@ Each authorization represents an app installation that the event is visible to.
             &#34;username&#34;: username,
             &#34;parse&#34;: parse,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postMessage&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.postMessage&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return await self.api_call(&#34;chat.postMessage&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends a message to a channel.
-<a href="https://api.slack.com/methods/chat.postMessage">https://api.slack.com/methods/chat.postMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.postMessage">https://docs.slack.dev/reference/methods/chat.postMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_scheduleMessage"><code class="name flex">
-<span>async def <span class="ident">chat_scheduleMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>post_at: str | int,<br>text: str,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>link_names: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">chat_scheduleMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>post_at: str | int,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>link_names: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9890,7 +9968,7 @@ Each authorization represents an app installation that the event is visible to.
     *,
     channel: str,
     post_at: Union[str, int],
-    text: str,
+    text: Optional[str] = None,
     as_user: Optional[bool] = None,
     attachments: Optional[Union[str, Sequence[Union[Dict, Attachment]]]] = None,
     blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
@@ -9901,10 +9979,11 @@ Each authorization represents an app installation that the event is visible to.
     unfurl_media: Optional[bool] = None,
     link_names: Optional[bool] = None,
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Schedules a message.
-    https://api.slack.com/methods/chat.scheduleMessage
+    https://docs.slack.dev/reference/methods/chat.scheduleMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9921,16 +10000,17 @@ Each authorization represents an app installation that the event is visible to.
             &#34;unfurl_media&#34;: unfurl_media,
             &#34;link_names&#34;: link_names,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return await self.api_call(&#34;chat.scheduleMessage&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Schedules a message.
-<a href="https://api.slack.com/methods/chat.scheduleMessage">https://api.slack.com/methods/chat.scheduleMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.scheduleMessage">https://docs.slack.dev/reference/methods/chat.scheduleMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_scheduledMessages_list"><code class="name flex">
 <span>async def <span class="ident">chat_scheduledMessages_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>cursor: str | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9952,7 +10032,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists all scheduled messages.
-    https://api.slack.com/methods/chat.scheduledMessages.list
+    https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9967,7 +10047,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all scheduled messages.
-<a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.scheduledMessages.list">https://docs.slack.dev/reference/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_unfurl"><code class="name flex">
 <span>async def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -9992,7 +10072,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Provide custom unfurl behavior for user-posted URLs.
-    https://api.slack.com/methods/chat.unfurl
+    https://docs.slack.dev/reference/methods/chat.unfurl
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10013,10 +10093,10 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;chat.unfurl&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Provide custom unfurl behavior for user-posted URLs.
-<a href="https://api.slack.com/methods/chat.unfurl">https://api.slack.com/methods/chat.unfurl</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.unfurl">https://docs.slack.dev/reference/methods/chat.unfurl</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_update"><code class="name flex">
-<span>async def <span class="ident">chat_update</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>text: str | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>as_user: bool | None = None,<br>file_ids: str | Sequence[str] | None = None,<br>link_names: bool | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">chat_update</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>text: str | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>as_user: bool | None = None,<br>file_ids: str | Sequence[str] | None = None,<br>link_names: bool | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10037,10 +10117,11 @@ Each authorization represents an app installation that the event is visible to.
     parse: Optional[str] = None,  # none, full
     reply_broadcast: Optional[bool] = None,
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Updates a message in a channel.
-    https://api.slack.com/methods/chat.update
+    https://docs.slack.dev/reference/methods/chat.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10054,6 +10135,7 @@ Each authorization represents an app installation that the event is visible to.
             &#34;parse&#34;: parse,
             &#34;reply_broadcast&#34;: reply_broadcast,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     if isinstance(file_ids, (list, tuple)):
@@ -10062,12 +10144,12 @@ Each authorization represents an app installation that the event is visible to.
         kwargs.update({&#34;file_ids&#34;: file_ids})
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.update&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.update&#34;, kwargs)
     # NOTE: intentionally using json over params for API methods using blocks/attachments
     return await self.api_call(&#34;chat.update&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Updates a message in a channel.
-<a href="https://api.slack.com/methods/chat.update">https://api.slack.com/methods/chat.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.update">https://docs.slack.dev/reference/methods/chat.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_acceptSharedInvite"><code class="name flex">
 <span>async def <span class="ident">conversations_acceptSharedInvite</span></span>(<span>self,<br>*,<br>channel_name: str,<br>channel_id: str | None = None,<br>invite_id: str | None = None,<br>free_trial_accepted: bool | None = None,<br>is_private: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10089,7 +10171,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Accepts an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.acceptSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
     &#34;&#34;&#34;
     if channel_id is None and invite_id is None:
         raise e.SlackRequestError(&#34;Either channel_id or invite_id must be provided.&#34;)
@@ -10106,7 +10188,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;conversations.acceptSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Accepts an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.acceptSharedInvite">https://api.slack.com/methods/conversations.acceptSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite">https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_approveSharedInvite"><code class="name flex">
 <span>async def <span class="ident">conversations_approveSharedInvite</span></span>(<span>self, *, invite_id: str, target_team: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10124,13 +10206,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Approves an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.approveSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
     return await self.api_call(&#34;conversations.approveSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approves an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.approveSharedInvite">https://api.slack.com/methods/conversations.approveSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.approveSharedInvite">https://docs.slack.dev/reference/methods/conversations.approveSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_archive"><code class="name flex">
 <span>async def <span class="ident">conversations_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10147,13 +10229,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Archives a conversation.
-    https://api.slack.com/methods/conversations.archive
+    https://docs.slack.dev/reference/methods/conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return await self.api_call(&#34;conversations.archive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archives a conversation.
-<a href="https://api.slack.com/methods/conversations.archive">https://api.slack.com/methods/conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.archive">https://docs.slack.dev/reference/methods/conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_canvases_create"><code class="name flex">
 <span>async def <span class="ident">conversations_canvases_create</span></span>(<span>self, *, channel_id: str, document_content: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10171,13 +10253,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Create a Channel Canvas for a channel
-    https://api.slack.com/methods/conversations.canvases.create
+    https://docs.slack.dev/reference/methods/conversations.canvases.create
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;document_content&#34;: document_content})
     return await self.api_call(&#34;conversations.canvases.create&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Channel Canvas for a channel
-<a href="https://api.slack.com/methods/conversations.canvases.create">https://api.slack.com/methods/conversations.canvases.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.canvases.create">https://docs.slack.dev/reference/methods/conversations.canvases.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_close"><code class="name flex">
 <span>async def <span class="ident">conversations_close</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10194,13 +10276,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Closes a direct message or multi-person direct message.
-    https://api.slack.com/methods/conversations.close
+    https://docs.slack.dev/reference/methods/conversations.close
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return await self.api_call(&#34;conversations.close&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Closes a direct message or multi-person direct message.
-<a href="https://api.slack.com/methods/conversations.close">https://api.slack.com/methods/conversations.close</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.close">https://docs.slack.dev/reference/methods/conversations.close</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_create"><code class="name flex">
 <span>async def <span class="ident">conversations_create</span></span>(<span>self,<br>*,<br>name: str,<br>is_private: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10219,13 +10301,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Initiates a public or private channel-based conversation
-    https://api.slack.com/methods/conversations.create
+    https://docs.slack.dev/reference/methods/conversations.create
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;is_private&#34;: is_private, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;conversations.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Initiates a public or private channel-based conversation
-<a href="https://api.slack.com/methods/conversations.create">https://api.slack.com/methods/conversations.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.create">https://docs.slack.dev/reference/methods/conversations.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_declineSharedInvite"><code class="name flex">
 <span>async def <span class="ident">conversations_declineSharedInvite</span></span>(<span>self, *, invite_id: str, target_team: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10243,13 +10325,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Declines a Slack Connect channel invite.
-    https://api.slack.com/methods/conversations.declineSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
     return await self.api_call(&#34;conversations.declineSharedInvite&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Declines a Slack Connect channel invite.
-<a href="https://api.slack.com/methods/conversations.declineSharedInvite">https://api.slack.com/methods/conversations.declineSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.declineSharedInvite">https://docs.slack.dev/reference/methods/conversations.declineSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_externalInvitePermissions_set"><code class="name flex">
 <span>async def <span class="ident">conversations_externalInvitePermissions_set</span></span>(<span>self, *, action: str, channel: str, target_team: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10263,7 +10345,7 @@ Each authorization represents an app installation that the event is visible to.
     self, *, action: str, channel: str, target_team: str, **kwargs
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-    https://api.slack.com/methods/conversations.externalInvitePermissions.set
+    https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10275,7 +10357,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;conversations.externalInvitePermissions.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-<a href="https://api.slack.com/methods/conversations.externalInvitePermissions.set">https://api.slack.com/methods/conversations.externalInvitePermissions.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set">https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_history"><code class="name flex">
 <span>async def <span class="ident">conversations_history</span></span>(<span>self,<br>*,<br>channel: str,<br>cursor: str | None = None,<br>inclusive: bool | None = None,<br>include_all_metadata: bool | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10298,7 +10380,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Fetches a conversation&#39;s history of messages and events.
-    https://api.slack.com/methods/conversations.history
+    https://docs.slack.dev/reference/methods/conversations.history
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10314,7 +10396,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;conversations.history&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetches a conversation's history of messages and events.
-<a href="https://api.slack.com/methods/conversations.history">https://api.slack.com/methods/conversations.history</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.history">https://docs.slack.dev/reference/methods/conversations.history</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_info"><code class="name flex">
 <span>async def <span class="ident">conversations_info</span></span>(<span>self,<br>*,<br>channel: str,<br>include_locale: bool | None = None,<br>include_num_members: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10333,7 +10415,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieve information about a conversation.
-    https://api.slack.com/methods/conversations.info
+    https://docs.slack.dev/reference/methods/conversations.info
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10345,7 +10427,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;conversations.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a conversation.
-<a href="https://api.slack.com/methods/conversations.info">https://api.slack.com/methods/conversations.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.info">https://docs.slack.dev/reference/methods/conversations.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_invite"><code class="name flex">
 <span>async def <span class="ident">conversations_invite</span></span>(<span>self,<br>*,<br>channel: str,<br>users: str | Sequence[str],<br>force: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10364,7 +10446,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Invites users to a channel.
-    https://api.slack.com/methods/conversations.invite
+    https://docs.slack.dev/reference/methods/conversations.invite
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10379,7 +10461,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invites users to a channel.
-<a href="https://api.slack.com/methods/conversations.invite">https://api.slack.com/methods/conversations.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.invite">https://docs.slack.dev/reference/methods/conversations.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_inviteShared"><code class="name flex">
 <span>async def <span class="ident">conversations_inviteShared</span></span>(<span>self,<br>*,<br>channel: str,<br>emails: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10398,7 +10480,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sends an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.inviteShared
+    https://docs.slack.dev/reference/methods/conversations.inviteShared
     &#34;&#34;&#34;
     if emails is None and user_ids is None:
         raise e.SlackRequestError(&#34;Either emails or user ids must be provided.&#34;)
@@ -10414,7 +10496,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;conversations.inviteShared&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.inviteShared">https://api.slack.com/methods/conversations.inviteShared</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.inviteShared">https://docs.slack.dev/reference/methods/conversations.inviteShared</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_join"><code class="name flex">
 <span>async def <span class="ident">conversations_join</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10431,13 +10513,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Joins an existing conversation.
-    https://api.slack.com/methods/conversations.join
+    https://docs.slack.dev/reference/methods/conversations.join
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return await self.api_call(&#34;conversations.join&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Joins an existing conversation.
-<a href="https://api.slack.com/methods/conversations.join">https://api.slack.com/methods/conversations.join</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.join">https://docs.slack.dev/reference/methods/conversations.join</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_kick"><code class="name flex">
 <span>async def <span class="ident">conversations_kick</span></span>(<span>self, *, channel: str, user: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10455,13 +10537,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Removes a user from a conversation.
-    https://api.slack.com/methods/conversations.kick
+    https://docs.slack.dev/reference/methods/conversations.kick
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;user&#34;: user})
     return await self.api_call(&#34;conversations.kick&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a user from a conversation.
-<a href="https://api.slack.com/methods/conversations.kick">https://api.slack.com/methods/conversations.kick</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.kick">https://docs.slack.dev/reference/methods/conversations.kick</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_leave"><code class="name flex">
 <span>async def <span class="ident">conversations_leave</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10478,13 +10560,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Leaves a conversation.
-    https://api.slack.com/methods/conversations.leave
+    https://docs.slack.dev/reference/methods/conversations.leave
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return await self.api_call(&#34;conversations.leave&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Leaves a conversation.
-<a href="https://api.slack.com/methods/conversations.leave">https://api.slack.com/methods/conversations.leave</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.leave">https://docs.slack.dev/reference/methods/conversations.leave</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_list"><code class="name flex">
 <span>async def <span class="ident">conversations_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>exclude_archived: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>types: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10505,7 +10587,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists all channels in a Slack team.
-    https://api.slack.com/methods/conversations.list
+    https://docs.slack.dev/reference/methods/conversations.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10522,7 +10604,7 @@ Each authorization represents an app installation that the event is visible to.
     return await self.api_call(&#34;conversations.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all channels in a Slack team.
-<a href="https://api.slack.com/methods/conversations.list">https://api.slack.com/methods/conversations.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.list">https://docs.slack.dev/reference/methods/conversations.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_listConnectInvites"><code class="name flex">
 <span>async def <span class="ident">conversations_listConnectInvites</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10542,14 +10624,14 @@ Each authorization represents an app installation that the event is visible to.
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List shared channel invites that have been generated
     or received but have not yet been approved by all parties.
-    https://api.slack.com/methods/conversations.listConnectInvites
+    https://docs.slack.dev/reference/methods/conversations.listConnectInvites
     &#34;&#34;&#34;
     kwargs.update({&#34;count&#34;: count, &#34;cursor&#34;: cursor, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;conversations.listConnectInvites&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List shared channel invites that have been generated
 or received but have not yet been approved by all parties.
-<a href="https://api.slack.com/methods/conversations.listConnectInvites">https://api.slack.com/methods/conversations.listConnectInvites</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.listConnectInvites">https://docs.slack.dev/reference/methods/conversations.listConnectInvites</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_mark"><code class="name flex">
 <span>async def <span class="ident">conversations_mark</span></span>(<span>self, *, channel: str, ts: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10567,13 +10649,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sets the read cursor in a channel.
-    https://api.slack.com/methods/conversations.mark
+    https://docs.slack.dev/reference/methods/conversations.mark
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts})
     return await self.api_call(&#34;conversations.mark&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the read cursor in a channel.
-<a href="https://api.slack.com/methods/conversations.mark">https://api.slack.com/methods/conversations.mark</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.mark">https://docs.slack.dev/reference/methods/conversations.mark</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_members"><code class="name flex">
 <span>async def <span class="ident">conversations_members</span></span>(<span>self, *, channel: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10592,13 +10674,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieve members of a conversation.
-    https://api.slack.com/methods/conversations.members
+    https://docs.slack.dev/reference/methods/conversations.members
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return await self.api_call(&#34;conversations.members&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve members of a conversation.
-<a href="https://api.slack.com/methods/conversations.members">https://api.slack.com/methods/conversations.members</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.members">https://docs.slack.dev/reference/methods/conversations.members</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_open"><code class="name flex">
 <span>async def <span class="ident">conversations_open</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>return_im: bool | None = None,<br>users: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10617,7 +10699,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Opens or resumes a direct message or multi-person direct message.
-    https://api.slack.com/methods/conversations.open
+    https://docs.slack.dev/reference/methods/conversations.open
     &#34;&#34;&#34;
     if channel is None and users is None:
         raise e.SlackRequestError(&#34;Either channel or users must be provided.&#34;)
@@ -10629,7 +10711,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;conversations.open&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Opens or resumes a direct message or multi-person direct message.
-<a href="https://api.slack.com/methods/conversations.open">https://api.slack.com/methods/conversations.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.open">https://docs.slack.dev/reference/methods/conversations.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_rename"><code class="name flex">
 <span>async def <span class="ident">conversations_rename</span></span>(<span>self, *, channel: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10647,13 +10729,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Renames a conversation.
-    https://api.slack.com/methods/conversations.rename
+    https://docs.slack.dev/reference/methods/conversations.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name})
     return await self.api_call(&#34;conversations.rename&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Renames a conversation.
-<a href="https://api.slack.com/methods/conversations.rename">https://api.slack.com/methods/conversations.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.rename">https://docs.slack.dev/reference/methods/conversations.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_replies"><code class="name flex">
 <span>async def <span class="ident">conversations_replies</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>cursor: str | None = None,<br>inclusive: bool | None = None,<br>include_all_metadata: bool | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10677,7 +10759,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieve a thread of messages posted to a conversation
-    https://api.slack.com/methods/conversations.replies
+    https://docs.slack.dev/reference/methods/conversations.replies
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10694,7 +10776,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;conversations.replies&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a thread of messages posted to a conversation
-<a href="https://api.slack.com/methods/conversations.replies">https://api.slack.com/methods/conversations.replies</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.replies">https://docs.slack.dev/reference/methods/conversations.replies</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_requestSharedInvite_approve"><code class="name flex">
 <span>async def <span class="ident">conversations_requestSharedInvite_approve</span></span>(<span>self,<br>*,<br>invite_id: str,<br>channel_id: str | None = None,<br>is_external_limited: str | None = None,<br>message: Dict[str, Any] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10714,7 +10796,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-    https://api.slack.com/methods/conversations.requestSharedInvite.approve
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10728,7 +10810,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;conversations.requestSharedInvite.approve&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.approve">https://api.slack.com/methods/conversations.requestSharedInvite.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_requestSharedInvite_deny"><code class="name flex">
 <span>async def <span class="ident">conversations_requestSharedInvite_deny</span></span>(<span>self, *, invite_id: str, message: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10746,13 +10828,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Deny a request to invite an external user to a channel.
-    https://api.slack.com/methods/conversations.requestSharedInvite.deny
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;message&#34;: message})
     return await self.api_call(&#34;conversations.requestSharedInvite.deny&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deny a request to invite an external user to a channel.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.deny">https://api.slack.com/methods/conversations.requestSharedInvite.deny</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_requestSharedInvite_list"><code class="name flex">
 <span>async def <span class="ident">conversations_requestSharedInvite_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>include_approved: bool | None = None,<br>include_denied: bool | None = None,<br>include_expired: bool | None = None,<br>invite_ids: str | Sequence[str] | None = None,<br>limit: int | None = None,<br>user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10775,7 +10857,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists requests to add external users to channels with ability to filter.
-    https://api.slack.com/methods/conversations.requestSharedInvite.list
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10795,7 +10877,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;conversations.requestSharedInvite.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists requests to add external users to channels with ability to filter.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.list">https://api.slack.com/methods/conversations.requestSharedInvite.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_setPurpose"><code class="name flex">
 <span>async def <span class="ident">conversations_setPurpose</span></span>(<span>self, *, channel: str, purpose: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10813,13 +10895,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sets the purpose for a conversation.
-    https://api.slack.com/methods/conversations.setPurpose
+    https://docs.slack.dev/reference/methods/conversations.setPurpose
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;purpose&#34;: purpose})
     return await self.api_call(&#34;conversations.setPurpose&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the purpose for a conversation.
-<a href="https://api.slack.com/methods/conversations.setPurpose">https://api.slack.com/methods/conversations.setPurpose</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.setPurpose">https://docs.slack.dev/reference/methods/conversations.setPurpose</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_setTopic"><code class="name flex">
 <span>async def <span class="ident">conversations_setTopic</span></span>(<span>self, *, channel: str, topic: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10837,13 +10919,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Sets the topic for a conversation.
-    https://api.slack.com/methods/conversations.setTopic
+    https://docs.slack.dev/reference/methods/conversations.setTopic
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;topic&#34;: topic})
     return await self.api_call(&#34;conversations.setTopic&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the topic for a conversation.
-<a href="https://api.slack.com/methods/conversations.setTopic">https://api.slack.com/methods/conversations.setTopic</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.setTopic">https://docs.slack.dev/reference/methods/conversations.setTopic</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.conversations_unarchive"><code class="name flex">
 <span>async def <span class="ident">conversations_unarchive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10860,13 +10942,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Reverses conversation archival.
-    https://api.slack.com/methods/conversations.unarchive
+    https://docs.slack.dev/reference/methods/conversations.unarchive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return await self.api_call(&#34;conversations.unarchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Reverses conversation archival.
-<a href="https://api.slack.com/methods/conversations.unarchive">https://api.slack.com/methods/conversations.unarchive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.unarchive">https://docs.slack.dev/reference/methods/conversations.unarchive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.dialog_open"><code class="name flex">
 <span>async def <span class="ident">dialog_open</span></span>(<span>self, *, dialog: Dict[str, Any], trigger_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10884,7 +10966,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Open a dialog with a user.
-    https://api.slack.com/methods/dialog.open
+    https://docs.slack.dev/reference/methods/dialog.open
     &#34;&#34;&#34;
     kwargs.update({&#34;dialog&#34;: dialog, &#34;trigger_id&#34;: trigger_id})
     kwargs = _remove_none_values(kwargs)
@@ -10892,7 +10974,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;dialog.open&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Open a dialog with a user.
-<a href="https://api.slack.com/methods/dialog.open">https://api.slack.com/methods/dialog.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dialog.open">https://docs.slack.dev/reference/methods/dialog.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.dnd_endDnd"><code class="name flex">
 <span>async def <span class="ident">dnd_endDnd</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10907,12 +10989,12 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Ends the current user&#39;s Do Not Disturb session immediately.
-    https://api.slack.com/methods/dnd.endDnd
+    https://docs.slack.dev/reference/methods/dnd.endDnd
     &#34;&#34;&#34;
     return await self.api_call(&#34;dnd.endDnd&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends the current user's Do Not Disturb session immediately.
-<a href="https://api.slack.com/methods/dnd.endDnd">https://api.slack.com/methods/dnd.endDnd</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.endDnd">https://docs.slack.dev/reference/methods/dnd.endDnd</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.dnd_endSnooze"><code class="name flex">
 <span>async def <span class="ident">dnd_endSnooze</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10927,12 +11009,12 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Ends the current user&#39;s snooze mode immediately.
-    https://api.slack.com/methods/dnd.endSnooze
+    https://docs.slack.dev/reference/methods/dnd.endSnooze
     &#34;&#34;&#34;
     return await self.api_call(&#34;dnd.endSnooze&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends the current user's snooze mode immediately.
-<a href="https://api.slack.com/methods/dnd.endSnooze">https://api.slack.com/methods/dnd.endSnooze</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.endSnooze">https://docs.slack.dev/reference/methods/dnd.endSnooze</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.dnd_info"><code class="name flex">
 <span>async def <span class="ident">dnd_info</span></span>(<span>self, *, team_id: str | None = None, user: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10950,13 +11032,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieves a user&#39;s current Do Not Disturb status.
-    https://api.slack.com/methods/dnd.info
+    https://docs.slack.dev/reference/methods/dnd.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
     return await self.api_call(&#34;dnd.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves a user's current Do Not Disturb status.
-<a href="https://api.slack.com/methods/dnd.info">https://api.slack.com/methods/dnd.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.info">https://docs.slack.dev/reference/methods/dnd.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.dnd_setSnooze"><code class="name flex">
 <span>async def <span class="ident">dnd_setSnooze</span></span>(<span>self, *, num_minutes: str | int, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10973,13 +11055,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Turns on Do Not Disturb mode for the current user, or changes its duration.
-    https://api.slack.com/methods/dnd.setSnooze
+    https://docs.slack.dev/reference/methods/dnd.setSnooze
     &#34;&#34;&#34;
     kwargs.update({&#34;num_minutes&#34;: num_minutes})
     return await self.api_call(&#34;dnd.setSnooze&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Turns on Do Not Disturb mode for the current user, or changes its duration.
-<a href="https://api.slack.com/methods/dnd.setSnooze">https://api.slack.com/methods/dnd.setSnooze</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.setSnooze">https://docs.slack.dev/reference/methods/dnd.setSnooze</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.dnd_teamInfo"><code class="name flex">
 <span>async def <span class="ident">dnd_teamInfo</span></span>(<span>self, users: str | Sequence[str], team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -10996,7 +11078,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieves the Do Not Disturb status for users on a team.
-    https://api.slack.com/methods/dnd.teamInfo
+    https://docs.slack.dev/reference/methods/dnd.teamInfo
     &#34;&#34;&#34;
     if isinstance(users, (list, tuple)):
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -11006,7 +11088,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;dnd.teamInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves the Do Not Disturb status for users on a team.
-<a href="https://api.slack.com/methods/dnd.teamInfo">https://api.slack.com/methods/dnd.teamInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.teamInfo">https://docs.slack.dev/reference/methods/dnd.teamInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.emoji_list"><code class="name flex">
 <span>async def <span class="ident">emoji_list</span></span>(<span>self, include_categories: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11022,13 +11104,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists custom emoji for a team.
-    https://api.slack.com/methods/emoji.list
+    https://docs.slack.dev/reference/methods/emoji.list
     &#34;&#34;&#34;
     kwargs.update({&#34;include_categories&#34;: include_categories})
     return await self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists custom emoji for a team.
-<a href="https://api.slack.com/methods/emoji.list">https://api.slack.com/methods/emoji.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/emoji.list">https://docs.slack.dev/reference/methods/emoji.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_comments_delete"><code class="name flex">
 <span>async def <span class="ident">files_comments_delete</span></span>(<span>self, *, file: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11046,13 +11128,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Deletes an existing comment on a file.
-    https://api.slack.com/methods/files.comments.delete
+    https://docs.slack.dev/reference/methods/files.comments.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file, &#34;id&#34;: id})
     return await self.api_call(&#34;files.comments.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes an existing comment on a file.
-<a href="https://api.slack.com/methods/files.comments.delete">https://api.slack.com/methods/files.comments.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.comments.delete">https://docs.slack.dev/reference/methods/files.comments.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_completeUploadExternal"><code class="name flex">
 <span>async def <span class="ident">files_completeUploadExternal</span></span>(<span>self,<br>*,<br>files: List[Dict[str, str]],<br>channel_id: str | None = None,<br>channels: List[str] | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11073,7 +11155,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Finishes an upload started with files.getUploadURLExternal.
-    https://api.slack.com/methods/files.completeUploadExternal
+    https://docs.slack.dev/reference/methods/files.completeUploadExternal
     &#34;&#34;&#34;
     _files = [{k: v for k, v in f.items() if v is not None} for f in files]
     kwargs.update(
@@ -11089,7 +11171,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;files.completeUploadExternal&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Finishes an upload started with files.getUploadURLExternal.
-<a href="https://api.slack.com/methods/files.completeUploadExternal">https://api.slack.com/methods/files.completeUploadExternal</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.completeUploadExternal">https://docs.slack.dev/reference/methods/files.completeUploadExternal</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_delete"><code class="name flex">
 <span>async def <span class="ident">files_delete</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11106,13 +11188,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Deletes a file.
-    https://api.slack.com/methods/files.delete
+    https://docs.slack.dev/reference/methods/files.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return await self.api_call(&#34;files.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a file.
-<a href="https://api.slack.com/methods/files.delete">https://api.slack.com/methods/files.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.delete">https://docs.slack.dev/reference/methods/files.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_getUploadURLExternal"><code class="name flex">
 <span>async def <span class="ident">files_getUploadURLExternal</span></span>(<span>self,<br>*,<br>filename: str,<br>length: int,<br>alt_txt: str | None = None,<br>snippet_type: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11132,7 +11214,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets a URL for an edge external upload.
-    https://api.slack.com/methods/files.getUploadURLExternal
+    https://docs.slack.dev/reference/methods/files.getUploadURLExternal
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11145,7 +11227,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;files.getUploadURLExternal&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets a URL for an edge external upload.
-<a href="https://api.slack.com/methods/files.getUploadURLExternal">https://api.slack.com/methods/files.getUploadURLExternal</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.getUploadURLExternal">https://docs.slack.dev/reference/methods/files.getUploadURLExternal</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_info"><code class="name flex">
 <span>async def <span class="ident">files_info</span></span>(<span>self,<br>*,<br>file: str,<br>count: int | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11166,7 +11248,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets information about a team file.
-    https://api.slack.com/methods/files.info
+    https://docs.slack.dev/reference/methods/files.info
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11180,7 +11262,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;files.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a team file.
-<a href="https://api.slack.com/methods/files.info">https://api.slack.com/methods/files.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.info">https://docs.slack.dev/reference/methods/files.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_list"><code class="name flex">
 <span>async def <span class="ident">files_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>count: int | None = None,<br>page: int | None = None,<br>show_files_hidden_by_limit: bool | None = None,<br>team_id: str | None = None,<br>ts_from: str | None = None,<br>ts_to: str | None = None,<br>types: str | Sequence[str] | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11205,7 +11287,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists &amp; filters team files.
-    https://api.slack.com/methods/files.list
+    https://docs.slack.dev/reference/methods/files.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11226,7 +11308,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;files.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists &amp; filters team files.
-<a href="https://api.slack.com/methods/files.list">https://api.slack.com/methods/files.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.list">https://docs.slack.dev/reference/methods/files.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_remote_add"><code class="name flex">
 <span>async def <span class="ident">files_remote_add</span></span>(<span>self,<br>*,<br>external_id: str,<br>external_url: str,<br>title: str,<br>filetype: str | None = None,<br>indexable_file_contents: str | bytes | io.IOBase | None = None,<br>preview_image: str | bytes | io.IOBase | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11248,7 +11330,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Adds a file from a remote service.
-    https://api.slack.com/methods/files.remote.add
+    https://docs.slack.dev/reference/methods/files.remote.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11275,7 +11357,7 @@ or received but have not yet been approved by all parties.
     )</code></pre>
 </details>
 <div class="desc"><p>Adds a file from a remote service.
-<a href="https://api.slack.com/methods/files.remote.add">https://api.slack.com/methods/files.remote.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.add">https://docs.slack.dev/reference/methods/files.remote.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_remote_info"><code class="name flex">
 <span>async def <span class="ident">files_remote_info</span></span>(<span>self, *, external_id: str | None = None, file: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11293,13 +11375,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-    https://api.slack.com/methods/files.remote.info
+    https://docs.slack.dev/reference/methods/files.remote.info
     &#34;&#34;&#34;
     kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
     return await self.api_call(&#34;files.remote.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a remote file added to Slack.
-<a href="https://api.slack.com/methods/files.remote.info">https://api.slack.com/methods/files.remote.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.info">https://docs.slack.dev/reference/methods/files.remote.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_remote_list"><code class="name flex">
 <span>async def <span class="ident">files_remote_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>ts_from: str | None = None,<br>ts_to: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11320,7 +11402,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-    https://api.slack.com/methods/files.remote.list
+    https://docs.slack.dev/reference/methods/files.remote.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11334,7 +11416,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;files.remote.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a remote file added to Slack.
-<a href="https://api.slack.com/methods/files.remote.list">https://api.slack.com/methods/files.remote.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.list">https://docs.slack.dev/reference/methods/files.remote.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_remote_remove"><code class="name flex">
 <span>async def <span class="ident">files_remote_remove</span></span>(<span>self, *, external_id: str | None = None, file: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11352,13 +11434,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Remove a remote file.
-    https://api.slack.com/methods/files.remote.remove
+    https://docs.slack.dev/reference/methods/files.remote.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
     return await self.api_call(&#34;files.remote.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a remote file.
-<a href="https://api.slack.com/methods/files.remote.remove">https://api.slack.com/methods/files.remote.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.remove">https://docs.slack.dev/reference/methods/files.remote.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_remote_share"><code class="name flex">
 <span>async def <span class="ident">files_remote_share</span></span>(<span>self,<br>*,<br>channels: str | Sequence[str],<br>external_id: str | None = None,<br>file: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11377,7 +11459,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Share a remote file into a channel.
-    https://api.slack.com/methods/files.remote.share
+    https://docs.slack.dev/reference/methods/files.remote.share
     &#34;&#34;&#34;
     if external_id is None and file is None:
         raise e.SlackRequestError(&#34;Either external_id or file must be provided.&#34;)
@@ -11389,7 +11471,7 @@ or received but have not yet been approved by all parties.
     return await self.api_call(&#34;files.remote.share&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Share a remote file into a channel.
-<a href="https://api.slack.com/methods/files.remote.share">https://api.slack.com/methods/files.remote.share</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.share">https://docs.slack.dev/reference/methods/files.remote.share</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_remote_update"><code class="name flex">
 <span>async def <span class="ident">files_remote_update</span></span>(<span>self,<br>*,<br>external_id: str | None = None,<br>external_url: str | None = None,<br>file: str | None = None,<br>title: str | None = None,<br>filetype: str | None = None,<br>indexable_file_contents: str | None = None,<br>preview_image: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11412,7 +11494,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Updates an existing remote file.
-    https://api.slack.com/methods/files.remote.update
+    https://docs.slack.dev/reference/methods/files.remote.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11440,7 +11522,7 @@ or received but have not yet been approved by all parties.
     )</code></pre>
 </details>
 <div class="desc"><p>Updates an existing remote file.
-<a href="https://api.slack.com/methods/files.remote.update">https://api.slack.com/methods/files.remote.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.update">https://docs.slack.dev/reference/methods/files.remote.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_revokePublicURL"><code class="name flex">
 <span>async def <span class="ident">files_revokePublicURL</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11457,13 +11539,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Revokes public/external sharing access for a file
-    https://api.slack.com/methods/files.revokePublicURL
+    https://docs.slack.dev/reference/methods/files.revokePublicURL
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return await self.api_call(&#34;files.revokePublicURL&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes public/external sharing access for a file
-<a href="https://api.slack.com/methods/files.revokePublicURL">https://api.slack.com/methods/files.revokePublicURL</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.revokePublicURL">https://docs.slack.dev/reference/methods/files.revokePublicURL</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_sharedPublicURL"><code class="name flex">
 <span>async def <span class="ident">files_sharedPublicURL</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11480,13 +11562,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Enables a file for public/external sharing.
-    https://api.slack.com/methods/files.sharedPublicURL
+    https://docs.slack.dev/reference/methods/files.sharedPublicURL
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return await self.api_call(&#34;files.sharedPublicURL&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enables a file for public/external sharing.
-<a href="https://api.slack.com/methods/files.sharedPublicURL">https://api.slack.com/methods/files.sharedPublicURL</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.sharedPublicURL">https://docs.slack.dev/reference/methods/files.sharedPublicURL</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_upload"><code class="name flex">
 <span>async def <span class="ident">files_upload</span></span>(<span>self,<br>*,<br>file: str | bytes | io.IOBase | None = None,<br>content: str | bytes | None = None,<br>filename: str | None = None,<br>filetype: str | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>title: str | None = None,<br>channels: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11510,7 +11592,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Uploads or creates a file.
-    https://api.slack.com/methods/files.upload
+    https://docs.slack.dev/reference/methods/files.upload
     &#34;&#34;&#34;
     _print_files_upload_v2_suggestion()
 
@@ -11543,7 +11625,7 @@ or received but have not yet been approved by all parties.
         return await self.api_call(&#34;files.upload&#34;, data=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Uploads or creates a file.
-<a href="https://api.slack.com/methods/files.upload">https://api.slack.com/methods/files.upload</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.upload">https://docs.slack.dev/reference/methods/files.upload</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_upload_v2"><code class="name flex">
 <span>async def <span class="ident">files_upload_v2</span></span>(<span>self,<br>*,<br>filename: str | None = None,<br>file: str | bytes | io.IOBase | os.PathLike | None = None,<br>content: str | bytes | None = None,<br>title: str | None = None,<br>alt_txt: str | None = None,<br>snippet_type: str | None = None,<br>file_uploads: List[Dict[str, Any]] | None = None,<br>channel: str | None = None,<br>channels: List[str] | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>request_file_info: bool = True,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11574,12 +11656,12 @@ or received but have not yet been approved by all parties.
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;This wrapper method provides an easy way to upload files using the following endpoints:
 
-    - step1: https://api.slack.com/methods/files.getUploadURLExternal
+    - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
     - step2: &#34;https://files.slack.com/upload/v1/...&#34; URLs returned from files.getUploadURLExternal API
 
-    - step3: https://api.slack.com/methods/files.completeUploadExternal
-        and https://api.slack.com/methods/files.info
+    - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+        and https://docs.slack.dev/reference/methods/files.info
 
     &#34;&#34;&#34;
     if file is None and content is None and file_uploads is None:
@@ -11658,14 +11740,14 @@ or received but have not yet been approved by all parties.
 <div class="desc"><p>This wrapper method provides an easy way to upload files using the following endpoints:</p>
 <ul>
 <li>
-<p>step1: <a href="https://api.slack.com/methods/files.getUploadURLExternal">https://api.slack.com/methods/files.getUploadURLExternal</a></p>
+<p>step1: <a href="https://docs.slack.dev/reference/methods/files.getUploadURLExternal">https://docs.slack.dev/reference/methods/files.getUploadURLExternal</a></p>
 </li>
 <li>
 <p>step2: "https://files.slack.com/upload/v1/&hellip;" URLs returned from files.getUploadURLExternal API</p>
 </li>
 <li>
-<p>step3: <a href="https://api.slack.com/methods/files.completeUploadExternal">https://api.slack.com/methods/files.completeUploadExternal</a>
-and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/methods/files.info</a></p>
+<p>step3: <a href="https://docs.slack.dev/reference/methods/files.completeUploadExternal">https://docs.slack.dev/reference/methods/files.completeUploadExternal</a>
+and <a href="https://docs.slack.dev/reference/methods/files.info">https://docs.slack.dev/reference/methods/files.info</a></p>
 </li>
 </ul></div>
 </dd>
@@ -11685,13 +11767,13 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Signal the failure to execute a function
-    https://api.slack.com/methods/functions.completeError
+    https://docs.slack.dev/reference/methods/functions.completeError
     &#34;&#34;&#34;
     kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;error&#34;: error})
     return await self.api_call(&#34;functions.completeError&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Signal the failure to execute a function
-<a href="https://api.slack.com/methods/functions.completeError">https://api.slack.com/methods/functions.completeError</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/functions.completeError">https://docs.slack.dev/reference/methods/functions.completeError</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.functions_completeSuccess"><code class="name flex">
 <span>async def <span class="ident">functions_completeSuccess</span></span>(<span>self, *, function_execution_id: str, outputs: Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -11709,13 +11791,13 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Signal the successful completion of a function
-    https://api.slack.com/methods/functions.completeSuccess
+    https://docs.slack.dev/reference/methods/functions.completeSuccess
     &#34;&#34;&#34;
     kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;outputs&#34;: json.dumps(outputs)})
     return await self.api_call(&#34;functions.completeSuccess&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Signal the successful completion of a function
-<a href="https://api.slack.com/methods/functions.completeSuccess">https://api.slack.com/methods/functions.completeSuccess</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/functions.completeSuccess">https://docs.slack.dev/reference/methods/functions.completeSuccess</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.groups_archive"><code class="name flex">
 <span>async def <span class="ident">groups_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12191,7 +12273,7 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;For Enterprise Grid workspaces, map local user IDs to global user IDs
-    https://api.slack.com/methods/migration.exchange
+    https://docs.slack.dev/reference/methods/migration.exchange
     &#34;&#34;&#34;
     if isinstance(users, (list, tuple)):
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -12201,7 +12283,7 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     return await self.api_call(&#34;migration.exchange&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>For Enterprise Grid workspaces, map local user IDs to global user IDs
-<a href="https://api.slack.com/methods/migration.exchange">https://api.slack.com/methods/migration.exchange</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/migration.exchange">https://docs.slack.dev/reference/methods/migration.exchange</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.mpim_close"><code class="name flex">
 <span>async def <span class="ident">mpim_close</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12348,7 +12430,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-    https://api.slack.com/methods/oauth.access
+    https://docs.slack.dev/reference/methods/oauth.access
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12360,7 +12442,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.
-<a href="https://api.slack.com/methods/oauth.access">https://api.slack.com/methods/oauth.access</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.access">https://docs.slack.dev/reference/methods/oauth.access</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.oauth_v2_access"><code class="name flex">
 <span>async def <span class="ident">oauth_v2_access</span></span>(<span>self,<br>*,<br>client_id: str,<br>client_secret: str,<br>code: str | None = None,<br>redirect_uri: str | None = None,<br>grant_type: str | None = None,<br>refresh_token: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12386,7 +12468,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-    https://api.slack.com/methods/oauth.v2.access
+    https://docs.slack.dev/reference/methods/oauth.v2.access
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12403,7 +12485,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.
-<a href="https://api.slack.com/methods/oauth.v2.access">https://api.slack.com/methods/oauth.v2.access</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.v2.access">https://docs.slack.dev/reference/methods/oauth.v2.access</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.oauth_v2_exchange"><code class="name flex">
 <span>async def <span class="ident">oauth_v2_exchange</span></span>(<span>self, *, token: str, client_id: str, client_secret: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12422,13 +12504,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
-    https://api.slack.com/methods/oauth.v2.exchange
+    https://docs.slack.dev/reference/methods/oauth.v2.exchange
     &#34;&#34;&#34;
     kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token})
     return await self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Exchanges a legacy access token for a new expiring access token and refresh token
-<a href="https://api.slack.com/methods/oauth.v2.exchange">https://api.slack.com/methods/oauth.v2.exchange</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.v2.exchange">https://docs.slack.dev/reference/methods/oauth.v2.exchange</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.openid_connect_token"><code class="name flex">
 <span>async def <span class="ident">openid_connect_token</span></span>(<span>self,<br>client_id: str,<br>client_secret: str,<br>code: str | None = None,<br>redirect_uri: str | None = None,<br>grant_type: str | None = None,<br>refresh_token: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12449,7 +12531,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-    https://api.slack.com/methods/openid.connect.token
+    https://docs.slack.dev/reference/methods/openid.connect.token
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12466,7 +12548,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-<a href="https://api.slack.com/methods/openid.connect.token">https://api.slack.com/methods/openid.connect.token</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/openid.connect.token">https://docs.slack.dev/reference/methods/openid.connect.token</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.openid_connect_userInfo"><code class="name flex">
 <span>async def <span class="ident">openid_connect_userInfo</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12481,12 +12563,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Get the identity of a user who has authorized Sign in with Slack.
-    https://api.slack.com/methods/openid.connect.userInfo
+    https://docs.slack.dev/reference/methods/openid.connect.userInfo
     &#34;&#34;&#34;
     return await self.api_call(&#34;openid.connect.userInfo&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get the identity of a user who has authorized Sign in with Slack.
-<a href="https://api.slack.com/methods/openid.connect.userInfo">https://api.slack.com/methods/openid.connect.userInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/openid.connect.userInfo">https://docs.slack.dev/reference/methods/openid.connect.userInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.pins_add"><code class="name flex">
 <span>async def <span class="ident">pins_add</span></span>(<span>self, *, channel: str, timestamp: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12504,13 +12586,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Pins an item to a channel.
-    https://api.slack.com/methods/pins.add
+    https://docs.slack.dev/reference/methods/pins.add
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
     return await self.api_call(&#34;pins.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Pins an item to a channel.
-<a href="https://api.slack.com/methods/pins.add">https://api.slack.com/methods/pins.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.add">https://docs.slack.dev/reference/methods/pins.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.pins_list"><code class="name flex">
 <span>async def <span class="ident">pins_list</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12527,13 +12609,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists items pinned to a channel.
-    https://api.slack.com/methods/pins.list
+    https://docs.slack.dev/reference/methods/pins.list
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return await self.api_call(&#34;pins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists items pinned to a channel.
-<a href="https://api.slack.com/methods/pins.list">https://api.slack.com/methods/pins.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.list">https://docs.slack.dev/reference/methods/pins.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.pins_remove"><code class="name flex">
 <span>async def <span class="ident">pins_remove</span></span>(<span>self, *, channel: str, timestamp: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12551,13 +12633,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Un-pins an item from a channel.
-    https://api.slack.com/methods/pins.remove
+    https://docs.slack.dev/reference/methods/pins.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
     return await self.api_call(&#34;pins.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Un-pins an item from a channel.
-<a href="https://api.slack.com/methods/pins.remove">https://api.slack.com/methods/pins.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.remove">https://docs.slack.dev/reference/methods/pins.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.reactions_add"><code class="name flex">
 <span>async def <span class="ident">reactions_add</span></span>(<span>self, *, channel: str, name: str, timestamp: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12576,13 +12658,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Adds a reaction to an item.
-    https://api.slack.com/methods/reactions.add
+    https://docs.slack.dev/reference/methods/reactions.add
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name, &#34;timestamp&#34;: timestamp})
     return await self.api_call(&#34;reactions.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds a reaction to an item.
-<a href="https://api.slack.com/methods/reactions.add">https://api.slack.com/methods/reactions.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.add">https://docs.slack.dev/reference/methods/reactions.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.reactions_get"><code class="name flex">
 <span>async def <span class="ident">reactions_get</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>full: bool | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12603,7 +12685,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets reactions for an item.
-    https://api.slack.com/methods/reactions.get
+    https://docs.slack.dev/reference/methods/reactions.get
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12617,7 +12699,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;reactions.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets reactions for an item.
-<a href="https://api.slack.com/methods/reactions.get">https://api.slack.com/methods/reactions.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.get">https://docs.slack.dev/reference/methods/reactions.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.reactions_list"><code class="name flex">
 <span>async def <span class="ident">reactions_list</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>full: bool | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>team_id: str | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12640,7 +12722,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists reactions made by a user.
-    https://api.slack.com/methods/reactions.list
+    https://docs.slack.dev/reference/methods/reactions.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12656,7 +12738,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;reactions.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists reactions made by a user.
-<a href="https://api.slack.com/methods/reactions.list">https://api.slack.com/methods/reactions.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.list">https://docs.slack.dev/reference/methods/reactions.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.reactions_remove"><code class="name flex">
 <span>async def <span class="ident">reactions_remove</span></span>(<span>self,<br>*,<br>name: str,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12677,7 +12759,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Removes a reaction from an item.
-    https://api.slack.com/methods/reactions.remove
+    https://docs.slack.dev/reference/methods/reactions.remove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12691,7 +12773,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;reactions.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a reaction from an item.
-<a href="https://api.slack.com/methods/reactions.remove">https://api.slack.com/methods/reactions.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.remove">https://docs.slack.dev/reference/methods/reactions.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.reminders_add"><code class="name flex">
 <span>async def <span class="ident">reminders_add</span></span>(<span>self,<br>*,<br>text: str,<br>time: str,<br>team_id: str | None = None,<br>user: str | None = None,<br>recurrence: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12712,7 +12794,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Creates a reminder.
-    https://api.slack.com/methods/reminders.add
+    https://docs.slack.dev/reference/methods/reminders.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12726,7 +12808,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;reminders.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Creates a reminder.
-<a href="https://api.slack.com/methods/reminders.add">https://api.slack.com/methods/reminders.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.add">https://docs.slack.dev/reference/methods/reminders.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.reminders_complete"><code class="name flex">
 <span>async def <span class="ident">reminders_complete</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12744,13 +12826,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Marks a reminder as complete.
-    https://api.slack.com/methods/reminders.complete
+    https://docs.slack.dev/reference/methods/reminders.complete
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;reminders.complete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Marks a reminder as complete.
-<a href="https://api.slack.com/methods/reminders.complete">https://api.slack.com/methods/reminders.complete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.complete">https://docs.slack.dev/reference/methods/reminders.complete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.reminders_delete"><code class="name flex">
 <span>async def <span class="ident">reminders_delete</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12768,13 +12850,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Deletes a reminder.
-    https://api.slack.com/methods/reminders.delete
+    https://docs.slack.dev/reference/methods/reminders.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;reminders.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a reminder.
-<a href="https://api.slack.com/methods/reminders.delete">https://api.slack.com/methods/reminders.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.delete">https://docs.slack.dev/reference/methods/reminders.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.reminders_info"><code class="name flex">
 <span>async def <span class="ident">reminders_info</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12792,13 +12874,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets information about a reminder.
-    https://api.slack.com/methods/reminders.info
+    https://docs.slack.dev/reference/methods/reminders.info
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;reminders.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a reminder.
-<a href="https://api.slack.com/methods/reminders.info">https://api.slack.com/methods/reminders.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.info">https://docs.slack.dev/reference/methods/reminders.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.reminders_list"><code class="name flex">
 <span>async def <span class="ident">reminders_list</span></span>(<span>self, *, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12815,13 +12897,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists all reminders created by or for a given user.
-    https://api.slack.com/methods/reminders.list
+    https://docs.slack.dev/reference/methods/reminders.list
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     return await self.api_call(&#34;reminders.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all reminders created by or for a given user.
-<a href="https://api.slack.com/methods/reminders.list">https://api.slack.com/methods/reminders.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.list">https://docs.slack.dev/reference/methods/reminders.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.rtm_connect"><code class="name flex">
 <span>async def <span class="ident">rtm_connect</span></span>(<span>self,<br>*,<br>batch_presence_aware: bool | None = None,<br>presence_sub: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12839,13 +12921,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Starts a Real Time Messaging session.
-    https://api.slack.com/methods/rtm.connect
+    https://docs.slack.dev/reference/methods/rtm.connect
     &#34;&#34;&#34;
     kwargs.update({&#34;batch_presence_aware&#34;: batch_presence_aware, &#34;presence_sub&#34;: presence_sub})
     return await self.api_call(&#34;rtm.connect&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Starts a Real Time Messaging session.
-<a href="https://api.slack.com/methods/rtm.connect">https://api.slack.com/methods/rtm.connect</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/rtm.connect">https://docs.slack.dev/reference/methods/rtm.connect</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.rtm_start"><code class="name flex">
 <span>async def <span class="ident">rtm_start</span></span>(<span>self,<br>*,<br>batch_presence_aware: bool | None = None,<br>include_locale: bool | None = None,<br>mpim_aware: bool | None = None,<br>no_latest: bool | None = None,<br>no_unreads: bool | None = None,<br>presence_sub: bool | None = None,<br>simple_latest: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12868,7 +12950,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Starts a Real Time Messaging session.
-    https://api.slack.com/methods/rtm.start
+    https://docs.slack.dev/reference/methods/rtm.start
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12884,7 +12966,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;rtm.start&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Starts a Real Time Messaging session.
-<a href="https://api.slack.com/methods/rtm.start">https://api.slack.com/methods/rtm.start</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/rtm.start">https://docs.slack.dev/reference/methods/rtm.start</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.search_all"><code class="name flex">
 <span>async def <span class="ident">search_all</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12907,7 +12989,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Searches for messages and files matching a query.
-    https://api.slack.com/methods/search.all
+    https://docs.slack.dev/reference/methods/search.all
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12923,7 +13005,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;search.all&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for messages and files matching a query.
-<a href="https://api.slack.com/methods/search.all">https://api.slack.com/methods/search.all</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.all">https://docs.slack.dev/reference/methods/search.all</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.search_files"><code class="name flex">
 <span>async def <span class="ident">search_files</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12946,7 +13028,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Searches for files matching a query.
-    https://api.slack.com/methods/search.files
+    https://docs.slack.dev/reference/methods/search.files
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12962,7 +13044,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;search.files&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for files matching a query.
-<a href="https://api.slack.com/methods/search.files">https://api.slack.com/methods/search.files</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.files">https://docs.slack.dev/reference/methods/search.files</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.search_messages"><code class="name flex">
 <span>async def <span class="ident">search_messages</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>cursor: str | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -12986,7 +13068,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Searches for messages matching a query.
-    https://api.slack.com/methods/search.messages
+    https://docs.slack.dev/reference/methods/search.messages
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13003,7 +13085,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;search.messages&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for messages matching a query.
-<a href="https://api.slack.com/methods/search.messages">https://api.slack.com/methods/search.messages</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.messages">https://docs.slack.dev/reference/methods/search.messages</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.stars_add"><code class="name flex">
 <span>async def <span class="ident">stars_add</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13023,7 +13105,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Adds a star to an item.
-    https://api.slack.com/methods/stars.add
+    https://docs.slack.dev/reference/methods/stars.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13036,7 +13118,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;stars.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds a star to an item.
-<a href="https://api.slack.com/methods/stars.add">https://api.slack.com/methods/stars.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.add">https://docs.slack.dev/reference/methods/stars.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.stars_list"><code class="name flex">
 <span>async def <span class="ident">stars_list</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13057,7 +13139,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists stars for a user.
-    https://api.slack.com/methods/stars.list
+    https://docs.slack.dev/reference/methods/stars.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13071,7 +13153,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;stars.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists stars for a user.
-<a href="https://api.slack.com/methods/stars.list">https://api.slack.com/methods/stars.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.list">https://docs.slack.dev/reference/methods/stars.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.stars_remove"><code class="name flex">
 <span>async def <span class="ident">stars_remove</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13091,7 +13173,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Removes a star from an item.
-    https://api.slack.com/methods/stars.remove
+    https://docs.slack.dev/reference/methods/stars.remove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13104,7 +13186,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;stars.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a star from an item.
-<a href="https://api.slack.com/methods/stars.remove">https://api.slack.com/methods/stars.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.remove">https://docs.slack.dev/reference/methods/stars.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.team_accessLogs"><code class="name flex">
 <span>async def <span class="ident">team_accessLogs</span></span>(<span>self,<br>*,<br>before: str | int | None = None,<br>count: str | int | None = None,<br>page: str | int | None = None,<br>team_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13126,7 +13208,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets the access logs for the current team.
-    https://api.slack.com/methods/team.accessLogs
+    https://docs.slack.dev/reference/methods/team.accessLogs
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13141,7 +13223,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;team.accessLogs&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets the access logs for the current team.
-<a href="https://api.slack.com/methods/team.accessLogs">https://api.slack.com/methods/team.accessLogs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.accessLogs">https://docs.slack.dev/reference/methods/team.accessLogs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.team_billableInfo"><code class="name flex">
 <span>async def <span class="ident">team_billableInfo</span></span>(<span>self, *, team_id: str | None = None, user: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13159,13 +13241,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets billable users information for the current team.
-    https://api.slack.com/methods/team.billableInfo
+    https://docs.slack.dev/reference/methods/team.billableInfo
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
     return await self.api_call(&#34;team.billableInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets billable users information for the current team.
-<a href="https://api.slack.com/methods/team.billableInfo">https://api.slack.com/methods/team.billableInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.billableInfo">https://docs.slack.dev/reference/methods/team.billableInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.team_billing_info"><code class="name flex">
 <span>async def <span class="ident">team_billing_info</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13180,12 +13262,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Reads a workspace&#39;s billing plan information.
-    https://api.slack.com/methods/team.billing.info
+    https://docs.slack.dev/reference/methods/team.billing.info
     &#34;&#34;&#34;
     return await self.api_call(&#34;team.billing.info&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Reads a workspace's billing plan information.
-<a href="https://api.slack.com/methods/team.billing.info">https://api.slack.com/methods/team.billing.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.billing.info">https://docs.slack.dev/reference/methods/team.billing.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.team_externalTeams_disconnect"><code class="name flex">
 <span>async def <span class="ident">team_externalTeams_disconnect</span></span>(<span>self, *, target_team: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13202,7 +13284,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Disconnects an external organization.
-    https://api.slack.com/methods/team.externalTeams.disconnect
+    https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13212,7 +13294,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;team.externalTeams.disconnect&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disconnects an external organization.
-<a href="https://api.slack.com/methods/team.externalTeams.disconnect">https://api.slack.com/methods/team.externalTeams.disconnect</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.externalTeams.disconnect">https://docs.slack.dev/reference/methods/team.externalTeams.disconnect</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.team_externalTeams_list"><code class="name flex">
 <span>async def <span class="ident">team_externalTeams_list</span></span>(<span>self,<br>*,<br>connection_status_filter: str | None = None,<br>slack_connect_pref_filter: Sequence[str] | None = None,<br>sort_direction: str | None = None,<br>sort_field: str | None = None,<br>workspace_filter: Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13235,7 +13317,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
-    https://api.slack.com/methods/team.externalTeams.list
+    https://docs.slack.dev/reference/methods/team.externalTeams.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13259,7 +13341,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns a list of all the external teams connected and details about the connection.
-<a href="https://api.slack.com/methods/team.externalTeams.list">https://api.slack.com/methods/team.externalTeams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.externalTeams.list">https://docs.slack.dev/reference/methods/team.externalTeams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.team_info"><code class="name flex">
 <span>async def <span class="ident">team_info</span></span>(<span>self, *, team: str | None = None, domain: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13277,13 +13359,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets information about the current team.
-    https://api.slack.com/methods/team.info
+    https://docs.slack.dev/reference/methods/team.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team&#34;: team, &#34;domain&#34;: domain})
     return await self.api_call(&#34;team.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about the current team.
-<a href="https://api.slack.com/methods/team.info">https://api.slack.com/methods/team.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.info">https://docs.slack.dev/reference/methods/team.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.team_integrationLogs"><code class="name flex">
 <span>async def <span class="ident">team_integrationLogs</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>change_type: str | None = None,<br>count: str | int | None = None,<br>page: str | int | None = None,<br>service_id: str | None = None,<br>team_id: str | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13306,7 +13388,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets the integration logs for the current team.
-    https://api.slack.com/methods/team.integrationLogs
+    https://docs.slack.dev/reference/methods/team.integrationLogs
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13322,7 +13404,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;team.integrationLogs&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets the integration logs for the current team.
-<a href="https://api.slack.com/methods/team.integrationLogs">https://api.slack.com/methods/team.integrationLogs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.integrationLogs">https://docs.slack.dev/reference/methods/team.integrationLogs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.team_preferences_list"><code class="name flex">
 <span>async def <span class="ident">team_preferences_list</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13337,12 +13419,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieve a list of a workspace&#39;s team preferences.
-    https://api.slack.com/methods/team.preferences.list
+    https://docs.slack.dev/reference/methods/team.preferences.list
     &#34;&#34;&#34;
     return await self.api_call(&#34;team.preferences.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a list of a workspace's team preferences.
-<a href="https://api.slack.com/methods/team.preferences.list">https://api.slack.com/methods/team.preferences.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.preferences.list">https://docs.slack.dev/reference/methods/team.preferences.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.team_profile_get"><code class="name flex">
 <span>async def <span class="ident">team_profile_get</span></span>(<span>self, *, visibility: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13359,13 +13441,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieve a team&#39;s profile.
-    https://api.slack.com/methods/team.profile.get
+    https://docs.slack.dev/reference/methods/team.profile.get
     &#34;&#34;&#34;
     kwargs.update({&#34;visibility&#34;: visibility})
     return await self.api_call(&#34;team.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a team's profile.
-<a href="https://api.slack.com/methods/team.profile.get">https://api.slack.com/methods/team.profile.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.profile.get">https://docs.slack.dev/reference/methods/team.profile.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.tooling_tokens_rotate"><code class="name flex">
 <span>async def <span class="ident">tooling_tokens_rotate</span></span>(<span>self, *, refresh_token: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13382,13 +13464,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Exchanges a refresh token for a new app configuration token
-    https://api.slack.com/methods/tooling.tokens.rotate
+    https://docs.slack.dev/reference/methods/tooling.tokens.rotate
     &#34;&#34;&#34;
     kwargs.update({&#34;refresh_token&#34;: refresh_token})
     return await self.api_call(&#34;tooling.tokens.rotate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Exchanges a refresh token for a new app configuration token
-<a href="https://api.slack.com/methods/tooling.tokens.rotate">https://api.slack.com/methods/tooling.tokens.rotate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/tooling.tokens.rotate">https://docs.slack.dev/reference/methods/tooling.tokens.rotate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.usergroups_create"><code class="name flex">
 <span>async def <span class="ident">usergroups_create</span></span>(<span>self,<br>*,<br>name: str,<br>channels: str | Sequence[str] | None = None,<br>description: str | None = None,<br>handle: str | None = None,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13410,7 +13492,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Create a User Group
-    https://api.slack.com/methods/usergroups.create
+    https://docs.slack.dev/reference/methods/usergroups.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13428,7 +13510,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;usergroups.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a User Group
-<a href="https://api.slack.com/methods/usergroups.create">https://api.slack.com/methods/usergroups.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.create">https://docs.slack.dev/reference/methods/usergroups.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.usergroups_disable"><code class="name flex">
 <span>async def <span class="ident">usergroups_disable</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13447,13 +13529,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Disable an existing User Group
-    https://api.slack.com/methods/usergroups.disable
+    https://docs.slack.dev/reference/methods/usergroups.disable
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;usergroups.disable&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disable an existing User Group
-<a href="https://api.slack.com/methods/usergroups.disable">https://api.slack.com/methods/usergroups.disable</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.disable">https://docs.slack.dev/reference/methods/usergroups.disable</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.usergroups_enable"><code class="name flex">
 <span>async def <span class="ident">usergroups_enable</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13472,13 +13554,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Enable a User Group
-    https://api.slack.com/methods/usergroups.enable
+    https://docs.slack.dev/reference/methods/usergroups.enable
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
     return await self.api_call(&#34;usergroups.enable&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enable a User Group
-<a href="https://api.slack.com/methods/usergroups.enable">https://api.slack.com/methods/usergroups.enable</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.enable">https://docs.slack.dev/reference/methods/usergroups.enable</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.usergroups_list"><code class="name flex">
 <span>async def <span class="ident">usergroups_list</span></span>(<span>self,<br>*,<br>include_count: bool | None = None,<br>include_disabled: bool | None = None,<br>include_users: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13498,7 +13580,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all User Groups for a team
-    https://api.slack.com/methods/usergroups.list
+    https://docs.slack.dev/reference/methods/usergroups.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13511,7 +13593,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;usergroups.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all User Groups for a team
-<a href="https://api.slack.com/methods/usergroups.list">https://api.slack.com/methods/usergroups.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.list">https://docs.slack.dev/reference/methods/usergroups.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.usergroups_update"><code class="name flex">
 <span>async def <span class="ident">usergroups_update</span></span>(<span>self,<br>*,<br>usergroup: str,<br>channels: str | Sequence[str] | None = None,<br>description: str | None = None,<br>handle: str | None = None,<br>include_count: bool | None = None,<br>name: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13534,7 +13616,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Update an existing User Group
-    https://api.slack.com/methods/usergroups.update
+    https://docs.slack.dev/reference/methods/usergroups.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13553,7 +13635,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;usergroups.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing User Group
-<a href="https://api.slack.com/methods/usergroups.update">https://api.slack.com/methods/usergroups.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.update">https://docs.slack.dev/reference/methods/usergroups.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.usergroups_users_list"><code class="name flex">
 <span>async def <span class="ident">usergroups_users_list</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_disabled: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13572,7 +13654,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List all users in a User Group
-    https://api.slack.com/methods/usergroups.users.list
+    https://docs.slack.dev/reference/methods/usergroups.users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13584,7 +13666,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;usergroups.users.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all users in a User Group
-<a href="https://api.slack.com/methods/usergroups.users.list">https://api.slack.com/methods/usergroups.users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.users.list">https://docs.slack.dev/reference/methods/usergroups.users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.usergroups_users_update"><code class="name flex">
 <span>async def <span class="ident">usergroups_users_update</span></span>(<span>self,<br>*,<br>usergroup: str,<br>users: str | Sequence[str],<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13604,7 +13686,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Update the list of users for a User Group
-    https://api.slack.com/methods/usergroups.users.update
+    https://docs.slack.dev/reference/methods/usergroups.users.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13620,7 +13702,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update the list of users for a User Group
-<a href="https://api.slack.com/methods/usergroups.users.update">https://api.slack.com/methods/usergroups.users.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.users.update">https://docs.slack.dev/reference/methods/usergroups.users.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_conversations"><code class="name flex">
 <span>async def <span class="ident">users_conversations</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>exclude_archived: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>types: str | Sequence[str] | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13642,7 +13724,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;List conversations the calling user may access.
-    https://api.slack.com/methods/users.conversations
+    https://docs.slack.dev/reference/methods/users.conversations
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13660,7 +13742,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;users.conversations&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List conversations the calling user may access.
-<a href="https://api.slack.com/methods/users.conversations">https://api.slack.com/methods/users.conversations</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.conversations">https://docs.slack.dev/reference/methods/users.conversations</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_deletePhoto"><code class="name flex">
 <span>async def <span class="ident">users_deletePhoto</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13675,12 +13757,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Delete the user profile photo
-    https://api.slack.com/methods/users.deletePhoto
+    https://docs.slack.dev/reference/methods/users.deletePhoto
     &#34;&#34;&#34;
     return await self.api_call(&#34;users.deletePhoto&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete the user profile photo
-<a href="https://api.slack.com/methods/users.deletePhoto">https://api.slack.com/methods/users.deletePhoto</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.deletePhoto">https://docs.slack.dev/reference/methods/users.deletePhoto</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_discoverableContacts_lookup"><code class="name flex">
 <span>async def <span class="ident">users_discoverableContacts_lookup</span></span>(<span>self, email: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13696,13 +13778,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lookup an email address to see if someone is on Slack
-    https://api.slack.com/methods/users.discoverableContacts.lookup
+    https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
     &#34;&#34;&#34;
     kwargs.update({&#34;email&#34;: email})
     return await self.api_call(&#34;users.discoverableContacts.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lookup an email address to see if someone is on Slack
-<a href="https://api.slack.com/methods/users.discoverableContacts.lookup">https://api.slack.com/methods/users.discoverableContacts.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup">https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_getPresence"><code class="name flex">
 <span>async def <span class="ident">users_getPresence</span></span>(<span>self, *, user: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13719,13 +13801,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets user presence information.
-    https://api.slack.com/methods/users.getPresence
+    https://docs.slack.dev/reference/methods/users.getPresence
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user})
     return await self.api_call(&#34;users.getPresence&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets user presence information.
-<a href="https://api.slack.com/methods/users.getPresence">https://api.slack.com/methods/users.getPresence</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.getPresence">https://docs.slack.dev/reference/methods/users.getPresence</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_identity"><code class="name flex">
 <span>async def <span class="ident">users_identity</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13740,12 +13822,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Get a user&#39;s identity.
-    https://api.slack.com/methods/users.identity
+    https://docs.slack.dev/reference/methods/users.identity
     &#34;&#34;&#34;
     return await self.api_call(&#34;users.identity&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a user's identity.
-<a href="https://api.slack.com/methods/users.identity">https://api.slack.com/methods/users.identity</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.identity">https://docs.slack.dev/reference/methods/users.identity</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_info"><code class="name flex">
 <span>async def <span class="ident">users_info</span></span>(<span>self, *, user: str, include_locale: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13763,13 +13845,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Gets information about a user.
-    https://api.slack.com/methods/users.info
+    https://docs.slack.dev/reference/methods/users.info
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user, &#34;include_locale&#34;: include_locale})
     return await self.api_call(&#34;users.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a user.
-<a href="https://api.slack.com/methods/users.info">https://api.slack.com/methods/users.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.info">https://docs.slack.dev/reference/methods/users.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_list"><code class="name flex">
 <span>async def <span class="ident">users_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>include_locale: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13789,7 +13871,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Lists all users in a Slack team.
-    https://api.slack.com/methods/users.list
+    https://docs.slack.dev/reference/methods/users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13802,7 +13884,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;users.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all users in a Slack team.
-<a href="https://api.slack.com/methods/users.list">https://api.slack.com/methods/users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.list">https://docs.slack.dev/reference/methods/users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_lookupByEmail"><code class="name flex">
 <span>async def <span class="ident">users_lookupByEmail</span></span>(<span>self, *, email: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13819,13 +13901,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Find a user with an email address.
-    https://api.slack.com/methods/users.lookupByEmail
+    https://docs.slack.dev/reference/methods/users.lookupByEmail
     &#34;&#34;&#34;
     kwargs.update({&#34;email&#34;: email})
     return await self.api_call(&#34;users.lookupByEmail&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Find a user with an email address.
-<a href="https://api.slack.com/methods/users.lookupByEmail">https://api.slack.com/methods/users.lookupByEmail</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.lookupByEmail">https://docs.slack.dev/reference/methods/users.lookupByEmail</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_profile_get"><code class="name flex">
 <span>async def <span class="ident">users_profile_get</span></span>(<span>self, *, user: str | None = None, include_labels: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13843,13 +13925,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Retrieves a user&#39;s profile information.
-    https://api.slack.com/methods/users.profile.get
+    https://docs.slack.dev/reference/methods/users.profile.get
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user, &#34;include_labels&#34;: include_labels})
     return await self.api_call(&#34;users.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves a user's profile information.
-<a href="https://api.slack.com/methods/users.profile.get">https://api.slack.com/methods/users.profile.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.profile.get">https://docs.slack.dev/reference/methods/users.profile.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_profile_set"><code class="name flex">
 <span>async def <span class="ident">users_profile_set</span></span>(<span>self,<br>*,<br>name: str | None = None,<br>value: str | None = None,<br>user: str | None = None,<br>profile: Dict | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13869,7 +13951,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set the profile information for a user.
-    https://api.slack.com/methods/users.profile.set
+    https://docs.slack.dev/reference/methods/users.profile.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13884,7 +13966,7 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;users.profile.set&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the profile information for a user.
-<a href="https://api.slack.com/methods/users.profile.set">https://api.slack.com/methods/users.profile.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.profile.set">https://docs.slack.dev/reference/methods/users.profile.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_setPhoto"><code class="name flex">
 <span>async def <span class="ident">users_setPhoto</span></span>(<span>self,<br>*,<br>image: str | io.IOBase,<br>crop_w: str | int | None = None,<br>crop_x: str | int | None = None,<br>crop_y: str | int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13904,13 +13986,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Set the user profile photo
-    https://api.slack.com/methods/users.setPhoto
+    https://docs.slack.dev/reference/methods/users.setPhoto
     &#34;&#34;&#34;
     kwargs.update({&#34;crop_w&#34;: crop_w, &#34;crop_x&#34;: crop_x, &#34;crop_y&#34;: crop_y})
     return await self.api_call(&#34;users.setPhoto&#34;, files={&#34;image&#34;: image}, data=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the user profile photo
-<a href="https://api.slack.com/methods/users.setPhoto">https://api.slack.com/methods/users.setPhoto</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.setPhoto">https://docs.slack.dev/reference/methods/users.setPhoto</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.users_setPresence"><code class="name flex">
 <span>async def <span class="ident">users_setPresence</span></span>(<span>self, *, presence: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13927,13 +14009,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Manually sets user presence.
-    https://api.slack.com/methods/users.setPresence
+    https://docs.slack.dev/reference/methods/users.setPresence
     &#34;&#34;&#34;
     kwargs.update({&#34;presence&#34;: presence})
     return await self.api_call(&#34;users.setPresence&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Manually sets user presence.
-<a href="https://api.slack.com/methods/users.setPresence">https://api.slack.com/methods/users.setPresence</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.setPresence">https://docs.slack.dev/reference/methods/users.setPresence</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.views_open"><code class="name flex">
 <span>async def <span class="ident">views_open</span></span>(<span>self,<br>*,<br>trigger_id: str | None = None,<br>interactivity_pointer: str | None = None,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13952,8 +14034,8 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Open a view for a user.
-    https://api.slack.com/methods/views.open
-    See https://api.slack.com/surfaces/modals for details.
+    https://docs.slack.dev/reference/methods/views.open
+    See https://docs.slack.dev/surfaces/modals/ for details.
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
     if isinstance(view, View):
@@ -13965,8 +14047,8 @@ multiparty direct message.</p></div>
     return await self.api_call(&#34;views.open&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Open a view for a user.
-<a href="https://api.slack.com/methods/views.open">https://api.slack.com/methods/views.open</a>
-See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a> for details.</p></div>
+<a href="https://docs.slack.dev/reference/methods/views.open">https://docs.slack.dev/reference/methods/views.open</a>
+See <a href="https://docs.slack.dev/surfaces/modals/">https://docs.slack.dev/surfaces/modals/</a> for details.</p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.views_publish"><code class="name flex">
 <span>async def <span class="ident">views_publish</span></span>(<span>self,<br>*,<br>user_id: str,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>hash: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13986,8 +14068,8 @@ See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfac
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Publish a static view for a User.
     Create or update the view that comprises an
-    app&#39;s Home tab (https://api.slack.com/surfaces/tabs)
-    https://api.slack.com/methods/views.publish
+    app&#39;s Home tab (https://docs.slack.dev/surfaces/app-home/)
+    https://docs.slack.dev/reference/methods/views.publish
     &#34;&#34;&#34;
     kwargs.update({&#34;user_id&#34;: user_id, &#34;hash&#34;: hash})
     if isinstance(view, View):
@@ -14000,8 +14082,8 @@ See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfac
 </details>
 <div class="desc"><p>Publish a static view for a User.
 Create or update the view that comprises an
-app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.com/surfaces/tabs</a>)
-<a href="https://api.slack.com/methods/views.publish">https://api.slack.com/methods/views.publish</a></p></div>
+app's Home tab (<a href="https://docs.slack.dev/surfaces/app-home/">https://docs.slack.dev/surfaces/app-home/</a>)
+<a href="https://docs.slack.dev/reference/methods/views.publish">https://docs.slack.dev/reference/methods/views.publish</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.views_push"><code class="name flex">
 <span>async def <span class="ident">views_push</span></span>(<span>self,<br>*,<br>trigger_id: str | None = None,<br>interactivity_pointer: str | None = None,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -14023,9 +14105,9 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
     Push a new view onto the existing view stack by passing a view
     payload and a valid trigger_id generated from an interaction
     within the existing modal.
-    Read the modals documentation (https://api.slack.com/surfaces/modals)
+    Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
     to learn more about the lifecycle and intricacies of views.
-    https://api.slack.com/methods/views.push
+    https://docs.slack.dev/reference/methods/views.push
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
     if isinstance(view, View):
@@ -14040,9 +14122,9 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
 Push a new view onto the existing view stack by passing a view
 payload and a valid trigger_id generated from an interaction
 within the existing modal.
-Read the modals documentation (<a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a>)
+Read the modals documentation (<a href="https://docs.slack.dev/surfaces/modals/">https://docs.slack.dev/surfaces/modals/</a>)
 to learn more about the lifecycle and intricacies of views.
-<a href="https://api.slack.com/methods/views.push">https://api.slack.com/methods/views.push</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/views.push">https://docs.slack.dev/reference/methods/views.push</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.views_update"><code class="name flex">
 <span>async def <span class="ident">views_update</span></span>(<span>self,<br>*,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>external_id: str | None = None,<br>view_id: str | None = None,<br>hash: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -14064,9 +14146,9 @@ to learn more about the lifecycle and intricacies of views.
     &#34;&#34;&#34;Update an existing view.
     Update a view by passing a new view definition along with the
     view_id returned in views.open or the external_id.
-    See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+    See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
     to learn more about updating views and avoiding race conditions with the hash argument.
-    https://api.slack.com/methods/views.update
+    https://docs.slack.dev/reference/methods/views.update
     &#34;&#34;&#34;
     if isinstance(view, View):
         kwargs.update({&#34;view&#34;: view.to_dict()})
@@ -14086,9 +14168,119 @@ to learn more about the lifecycle and intricacies of views.
 <div class="desc"><p>Update an existing view.
 Update a view by passing a new view definition along with the
 view_id returned in views.open or the external_id.
-See the modals documentation (<a href="https://api.slack.com/surfaces/modals#updating_views">https://api.slack.com/surfaces/modals#updating_views</a>)
+See the modals documentation (<a href="https://docs.slack.dev/surfaces/modals/#updating_views">https://docs.slack.dev/surfaces/modals/#updating_views</a>)
 to learn more about updating views and avoiding race conditions with the hash argument.
-<a href="https://api.slack.com/methods/views.update">https://api.slack.com/methods/views.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/views.update">https://docs.slack.dev/reference/methods/views.update</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.workflows_featured_add"><code class="name flex">
+<span>async def <span class="ident">workflows_featured_add</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def workflows_featured_add(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Add featured workflows to a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.add
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return await self.api_call(&#34;workflows.featured.add&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Add featured workflows to a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.add">https://docs.slack.dev/reference/methods/workflows.featured.add</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.workflows_featured_list"><code class="name flex">
+<span>async def <span class="ident">workflows_featured_list</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def workflows_featured_list(
+    self,
+    *,
+    channel_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;List the featured workflows for specified channels.
+    https://docs.slack.dev/reference/methods/workflows.featured.list
+    &#34;&#34;&#34;
+    if isinstance(channel_ids, (list, tuple)):
+        kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
+    else:
+        kwargs.update({&#34;channel_ids&#34;: channel_ids})
+    return await self.api_call(&#34;workflows.featured.list&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>List the featured workflows for specified channels.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.list">https://docs.slack.dev/reference/methods/workflows.featured.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.workflows_featured_remove"><code class="name flex">
+<span>async def <span class="ident">workflows_featured_remove</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def workflows_featured_remove(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Remove featured workflows from a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.remove
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return await self.api_call(&#34;workflows.featured.remove&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Remove featured workflows from a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.remove">https://docs.slack.dev/reference/methods/workflows.featured.remove</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.workflows_featured_set"><code class="name flex">
+<span>async def <span class="ident">workflows_featured_set</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def workflows_featured_set(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Set featured workflows for a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.set
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return await self.api_call(&#34;workflows.featured.set&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Set featured workflows for a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.set">https://docs.slack.dev/reference/methods/workflows.featured.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.workflows_stepCompleted"><code class="name flex">
 <span>async def <span class="ident">workflows_stepCompleted</span></span>(<span>self, *, workflow_step_execute_id: str, outputs: dict | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -14106,7 +14298,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Indicate a successful outcome of a workflow step&#39;s execution.
-    https://api.slack.com/methods/workflows.stepCompleted
+    https://docs.slack.dev/reference/methods/workflows.stepCompleted
     &#34;&#34;&#34;
     kwargs.update({&#34;workflow_step_execute_id&#34;: workflow_step_execute_id})
     if outputs is not None:
@@ -14116,7 +14308,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return await self.api_call(&#34;workflows.stepCompleted&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Indicate a successful outcome of a workflow step's execution.
-<a href="https://api.slack.com/methods/workflows.stepCompleted">https://api.slack.com/methods/workflows.stepCompleted</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.stepCompleted">https://docs.slack.dev/reference/methods/workflows.stepCompleted</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.workflows_stepFailed"><code class="name flex">
 <span>async def <span class="ident">workflows_stepFailed</span></span>(<span>self, *, workflow_step_execute_id: str, error: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -14134,7 +14326,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Indicate an unsuccessful outcome of a workflow step&#39;s execution.
-    https://api.slack.com/methods/workflows.stepFailed
+    https://docs.slack.dev/reference/methods/workflows.stepFailed
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -14147,7 +14339,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return await self.api_call(&#34;workflows.stepFailed&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Indicate an unsuccessful outcome of a workflow step's execution.
-<a href="https://api.slack.com/methods/workflows.stepFailed">https://api.slack.com/methods/workflows.stepFailed</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.stepFailed">https://docs.slack.dev/reference/methods/workflows.stepFailed</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.workflows_updateStep"><code class="name flex">
 <span>async def <span class="ident">workflows_updateStep</span></span>(<span>self,<br>*,<br>workflow_step_edit_id: str,<br>inputs: Dict[str, Any] | None = None,<br>outputs: List[Dict[str, str]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -14166,7 +14358,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; AsyncSlackResponse:
     &#34;&#34;&#34;Update the configuration for a workflow extension step.
-    https://api.slack.com/methods/workflows.updateStep
+    https://docs.slack.dev/reference/methods/workflows.updateStep
     &#34;&#34;&#34;
     kwargs.update({&#34;workflow_step_edit_id&#34;: workflow_step_edit_id})
     if inputs is not None:
@@ -14178,7 +14370,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return await self.api_call(&#34;workflows.updateStep&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update the configuration for a workflow extension step.
-<a href="https://api.slack.com/methods/workflows.updateStep">https://api.slack.com/methods/workflows.updateStep</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.updateStep">https://docs.slack.dev/reference/methods/workflows.updateStep</a></p></div>
 </dd>
 </dl>
 <h3>Inherited members</h3>
@@ -14513,6 +14705,10 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.views_publish" href="#slack_sdk.web.async_client.AsyncWebClient.views_publish">views_publish</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.views_push" href="#slack_sdk.web.async_client.AsyncWebClient.views_push">views_push</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.views_update" href="#slack_sdk.web.async_client.AsyncWebClient.views_update">views_update</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.workflows_featured_add" href="#slack_sdk.web.async_client.AsyncWebClient.workflows_featured_add">workflows_featured_add</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.workflows_featured_list" href="#slack_sdk.web.async_client.AsyncWebClient.workflows_featured_list">workflows_featured_list</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.workflows_featured_remove" href="#slack_sdk.web.async_client.AsyncWebClient.workflows_featured_remove">workflows_featured_remove</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.workflows_featured_set" href="#slack_sdk.web.async_client.AsyncWebClient.workflows_featured_set">workflows_featured_set</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.workflows_stepCompleted" href="#slack_sdk.web.async_client.AsyncWebClient.workflows_stepCompleted">workflows_stepCompleted</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.workflows_stepFailed" href="#slack_sdk.web.async_client.AsyncWebClient.workflows_stepFailed">workflows_stepFailed</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.workflows_updateStep" href="#slack_sdk.web.async_client.AsyncWebClient.workflows_updateStep">workflows_updateStep</a></code></li>

--- a/docs/reference/web/base_client.html
+++ b/docs/reference/web/base_client.html
@@ -633,7 +633,7 @@ el.replaceWith(d);
         header. The signature is created by combining the signing secret with the
         body of the request we&#39;re sending using a standard HMAC-SHA256 keyed hash.
 
-        https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview
+        https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview
 
         Args:
             signing_secret: Your application&#39;s signing secret, available in the
@@ -690,7 +690,7 @@ def validate_slack_signature(*, signing_secret: str, data: str, timestamp: str, 
     header. The signature is created by combining the signing secret with the
     body of the request we&#39;re sending using a standard HMAC-SHA256 keyed hash.
 
-    https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview
+    https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview
 
     Args:
         signing_secret: Your application&#39;s signing secret, available in the
@@ -720,7 +720,7 @@ signing secret.</p>
 <p>On each HTTP request that Slack sends, we add an X-Slack-Signature HTTP
 header. The signature is created by combining the signing secret with the
 body of the request we're sending using a standard HMAC-SHA256 keyed hash.</p>
-<p><a href="https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview">https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview</a></p>
+<p><a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview">https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>signing_secret</code></strong></dt>

--- a/docs/reference/web/client.html
+++ b/docs/reference/web/client.html
@@ -59,7 +59,7 @@ el.replaceWith(d);
 <pre><code class="python">class WebClient(BaseClient):
     &#34;&#34;&#34;A WebClient allows apps to communicate with the Slack Platform&#39;s Web API.
 
-    https://api.slack.com/methods
+    https://docs.slack.dev/reference/methods
 
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
@@ -130,7 +130,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve analytics data for a given date, presented as a compressed JSON file
-        https://api.slack.com/methods/admin.analytics.getFile
+        https://docs.slack.dev/reference/methods/admin.analytics.getFile
         &#34;&#34;&#34;
         kwargs.update({&#34;type&#34;: type})
         if date is not None:
@@ -152,7 +152,7 @@ el.replaceWith(d);
         Either app_id or request_id is required.
         These IDs can be obtained either directly via the app_requested event,
         or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.approve
+        https://docs.slack.dev/reference/methods/admin.apps.approve
         &#34;&#34;&#34;
         if app_id:
             kwargs.update({&#34;app_id&#34;: app_id})
@@ -179,7 +179,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List approved apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.approved.list
+        https://docs.slack.dev/reference/methods/admin.apps.approved.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -200,7 +200,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Clear an app resolution
-        https://api.slack.com/methods/admin.apps.clearResolution
+        https://docs.slack.dev/reference/methods/admin.apps.clearResolution
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -220,7 +220,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.cancel
+        https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -240,7 +240,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.list
+        https://docs.slack.dev/reference/methods/admin.apps.requests.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -264,7 +264,7 @@ el.replaceWith(d);
         Exactly one of the team_id or enterprise_id arguments is required, not both.
         Either app_id or request_id is required. These IDs can be obtained either directly
         via the app_requested event, or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.restrict
+        https://docs.slack.dev/reference/methods/admin.apps.restrict
         &#34;&#34;&#34;
         if app_id:
             kwargs.update({&#34;app_id&#34;: app_id})
@@ -291,7 +291,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List restricted apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.restricted.list
+        https://docs.slack.dev/reference/methods/admin.apps.restricted.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -313,7 +313,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Uninstall an app from one or many workspaces, or an entire enterprise organization.
         With an org-level token, enterprise_id or team_ids is required.
-        https://api.slack.com/methods/admin.apps.uninstall
+        https://docs.slack.dev/reference/methods/admin.apps.uninstall
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         if enterprise_id is not None:
@@ -344,7 +344,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get logs for a specified team/org
-        https://api.slack.com/methods/admin.apps.activities.list
+        https://docs.slack.dev/reference/methods/admin.apps.activities.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -372,7 +372,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Look up the app config for connectors by their IDs
-        https://api.slack.com/methods/admin.apps.config.lookup
+        https://docs.slack.dev/reference/methods/admin.apps.config.lookup
         &#34;&#34;&#34;
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -389,7 +389,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the app config for a connector
-        https://api.slack.com/methods/admin.apps.config.set
+        https://docs.slack.dev/reference/methods/admin.apps.config.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -411,7 +411,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.
-        https://api.slack.com/methods/admin.auth.policy.getEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
         &#34;&#34;&#34;
         kwargs.update({&#34;policy_name&#34;: policy_name})
         if cursor is not None:
@@ -431,7 +431,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Assign entities to a particular authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.assignEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
         &#34;&#34;&#34;
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -450,7 +450,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove specified entities from a specified authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.removeEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
         &#34;&#34;&#34;
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -469,7 +469,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a Salesforce channel for the corresponding object provided.
-        https://api.slack.com/methods/admin.conversations.createForObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
         &#34;&#34;&#34;
         kwargs.update(
             {&#34;object_id&#34;: object_id, &#34;salesforce_org_id&#34;: salesforce_org_id, &#34;invite_object_team&#34;: invite_object_team}
@@ -485,7 +485,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Link a Salesforce record to a channel.
-        https://api.slack.com/methods/admin.conversations.linkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -504,7 +504,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Unlink a Salesforce record from a channel.
-        https://api.slack.com/methods/admin.conversations.unlinkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -523,7 +523,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create an Information Barrier
-        https://api.slack.com/methods/admin.barriers.create
+        https://docs.slack.dev/reference/methods/admin.barriers.create
         &#34;&#34;&#34;
         kwargs.update({&#34;primary_usergroup_id&#34;: primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -543,7 +543,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Delete an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.delete
+        https://docs.slack.dev/reference/methods/admin.barriers.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;barrier_id&#34;: barrier_id})
         return self.api_call(&#34;admin.barriers.delete&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -558,7 +558,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.update
+        https://docs.slack.dev/reference/methods/admin.barriers.update
         &#34;&#34;&#34;
         kwargs.update({&#34;barrier_id&#34;: barrier_id, &#34;primary_usergroup_id&#34;: primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -579,7 +579,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get all Information Barriers for your organization
-        https://api.slack.com/methods/admin.barriers.list&#34;&#34;&#34;
+        https://docs.slack.dev/reference/methods/admin.barriers.list&#34;&#34;&#34;
         kwargs.update(
             {
                 &#34;cursor&#34;: cursor,
@@ -599,7 +599,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a public or private channel-based conversation.
-        https://api.slack.com/methods/admin.conversations.create
+        https://docs.slack.dev/reference/methods/admin.conversations.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -619,7 +619,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Delete a public or private channel.
-        https://api.slack.com/methods/admin.conversations.delete
+        https://docs.slack.dev/reference/methods/admin.conversations.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.delete&#34;, params=kwargs)
@@ -632,7 +632,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invite a user to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.invite
+        https://docs.slack.dev/reference/methods/admin.conversations.invite
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(user_ids, (list, tuple)):
@@ -649,7 +649,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Archive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.archive&#34;, params=kwargs)
@@ -661,7 +661,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Unarchive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.unarchive&#34;, params=kwargs)
@@ -674,7 +674,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Rename a public or private channel.
-        https://api.slack.com/methods/admin.conversations.rename
+        https://docs.slack.dev/reference/methods/admin.conversations.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;name&#34;: name})
         return self.api_call(&#34;admin.conversations.rename&#34;, params=kwargs)
@@ -692,7 +692,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.
-        https://api.slack.com/methods/admin.conversations.search
+        https://docs.slack.dev/reference/methods/admin.conversations.search
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -723,7 +723,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Convert a public channel to a private channel.
-        https://api.slack.com/methods/admin.conversations.convertToPrivate
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.convertToPrivate&#34;, params=kwargs)
@@ -735,7 +735,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Convert a privte channel to a public channel.
-        https://api.slack.com/methods/admin.conversations.convertToPublic
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.convertToPublic&#34;, params=kwargs)
@@ -748,7 +748,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the posting permissions for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(prefs, dict):
@@ -764,7 +764,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get conversation preferences for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.getConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.getConversationPrefs&#34;, params=kwargs)
@@ -777,7 +777,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Disconnect a connected channel from one or more workspaces.
-        https://api.slack.com/methods/admin.conversations.disconnectShared
+        https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(leaving_team_ids, (list, tuple)):
@@ -797,7 +797,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Returns channels on the given team using the filters.
-        https://api.slack.com/methods/admin.conversations.lookup
+        https://docs.slack.dev/reference/methods/admin.conversations.lookup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -825,7 +825,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;List all disconnected channels—i.e.,
         channels that were once connected to other workspaces and then disconnected—and
         the corresponding original channel IDs for key revocation with EKM.
-        https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+        https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -852,7 +852,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an allowlist of IDP groups for accessing a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -875,7 +875,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all IDP Groups linked to a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -898,7 +898,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a linked IDP group linked from a private channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -923,7 +923,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.setTeams
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -947,7 +947,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a channel.
-        https://api.slack.com/methods/admin.conversations.getTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.getTeams
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -965,7 +965,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.getCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.getCustomRetention&#34;, params=kwargs)
@@ -977,7 +977,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.removeCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.removeCustomRetention&#34;, params=kwargs)
@@ -990,7 +990,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.setCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;duration_days&#34;: duration_days})
         return self.api_call(&#34;admin.conversations.setCustomRetention&#34;, params=kwargs)
@@ -1002,7 +1002,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Archive public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkArchive
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
         return self.api_call(&#34;admin.conversations.bulkArchive&#34;, params=kwargs)
@@ -1027,7 +1027,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Move public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkMove
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1045,7 +1045,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an emoji.
-        https://api.slack.com/methods/admin.emoji.add
+        https://docs.slack.dev/reference/methods/admin.emoji.add
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;url&#34;: url})
         return self.api_call(&#34;admin.emoji.add&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1058,7 +1058,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an emoji alias.
-        https://api.slack.com/methods/admin.emoji.addAlias
+        https://docs.slack.dev/reference/methods/admin.emoji.addAlias
         &#34;&#34;&#34;
         kwargs.update({&#34;alias_for&#34;: alias_for, &#34;name&#34;: name})
         return self.api_call(&#34;admin.emoji.addAlias&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1071,7 +1071,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List emoji for an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.list
+        https://docs.slack.dev/reference/methods/admin.emoji.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1083,7 +1083,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove an emoji across an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.remove
+        https://docs.slack.dev/reference/methods/admin.emoji.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name})
         return self.api_call(&#34;admin.emoji.remove&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1096,7 +1096,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Rename an emoji.
-        https://api.slack.com/methods/admin.emoji.rename
+        https://docs.slack.dev/reference/methods/admin.emoji.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;new_name&#34;: new_name})
         return self.api_call(&#34;admin.emoji.rename&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1111,7 +1111,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Look up functions by a set of apps
-        https://api.slack.com/methods/admin.functions.list
+        https://docs.slack.dev/reference/methods/admin.functions.list
         &#34;&#34;&#34;
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -1134,7 +1134,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lookup the visibility of multiple Slack functions
         and include the users if it is limited to particular named entities.
-        https://api.slack.com/methods/admin.functions.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
         &#34;&#34;&#34;
         if isinstance(function_ids, (list, tuple)):
             kwargs.update({&#34;function_ids&#34;: &#34;,&#34;.join(function_ids)})
@@ -1152,7 +1152,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the visibility of a Slack function
         and define the users or workspaces if it is set to named_entities
-        https://api.slack.com/methods/admin.functions.permissions.set
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1176,7 +1176,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds members to the specified role with the specified scopes
-        https://api.slack.com/methods/admin.roles.addAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.addAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;role_id&#34;: role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1201,7 +1201,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists assignments for all roles across entities.
             Options to scope results by any combination of roles or entities
-        https://api.slack.com/methods/admin.roles.listAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.listAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;sort_dir&#34;: sort_dir})
         if isinstance(entity_ids, (list, tuple)):
@@ -1223,7 +1223,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a set of users from a role for the given scopes and entities
-        https://api.slack.com/methods/admin.roles.removeAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;role_id&#34;: role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1245,7 +1245,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Wipes all valid sessions on all devices for a given user.
-        https://api.slack.com/methods/admin.users.session.reset
+        https://docs.slack.dev/reference/methods/admin.users.session.reset
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1265,7 +1265,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-        https://api.slack.com/methods/admin.users.session.resetBulk
+        https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1287,7 +1287,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invalidate a single session for a user by session_id.
-        https://api.slack.com/methods/admin.users.session.invalidate
+        https://docs.slack.dev/reference/methods/admin.users.session.invalidate
         &#34;&#34;&#34;
         kwargs.update({&#34;session_id&#34;: session_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.users.session.invalidate&#34;, params=kwargs)
@@ -1302,7 +1302,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all active user sessions for an organization
-        https://api.slack.com/methods/admin.users.session.list
+        https://docs.slack.dev/reference/methods/admin.users.session.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1322,7 +1322,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the default channels of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1339,7 +1339,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get user-specific session settings—the session duration
         and what happens when the client closes—given a list of users.
-        https://api.slack.com/methods/admin.users.session.getSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.getSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1357,7 +1357,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Configure the user-level session settings—the session duration
         and what happens when the client closes—for one or more users.
-        https://api.slack.com/methods/admin.users.session.setSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.setSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1379,7 +1379,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Clear user-specific session settings—the session duration
         and what happens when the client closes—for a list of users.
-        https://api.slack.com/methods/admin.users.session.clearSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1396,7 +1396,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ask Slackbot to send you an export listing all workspace members using unsupported software,
         presented as a zipped CSV file.
-        https://api.slack.com/methods/admin.users.unsupportedVersions.export
+        https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1414,7 +1414,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Approve a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.approve
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.inviteRequests.approve&#34;, params=kwargs)
@@ -1428,7 +1428,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all approved workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.approved.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1448,7 +1448,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all denied workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.denied.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1467,7 +1467,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deny a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.deny
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.inviteRequests.deny&#34;, params=kwargs)
@@ -1488,7 +1488,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.inviteRequests.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1509,7 +1509,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create an Enterprise team.
-        https://api.slack.com/methods/admin.teams.create
+        https://docs.slack.dev/reference/methods/admin.teams.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1529,7 +1529,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all teams on an Enterprise organization.
-        https://api.slack.com/methods/admin.teams.list
+        https://docs.slack.dev/reference/methods/admin.teams.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
@@ -1543,7 +1543,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.teams.owners.list
+        https://docs.slack.dev/reference/methods/admin.teams.owners.list
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.teams.owners.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1555,7 +1555,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Fetch information about settings in a workspace
-        https://api.slack.com/methods/admin.teams.settings.info
+        https://docs.slack.dev/reference/methods/admin.teams.settings.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.teams.settings.info&#34;, params=kwargs)
@@ -1568,7 +1568,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the description of a given workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDescription
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;description&#34;: description})
         return self.api_call(&#34;admin.teams.settings.setDescription&#34;, params=kwargs)
@@ -1581,7 +1581,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;discoverability&#34;: discoverability})
         return self.api_call(&#34;admin.teams.settings.setDiscoverability&#34;, params=kwargs)
@@ -1594,7 +1594,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setIcon
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;image_url&#34;: image_url})
         return self.api_call(&#34;admin.teams.settings.setIcon&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1607,7 +1607,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setName
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setName
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;name&#34;: name})
         return self.api_call(&#34;admin.teams.settings.setName&#34;, params=kwargs)
@@ -1621,7 +1621,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.addChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;usergroup_id&#34;: usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1639,7 +1639,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Associate one or more default workspaces with an organization-wide IDP group.
-        https://api.slack.com/methods/admin.usergroups.addTeams
+        https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup_id&#34;: usergroup_id, &#34;auto_provision&#34;: auto_provision})
         if isinstance(team_ids, (list, tuple)):
@@ -1657,7 +1657,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.listChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1676,7 +1676,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.removeChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup_id&#34;: usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1696,7 +1696,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an Enterprise user to a workspace.
-        https://api.slack.com/methods/admin.users.assign
+        https://docs.slack.dev/reference/methods/admin.users.assign
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1728,7 +1728,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invite a user to a workspace.
-        https://api.slack.com/methods/admin.users.invite
+        https://docs.slack.dev/reference/methods/admin.users.invite
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1752,7 +1752,7 @@ el.replaceWith(d);
     def admin_users_list(
         self,
         *,
-        team_id: str,
+        team_id: Optional[str] = None,
         include_deactivated_user_workspaces: Optional[bool] = None,
         is_active: Optional[bool] = None,
         cursor: Optional[str] = None,
@@ -1760,7 +1760,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List users on a workspace
-        https://api.slack.com/methods/admin.users.list
+        https://docs.slack.dev/reference/methods/admin.users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1781,7 +1781,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a user from a workspace.
-        https://api.slack.com/methods/admin.users.remove
+        https://docs.slack.dev/reference/methods/admin.users.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.remove&#34;, params=kwargs)
@@ -1794,7 +1794,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an existing guest, regular user, or owner to be an admin user.
-        https://api.slack.com/methods/admin.users.setAdmin
+        https://docs.slack.dev/reference/methods/admin.users.setAdmin
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setAdmin&#34;, params=kwargs)
@@ -1808,7 +1808,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an expiration for a guest user.
-        https://api.slack.com/methods/admin.users.setExpiration
+        https://docs.slack.dev/reference/methods/admin.users.setExpiration
         &#34;&#34;&#34;
         kwargs.update({&#34;expiration_ts&#34;: expiration_ts, &#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setExpiration&#34;, params=kwargs)
@@ -1821,7 +1821,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an existing guest, regular user, or admin user to be a workspace owner.
-        https://api.slack.com/methods/admin.users.setOwner
+        https://docs.slack.dev/reference/methods/admin.users.setOwner
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setOwner&#34;, params=kwargs)
@@ -1834,7 +1834,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an existing guest user, admin user, or owner to be a regular user.
-        https://api.slack.com/methods/admin.users.setRegular
+        https://docs.slack.dev/reference/methods/admin.users.setRegular
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setRegular&#34;, params=kwargs)
@@ -1855,7 +1855,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Search workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.search
+        https://docs.slack.dev/reference/methods/admin.workflows.search
         &#34;&#34;&#34;
         if collaborator_ids is not None:
             if isinstance(collaborator_ids, (list, tuple)):
@@ -1885,7 +1885,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Look up the permissions for a set of workflows
-        https://api.slack.com/methods/admin.workflows.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
         &#34;&#34;&#34;
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -1906,7 +1906,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add collaborators to workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.add
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
         &#34;&#34;&#34;
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -1926,7 +1926,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove collaborators from workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.remove
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
         &#34;&#34;&#34;
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -1945,7 +1945,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Unpublish workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.unpublish
+        https://docs.slack.dev/reference/methods/admin.workflows.unpublish
         &#34;&#34;&#34;
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -1960,7 +1960,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Checks API calling code.
-        https://api.slack.com/methods/api.test
+        https://docs.slack.dev/reference/methods/api.test
         &#34;&#34;&#34;
         kwargs.update({&#34;error&#34;: error})
         return self.api_call(&#34;api.test&#34;, params=kwargs)
@@ -1973,7 +1973,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Generate a temporary Socket Mode WebSocket URL that your app can connect to
         in order to receive events and interactive payloads
-        https://api.slack.com/methods/apps.connections.open
+        https://docs.slack.dev/reference/methods/apps.connections.open
         &#34;&#34;&#34;
         kwargs.update({&#34;token&#34;: app_token})
         return self.api_call(&#34;apps.connections.open&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -1988,7 +1988,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get a list of authorizations for the given event context.
         Each authorization represents an app installation that the event is visible to.
-        https://api.slack.com/methods/apps.event.authorizations.list
+        https://docs.slack.dev/reference/methods/apps.event.authorizations.list
         &#34;&#34;&#34;
         kwargs.update({&#34;event_context&#34;: event_context, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;apps.event.authorizations.list&#34;, params=kwargs)
@@ -2001,7 +2001,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Uninstalls your app from a workspace.
-        https://api.slack.com/methods/apps.uninstall
+        https://docs.slack.dev/reference/methods/apps.uninstall
         &#34;&#34;&#34;
         kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret})
         return self.api_call(&#34;apps.uninstall&#34;, params=kwargs)
@@ -2013,7 +2013,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.create
+        https://docs.slack.dev/reference/methods/apps.manifest.create
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2028,7 +2028,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Permanently deletes an app created through app manifests
-        https://api.slack.com/methods/apps.manifest.delete
+        https://docs.slack.dev/reference/methods/apps.manifest.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         return self.api_call(&#34;apps.manifest.delete&#34;, params=kwargs)
@@ -2040,7 +2040,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Export an app manifest from an existing app
-        https://api.slack.com/methods/apps.manifest.export
+        https://docs.slack.dev/reference/methods/apps.manifest.export
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         return self.api_call(&#34;apps.manifest.export&#34;, params=kwargs)
@@ -2053,7 +2053,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.update
+        https://docs.slack.dev/reference/methods/apps.manifest.update
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2070,7 +2070,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Validate an app manifest
-        https://api.slack.com/methods/apps.manifest.validate
+        https://docs.slack.dev/reference/methods/apps.manifest.validate
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2086,7 +2086,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a refresh token for a new app configuration token
-        https://api.slack.com/methods/tooling.tokens.rotate
+        https://docs.slack.dev/reference/methods/tooling.tokens.rotate
         &#34;&#34;&#34;
         kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return self.api_call(&#34;tooling.tokens.rotate&#34;, params=kwargs)
@@ -2100,7 +2100,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setStatus
+        https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status})
         return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)
@@ -2114,7 +2114,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setTitle
+        https://docs.slack.dev/reference/methods/assistant.threads.setTitle
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;title&#34;: title})
         return self.api_call(&#34;assistant.threads.setTitle&#34;, params=kwargs)
@@ -2129,7 +2129,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+        https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
         if title is not None:
@@ -2143,7 +2143,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/auth.revoke
+        https://docs.slack.dev/reference/methods/auth.revoke
         &#34;&#34;&#34;
         kwargs.update({&#34;test&#34;: test})
         return self.api_call(&#34;auth.revoke&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2153,7 +2153,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Checks authentication &amp; identity.
-        https://api.slack.com/methods/auth.test
+        https://docs.slack.dev/reference/methods/auth.test
         &#34;&#34;&#34;
         return self.api_call(&#34;auth.test&#34;, params=kwargs)
 
@@ -2165,7 +2165,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List the workspaces a token can access.
-        https://api.slack.com/methods/auth.teams.list
+        https://docs.slack.dev/reference/methods/auth.teams.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;include_icon&#34;: include_icon})
         return self.api_call(&#34;auth.teams.list&#34;, params=kwargs)
@@ -2183,7 +2183,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add bookmark to a channel.
-        https://api.slack.com/methods/bookmarks.add
+        https://docs.slack.dev/reference/methods/bookmarks.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2209,7 +2209,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Edit bookmark.
-        https://api.slack.com/methods/bookmarks.edit
+        https://docs.slack.dev/reference/methods/bookmarks.edit
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2229,7 +2229,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List bookmark for the channel.
-        https://api.slack.com/methods/bookmarks.list
+        https://docs.slack.dev/reference/methods/bookmarks.list
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;bookmarks.list&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2242,7 +2242,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove bookmark from the channel.
-        https://api.slack.com/methods/bookmarks.remove
+        https://docs.slack.dev/reference/methods/bookmarks.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;bookmark_id&#34;: bookmark_id, &#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;bookmarks.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2255,7 +2255,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a bot user.
-        https://api.slack.com/methods/bots.info
+        https://docs.slack.dev/reference/methods/bots.info
         &#34;&#34;&#34;
         kwargs.update({&#34;bot&#34;: bot, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;bots.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2274,7 +2274,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Registers a new Call.
-        https://api.slack.com/methods/calls.add
+        https://docs.slack.dev/reference/methods/calls.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2301,7 +2301,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ends a Call.
-        https://api.slack.com/methods/calls.end
+        https://docs.slack.dev/reference/methods/calls.end
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id, &#34;duration&#34;: duration})
         return self.api_call(&#34;calls.end&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2313,7 +2313,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Returns information about a Call.
-        https://api.slack.com/methods/calls.info
+        https://docs.slack.dev/reference/methods/calls.info
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         return self.api_call(&#34;calls.info&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2326,7 +2326,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Registers new participants added to a Call.
-        https://api.slack.com/methods/calls.participants.add
+        https://docs.slack.dev/reference/methods/calls.participants.add
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         _update_call_participants(kwargs, users)
@@ -2340,7 +2340,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Registers participants removed from a Call.
-        https://api.slack.com/methods/calls.participants.remove
+        https://docs.slack.dev/reference/methods/calls.participants.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         _update_call_participants(kwargs, users)
@@ -2356,7 +2356,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Updates information about a Call.
-        https://api.slack.com/methods/calls.update
+        https://docs.slack.dev/reference/methods/calls.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2376,7 +2376,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create Canvas for a user
-        https://api.slack.com/methods/canvases.create
+        https://docs.slack.dev/reference/methods/canvases.create
         &#34;&#34;&#34;
         kwargs.update({&#34;title&#34;: title, &#34;document_content&#34;: document_content})
         return self.api_call(&#34;canvases.create&#34;, json=kwargs)
@@ -2389,7 +2389,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an existing canvas
-        https://api.slack.com/methods/canvases.edit
+        https://docs.slack.dev/reference/methods/canvases.edit
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;changes&#34;: changes})
         return self.api_call(&#34;canvases.edit&#34;, json=kwargs)
@@ -2401,7 +2401,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a canvas
-        https://api.slack.com/methods/canvases.delete
+        https://docs.slack.dev/reference/methods/canvases.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id})
         return self.api_call(&#34;canvases.delete&#34;, params=kwargs)
@@ -2416,7 +2416,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the access level to a canvas for specified entities
-        https://api.slack.com/methods/canvases.access.set
+        https://docs.slack.dev/reference/methods/canvases.access.set
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;access_level&#34;: access_level})
         if channel_ids is not None:
@@ -2441,7 +2441,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a Channel Canvas for a channel
-        https://api.slack.com/methods/canvases.access.delete
+        https://docs.slack.dev/reference/methods/canvases.access.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id})
         if channel_ids is not None:
@@ -2464,7 +2464,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Find sections matching the provided criteria
-        https://api.slack.com/methods/canvases.sections.lookup
+        https://docs.slack.dev/reference/methods/canvases.sections.lookup
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;criteria&#34;: json.dumps(criteria)})
         return self.api_call(&#34;canvases.sections.lookup&#34;, params=kwargs)
@@ -2472,7 +2472,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: channels.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def channels_archive(
@@ -2651,7 +2651,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a message.
-        https://api.slack.com/methods/chat.delete
+        https://docs.slack.dev/reference/methods/chat.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts, &#34;as_user&#34;: as_user})
         return self.api_call(&#34;chat.delete&#34;, params=kwargs)
@@ -2665,7 +2665,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a scheduled message.
-        https://api.slack.com/methods/chat.deleteScheduledMessage
+        https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2684,7 +2684,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a permalink URL for a specific extant message
-        https://api.slack.com/methods/chat.getPermalink
+        https://docs.slack.dev/reference/methods/chat.getPermalink
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;message_ts&#34;: message_ts})
         return self.api_call(&#34;chat.getPermalink&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2697,7 +2697,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Share a me message into a channel.
-        https://api.slack.com/methods/chat.meMessage
+        https://docs.slack.dev/reference/methods/chat.meMessage
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;text&#34;: text})
         return self.api_call(&#34;chat.meMessage&#34;, params=kwargs)
@@ -2717,10 +2717,11 @@ el.replaceWith(d);
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sends an ephemeral message to a user in a channel.
-        https://api.slack.com/methods/chat.postEphemeral
+        https://docs.slack.dev/reference/methods/chat.postEphemeral
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2736,11 +2737,12 @@ el.replaceWith(d);
                 &#34;link_names&#34;: link_names,
                 &#34;username&#34;: username,
                 &#34;parse&#34;: parse,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.postEphemeral&#34;, json=kwargs)
 
@@ -2764,10 +2766,11 @@ el.replaceWith(d);
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sends a message to a channel.
-        https://api.slack.com/methods/chat.postMessage
+        https://docs.slack.dev/reference/methods/chat.postMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2788,11 +2791,12 @@ el.replaceWith(d);
                 &#34;username&#34;: username,
                 &#34;parse&#34;: parse,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postMessage&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.postMessage&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.postMessage&#34;, json=kwargs)
 
@@ -2801,7 +2805,7 @@ el.replaceWith(d);
         *,
         channel: str,
         post_at: Union[str, int],
-        text: str,
+        text: Optional[str] = None,
         as_user: Optional[bool] = None,
         attachments: Optional[Union[str, Sequence[Union[Dict, Attachment]]]] = None,
         blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
@@ -2812,10 +2816,11 @@ el.replaceWith(d);
         unfurl_media: Optional[bool] = None,
         link_names: Optional[bool] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Schedules a message.
-        https://api.slack.com/methods/chat.scheduleMessage
+        https://docs.slack.dev/reference/methods/chat.scheduleMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2832,11 +2837,12 @@ el.replaceWith(d);
                 &#34;unfurl_media&#34;: unfurl_media,
                 &#34;link_names&#34;: link_names,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.scheduleMessage&#34;, json=kwargs)
 
@@ -2855,7 +2861,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Provide custom unfurl behavior for user-posted URLs.
-        https://api.slack.com/methods/chat.unfurl
+        https://docs.slack.dev/reference/methods/chat.unfurl
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2889,10 +2895,11 @@ el.replaceWith(d);
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Updates a message in a channel.
-        https://api.slack.com/methods/chat.update
+        https://docs.slack.dev/reference/methods/chat.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2906,6 +2913,7 @@ el.replaceWith(d);
                 &#34;parse&#34;: parse,
                 &#34;reply_broadcast&#34;: reply_broadcast,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         if isinstance(file_ids, (list, tuple)):
@@ -2914,7 +2922,7 @@ el.replaceWith(d);
             kwargs.update({&#34;file_ids&#34;: file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.update&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.update&#34;, kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return self.api_call(&#34;chat.update&#34;, json=kwargs)
 
@@ -2930,7 +2938,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all scheduled messages.
-        https://api.slack.com/methods/chat.scheduledMessages.list
+        https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2956,7 +2964,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Accepts an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.acceptSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
         &#34;&#34;&#34;
         if channel_id is None and invite_id is None:
             raise e.SlackRequestError(&#34;Either channel_id or invite_id must be provided.&#34;)
@@ -2980,7 +2988,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Approves an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.approveSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
         return self.api_call(&#34;conversations.approveSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2992,7 +3000,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Archives a conversation.
-        https://api.slack.com/methods/conversations.archive
+        https://docs.slack.dev/reference/methods/conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.archive&#34;, params=kwargs)
@@ -3004,7 +3012,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Closes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.close
+        https://docs.slack.dev/reference/methods/conversations.close
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.close&#34;, params=kwargs)
@@ -3018,7 +3026,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Initiates a public or private channel-based conversation
-        https://api.slack.com/methods/conversations.create
+        https://docs.slack.dev/reference/methods/conversations.create
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;is_private&#34;: is_private, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;conversations.create&#34;, params=kwargs)
@@ -3031,7 +3039,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Declines a Slack Connect channel invite.
-        https://api.slack.com/methods/conversations.declineSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
         return self.api_call(&#34;conversations.declineSharedInvite&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3040,7 +3048,7 @@ el.replaceWith(d);
         self, *, action: str, channel: str, target_team: str, **kwargs
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-        https://api.slack.com/methods/conversations.externalInvitePermissions.set
+        https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3064,7 +3072,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Fetches a conversation&#39;s history of messages and events.
-        https://api.slack.com/methods/conversations.history
+        https://docs.slack.dev/reference/methods/conversations.history
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3088,7 +3096,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve information about a conversation.
-        https://api.slack.com/methods/conversations.info
+        https://docs.slack.dev/reference/methods/conversations.info
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3108,7 +3116,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invites users to a channel.
-        https://api.slack.com/methods/conversations.invite
+        https://docs.slack.dev/reference/methods/conversations.invite
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3131,7 +3139,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sends an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.inviteShared
+        https://docs.slack.dev/reference/methods/conversations.inviteShared
         &#34;&#34;&#34;
         if emails is None and user_ids is None:
             raise e.SlackRequestError(&#34;Either emails or user ids must be provided.&#34;)
@@ -3153,7 +3161,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Joins an existing conversation.
-        https://api.slack.com/methods/conversations.join
+        https://docs.slack.dev/reference/methods/conversations.join
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.join&#34;, params=kwargs)
@@ -3166,7 +3174,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a user from a conversation.
-        https://api.slack.com/methods/conversations.kick
+        https://docs.slack.dev/reference/methods/conversations.kick
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;user&#34;: user})
         return self.api_call(&#34;conversations.kick&#34;, params=kwargs)
@@ -3178,7 +3186,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Leaves a conversation.
-        https://api.slack.com/methods/conversations.leave
+        https://docs.slack.dev/reference/methods/conversations.leave
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.leave&#34;, params=kwargs)
@@ -3194,7 +3202,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all channels in a Slack team.
-        https://api.slack.com/methods/conversations.list
+        https://docs.slack.dev/reference/methods/conversations.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3220,7 +3228,7 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List shared channel invites that have been generated
         or received but have not yet been approved by all parties.
-        https://api.slack.com/methods/conversations.listConnectInvites
+        https://docs.slack.dev/reference/methods/conversations.listConnectInvites
         &#34;&#34;&#34;
         kwargs.update({&#34;count&#34;: count, &#34;cursor&#34;: cursor, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;conversations.listConnectInvites&#34;, params=kwargs)
@@ -3233,7 +3241,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the read cursor in a channel.
-        https://api.slack.com/methods/conversations.mark
+        https://docs.slack.dev/reference/methods/conversations.mark
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts})
         return self.api_call(&#34;conversations.mark&#34;, params=kwargs)
@@ -3247,7 +3255,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve members of a conversation.
-        https://api.slack.com/methods/conversations.members
+        https://docs.slack.dev/reference/methods/conversations.members
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;conversations.members&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3261,7 +3269,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Opens or resumes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.open
+        https://docs.slack.dev/reference/methods/conversations.open
         &#34;&#34;&#34;
         if channel is None and users is None:
             raise e.SlackRequestError(&#34;Either channel or users must be provided.&#34;)
@@ -3280,7 +3288,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Renames a conversation.
-        https://api.slack.com/methods/conversations.rename
+        https://docs.slack.dev/reference/methods/conversations.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name})
         return self.api_call(&#34;conversations.rename&#34;, params=kwargs)
@@ -3299,7 +3307,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a thread of messages posted to a conversation
-        https://api.slack.com/methods/conversations.replies
+        https://docs.slack.dev/reference/methods/conversations.replies
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3325,7 +3333,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-        https://api.slack.com/methods/conversations.requestSharedInvite.approve
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3346,7 +3354,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deny a request to invite an external user to a channel.
-        https://api.slack.com/methods/conversations.requestSharedInvite.deny
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;message&#34;: message})
         return self.api_call(&#34;conversations.requestSharedInvite.deny&#34;, params=kwargs)
@@ -3364,7 +3372,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists requests to add external users to channels with ability to filter.
-        https://api.slack.com/methods/conversations.requestSharedInvite.list
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3391,7 +3399,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the purpose for a conversation.
-        https://api.slack.com/methods/conversations.setPurpose
+        https://docs.slack.dev/reference/methods/conversations.setPurpose
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;purpose&#34;: purpose})
         return self.api_call(&#34;conversations.setPurpose&#34;, params=kwargs)
@@ -3404,7 +3412,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the topic for a conversation.
-        https://api.slack.com/methods/conversations.setTopic
+        https://docs.slack.dev/reference/methods/conversations.setTopic
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;topic&#34;: topic})
         return self.api_call(&#34;conversations.setTopic&#34;, params=kwargs)
@@ -3416,7 +3424,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Reverses conversation archival.
-        https://api.slack.com/methods/conversations.unarchive
+        https://docs.slack.dev/reference/methods/conversations.unarchive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.unarchive&#34;, params=kwargs)
@@ -3429,7 +3437,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a Channel Canvas for a channel
-        https://api.slack.com/methods/conversations.canvases.create
+        https://docs.slack.dev/reference/methods/conversations.canvases.create
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;document_content&#34;: document_content})
         return self.api_call(&#34;conversations.canvases.create&#34;, json=kwargs)
@@ -3442,7 +3450,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Open a dialog with a user.
-        https://api.slack.com/methods/dialog.open
+        https://docs.slack.dev/reference/methods/dialog.open
         &#34;&#34;&#34;
         kwargs.update({&#34;dialog&#34;: dialog, &#34;trigger_id&#34;: trigger_id})
         kwargs = _remove_none_values(kwargs)
@@ -3454,7 +3462,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ends the current user&#39;s Do Not Disturb session immediately.
-        https://api.slack.com/methods/dnd.endDnd
+        https://docs.slack.dev/reference/methods/dnd.endDnd
         &#34;&#34;&#34;
         return self.api_call(&#34;dnd.endDnd&#34;, params=kwargs)
 
@@ -3463,7 +3471,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ends the current user&#39;s snooze mode immediately.
-        https://api.slack.com/methods/dnd.endSnooze
+        https://docs.slack.dev/reference/methods/dnd.endSnooze
         &#34;&#34;&#34;
         return self.api_call(&#34;dnd.endSnooze&#34;, params=kwargs)
 
@@ -3475,7 +3483,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieves a user&#39;s current Do Not Disturb status.
-        https://api.slack.com/methods/dnd.info
+        https://docs.slack.dev/reference/methods/dnd.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
         return self.api_call(&#34;dnd.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3487,7 +3495,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Turns on Do Not Disturb mode for the current user, or changes its duration.
-        https://api.slack.com/methods/dnd.setSnooze
+        https://docs.slack.dev/reference/methods/dnd.setSnooze
         &#34;&#34;&#34;
         kwargs.update({&#34;num_minutes&#34;: num_minutes})
         return self.api_call(&#34;dnd.setSnooze&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3499,7 +3507,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieves the Do Not Disturb status for users on a team.
-        https://api.slack.com/methods/dnd.teamInfo
+        https://docs.slack.dev/reference/methods/dnd.teamInfo
         &#34;&#34;&#34;
         if isinstance(users, (list, tuple)):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -3514,7 +3522,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists custom emoji for a team.
-        https://api.slack.com/methods/emoji.list
+        https://docs.slack.dev/reference/methods/emoji.list
         &#34;&#34;&#34;
         kwargs.update({&#34;include_categories&#34;: include_categories})
         return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3527,7 +3535,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes an existing comment on a file.
-        https://api.slack.com/methods/files.comments.delete
+        https://docs.slack.dev/reference/methods/files.comments.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file, &#34;id&#34;: id})
         return self.api_call(&#34;files.comments.delete&#34;, params=kwargs)
@@ -3539,7 +3547,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a file.
-        https://api.slack.com/methods/files.delete
+        https://docs.slack.dev/reference/methods/files.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.delete&#34;, params=kwargs)
@@ -3555,7 +3563,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a team file.
-        https://api.slack.com/methods/files.info
+        https://docs.slack.dev/reference/methods/files.info
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3583,7 +3591,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists &amp; filters team files.
-        https://api.slack.com/methods/files.list
+        https://docs.slack.dev/reference/methods/files.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3611,7 +3619,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.info
+        https://docs.slack.dev/reference/methods/files.remote.info
         &#34;&#34;&#34;
         kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
         return self.api_call(&#34;files.remote.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3627,7 +3635,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.list
+        https://docs.slack.dev/reference/methods/files.remote.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3652,7 +3660,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds a file from a remote service.
-        https://api.slack.com/methods/files.remote.add
+        https://docs.slack.dev/reference/methods/files.remote.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3691,7 +3699,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Updates an existing remote file.
-        https://api.slack.com/methods/files.remote.update
+        https://docs.slack.dev/reference/methods/files.remote.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3726,7 +3734,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a remote file.
-        https://api.slack.com/methods/files.remote.remove
+        https://docs.slack.dev/reference/methods/files.remote.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
         return self.api_call(&#34;files.remote.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -3740,7 +3748,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Share a remote file into a channel.
-        https://api.slack.com/methods/files.remote.share
+        https://docs.slack.dev/reference/methods/files.remote.share
         &#34;&#34;&#34;
         if external_id is None and file is None:
             raise e.SlackRequestError(&#34;Either external_id or file must be provided.&#34;)
@@ -3758,7 +3766,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes public/external sharing access for a file
-        https://api.slack.com/methods/files.revokePublicURL
+        https://docs.slack.dev/reference/methods/files.revokePublicURL
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.revokePublicURL&#34;, params=kwargs)
@@ -3770,7 +3778,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Enables a file for public/external sharing.
-        https://api.slack.com/methods/files.sharedPublicURL
+        https://docs.slack.dev/reference/methods/files.sharedPublicURL
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.sharedPublicURL&#34;, params=kwargs)
@@ -3789,7 +3797,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Uploads or creates a file.
-        https://api.slack.com/methods/files.upload
+        https://docs.slack.dev/reference/methods/files.upload
         &#34;&#34;&#34;
         _print_files_upload_v2_suggestion()
 
@@ -3842,12 +3850,12 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;This wrapper method provides an easy way to upload files using the following endpoints:
 
-        - step1: https://api.slack.com/methods/files.getUploadURLExternal
+        - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
         - step2: &#34;https://files.slack.com/upload/v1/...&#34; URLs returned from files.getUploadURLExternal API
 
-        - step3: https://api.slack.com/methods/files.completeUploadExternal
-            and https://api.slack.com/methods/files.info
+        - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+            and https://docs.slack.dev/reference/methods/files.info
 
         &#34;&#34;&#34;
         if file is None and content is None and file_uploads is None:
@@ -3933,7 +3941,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets a URL for an edge external upload.
-        https://api.slack.com/methods/files.getUploadURLExternal
+        https://docs.slack.dev/reference/methods/files.getUploadURLExternal
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3956,7 +3964,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Finishes an upload started with files.getUploadURLExternal.
-        https://api.slack.com/methods/files.completeUploadExternal
+        https://docs.slack.dev/reference/methods/files.completeUploadExternal
         &#34;&#34;&#34;
         _files = [{k: v for k, v in f.items() if v is not None} for f in files]
         kwargs.update(
@@ -3979,7 +3987,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Signal the successful completion of a function
-        https://api.slack.com/methods/functions.completeSuccess
+        https://docs.slack.dev/reference/methods/functions.completeSuccess
         &#34;&#34;&#34;
         kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;outputs&#34;: json.dumps(outputs)})
         return self.api_call(&#34;functions.completeSuccess&#34;, params=kwargs)
@@ -3992,7 +4000,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Signal the failure to execute a function
-        https://api.slack.com/methods/functions.completeError
+        https://docs.slack.dev/reference/methods/functions.completeError
         &#34;&#34;&#34;
         kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;error&#34;: error})
         return self.api_call(&#34;functions.completeError&#34;, params=kwargs)
@@ -4000,7 +4008,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def groups_archive(
@@ -4181,7 +4189,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: im.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def im_close(
@@ -4257,7 +4265,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;For Enterprise Grid workspaces, map local user IDs to global user IDs
-        https://api.slack.com/methods/migration.exchange
+        https://docs.slack.dev/reference/methods/migration.exchange
         &#34;&#34;&#34;
         if isinstance(users, (list, tuple)):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -4269,7 +4277,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: mpim.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def mpim_close(
@@ -4356,7 +4364,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.v2.access
+        https://docs.slack.dev/reference/methods/oauth.v2.access
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4382,7 +4390,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.access
+        https://docs.slack.dev/reference/methods/oauth.access
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4402,7 +4410,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
-        https://api.slack.com/methods/oauth.v2.exchange
+        https://docs.slack.dev/reference/methods/oauth.v2.exchange
         &#34;&#34;&#34;
         kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token})
         return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
@@ -4418,7 +4426,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.token
+        https://docs.slack.dev/reference/methods/openid.connect.token
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4439,7 +4447,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get the identity of a user who has authorized Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.userInfo
+        https://docs.slack.dev/reference/methods/openid.connect.userInfo
         &#34;&#34;&#34;
         return self.api_call(&#34;openid.connect.userInfo&#34;, params=kwargs)
 
@@ -4451,7 +4459,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Pins an item to a channel.
-        https://api.slack.com/methods/pins.add
+        https://docs.slack.dev/reference/methods/pins.add
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;pins.add&#34;, params=kwargs)
@@ -4463,7 +4471,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists items pinned to a channel.
-        https://api.slack.com/methods/pins.list
+        https://docs.slack.dev/reference/methods/pins.list
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;pins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4476,7 +4484,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Un-pins an item from a channel.
-        https://api.slack.com/methods/pins.remove
+        https://docs.slack.dev/reference/methods/pins.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;pins.remove&#34;, params=kwargs)
@@ -4490,7 +4498,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds a reaction to an item.
-        https://api.slack.com/methods/reactions.add
+        https://docs.slack.dev/reference/methods/reactions.add
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;reactions.add&#34;, params=kwargs)
@@ -4506,7 +4514,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets reactions for an item.
-        https://api.slack.com/methods/reactions.get
+        https://docs.slack.dev/reference/methods/reactions.get
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4532,7 +4540,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists reactions made by a user.
-        https://api.slack.com/methods/reactions.list
+        https://docs.slack.dev/reference/methods/reactions.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4558,7 +4566,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a reaction from an item.
-        https://api.slack.com/methods/reactions.remove
+        https://docs.slack.dev/reference/methods/reactions.remove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4582,7 +4590,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Creates a reminder.
-        https://api.slack.com/methods/reminders.add
+        https://docs.slack.dev/reference/methods/reminders.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4603,7 +4611,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Marks a reminder as complete.
-        https://api.slack.com/methods/reminders.complete
+        https://docs.slack.dev/reference/methods/reminders.complete
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.complete&#34;, params=kwargs)
@@ -4616,7 +4624,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a reminder.
-        https://api.slack.com/methods/reminders.delete
+        https://docs.slack.dev/reference/methods/reminders.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.delete&#34;, params=kwargs)
@@ -4629,7 +4637,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a reminder.
-        https://api.slack.com/methods/reminders.info
+        https://docs.slack.dev/reference/methods/reminders.info
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4641,7 +4649,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all reminders created by or for a given user.
-        https://api.slack.com/methods/reminders.list
+        https://docs.slack.dev/reference/methods/reminders.list
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4654,7 +4662,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.connect
+        https://docs.slack.dev/reference/methods/rtm.connect
         &#34;&#34;&#34;
         kwargs.update({&#34;batch_presence_aware&#34;: batch_presence_aware, &#34;presence_sub&#34;: presence_sub})
         return self.api_call(&#34;rtm.connect&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4672,7 +4680,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.start
+        https://docs.slack.dev/reference/methods/rtm.start
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4700,7 +4708,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Searches for messages and files matching a query.
-        https://api.slack.com/methods/search.all
+        https://docs.slack.dev/reference/methods/search.all
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4728,7 +4736,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Searches for files matching a query.
-        https://api.slack.com/methods/search.files
+        https://docs.slack.dev/reference/methods/search.files
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4757,7 +4765,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Searches for messages matching a query.
-        https://api.slack.com/methods/search.messages
+        https://docs.slack.dev/reference/methods/search.messages
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4783,7 +4791,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds a star to an item.
-        https://api.slack.com/methods/stars.add
+        https://docs.slack.dev/reference/methods/stars.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4806,7 +4814,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists stars for a user.
-        https://api.slack.com/methods/stars.list
+        https://docs.slack.dev/reference/methods/stars.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4829,7 +4837,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a star from an item.
-        https://api.slack.com/methods/stars.remove
+        https://docs.slack.dev/reference/methods/stars.remove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4853,7 +4861,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets the access logs for the current team.
-        https://api.slack.com/methods/team.accessLogs
+        https://docs.slack.dev/reference/methods/team.accessLogs
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4875,7 +4883,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets billable users information for the current team.
-        https://api.slack.com/methods/team.billableInfo
+        https://docs.slack.dev/reference/methods/team.billableInfo
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
         return self.api_call(&#34;team.billableInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4885,7 +4893,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Reads a workspace&#39;s billing plan information.
-        https://api.slack.com/methods/team.billing.info
+        https://docs.slack.dev/reference/methods/team.billing.info
         &#34;&#34;&#34;
         return self.api_call(&#34;team.billing.info&#34;, params=kwargs)
 
@@ -4896,7 +4904,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Disconnects an external organization.
-        https://api.slack.com/methods/team.externalTeams.disconnect
+        https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4918,7 +4926,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
-        https://api.slack.com/methods/team.externalTeams.list
+        https://docs.slack.dev/reference/methods/team.externalTeams.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4949,7 +4957,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about the current team.
-        https://api.slack.com/methods/team.info
+        https://docs.slack.dev/reference/methods/team.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team&#34;: team, &#34;domain&#34;: domain})
         return self.api_call(&#34;team.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4967,7 +4975,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets the integration logs for the current team.
-        https://api.slack.com/methods/team.integrationLogs
+        https://docs.slack.dev/reference/methods/team.integrationLogs
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4989,7 +4997,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a team&#39;s profile.
-        https://api.slack.com/methods/team.profile.get
+        https://docs.slack.dev/reference/methods/team.profile.get
         &#34;&#34;&#34;
         kwargs.update({&#34;visibility&#34;: visibility})
         return self.api_call(&#34;team.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4999,7 +5007,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a list of a workspace&#39;s team preferences.
-        https://api.slack.com/methods/team.preferences.list
+        https://docs.slack.dev/reference/methods/team.preferences.list
         &#34;&#34;&#34;
         return self.api_call(&#34;team.preferences.list&#34;, params=kwargs)
 
@@ -5015,7 +5023,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a User Group
-        https://api.slack.com/methods/usergroups.create
+        https://docs.slack.dev/reference/methods/usergroups.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5041,7 +5049,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Disable an existing User Group
-        https://api.slack.com/methods/usergroups.disable
+        https://docs.slack.dev/reference/methods/usergroups.disable
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;usergroups.disable&#34;, params=kwargs)
@@ -5055,7 +5063,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Enable a User Group
-        https://api.slack.com/methods/usergroups.enable
+        https://docs.slack.dev/reference/methods/usergroups.enable
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;usergroups.enable&#34;, params=kwargs)
@@ -5070,7 +5078,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all User Groups for a team
-        https://api.slack.com/methods/usergroups.list
+        https://docs.slack.dev/reference/methods/usergroups.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5095,7 +5103,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an existing User Group
-        https://api.slack.com/methods/usergroups.update
+        https://docs.slack.dev/reference/methods/usergroups.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5122,7 +5130,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all users in a User Group
-        https://api.slack.com/methods/usergroups.users.list
+        https://docs.slack.dev/reference/methods/usergroups.users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5143,7 +5151,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update the list of users for a User Group
-        https://api.slack.com/methods/usergroups.users.update
+        https://docs.slack.dev/reference/methods/usergroups.users.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5170,7 +5178,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List conversations the calling user may access.
-        https://api.slack.com/methods/users.conversations
+        https://docs.slack.dev/reference/methods/users.conversations
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5192,7 +5200,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Delete the user profile photo
-        https://api.slack.com/methods/users.deletePhoto
+        https://docs.slack.dev/reference/methods/users.deletePhoto
         &#34;&#34;&#34;
         return self.api_call(&#34;users.deletePhoto&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
@@ -5203,7 +5211,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets user presence information.
-        https://api.slack.com/methods/users.getPresence
+        https://docs.slack.dev/reference/methods/users.getPresence
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user})
         return self.api_call(&#34;users.getPresence&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5213,7 +5221,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get a user&#39;s identity.
-        https://api.slack.com/methods/users.identity
+        https://docs.slack.dev/reference/methods/users.identity
         &#34;&#34;&#34;
         return self.api_call(&#34;users.identity&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
@@ -5225,7 +5233,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a user.
-        https://api.slack.com/methods/users.info
+        https://docs.slack.dev/reference/methods/users.info
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user, &#34;include_locale&#34;: include_locale})
         return self.api_call(&#34;users.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5240,7 +5248,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all users in a Slack team.
-        https://api.slack.com/methods/users.list
+        https://docs.slack.dev/reference/methods/users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5259,7 +5267,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Find a user with an email address.
-        https://api.slack.com/methods/users.lookupByEmail
+        https://docs.slack.dev/reference/methods/users.lookupByEmail
         &#34;&#34;&#34;
         kwargs.update({&#34;email&#34;: email})
         return self.api_call(&#34;users.lookupByEmail&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5274,7 +5282,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the user profile photo
-        https://api.slack.com/methods/users.setPhoto
+        https://docs.slack.dev/reference/methods/users.setPhoto
         &#34;&#34;&#34;
         kwargs.update({&#34;crop_w&#34;: crop_w, &#34;crop_x&#34;: crop_x, &#34;crop_y&#34;: crop_y})
         return self.api_call(&#34;users.setPhoto&#34;, files={&#34;image&#34;: image}, data=kwargs)
@@ -5286,7 +5294,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Manually sets user presence.
-        https://api.slack.com/methods/users.setPresence
+        https://docs.slack.dev/reference/methods/users.setPresence
         &#34;&#34;&#34;
         kwargs.update({&#34;presence&#34;: presence})
         return self.api_call(&#34;users.setPresence&#34;, params=kwargs)
@@ -5297,7 +5305,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lookup an email address to see if someone is on Slack
-        https://api.slack.com/methods/users.discoverableContacts.lookup
+        https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
         &#34;&#34;&#34;
         kwargs.update({&#34;email&#34;: email})
         return self.api_call(&#34;users.discoverableContacts.lookup&#34;, params=kwargs)
@@ -5310,7 +5318,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieves a user&#39;s profile information.
-        https://api.slack.com/methods/users.profile.get
+        https://docs.slack.dev/reference/methods/users.profile.get
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user, &#34;include_labels&#34;: include_labels})
         return self.api_call(&#34;users.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5325,7 +5333,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the profile information for a user.
-        https://api.slack.com/methods/users.profile.set
+        https://docs.slack.dev/reference/methods/users.profile.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5348,8 +5356,8 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Open a view for a user.
-        https://api.slack.com/methods/views.open
-        See https://api.slack.com/surfaces/modals for details.
+        https://docs.slack.dev/reference/methods/views.open
+        See https://docs.slack.dev/surfaces/modals/ for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
         if isinstance(view, View):
@@ -5372,9 +5380,9 @@ el.replaceWith(d);
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/surfaces/modals)
+        Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
         to learn more about the lifecycle and intricacies of views.
-        https://api.slack.com/methods/views.push
+        https://docs.slack.dev/reference/methods/views.push
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
         if isinstance(view, View):
@@ -5397,9 +5405,9 @@ el.replaceWith(d);
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+        See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
-        https://api.slack.com/methods/views.update
+        https://docs.slack.dev/reference/methods/views.update
         &#34;&#34;&#34;
         if isinstance(view, View):
             kwargs.update({&#34;view&#34;: view.to_dict()})
@@ -5426,8 +5434,8 @@ el.replaceWith(d);
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Publish a static view for a User.
         Create or update the view that comprises an
-        app&#39;s Home tab (https://api.slack.com/surfaces/tabs)
-        https://api.slack.com/methods/views.publish
+        app&#39;s Home tab (https://docs.slack.dev/surfaces/app-home/)
+        https://docs.slack.dev/reference/methods/views.publish
         &#34;&#34;&#34;
         kwargs.update({&#34;user_id&#34;: user_id, &#34;hash&#34;: hash})
         if isinstance(view, View):
@@ -5438,6 +5446,72 @@ el.replaceWith(d);
         # NOTE: Intentionally using json for the &#34;view&#34; parameter
         return self.api_call(&#34;views.publish&#34;, json=kwargs)
 
+    def workflows_featured_add(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Add featured workflows to a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.add
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.add&#34;, params=kwargs)
+
+    def workflows_featured_list(
+        self,
+        *,
+        channel_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;List the featured workflows for specified channels.
+        https://docs.slack.dev/reference/methods/workflows.featured.list
+        &#34;&#34;&#34;
+        if isinstance(channel_ids, (list, tuple)):
+            kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
+        else:
+            kwargs.update({&#34;channel_ids&#34;: channel_ids})
+        return self.api_call(&#34;workflows.featured.list&#34;, params=kwargs)
+
+    def workflows_featured_remove(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Remove featured workflows from a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.remove
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.remove&#34;, params=kwargs)
+
+    def workflows_featured_set(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Set featured workflows for a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.set
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.set&#34;, params=kwargs)
+
     def workflows_stepCompleted(
         self,
         *,
@@ -5446,7 +5520,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Indicate a successful outcome of a workflow step&#39;s execution.
-        https://api.slack.com/methods/workflows.stepCompleted
+        https://docs.slack.dev/reference/methods/workflows.stepCompleted
         &#34;&#34;&#34;
         kwargs.update({&#34;workflow_step_execute_id&#34;: workflow_step_execute_id})
         if outputs is not None:
@@ -5463,7 +5537,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Indicate an unsuccessful outcome of a workflow step&#39;s execution.
-        https://api.slack.com/methods/workflows.stepFailed
+        https://docs.slack.dev/reference/methods/workflows.stepFailed
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5484,7 +5558,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update the configuration for a workflow extension step.
-        https://api.slack.com/methods/workflows.updateStep
+        https://docs.slack.dev/reference/methods/workflows.updateStep
         &#34;&#34;&#34;
         kwargs.update({&#34;workflow_step_edit_id&#34;: workflow_step_edit_id})
         if inputs is not None:
@@ -5496,7 +5570,7 @@ el.replaceWith(d);
         return self.api_call(&#34;workflows.updateStep&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>A WebClient allows apps to communicate with the Slack Platform's Web API.</p>
-<p><a href="https://api.slack.com/methods">https://api.slack.com/methods</a></p>
+<p><a href="https://docs.slack.dev/reference/methods">https://docs.slack.dev/reference/methods</a></p>
 <p>The Slack Web API is an interface for querying information from
 and enacting change in a Slack workspace.</p>
 <p>This client handles constructing and sending HTTP requests to Slack
@@ -5576,7 +5650,7 @@ removed at anytime.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve analytics data for a given date, presented as a compressed JSON file
-    https://api.slack.com/methods/admin.analytics.getFile
+    https://docs.slack.dev/reference/methods/admin.analytics.getFile
     &#34;&#34;&#34;
     kwargs.update({&#34;type&#34;: type})
     if date is not None:
@@ -5586,7 +5660,7 @@ removed at anytime.</p></div>
     return self.api_call(&#34;admin.analytics.getFile&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve analytics data for a given date, presented as a compressed JSON file
-<a href="https://api.slack.com/methods/admin.analytics.getFile">https://api.slack.com/methods/admin.analytics.getFile</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.analytics.getFile">https://docs.slack.dev/reference/methods/admin.analytics.getFile</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_activities_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_activities_list</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>component_id: str | None = None,<br>component_type: str | None = None,<br>log_event_type: str | None = None,<br>max_date_created: int | None = None,<br>min_date_created: int | None = None,<br>min_log_level: str | None = None,<br>sort_direction: str | None = None,<br>source: str | None = None,<br>team_id: str | None = None,<br>trace_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5615,7 +5689,7 @@ removed at anytime.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get logs for a specified team/org
-    https://api.slack.com/methods/admin.apps.activities.list
+    https://docs.slack.dev/reference/methods/admin.apps.activities.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5637,7 +5711,7 @@ removed at anytime.</p></div>
     return self.api_call(&#34;admin.apps.activities.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get logs for a specified team/org
-<a href="https://api.slack.com/methods/admin.apps.activities.list">https://api.slack.com/methods/admin.apps.activities.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.activities.list">https://docs.slack.dev/reference/methods/admin.apps.activities.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_approve"><code class="name flex">
 <span>def <span class="ident">admin_apps_approve</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>request_id: str | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5660,7 +5734,7 @@ removed at anytime.</p></div>
     Either app_id or request_id is required.
     These IDs can be obtained either directly via the app_requested event,
     or by the admin.apps.requests.list method.
-    https://api.slack.com/methods/admin.apps.approve
+    https://docs.slack.dev/reference/methods/admin.apps.approve
     &#34;&#34;&#34;
     if app_id:
         kwargs.update({&#34;app_id&#34;: app_id})
@@ -5681,7 +5755,7 @@ removed at anytime.</p></div>
 Either app_id or request_id is required.
 These IDs can be obtained either directly via the app_requested event,
 or by the admin.apps.requests.list method.
-<a href="https://api.slack.com/methods/admin.apps.approve">https://api.slack.com/methods/admin.apps.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.approve">https://docs.slack.dev/reference/methods/admin.apps.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_approved_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_approved_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5701,7 +5775,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List approved apps for an org or workspace.
-    https://api.slack.com/methods/admin.apps.approved.list
+    https://docs.slack.dev/reference/methods/admin.apps.approved.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5714,7 +5788,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.approved.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List approved apps for an org or workspace.
-<a href="https://api.slack.com/methods/admin.apps.approved.list">https://api.slack.com/methods/admin.apps.approved.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.approved.list">https://docs.slack.dev/reference/methods/admin.apps.approved.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_clearResolution"><code class="name flex">
 <span>def <span class="ident">admin_apps_clearResolution</span></span>(<span>self,<br>*,<br>app_id: str,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5733,7 +5807,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Clear an app resolution
-    https://api.slack.com/methods/admin.apps.clearResolution
+    https://docs.slack.dev/reference/methods/admin.apps.clearResolution
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5745,7 +5819,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.clearResolution&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Clear an app resolution
-<a href="https://api.slack.com/methods/admin.apps.clearResolution">https://api.slack.com/methods/admin.apps.clearResolution</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.clearResolution">https://docs.slack.dev/reference/methods/admin.apps.clearResolution</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_config_lookup"><code class="name flex">
 <span>def <span class="ident">admin_apps_config_lookup</span></span>(<span>self, *, app_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5762,7 +5836,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Look up the app config for connectors by their IDs
-    https://api.slack.com/methods/admin.apps.config.lookup
+    https://docs.slack.dev/reference/methods/admin.apps.config.lookup
     &#34;&#34;&#34;
     if isinstance(app_ids, (list, tuple)):
         kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -5771,7 +5845,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.config.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up the app config for connectors by their IDs
-<a href="https://api.slack.com/methods/admin.apps.config.lookup">https://api.slack.com/methods/admin.apps.config.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.config.lookup">https://docs.slack.dev/reference/methods/admin.apps.config.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_config_set"><code class="name flex">
 <span>def <span class="ident">admin_apps_config_set</span></span>(<span>self,<br>*,<br>app_id: str,<br>domain_restrictions: Dict[str, Any] | None = None,<br>workflow_auth_strategy: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5790,7 +5864,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the app config for a connector
-    https://api.slack.com/methods/admin.apps.config.set
+    https://docs.slack.dev/reference/methods/admin.apps.config.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5803,7 +5877,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.config.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the app config for a connector
-<a href="https://api.slack.com/methods/admin.apps.config.set">https://api.slack.com/methods/admin.apps.config.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.config.set">https://docs.slack.dev/reference/methods/admin.apps.config.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_requests_cancel"><code class="name flex">
 <span>def <span class="ident">admin_apps_requests_cancel</span></span>(<span>self,<br>*,<br>request_id: str,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5822,7 +5896,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List app requests for a team/workspace.
-    https://api.slack.com/methods/admin.apps.requests.cancel
+    https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5834,7 +5908,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.requests.cancel&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List app requests for a team/workspace.
-<a href="https://api.slack.com/methods/admin.apps.requests.cancel">https://api.slack.com/methods/admin.apps.requests.cancel</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.requests.cancel">https://docs.slack.dev/reference/methods/admin.apps.requests.cancel</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_requests_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_requests_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5853,7 +5927,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List app requests for a team/workspace.
-    https://api.slack.com/methods/admin.apps.requests.list
+    https://docs.slack.dev/reference/methods/admin.apps.requests.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5865,7 +5939,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.requests.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List app requests for a team/workspace.
-<a href="https://api.slack.com/methods/admin.apps.requests.list">https://api.slack.com/methods/admin.apps.requests.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.requests.list">https://docs.slack.dev/reference/methods/admin.apps.requests.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_restrict"><code class="name flex">
 <span>def <span class="ident">admin_apps_restrict</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>request_id: str | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5888,7 +5962,7 @@ or by the admin.apps.requests.list method.
     Exactly one of the team_id or enterprise_id arguments is required, not both.
     Either app_id or request_id is required. These IDs can be obtained either directly
     via the app_requested event, or by the admin.apps.requests.list method.
-    https://api.slack.com/methods/admin.apps.restrict
+    https://docs.slack.dev/reference/methods/admin.apps.restrict
     &#34;&#34;&#34;
     if app_id:
         kwargs.update({&#34;app_id&#34;: app_id})
@@ -5909,7 +5983,7 @@ or by the admin.apps.requests.list method.
 Exactly one of the team_id or enterprise_id arguments is required, not both.
 Either app_id or request_id is required. These IDs can be obtained either directly
 via the app_requested event, or by the admin.apps.requests.list method.
-<a href="https://api.slack.com/methods/admin.apps.restrict">https://api.slack.com/methods/admin.apps.restrict</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.restrict">https://docs.slack.dev/reference/methods/admin.apps.restrict</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_restricted_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_restricted_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5929,7 +6003,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List restricted apps for an org or workspace.
-    https://api.slack.com/methods/admin.apps.restricted.list
+    https://docs.slack.dev/reference/methods/admin.apps.restricted.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5942,7 +6016,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.restricted.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List restricted apps for an org or workspace.
-<a href="https://api.slack.com/methods/admin.apps.restricted.list">https://api.slack.com/methods/admin.apps.restricted.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.restricted.list">https://docs.slack.dev/reference/methods/admin.apps.restricted.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_apps_uninstall"><code class="name flex">
 <span>def <span class="ident">admin_apps_uninstall</span></span>(<span>self,<br>*,<br>app_id: str,<br>enterprise_id: str | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5962,7 +6036,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Uninstall an app from one or many workspaces, or an entire enterprise organization.
     With an org-level token, enterprise_id or team_ids is required.
-    https://api.slack.com/methods/admin.apps.uninstall
+    https://docs.slack.dev/reference/methods/admin.apps.uninstall
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     if enterprise_id is not None:
@@ -5976,7 +6050,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
 </details>
 <div class="desc"><p>Uninstall an app from one or many workspaces, or an entire enterprise organization.
 With an org-level token, enterprise_id or team_ids is required.
-<a href="https://api.slack.com/methods/admin.apps.uninstall">https://api.slack.com/methods/admin.apps.uninstall</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.uninstall">https://docs.slack.dev/reference/methods/admin.apps.uninstall</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_auth_policy_assignEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_assignEntities</span></span>(<span>self,<br>*,<br>entity_ids: str | Sequence[str],<br>policy_name: str,<br>entity_type: str,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5995,7 +6069,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Assign entities to a particular authentication policy.
-    https://api.slack.com/methods/admin.auth.policy.assignEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
     &#34;&#34;&#34;
     if isinstance(entity_ids, (list, tuple)):
         kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -6006,7 +6080,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Assign entities to a particular authentication policy.
-<a href="https://api.slack.com/methods/admin.auth.policy.assignEntities">https://api.slack.com/methods/admin.auth.policy.assignEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_auth_policy_getEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_getEntities</span></span>(<span>self,<br>*,<br>policy_name: str,<br>cursor: str | None = None,<br>entity_type: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6026,7 +6100,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.
-    https://api.slack.com/methods/admin.auth.policy.getEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
     &#34;&#34;&#34;
     kwargs.update({&#34;policy_name&#34;: policy_name})
     if cursor is not None:
@@ -6038,7 +6112,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetch all the entities assigned to a particular authentication policy by name.
-<a href="https://api.slack.com/methods/admin.auth.policy.getEntities">https://api.slack.com/methods/admin.auth.policy.getEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_auth_policy_removeEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_removeEntities</span></span>(<span>self,<br>*,<br>entity_ids: str | Sequence[str],<br>policy_name: str,<br>entity_type: str,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6057,7 +6131,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove specified entities from a specified authentication policy.
-    https://api.slack.com/methods/admin.auth.policy.removeEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
     &#34;&#34;&#34;
     if isinstance(entity_ids, (list, tuple)):
         kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -6068,7 +6142,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove specified entities from a specified authentication policy.
-<a href="https://api.slack.com/methods/admin.auth.policy.removeEntities">https://api.slack.com/methods/admin.auth.policy.removeEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_barriers_create"><code class="name flex">
 <span>def <span class="ident">admin_barriers_create</span></span>(<span>self,<br>*,<br>barriered_from_usergroup_ids: str | Sequence[str],<br>primary_usergroup_id: str,<br>restricted_subjects: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6087,7 +6161,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create an Information Barrier
-    https://api.slack.com/methods/admin.barriers.create
+    https://docs.slack.dev/reference/methods/admin.barriers.create
     &#34;&#34;&#34;
     kwargs.update({&#34;primary_usergroup_id&#34;: primary_usergroup_id})
     if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -6101,7 +6175,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.create&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.create">https://api.slack.com/methods/admin.barriers.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.create">https://docs.slack.dev/reference/methods/admin.barriers.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_barriers_delete"><code class="name flex">
 <span>def <span class="ident">admin_barriers_delete</span></span>(<span>self, *, barrier_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6118,13 +6192,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Delete an existing Information Barrier
-    https://api.slack.com/methods/admin.barriers.delete
+    https://docs.slack.dev/reference/methods/admin.barriers.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;barrier_id&#34;: barrier_id})
     return self.api_call(&#34;admin.barriers.delete&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete an existing Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.delete">https://api.slack.com/methods/admin.barriers.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.delete">https://docs.slack.dev/reference/methods/admin.barriers.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_barriers_list"><code class="name flex">
 <span>def <span class="ident">admin_barriers_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6142,7 +6216,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get all Information Barriers for your organization
-    https://api.slack.com/methods/admin.barriers.list&#34;&#34;&#34;
+    https://docs.slack.dev/reference/methods/admin.barriers.list&#34;&#34;&#34;
     kwargs.update(
         {
             &#34;cursor&#34;: cursor,
@@ -6152,7 +6226,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get all Information Barriers for your organization
-<a href="https://api.slack.com/methods/admin.barriers.list">https://api.slack.com/methods/admin.barriers.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.list">https://docs.slack.dev/reference/methods/admin.barriers.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_barriers_update"><code class="name flex">
 <span>def <span class="ident">admin_barriers_update</span></span>(<span>self,<br>*,<br>barrier_id: str,<br>barriered_from_usergroup_ids: str | Sequence[str],<br>primary_usergroup_id: str,<br>restricted_subjects: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6172,7 +6246,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an existing Information Barrier
-    https://api.slack.com/methods/admin.barriers.update
+    https://docs.slack.dev/reference/methods/admin.barriers.update
     &#34;&#34;&#34;
     kwargs.update({&#34;barrier_id&#34;: barrier_id, &#34;primary_usergroup_id&#34;: primary_usergroup_id})
     if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -6186,7 +6260,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.update&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.update">https://api.slack.com/methods/admin.barriers.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.update">https://docs.slack.dev/reference/methods/admin.barriers.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_archive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_archive</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6203,13 +6277,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Archive a public or private channel.
-    https://api.slack.com/methods/admin.conversations.archive
+    https://docs.slack.dev/reference/methods/admin.conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.archive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archive a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.archive">https://api.slack.com/methods/admin.conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.archive">https://docs.slack.dev/reference/methods/admin.conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_bulkArchive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_bulkArchive</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6226,13 +6300,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Archive public or private channels in bulk.
-    https://api.slack.com/methods/admin.conversations.bulkArchive
+    https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
     return self.api_call(&#34;admin.conversations.bulkArchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archive public or private channels in bulk.
-<a href="https://api.slack.com/methods/admin.conversations.bulkArchive">https://api.slack.com/methods/admin.conversations.bulkArchive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive">https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_bulkDelete"><code class="name flex">
 <span>def <span class="ident">admin_conversations_bulkDelete</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6273,7 +6347,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Move public or private channels in bulk.
-    https://api.slack.com/methods/admin.conversations.bulkMove
+    https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6284,7 +6358,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.bulkMove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Move public or private channels in bulk.
-<a href="https://api.slack.com/methods/admin.conversations.bulkMove">https://api.slack.com/methods/admin.conversations.bulkMove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.bulkMove">https://docs.slack.dev/reference/methods/admin.conversations.bulkMove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_convertToPrivate"><code class="name flex">
 <span>def <span class="ident">admin_conversations_convertToPrivate</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6301,13 +6375,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Convert a public channel to a private channel.
-    https://api.slack.com/methods/admin.conversations.convertToPrivate
+    https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.convertToPrivate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Convert a public channel to a private channel.
-<a href="https://api.slack.com/methods/admin.conversations.convertToPrivate">https://api.slack.com/methods/admin.conversations.convertToPrivate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate">https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_convertToPublic"><code class="name flex">
 <span>def <span class="ident">admin_conversations_convertToPublic</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6324,13 +6398,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Convert a privte channel to a public channel.
-    https://api.slack.com/methods/admin.conversations.convertToPublic
+    https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.convertToPublic&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Convert a privte channel to a public channel.
-<a href="https://api.slack.com/methods/admin.conversations.convertToPublic">https://api.slack.com/methods/admin.conversations.convertToPublic</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic">https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_create"><code class="name flex">
 <span>def <span class="ident">admin_conversations_create</span></span>(<span>self,<br>*,<br>is_private: bool,<br>name: str,<br>description: str | None = None,<br>org_wide: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6351,7 +6425,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a public or private channel-based conversation.
-    https://api.slack.com/methods/admin.conversations.create
+    https://docs.slack.dev/reference/methods/admin.conversations.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6365,7 +6439,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a public or private channel-based conversation.
-<a href="https://api.slack.com/methods/admin.conversations.create">https://api.slack.com/methods/admin.conversations.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.create">https://docs.slack.dev/reference/methods/admin.conversations.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_createForObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_createForObjects</span></span>(<span>self,<br>*,<br>object_id: str,<br>salesforce_org_id: str,<br>invite_object_team: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6384,7 +6458,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a Salesforce channel for the corresponding object provided.
-    https://api.slack.com/methods/admin.conversations.createForObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
     &#34;&#34;&#34;
     kwargs.update(
         {&#34;object_id&#34;: object_id, &#34;salesforce_org_id&#34;: salesforce_org_id, &#34;invite_object_team&#34;: invite_object_team}
@@ -6392,7 +6466,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.createForObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Salesforce channel for the corresponding object provided.
-<a href="https://api.slack.com/methods/admin.conversations.createForObjects">https://api.slack.com/methods/admin.conversations.createForObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.createForObjects">https://docs.slack.dev/reference/methods/admin.conversations.createForObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_delete"><code class="name flex">
 <span>def <span class="ident">admin_conversations_delete</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6409,13 +6483,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Delete a public or private channel.
-    https://api.slack.com/methods/admin.conversations.delete
+    https://docs.slack.dev/reference/methods/admin.conversations.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.delete">https://api.slack.com/methods/admin.conversations.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.delete">https://docs.slack.dev/reference/methods/admin.conversations.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_disconnectShared"><code class="name flex">
 <span>def <span class="ident">admin_conversations_disconnectShared</span></span>(<span>self,<br>*,<br>channel_id: str,<br>leaving_team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6433,7 +6507,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Disconnect a connected channel from one or more workspaces.
-    https://api.slack.com/methods/admin.conversations.disconnectShared
+    https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(leaving_team_ids, (list, tuple)):
@@ -6443,7 +6517,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.disconnectShared&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disconnect a connected channel from one or more workspaces.
-<a href="https://api.slack.com/methods/admin.conversations.disconnectShared">https://api.slack.com/methods/admin.conversations.disconnectShared</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared">https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_ekm_listOriginalConnectedChannelInfo"><code class="name flex">
 <span>def <span class="ident">admin_conversations_ekm_listOriginalConnectedChannelInfo</span></span>(<span>self,<br>*,<br>channel_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6465,7 +6539,7 @@ With an org-level token, enterprise_id or team_ids is required.
     &#34;&#34;&#34;List all disconnected channels—i.e.,
     channels that were once connected to other workspaces and then disconnected—and
     the corresponding original channel IDs for key revocation with EKM.
-    https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+    https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6486,7 +6560,7 @@ With an org-level token, enterprise_id or team_ids is required.
 <div class="desc"><p>List all disconnected channels—i.e.,
 channels that were once connected to other workspaces and then disconnected—and
 the corresponding original channel IDs for key revocation with EKM.
-<a href="https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo">https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo">https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_getConversationPrefs"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getConversationPrefs</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6503,13 +6577,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get conversation preferences for a public or private channel.
-    https://api.slack.com/methods/admin.conversations.getConversationPrefs
+    https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.getConversationPrefs&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get conversation preferences for a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.getConversationPrefs">https://api.slack.com/methods/admin.conversations.getConversationPrefs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs">https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_getCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getCustomRetention</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6526,13 +6600,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.getCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.getCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.getCustomRetention">https://api.slack.com/methods/admin.conversations.getCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_getTeams"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getTeams</span></span>(<span>self,<br>*,<br>channel_id: str,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6551,7 +6625,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a channel.
-    https://api.slack.com/methods/admin.conversations.getTeams
+    https://docs.slack.dev/reference/methods/admin.conversations.getTeams
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6563,7 +6637,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the workspaces in an Enterprise grid org that connect to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.getTeams">https://api.slack.com/methods/admin.conversations.getTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getTeams">https://docs.slack.dev/reference/methods/admin.conversations.getTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_invite"><code class="name flex">
 <span>def <span class="ident">admin_conversations_invite</span></span>(<span>self, *, channel_id: str, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6581,7 +6655,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invite a user to a public or private channel.
-    https://api.slack.com/methods/admin.conversations.invite
+    https://docs.slack.dev/reference/methods/admin.conversations.invite
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(user_ids, (list, tuple)):
@@ -6592,7 +6666,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invite a user to a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.invite">https://api.slack.com/methods/admin.conversations.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.invite">https://docs.slack.dev/reference/methods/admin.conversations.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_linkObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_linkObjects</span></span>(<span>self, *, channel: str, record_id: str, salesforce_org_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6611,7 +6685,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Link a Salesforce record to a channel.
-    https://api.slack.com/methods/admin.conversations.linkObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6623,7 +6697,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.linkObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Link a Salesforce record to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.linkObjects">https://api.slack.com/methods/admin.conversations.linkObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.linkObjects">https://docs.slack.dev/reference/methods/admin.conversations.linkObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_lookup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_lookup</span></span>(<span>self,<br>*,<br>last_message_activity_before: int,<br>team_ids: str | Sequence[str],<br>cursor: str | None = None,<br>limit: int | None = None,<br>max_member_count: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6644,7 +6718,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Returns channels on the given team using the filters.
-    https://api.slack.com/methods/admin.conversations.lookup
+    https://docs.slack.dev/reference/methods/admin.conversations.lookup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6661,7 +6735,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns channels on the given team using the filters.
-<a href="https://api.slack.com/methods/admin.conversations.lookup">https://api.slack.com/methods/admin.conversations.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.lookup">https://docs.slack.dev/reference/methods/admin.conversations.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_removeCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_removeCustomRetention</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6678,13 +6752,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.removeCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.removeCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.removeCustomRetention">https://api.slack.com/methods/admin.conversations.removeCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_rename"><code class="name flex">
 <span>def <span class="ident">admin_conversations_rename</span></span>(<span>self, *, channel_id: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6702,13 +6776,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Rename a public or private channel.
-    https://api.slack.com/methods/admin.conversations.rename
+    https://docs.slack.dev/reference/methods/admin.conversations.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;name&#34;: name})
     return self.api_call(&#34;admin.conversations.rename&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Rename a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.rename">https://api.slack.com/methods/admin.conversations.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.rename">https://docs.slack.dev/reference/methods/admin.conversations.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_restrictAccess_addGroup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_addGroup</span></span>(<span>self, *, channel_id: str, group_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6727,7 +6801,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an allowlist of IDP groups for accessing a channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6743,7 +6817,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>Add an allowlist of IDP groups for accessing a channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup">https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_restrictAccess_listGroups"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_listGroups</span></span>(<span>self, *, channel_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6761,7 +6835,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all IDP Groups linked to a channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6776,7 +6850,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>List all IDP Groups linked to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups">https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_restrictAccess_removeGroup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_removeGroup</span></span>(<span>self, *, channel_id: str, group_id: str, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6795,7 +6869,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a linked IDP group linked from a private channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6811,7 +6885,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>Remove a linked IDP group linked from a private channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup">https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_search"><code class="name flex">
 <span>def <span class="ident">admin_conversations_search</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>query: str | None = None,<br>search_channel_types: str | Sequence[str] | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6834,7 +6908,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.
-    https://api.slack.com/methods/admin.conversations.search
+    https://docs.slack.dev/reference/methods/admin.conversations.search
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6859,7 +6933,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Search for public or private channels in an Enterprise organization.
-<a href="https://api.slack.com/methods/admin.conversations.search">https://api.slack.com/methods/admin.conversations.search</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.search">https://docs.slack.dev/reference/methods/admin.conversations.search</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_setConversationPrefs"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setConversationPrefs</span></span>(<span>self, *, channel_id: str, prefs: str | Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6877,7 +6951,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the posting permissions for a public or private channel.
-    https://api.slack.com/methods/admin.conversations.setConversationPrefs
+    https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(prefs, dict):
@@ -6887,7 +6961,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.setConversationPrefs&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the posting permissions for a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.setConversationPrefs">https://api.slack.com/methods/admin.conversations.setConversationPrefs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs">https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_setCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setCustomRetention</span></span>(<span>self, *, channel_id: str, duration_days: int, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6905,13 +6979,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.setCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;duration_days&#34;: duration_days})
     return self.api_call(&#34;admin.conversations.setCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.setCustomRetention">https://api.slack.com/methods/admin.conversations.setCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_setTeams"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setTeams</span></span>(<span>self,<br>*,<br>channel_id: str,<br>org_channel: bool | None = None,<br>target_team_ids: str | Sequence[str] | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6931,7 +7005,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-    https://api.slack.com/methods/admin.conversations.setTeams
+    https://docs.slack.dev/reference/methods/admin.conversations.setTeams
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6947,7 +7021,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.setTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.setTeams">https://api.slack.com/methods/admin.conversations.setTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setTeams">https://docs.slack.dev/reference/methods/admin.conversations.setTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_unarchive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_unarchive</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6964,13 +7038,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Unarchive a public or private channel.
-    https://api.slack.com/methods/admin.conversations.archive
+    https://docs.slack.dev/reference/methods/admin.conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.unarchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unarchive a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.archive">https://api.slack.com/methods/admin.conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.archive">https://docs.slack.dev/reference/methods/admin.conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_conversations_unlinkObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_unlinkObjects</span></span>(<span>self, *, channel: str, new_name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6988,7 +7062,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Unlink a Salesforce record from a channel.
-    https://api.slack.com/methods/admin.conversations.unlinkObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6999,7 +7073,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.unlinkObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unlink a Salesforce record from a channel.
-<a href="https://api.slack.com/methods/admin.conversations.unlinkObjects">https://api.slack.com/methods/admin.conversations.unlinkObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects">https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_emoji_add"><code class="name flex">
 <span>def <span class="ident">admin_emoji_add</span></span>(<span>self, *, name: str, url: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7017,13 +7091,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an emoji.
-    https://api.slack.com/methods/admin.emoji.add
+    https://docs.slack.dev/reference/methods/admin.emoji.add
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;url&#34;: url})
     return self.api_call(&#34;admin.emoji.add&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an emoji.
-<a href="https://api.slack.com/methods/admin.emoji.add">https://api.slack.com/methods/admin.emoji.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.add">https://docs.slack.dev/reference/methods/admin.emoji.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_emoji_addAlias"><code class="name flex">
 <span>def <span class="ident">admin_emoji_addAlias</span></span>(<span>self, *, alias_for: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7041,13 +7115,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an emoji alias.
-    https://api.slack.com/methods/admin.emoji.addAlias
+    https://docs.slack.dev/reference/methods/admin.emoji.addAlias
     &#34;&#34;&#34;
     kwargs.update({&#34;alias_for&#34;: alias_for, &#34;name&#34;: name})
     return self.api_call(&#34;admin.emoji.addAlias&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an emoji alias.
-<a href="https://api.slack.com/methods/admin.emoji.addAlias">https://api.slack.com/methods/admin.emoji.addAlias</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.addAlias">https://docs.slack.dev/reference/methods/admin.emoji.addAlias</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_emoji_list"><code class="name flex">
 <span>def <span class="ident">admin_emoji_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7065,13 +7139,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List emoji for an Enterprise Grid organization.
-    https://api.slack.com/methods/admin.emoji.list
+    https://docs.slack.dev/reference/methods/admin.emoji.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List emoji for an Enterprise Grid organization.
-<a href="https://api.slack.com/methods/admin.emoji.list">https://api.slack.com/methods/admin.emoji.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.list">https://docs.slack.dev/reference/methods/admin.emoji.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_emoji_remove"><code class="name flex">
 <span>def <span class="ident">admin_emoji_remove</span></span>(<span>self, *, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7088,13 +7162,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove an emoji across an Enterprise Grid organization.
-    https://api.slack.com/methods/admin.emoji.remove
+    https://docs.slack.dev/reference/methods/admin.emoji.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name})
     return self.api_call(&#34;admin.emoji.remove&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove an emoji across an Enterprise Grid organization.
-<a href="https://api.slack.com/methods/admin.emoji.remove">https://api.slack.com/methods/admin.emoji.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.remove">https://docs.slack.dev/reference/methods/admin.emoji.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_emoji_rename"><code class="name flex">
 <span>def <span class="ident">admin_emoji_rename</span></span>(<span>self, *, name: str, new_name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7112,13 +7186,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Rename an emoji.
-    https://api.slack.com/methods/admin.emoji.rename
+    https://docs.slack.dev/reference/methods/admin.emoji.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;new_name&#34;: new_name})
     return self.api_call(&#34;admin.emoji.rename&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Rename an emoji.
-<a href="https://api.slack.com/methods/admin.emoji.rename">https://api.slack.com/methods/admin.emoji.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.rename">https://docs.slack.dev/reference/methods/admin.emoji.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_functions_list"><code class="name flex">
 <span>def <span class="ident">admin_functions_list</span></span>(<span>self,<br>*,<br>app_ids: str | Sequence[str],<br>team_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7138,7 +7212,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Look up functions by a set of apps
-    https://api.slack.com/methods/admin.functions.list
+    https://docs.slack.dev/reference/methods/admin.functions.list
     &#34;&#34;&#34;
     if isinstance(app_ids, (list, tuple)):
         kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -7154,7 +7228,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.functions.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up functions by a set of apps
-<a href="https://api.slack.com/methods/admin.functions.list">https://api.slack.com/methods/admin.functions.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.list">https://docs.slack.dev/reference/methods/admin.functions.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_functions_permissions_lookup"><code class="name flex">
 <span>def <span class="ident">admin_functions_permissions_lookup</span></span>(<span>self, *, function_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7172,7 +7246,7 @@ the corresponding original channel IDs for key revocation with EKM.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lookup the visibility of multiple Slack functions
     and include the users if it is limited to particular named entities.
-    https://api.slack.com/methods/admin.functions.permissions.lookup
+    https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
     &#34;&#34;&#34;
     if isinstance(function_ids, (list, tuple)):
         kwargs.update({&#34;function_ids&#34;: &#34;,&#34;.join(function_ids)})
@@ -7182,7 +7256,7 @@ the corresponding original channel IDs for key revocation with EKM.
 </details>
 <div class="desc"><p>Lookup the visibility of multiple Slack functions
 and include the users if it is limited to particular named entities.
-<a href="https://api.slack.com/methods/admin.functions.permissions.lookup">https://api.slack.com/methods/admin.functions.permissions.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup">https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_functions_permissions_set"><code class="name flex">
 <span>def <span class="ident">admin_functions_permissions_set</span></span>(<span>self,<br>*,<br>function_id: str,<br>visibility: str,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7202,7 +7276,7 @@ and include the users if it is limited to particular named entities.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the visibility of a Slack function
     and define the users or workspaces if it is set to named_entities
-    https://api.slack.com/methods/admin.functions.permissions.set
+    https://docs.slack.dev/reference/methods/admin.functions.permissions.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7219,7 +7293,7 @@ and include the users if it is limited to particular named entities.
 </details>
 <div class="desc"><p>Set the visibility of a Slack function
 and define the users or workspaces if it is set to named_entities
-<a href="https://api.slack.com/methods/admin.functions.permissions.set">https://api.slack.com/methods/admin.functions.permissions.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.permissions.set">https://docs.slack.dev/reference/methods/admin.functions.permissions.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_inviteRequests_approve"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_approve</span></span>(<span>self, *, invite_request_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7237,13 +7311,13 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Approve a workspace invite request.
-    https://api.slack.com/methods/admin.inviteRequests.approve
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.inviteRequests.approve&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approve a workspace invite request.
-<a href="https://api.slack.com/methods/admin.inviteRequests.approve">https://api.slack.com/methods/admin.inviteRequests.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.approve">https://docs.slack.dev/reference/methods/admin.inviteRequests.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_inviteRequests_approved_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_approved_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7262,7 +7336,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all approved workspace invite requests.
-    https://api.slack.com/methods/admin.inviteRequests.approved.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7274,7 +7348,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all approved workspace invite requests.
-<a href="https://api.slack.com/methods/admin.inviteRequests.approved.list">https://api.slack.com/methods/admin.inviteRequests.approved.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_inviteRequests_denied_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_denied_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7293,7 +7367,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all denied workspace invite requests.
-    https://api.slack.com/methods/admin.inviteRequests.denied.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7305,7 +7379,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all denied workspace invite requests.
-<a href="https://api.slack.com/methods/admin.inviteRequests.denied.list">https://api.slack.com/methods/admin.inviteRequests.denied.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_inviteRequests_deny"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_deny</span></span>(<span>self, *, invite_request_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7323,13 +7397,13 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deny a workspace invite request.
-    https://api.slack.com/methods/admin.inviteRequests.deny
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.inviteRequests.deny&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deny a workspace invite request.
-<a href="https://api.slack.com/methods/admin.inviteRequests.deny">https://api.slack.com/methods/admin.inviteRequests.deny</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.deny">https://docs.slack.dev/reference/methods/admin.inviteRequests.deny</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_inviteRequests_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_list</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7365,7 +7439,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds members to the specified role with the specified scopes
-    https://api.slack.com/methods/admin.roles.addAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.addAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;role_id&#34;: role_id})
     if isinstance(entity_ids, (list, tuple)):
@@ -7379,7 +7453,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.roles.addAssignments&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds members to the specified role with the specified scopes
-<a href="https://api.slack.com/methods/admin.roles.addAssignments">https://api.slack.com/methods/admin.roles.addAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.addAssignments">https://docs.slack.dev/reference/methods/admin.roles.addAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_roles_listAssignments"><code class="name flex">
 <span>def <span class="ident">admin_roles_listAssignments</span></span>(<span>self,<br>*,<br>role_ids: str | Sequence[str] | None = None,<br>entity_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: str | int | None = None,<br>sort_dir: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7401,7 +7475,7 @@ and define the users or workspaces if it is set to named_entities
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists assignments for all roles across entities.
         Options to scope results by any combination of roles or entities
-    https://api.slack.com/methods/admin.roles.listAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.listAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;sort_dir&#34;: sort_dir})
     if isinstance(entity_ids, (list, tuple)):
@@ -7416,7 +7490,7 @@ and define the users or workspaces if it is set to named_entities
 </details>
 <div class="desc"><p>Lists assignments for all roles across entities.
 Options to scope results by any combination of roles or entities
-<a href="https://api.slack.com/methods/admin.roles.listAssignments">https://api.slack.com/methods/admin.roles.listAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.listAssignments">https://docs.slack.dev/reference/methods/admin.roles.listAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_roles_removeAssignments"><code class="name flex">
 <span>def <span class="ident">admin_roles_removeAssignments</span></span>(<span>self,<br>*,<br>role_id: str,<br>entity_ids: str | Sequence[str],<br>user_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7435,7 +7509,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a set of users from a role for the given scopes and entities
-    https://api.slack.com/methods/admin.roles.removeAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;role_id&#34;: role_id})
     if isinstance(entity_ids, (list, tuple)):
@@ -7449,7 +7523,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.roles.removeAssignments&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a set of users from a role for the given scopes and entities
-<a href="https://api.slack.com/methods/admin.roles.removeAssignments">https://api.slack.com/methods/admin.roles.removeAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.removeAssignments">https://docs.slack.dev/reference/methods/admin.roles.removeAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_admins_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_admins_list</span></span>(<span>self, *, team_id: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7468,7 +7542,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all of the admins on a given workspace.
-    https://api.slack.com/methods/admin.inviteRequests.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7480,7 +7554,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.admins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all of the admins on a given workspace.
-<a href="https://api.slack.com/methods/admin.inviteRequests.list">https://api.slack.com/methods/admin.inviteRequests.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_create"><code class="name flex">
 <span>def <span class="ident">admin_teams_create</span></span>(<span>self,<br>*,<br>team_domain: str,<br>team_name: str,<br>team_description: str | None = None,<br>team_discoverability: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7500,7 +7574,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create an Enterprise team.
-    https://api.slack.com/methods/admin.teams.create
+    https://docs.slack.dev/reference/methods/admin.teams.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7513,7 +7587,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an Enterprise team.
-<a href="https://api.slack.com/methods/admin.teams.create">https://api.slack.com/methods/admin.teams.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.create">https://docs.slack.dev/reference/methods/admin.teams.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7531,13 +7605,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all teams on an Enterprise organization.
-    https://api.slack.com/methods/admin.teams.list
+    https://docs.slack.dev/reference/methods/admin.teams.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all teams on an Enterprise organization.
-<a href="https://api.slack.com/methods/admin.teams.list">https://api.slack.com/methods/admin.teams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.list">https://docs.slack.dev/reference/methods/admin.teams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_owners_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_owners_list</span></span>(<span>self, *, team_id: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7556,13 +7630,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all of the admins on a given workspace.
-    https://api.slack.com/methods/admin.teams.owners.list
+    https://docs.slack.dev/reference/methods/admin.teams.owners.list
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.teams.owners.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all of the admins on a given workspace.
-<a href="https://api.slack.com/methods/admin.teams.owners.list">https://api.slack.com/methods/admin.teams.owners.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.owners.list">https://docs.slack.dev/reference/methods/admin.teams.owners.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_settings_info"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_info</span></span>(<span>self, *, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7579,13 +7653,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Fetch information about settings in a workspace
-    https://api.slack.com/methods/admin.teams.settings.info
+    https://docs.slack.dev/reference/methods/admin.teams.settings.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.teams.settings.info&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetch information about settings in a workspace
-<a href="https://api.slack.com/methods/admin.teams.settings.info">https://api.slack.com/methods/admin.teams.settings.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.info">https://docs.slack.dev/reference/methods/admin.teams.settings.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_settings_setDefaultChannels"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDefaultChannels</span></span>(<span>self, *, team_id: str, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7603,7 +7677,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the default channels of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7613,7 +7687,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.settings.setDefaultChannels&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the default channels of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDefaultChannels">https://api.slack.com/methods/admin.teams.settings.setDefaultChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels">https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_settings_setDescription"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDescription</span></span>(<span>self, *, team_id: str, description: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7631,13 +7705,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the description of a given workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDescription
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;description&#34;: description})
     return self.api_call(&#34;admin.teams.settings.setDescription&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the description of a given workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDescription">https://api.slack.com/methods/admin.teams.settings.setDescription</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription">https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_settings_setDiscoverability"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDiscoverability</span></span>(<span>self, *, team_id: str, discoverability: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7655,13 +7729,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;discoverability&#34;: discoverability})
     return self.api_call(&#34;admin.teams.settings.setDiscoverability&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDiscoverability">https://api.slack.com/methods/admin.teams.settings.setDiscoverability</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability">https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_settings_setIcon"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setIcon</span></span>(<span>self, *, team_id: str, image_url: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7679,13 +7753,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setIcon
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;image_url&#34;: image_url})
     return self.api_call(&#34;admin.teams.settings.setIcon&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setIcon">https://api.slack.com/methods/admin.teams.settings.setIcon</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon">https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_teams_settings_setName"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setName</span></span>(<span>self, *, team_id: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7703,13 +7777,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setName
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setName
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;name&#34;: name})
     return self.api_call(&#34;admin.teams.settings.setName&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setName">https://api.slack.com/methods/admin.teams.settings.setName</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setName">https://docs.slack.dev/reference/methods/admin.teams.settings.setName</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_usergroups_addChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_addChannels</span></span>(<span>self,<br>*,<br>channel_ids: str | Sequence[str],<br>usergroup_id: str,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7728,7 +7802,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.addChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;usergroup_id&#34;: usergroup_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7738,7 +7812,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.addChannels">https://api.slack.com/methods/admin.usergroups.addChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.addChannels">https://docs.slack.dev/reference/methods/admin.usergroups.addChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_usergroups_addTeams"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_addTeams</span></span>(<span>self,<br>*,<br>usergroup_id: str,<br>team_ids: str | Sequence[str],<br>auto_provision: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7757,7 +7831,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Associate one or more default workspaces with an organization-wide IDP group.
-    https://api.slack.com/methods/admin.usergroups.addTeams
+    https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup_id&#34;: usergroup_id, &#34;auto_provision&#34;: auto_provision})
     if isinstance(team_ids, (list, tuple)):
@@ -7767,7 +7841,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Associate one or more default workspaces with an organization-wide IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.addTeams">https://api.slack.com/methods/admin.usergroups.addTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.addTeams">https://docs.slack.dev/reference/methods/admin.usergroups.addTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_usergroups_listChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_listChannels</span></span>(<span>self,<br>*,<br>usergroup_id: str,<br>include_num_members: bool | None = None,<br>team_id: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7786,7 +7860,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.listChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7798,7 +7872,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.listChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.listChannels">https://api.slack.com/methods/admin.usergroups.listChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.listChannels">https://docs.slack.dev/reference/methods/admin.usergroups.listChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_usergroups_removeChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_removeChannels</span></span>(<span>self, *, usergroup_id: str, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7816,7 +7890,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.removeChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup_id&#34;: usergroup_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7826,7 +7900,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.removeChannels">https://api.slack.com/methods/admin.usergroups.removeChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels">https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_assign"><code class="name flex">
 <span>def <span class="ident">admin_users_assign</span></span>(<span>self,<br>*,<br>team_id: str,<br>user_id: str,<br>channel_ids: str | Sequence[str] | None = None,<br>is_restricted: bool | None = None,<br>is_ultra_restricted: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7847,7 +7921,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an Enterprise user to a workspace.
-    https://api.slack.com/methods/admin.users.assign
+    https://docs.slack.dev/reference/methods/admin.users.assign
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7864,7 +7938,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.assign&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an Enterprise user to a workspace.
-<a href="https://api.slack.com/methods/admin.users.assign">https://api.slack.com/methods/admin.users.assign</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.assign">https://docs.slack.dev/reference/methods/admin.users.assign</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_invite"><code class="name flex">
 <span>def <span class="ident">admin_users_invite</span></span>(<span>self,<br>*,<br>team_id: str,<br>email: str,<br>channel_ids: str | Sequence[str],<br>custom_message: str | None = None,<br>email_password_policy_enabled: bool | None = None,<br>guest_expiration_ts: str | float | None = None,<br>is_restricted: bool | None = None,<br>is_ultra_restricted: bool | None = None,<br>real_name: str | None = None,<br>resend: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7890,7 +7964,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invite a user to a workspace.
-    https://api.slack.com/methods/admin.users.invite
+    https://docs.slack.dev/reference/methods/admin.users.invite
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7912,10 +7986,10 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invite a user to a workspace.
-<a href="https://api.slack.com/methods/admin.users.invite">https://api.slack.com/methods/admin.users.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.invite">https://docs.slack.dev/reference/methods/admin.users.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_list"><code class="name flex">
-<span>def <span class="ident">admin_users_list</span></span>(<span>self,<br>*,<br>team_id: str,<br>include_deactivated_user_workspaces: bool | None = None,<br>is_active: bool | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">admin_users_list</span></span>(<span>self,<br>*,<br>team_id: str | None = None,<br>include_deactivated_user_workspaces: bool | None = None,<br>is_active: bool | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -7925,7 +7999,7 @@ Options to scope results by any combination of roles or entities
 <pre><code class="python">def admin_users_list(
     self,
     *,
-    team_id: str,
+    team_id: Optional[str] = None,
     include_deactivated_user_workspaces: Optional[bool] = None,
     is_active: Optional[bool] = None,
     cursor: Optional[str] = None,
@@ -7933,7 +8007,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List users on a workspace
-    https://api.slack.com/methods/admin.users.list
+    https://docs.slack.dev/reference/methods/admin.users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7947,7 +8021,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List users on a workspace
-<a href="https://api.slack.com/methods/admin.users.list">https://api.slack.com/methods/admin.users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.list">https://docs.slack.dev/reference/methods/admin.users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_remove"><code class="name flex">
 <span>def <span class="ident">admin_users_remove</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7965,13 +8039,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a user from a workspace.
-    https://api.slack.com/methods/admin.users.remove
+    https://docs.slack.dev/reference/methods/admin.users.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a user from a workspace.
-<a href="https://api.slack.com/methods/admin.users.remove">https://api.slack.com/methods/admin.users.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.remove">https://docs.slack.dev/reference/methods/admin.users.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_session_clearSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_clearSettings</span></span>(<span>self, *, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7989,7 +8063,7 @@ Options to scope results by any combination of roles or entities
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Clear user-specific session settings—the session duration
     and what happens when the client closes—for a list of users.
-    https://api.slack.com/methods/admin.users.session.clearSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -7999,7 +8073,7 @@ Options to scope results by any combination of roles or entities
 </details>
 <div class="desc"><p>Clear user-specific session settings—the session duration
 and what happens when the client closes—for a list of users.
-<a href="https://api.slack.com/methods/admin.users.session.clearSettings">https://api.slack.com/methods/admin.users.session.clearSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.clearSettings">https://docs.slack.dev/reference/methods/admin.users.session.clearSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_session_getSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_getSettings</span></span>(<span>self, *, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8017,7 +8091,7 @@ and what happens when the client closes—for a list of users.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get user-specific session settings—the session duration
     and what happens when the client closes—given a list of users.
-    https://api.slack.com/methods/admin.users.session.getSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.getSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8027,7 +8101,7 @@ and what happens when the client closes—for a list of users.
 </details>
 <div class="desc"><p>Get user-specific session settings—the session duration
 and what happens when the client closes—given a list of users.
-<a href="https://api.slack.com/methods/admin.users.session.getSettings">https://api.slack.com/methods/admin.users.session.getSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.getSettings">https://docs.slack.dev/reference/methods/admin.users.session.getSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_session_invalidate"><code class="name flex">
 <span>def <span class="ident">admin_users_session_invalidate</span></span>(<span>self, *, session_id: str, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8045,13 +8119,13 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invalidate a single session for a user by session_id.
-    https://api.slack.com/methods/admin.users.session.invalidate
+    https://docs.slack.dev/reference/methods/admin.users.session.invalidate
     &#34;&#34;&#34;
     kwargs.update({&#34;session_id&#34;: session_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.users.session.invalidate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invalidate a single session for a user by session_id.
-<a href="https://api.slack.com/methods/admin.users.session.invalidate">https://api.slack.com/methods/admin.users.session.invalidate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.invalidate">https://docs.slack.dev/reference/methods/admin.users.session.invalidate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_session_list"><code class="name flex">
 <span>def <span class="ident">admin_users_session_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8071,7 +8145,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all active user sessions for an organization
-    https://api.slack.com/methods/admin.users.session.list
+    https://docs.slack.dev/reference/methods/admin.users.session.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8084,7 +8158,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all active user sessions for an organization
-<a href="https://api.slack.com/methods/admin.users.session.list">https://api.slack.com/methods/admin.users.session.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.list">https://docs.slack.dev/reference/methods/admin.users.session.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_session_reset"><code class="name flex">
 <span>def <span class="ident">admin_users_session_reset</span></span>(<span>self,<br>*,<br>user_id: str,<br>mobile_only: bool | None = None,<br>web_only: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8103,7 +8177,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Wipes all valid sessions on all devices for a given user.
-    https://api.slack.com/methods/admin.users.session.reset
+    https://docs.slack.dev/reference/methods/admin.users.session.reset
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8115,7 +8189,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.reset&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Wipes all valid sessions on all devices for a given user.
-<a href="https://api.slack.com/methods/admin.users.session.reset">https://api.slack.com/methods/admin.users.session.reset</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.reset">https://docs.slack.dev/reference/methods/admin.users.session.reset</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_session_resetBulk"><code class="name flex">
 <span>def <span class="ident">admin_users_session_resetBulk</span></span>(<span>self,<br>*,<br>user_ids: str | Sequence[str],<br>mobile_only: bool | None = None,<br>web_only: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8134,7 +8208,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-    https://api.slack.com/methods/admin.users.session.resetBulk
+    https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8149,7 +8223,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.resetBulk&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-<a href="https://api.slack.com/methods/admin.users.session.resetBulk">https://api.slack.com/methods/admin.users.session.resetBulk</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.resetBulk">https://docs.slack.dev/reference/methods/admin.users.session.resetBulk</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_session_setSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_setSettings</span></span>(<span>self,<br>*,<br>user_ids: str | Sequence[str],<br>desktop_app_browser_quit: bool | None = None,<br>duration: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8169,7 +8243,7 @@ and what happens when the client closes—given a list of users.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Configure the user-level session settings—the session duration
     and what happens when the client closes—for one or more users.
-    https://api.slack.com/methods/admin.users.session.setSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.setSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8185,7 +8259,7 @@ and what happens when the client closes—given a list of users.
 </details>
 <div class="desc"><p>Configure the user-level session settings—the session duration
 and what happens when the client closes—for one or more users.
-<a href="https://api.slack.com/methods/admin.users.session.setSettings">https://api.slack.com/methods/admin.users.session.setSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.setSettings">https://docs.slack.dev/reference/methods/admin.users.session.setSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_setAdmin"><code class="name flex">
 <span>def <span class="ident">admin_users_setAdmin</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8203,13 +8277,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an existing guest, regular user, or owner to be an admin user.
-    https://api.slack.com/methods/admin.users.setAdmin
+    https://docs.slack.dev/reference/methods/admin.users.setAdmin
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setAdmin&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest, regular user, or owner to be an admin user.
-<a href="https://api.slack.com/methods/admin.users.setAdmin">https://api.slack.com/methods/admin.users.setAdmin</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setAdmin">https://docs.slack.dev/reference/methods/admin.users.setAdmin</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_setExpiration"><code class="name flex">
 <span>def <span class="ident">admin_users_setExpiration</span></span>(<span>self, *, expiration_ts: int, user_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8228,13 +8302,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an expiration for a guest user.
-    https://api.slack.com/methods/admin.users.setExpiration
+    https://docs.slack.dev/reference/methods/admin.users.setExpiration
     &#34;&#34;&#34;
     kwargs.update({&#34;expiration_ts&#34;: expiration_ts, &#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setExpiration&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an expiration for a guest user.
-<a href="https://api.slack.com/methods/admin.users.setExpiration">https://api.slack.com/methods/admin.users.setExpiration</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setExpiration">https://docs.slack.dev/reference/methods/admin.users.setExpiration</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_setOwner"><code class="name flex">
 <span>def <span class="ident">admin_users_setOwner</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8252,13 +8326,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an existing guest, regular user, or admin user to be a workspace owner.
-    https://api.slack.com/methods/admin.users.setOwner
+    https://docs.slack.dev/reference/methods/admin.users.setOwner
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setOwner&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest, regular user, or admin user to be a workspace owner.
-<a href="https://api.slack.com/methods/admin.users.setOwner">https://api.slack.com/methods/admin.users.setOwner</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setOwner">https://docs.slack.dev/reference/methods/admin.users.setOwner</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_setRegular"><code class="name flex">
 <span>def <span class="ident">admin_users_setRegular</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8276,13 +8350,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an existing guest user, admin user, or owner to be a regular user.
-    https://api.slack.com/methods/admin.users.setRegular
+    https://docs.slack.dev/reference/methods/admin.users.setRegular
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setRegular&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest user, admin user, or owner to be a regular user.
-<a href="https://api.slack.com/methods/admin.users.setRegular">https://api.slack.com/methods/admin.users.setRegular</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setRegular">https://docs.slack.dev/reference/methods/admin.users.setRegular</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_users_unsupportedVersions_export"><code class="name flex">
 <span>def <span class="ident">admin_users_unsupportedVersions_export</span></span>(<span>self,<br>*,<br>date_end_of_support: str | int | None = None,<br>date_sessions_started: str | int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8301,7 +8375,7 @@ and what happens when the client closes—for one or more users.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ask Slackbot to send you an export listing all workspace members using unsupported software,
     presented as a zipped CSV file.
-    https://api.slack.com/methods/admin.users.unsupportedVersions.export
+    https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8313,7 +8387,7 @@ and what happens when the client closes—for one or more users.
 </details>
 <div class="desc"><p>Ask Slackbot to send you an export listing all workspace members using unsupported software,
 presented as a zipped CSV file.
-<a href="https://api.slack.com/methods/admin.users.unsupportedVersions.export">https://api.slack.com/methods/admin.users.unsupportedVersions.export</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export">https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_workflows_collaborators_add"><code class="name flex">
 <span>def <span class="ident">admin_workflows_collaborators_add</span></span>(<span>self,<br>*,<br>collaborator_ids: str | Sequence[str],<br>workflow_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8331,7 +8405,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add collaborators to workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.collaborators.add
+    https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
     &#34;&#34;&#34;
     if isinstance(collaborator_ids, (list, tuple)):
         kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -8344,7 +8418,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.collaborators.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add collaborators to workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.collaborators.add">https://api.slack.com/methods/admin.workflows.collaborators.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add">https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_workflows_collaborators_remove"><code class="name flex">
 <span>def <span class="ident">admin_workflows_collaborators_remove</span></span>(<span>self,<br>*,<br>collaborator_ids: str | Sequence[str],<br>workflow_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8362,7 +8436,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove collaborators from workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.collaborators.remove
+    https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
     &#34;&#34;&#34;
     if isinstance(collaborator_ids, (list, tuple)):
         kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -8375,7 +8449,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.collaborators.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove collaborators from workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.collaborators.remove">https://api.slack.com/methods/admin.workflows.collaborators.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove">https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_workflows_permissions_lookup"><code class="name flex">
 <span>def <span class="ident">admin_workflows_permissions_lookup</span></span>(<span>self,<br>*,<br>workflow_ids: str | Sequence[str],<br>max_workflow_triggers: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8393,7 +8467,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Look up the permissions for a set of workflows
-    https://api.slack.com/methods/admin.workflows.permissions.lookup
+    https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
     &#34;&#34;&#34;
     if isinstance(workflow_ids, (list, tuple)):
         kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -8407,7 +8481,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.permissions.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up the permissions for a set of workflows
-<a href="https://api.slack.com/methods/admin.workflows.permissions.lookup">https://api.slack.com/methods/admin.workflows.permissions.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup">https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_workflows_search"><code class="name flex">
 <span>def <span class="ident">admin_workflows_search</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>collaborator_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>no_collaborators: bool | None = None,<br>num_trigger_ids: int | None = None,<br>query: str | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>source: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8433,7 +8507,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Search workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.search
+    https://docs.slack.dev/reference/methods/admin.workflows.search
     &#34;&#34;&#34;
     if collaborator_ids is not None:
         if isinstance(collaborator_ids, (list, tuple)):
@@ -8456,7 +8530,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.search&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Search workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.search">https://api.slack.com/methods/admin.workflows.search</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.search">https://docs.slack.dev/reference/methods/admin.workflows.search</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.admin_workflows_unpublish"><code class="name flex">
 <span>def <span class="ident">admin_workflows_unpublish</span></span>(<span>self, *, workflow_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8473,7 +8547,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Unpublish workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.unpublish
+    https://docs.slack.dev/reference/methods/admin.workflows.unpublish
     &#34;&#34;&#34;
     if isinstance(workflow_ids, (list, tuple)):
         kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -8482,7 +8556,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.unpublish&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unpublish workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.unpublish">https://api.slack.com/methods/admin.workflows.unpublish</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.unpublish">https://docs.slack.dev/reference/methods/admin.workflows.unpublish</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.api_test"><code class="name flex">
 <span>def <span class="ident">api_test</span></span>(<span>self, *, error: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8499,13 +8573,13 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Checks API calling code.
-    https://api.slack.com/methods/api.test
+    https://docs.slack.dev/reference/methods/api.test
     &#34;&#34;&#34;
     kwargs.update({&#34;error&#34;: error})
     return self.api_call(&#34;api.test&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Checks API calling code.
-<a href="https://api.slack.com/methods/api.test">https://api.slack.com/methods/api.test</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/api.test">https://docs.slack.dev/reference/methods/api.test</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.apps_connections_open"><code class="name flex">
 <span>def <span class="ident">apps_connections_open</span></span>(<span>self, *, app_token: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8523,14 +8597,14 @@ presented as a zipped CSV file.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Generate a temporary Socket Mode WebSocket URL that your app can connect to
     in order to receive events and interactive payloads
-    https://api.slack.com/methods/apps.connections.open
+    https://docs.slack.dev/reference/methods/apps.connections.open
     &#34;&#34;&#34;
     kwargs.update({&#34;token&#34;: app_token})
     return self.api_call(&#34;apps.connections.open&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Generate a temporary Socket Mode WebSocket URL that your app can connect to
 in order to receive events and interactive payloads
-<a href="https://api.slack.com/methods/apps.connections.open">https://api.slack.com/methods/apps.connections.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.connections.open">https://docs.slack.dev/reference/methods/apps.connections.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.apps_event_authorizations_list"><code class="name flex">
 <span>def <span class="ident">apps_event_authorizations_list</span></span>(<span>self,<br>*,<br>event_context: str,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8550,14 +8624,14 @@ in order to receive events and interactive payloads
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get a list of authorizations for the given event context.
     Each authorization represents an app installation that the event is visible to.
-    https://api.slack.com/methods/apps.event.authorizations.list
+    https://docs.slack.dev/reference/methods/apps.event.authorizations.list
     &#34;&#34;&#34;
     kwargs.update({&#34;event_context&#34;: event_context, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;apps.event.authorizations.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a list of authorizations for the given event context.
 Each authorization represents an app installation that the event is visible to.
-<a href="https://api.slack.com/methods/apps.event.authorizations.list">https://api.slack.com/methods/apps.event.authorizations.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.event.authorizations.list">https://docs.slack.dev/reference/methods/apps.event.authorizations.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.apps_manifest_create"><code class="name flex">
 <span>def <span class="ident">apps_manifest_create</span></span>(<span>self, *, manifest: str | Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8574,7 +8648,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create an app from an app manifest
-    https://api.slack.com/methods/apps.manifest.create
+    https://docs.slack.dev/reference/methods/apps.manifest.create
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8583,7 +8657,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an app from an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.create">https://api.slack.com/methods/apps.manifest.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.create">https://docs.slack.dev/reference/methods/apps.manifest.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.apps_manifest_delete"><code class="name flex">
 <span>def <span class="ident">apps_manifest_delete</span></span>(<span>self, *, app_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8600,13 +8674,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Permanently deletes an app created through app manifests
-    https://api.slack.com/methods/apps.manifest.delete
+    https://docs.slack.dev/reference/methods/apps.manifest.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     return self.api_call(&#34;apps.manifest.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Permanently deletes an app created through app manifests
-<a href="https://api.slack.com/methods/apps.manifest.delete">https://api.slack.com/methods/apps.manifest.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.delete">https://docs.slack.dev/reference/methods/apps.manifest.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.apps_manifest_export"><code class="name flex">
 <span>def <span class="ident">apps_manifest_export</span></span>(<span>self, *, app_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8623,13 +8697,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Export an app manifest from an existing app
-    https://api.slack.com/methods/apps.manifest.export
+    https://docs.slack.dev/reference/methods/apps.manifest.export
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     return self.api_call(&#34;apps.manifest.export&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Export an app manifest from an existing app
-<a href="https://api.slack.com/methods/apps.manifest.export">https://api.slack.com/methods/apps.manifest.export</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.export">https://docs.slack.dev/reference/methods/apps.manifest.export</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.apps_manifest_update"><code class="name flex">
 <span>def <span class="ident">apps_manifest_update</span></span>(<span>self, *, app_id: str, manifest: str | Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8647,7 +8721,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an app from an app manifest
-    https://api.slack.com/methods/apps.manifest.update
+    https://docs.slack.dev/reference/methods/apps.manifest.update
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8657,7 +8731,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an app from an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.update">https://api.slack.com/methods/apps.manifest.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.update">https://docs.slack.dev/reference/methods/apps.manifest.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.apps_manifest_validate"><code class="name flex">
 <span>def <span class="ident">apps_manifest_validate</span></span>(<span>self, *, manifest: str | Dict[str, Any], app_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8675,7 +8749,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Validate an app manifest
-    https://api.slack.com/methods/apps.manifest.validate
+    https://docs.slack.dev/reference/methods/apps.manifest.validate
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8685,7 +8759,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.validate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Validate an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.validate">https://api.slack.com/methods/apps.manifest.validate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.validate">https://docs.slack.dev/reference/methods/apps.manifest.validate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.apps_uninstall"><code class="name flex">
 <span>def <span class="ident">apps_uninstall</span></span>(<span>self, *, client_id: str, client_secret: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8703,13 +8777,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Uninstalls your app from a workspace.
-    https://api.slack.com/methods/apps.uninstall
+    https://docs.slack.dev/reference/methods/apps.uninstall
     &#34;&#34;&#34;
     kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret})
     return self.api_call(&#34;apps.uninstall&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Uninstalls your app from a workspace.
-<a href="https://api.slack.com/methods/apps.uninstall">https://api.slack.com/methods/apps.uninstall</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.uninstall">https://docs.slack.dev/reference/methods/apps.uninstall</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.assistant_threads_setStatus"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setStatus</span></span>(<span>self, *, channel_id: str, thread_ts: str, status: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8728,13 +8802,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setStatus
+    https://docs.slack.dev/reference/methods/assistant.threads.setStatus
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status})
     return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setStatus">https://api.slack.com/methods/assistant.threads.setStatus</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setStatus">https://docs.slack.dev/reference/methods/assistant.threads.setStatus</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.assistant_threads_setSuggestedPrompts"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8754,7 +8828,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+    https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
     if title is not None:
@@ -8762,7 +8836,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setSuggestedPrompts">https://api.slack.com/methods/assistant.threads.setSuggestedPrompts</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts">https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.assistant_threads_setTitle"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setTitle</span></span>(<span>self, *, channel_id: str, thread_ts: str, title: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8781,13 +8855,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setTitle
+    https://docs.slack.dev/reference/methods/assistant.threads.setTitle
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;title&#34;: title})
     return self.api_call(&#34;assistant.threads.setTitle&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setTitle">https://api.slack.com/methods/assistant.threads.setTitle</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setTitle">https://docs.slack.dev/reference/methods/assistant.threads.setTitle</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.auth_revoke"><code class="name flex">
 <span>def <span class="ident">auth_revoke</span></span>(<span>self, *, test: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8804,13 +8878,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/auth.revoke
+    https://docs.slack.dev/reference/methods/auth.revoke
     &#34;&#34;&#34;
     kwargs.update({&#34;test&#34;: test})
     return self.api_call(&#34;auth.revoke&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/auth.revoke">https://api.slack.com/methods/auth.revoke</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.revoke">https://docs.slack.dev/reference/methods/auth.revoke</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.auth_teams_list"><code class="name flex">
 <span>def <span class="ident">auth_teams_list</span></span>(<span>self,<br>cursor: str | None = None,<br>limit: int | None = None,<br>include_icon: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8828,13 +8902,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List the workspaces a token can access.
-    https://api.slack.com/methods/auth.teams.list
+    https://docs.slack.dev/reference/methods/auth.teams.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;include_icon&#34;: include_icon})
     return self.api_call(&#34;auth.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List the workspaces a token can access.
-<a href="https://api.slack.com/methods/auth.teams.list">https://api.slack.com/methods/auth.teams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.teams.list">https://docs.slack.dev/reference/methods/auth.teams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.auth_test"><code class="name flex">
 <span>def <span class="ident">auth_test</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8849,12 +8923,12 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Checks authentication &amp; identity.
-    https://api.slack.com/methods/auth.test
+    https://docs.slack.dev/reference/methods/auth.test
     &#34;&#34;&#34;
     return self.api_call(&#34;auth.test&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Checks authentication &amp; identity.
-<a href="https://api.slack.com/methods/auth.test">https://api.slack.com/methods/auth.test</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.test">https://docs.slack.dev/reference/methods/auth.test</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.bookmarks_add"><code class="name flex">
 <span>def <span class="ident">bookmarks_add</span></span>(<span>self,<br>*,<br>channel_id: str,<br>title: str,<br>type: str,<br>emoji: str | None = None,<br>entity_id: str | None = None,<br>link: str | None = None,<br>parent_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8877,7 +8951,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add bookmark to a channel.
-    https://api.slack.com/methods/bookmarks.add
+    https://docs.slack.dev/reference/methods/bookmarks.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8893,7 +8967,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;bookmarks.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add bookmark to a channel.
-<a href="https://api.slack.com/methods/bookmarks.add">https://api.slack.com/methods/bookmarks.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.add">https://docs.slack.dev/reference/methods/bookmarks.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.bookmarks_edit"><code class="name flex">
 <span>def <span class="ident">bookmarks_edit</span></span>(<span>self,<br>*,<br>bookmark_id: str,<br>channel_id: str,<br>emoji: str | None = None,<br>link: str | None = None,<br>title: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8914,7 +8988,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Edit bookmark.
-    https://api.slack.com/methods/bookmarks.edit
+    https://docs.slack.dev/reference/methods/bookmarks.edit
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8928,7 +9002,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;bookmarks.edit&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Edit bookmark.
-<a href="https://api.slack.com/methods/bookmarks.edit">https://api.slack.com/methods/bookmarks.edit</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.edit">https://docs.slack.dev/reference/methods/bookmarks.edit</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.bookmarks_list"><code class="name flex">
 <span>def <span class="ident">bookmarks_list</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8945,13 +9019,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List bookmark for the channel.
-    https://api.slack.com/methods/bookmarks.list
+    https://docs.slack.dev/reference/methods/bookmarks.list
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;bookmarks.list&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List bookmark for the channel.
-<a href="https://api.slack.com/methods/bookmarks.list">https://api.slack.com/methods/bookmarks.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.list">https://docs.slack.dev/reference/methods/bookmarks.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.bookmarks_remove"><code class="name flex">
 <span>def <span class="ident">bookmarks_remove</span></span>(<span>self, *, bookmark_id: str, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8969,13 +9043,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove bookmark from the channel.
-    https://api.slack.com/methods/bookmarks.remove
+    https://docs.slack.dev/reference/methods/bookmarks.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;bookmark_id&#34;: bookmark_id, &#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;bookmarks.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove bookmark from the channel.
-<a href="https://api.slack.com/methods/bookmarks.remove">https://api.slack.com/methods/bookmarks.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.remove">https://docs.slack.dev/reference/methods/bookmarks.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.bots_info"><code class="name flex">
 <span>def <span class="ident">bots_info</span></span>(<span>self, *, bot: str | None = None, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8993,13 +9067,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a bot user.
-    https://api.slack.com/methods/bots.info
+    https://docs.slack.dev/reference/methods/bots.info
     &#34;&#34;&#34;
     kwargs.update({&#34;bot&#34;: bot, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;bots.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a bot user.
-<a href="https://api.slack.com/methods/bots.info">https://api.slack.com/methods/bots.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bots.info">https://docs.slack.dev/reference/methods/bots.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.calls_add"><code class="name flex">
 <span>def <span class="ident">calls_add</span></span>(<span>self,<br>*,<br>external_unique_id: str,<br>join_url: str,<br>created_by: str | None = None,<br>date_start: int | None = None,<br>desktop_app_join_url: str | None = None,<br>external_display_id: str | None = None,<br>title: str | None = None,<br>users: str | Sequence[Dict[str, str]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9023,7 +9097,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Registers a new Call.
-    https://api.slack.com/methods/calls.add
+    https://docs.slack.dev/reference/methods/calls.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9043,7 +9117,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;calls.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers a new Call.
-<a href="https://api.slack.com/methods/calls.add">https://api.slack.com/methods/calls.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.add">https://docs.slack.dev/reference/methods/calls.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.calls_end"><code class="name flex">
 <span>def <span class="ident">calls_end</span></span>(<span>self, *, id: str, duration: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9061,13 +9135,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ends a Call.
-    https://api.slack.com/methods/calls.end
+    https://docs.slack.dev/reference/methods/calls.end
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id, &#34;duration&#34;: duration})
     return self.api_call(&#34;calls.end&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends a Call.
-<a href="https://api.slack.com/methods/calls.end">https://api.slack.com/methods/calls.end</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.end">https://docs.slack.dev/reference/methods/calls.end</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.calls_info"><code class="name flex">
 <span>def <span class="ident">calls_info</span></span>(<span>self, *, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9084,13 +9158,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Returns information about a Call.
-    https://api.slack.com/methods/calls.info
+    https://docs.slack.dev/reference/methods/calls.info
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     return self.api_call(&#34;calls.info&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns information about a Call.
-<a href="https://api.slack.com/methods/calls.info">https://api.slack.com/methods/calls.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.info">https://docs.slack.dev/reference/methods/calls.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.calls_participants_add"><code class="name flex">
 <span>def <span class="ident">calls_participants_add</span></span>(<span>self, *, id: str, users: str | Sequence[Dict[str, str]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9108,14 +9182,14 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Registers new participants added to a Call.
-    https://api.slack.com/methods/calls.participants.add
+    https://docs.slack.dev/reference/methods/calls.participants.add
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     _update_call_participants(kwargs, users)
     return self.api_call(&#34;calls.participants.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers new participants added to a Call.
-<a href="https://api.slack.com/methods/calls.participants.add">https://api.slack.com/methods/calls.participants.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.participants.add">https://docs.slack.dev/reference/methods/calls.participants.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.calls_participants_remove"><code class="name flex">
 <span>def <span class="ident">calls_participants_remove</span></span>(<span>self, *, id: str, users: str | Sequence[Dict[str, str]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9133,14 +9207,14 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Registers participants removed from a Call.
-    https://api.slack.com/methods/calls.participants.remove
+    https://docs.slack.dev/reference/methods/calls.participants.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     _update_call_participants(kwargs, users)
     return self.api_call(&#34;calls.participants.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers participants removed from a Call.
-<a href="https://api.slack.com/methods/calls.participants.remove">https://api.slack.com/methods/calls.participants.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.participants.remove">https://docs.slack.dev/reference/methods/calls.participants.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.calls_update"><code class="name flex">
 <span>def <span class="ident">calls_update</span></span>(<span>self,<br>*,<br>id: str,<br>desktop_app_join_url: str | None = None,<br>join_url: str | None = None,<br>title: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9160,7 +9234,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Updates information about a Call.
-    https://api.slack.com/methods/calls.update
+    https://docs.slack.dev/reference/methods/calls.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9173,7 +9247,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;calls.update&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Updates information about a Call.
-<a href="https://api.slack.com/methods/calls.update">https://api.slack.com/methods/calls.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.update">https://docs.slack.dev/reference/methods/calls.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.canvases_access_delete"><code class="name flex">
 <span>def <span class="ident">canvases_access_delete</span></span>(<span>self,<br>*,<br>canvas_id: str,<br>channel_ids: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9192,7 +9266,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a Channel Canvas for a channel
-    https://api.slack.com/methods/canvases.access.delete
+    https://docs.slack.dev/reference/methods/canvases.access.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id})
     if channel_ids is not None:
@@ -9208,7 +9282,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;canvases.access.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Channel Canvas for a channel
-<a href="https://api.slack.com/methods/canvases.access.delete">https://api.slack.com/methods/canvases.access.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.access.delete">https://docs.slack.dev/reference/methods/canvases.access.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.canvases_access_set"><code class="name flex">
 <span>def <span class="ident">canvases_access_set</span></span>(<span>self,<br>*,<br>canvas_id: str,<br>access_level: str,<br>channel_ids: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9228,7 +9302,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the access level to a canvas for specified entities
-    https://api.slack.com/methods/canvases.access.set
+    https://docs.slack.dev/reference/methods/canvases.access.set
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;access_level&#34;: access_level})
     if channel_ids is not None:
@@ -9245,7 +9319,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;canvases.access.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the access level to a canvas for specified entities
-<a href="https://api.slack.com/methods/canvases.access.set">https://api.slack.com/methods/canvases.access.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.access.set">https://docs.slack.dev/reference/methods/canvases.access.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.canvases_create"><code class="name flex">
 <span>def <span class="ident">canvases_create</span></span>(<span>self, *, title: str | None = None, document_content: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9263,13 +9337,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create Canvas for a user
-    https://api.slack.com/methods/canvases.create
+    https://docs.slack.dev/reference/methods/canvases.create
     &#34;&#34;&#34;
     kwargs.update({&#34;title&#34;: title, &#34;document_content&#34;: document_content})
     return self.api_call(&#34;canvases.create&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create Canvas for a user
-<a href="https://api.slack.com/methods/canvases.create">https://api.slack.com/methods/canvases.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.create">https://docs.slack.dev/reference/methods/canvases.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.canvases_delete"><code class="name flex">
 <span>def <span class="ident">canvases_delete</span></span>(<span>self, *, canvas_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9286,13 +9360,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a canvas
-    https://api.slack.com/methods/canvases.delete
+    https://docs.slack.dev/reference/methods/canvases.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id})
     return self.api_call(&#34;canvases.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a canvas
-<a href="https://api.slack.com/methods/canvases.delete">https://api.slack.com/methods/canvases.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.delete">https://docs.slack.dev/reference/methods/canvases.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.canvases_edit"><code class="name flex">
 <span>def <span class="ident">canvases_edit</span></span>(<span>self, *, canvas_id: str, changes: Sequence[Dict[str, Any]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9310,13 +9384,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an existing canvas
-    https://api.slack.com/methods/canvases.edit
+    https://docs.slack.dev/reference/methods/canvases.edit
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;changes&#34;: changes})
     return self.api_call(&#34;canvases.edit&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing canvas
-<a href="https://api.slack.com/methods/canvases.edit">https://api.slack.com/methods/canvases.edit</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.edit">https://docs.slack.dev/reference/methods/canvases.edit</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.canvases_sections_lookup"><code class="name flex">
 <span>def <span class="ident">canvases_sections_lookup</span></span>(<span>self, *, canvas_id: str, criteria: Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9334,13 +9408,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Find sections matching the provided criteria
-    https://api.slack.com/methods/canvases.sections.lookup
+    https://docs.slack.dev/reference/methods/canvases.sections.lookup
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;criteria&#34;: json.dumps(criteria)})
     return self.api_call(&#34;canvases.sections.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Find sections matching the provided criteria
-<a href="https://api.slack.com/methods/canvases.sections.lookup">https://api.slack.com/methods/canvases.sections.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.sections.lookup">https://docs.slack.dev/reference/methods/canvases.sections.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.channels_archive"><code class="name flex">
 <span>def <span class="ident">channels_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9674,13 +9748,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a message.
-    https://api.slack.com/methods/chat.delete
+    https://docs.slack.dev/reference/methods/chat.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts, &#34;as_user&#34;: as_user})
     return self.api_call(&#34;chat.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a message.
-<a href="https://api.slack.com/methods/chat.delete">https://api.slack.com/methods/chat.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.delete">https://docs.slack.dev/reference/methods/chat.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_deleteScheduledMessage"><code class="name flex">
 <span>def <span class="ident">chat_deleteScheduledMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>scheduled_message_id: str,<br>as_user: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9699,7 +9773,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a scheduled message.
-    https://api.slack.com/methods/chat.deleteScheduledMessage
+    https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9711,7 +9785,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.deleteScheduledMessage&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a scheduled message.
-<a href="https://api.slack.com/methods/chat.deleteScheduledMessage">https://api.slack.com/methods/chat.deleteScheduledMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage">https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_getPermalink"><code class="name flex">
 <span>def <span class="ident">chat_getPermalink</span></span>(<span>self, *, channel: str, message_ts: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9729,13 +9803,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a permalink URL for a specific extant message
-    https://api.slack.com/methods/chat.getPermalink
+    https://docs.slack.dev/reference/methods/chat.getPermalink
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;message_ts&#34;: message_ts})
     return self.api_call(&#34;chat.getPermalink&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a permalink URL for a specific extant message
-<a href="https://api.slack.com/methods/chat.getPermalink">https://api.slack.com/methods/chat.getPermalink</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.getPermalink">https://docs.slack.dev/reference/methods/chat.getPermalink</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_meMessage"><code class="name flex">
 <span>def <span class="ident">chat_meMessage</span></span>(<span>self, *, channel: str, text: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9753,16 +9827,16 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Share a me message into a channel.
-    https://api.slack.com/methods/chat.meMessage
+    https://docs.slack.dev/reference/methods/chat.meMessage
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;text&#34;: text})
     return self.api_call(&#34;chat.meMessage&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Share a me message into a channel.
-<a href="https://api.slack.com/methods/chat.meMessage">https://api.slack.com/methods/chat.meMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.meMessage">https://docs.slack.dev/reference/methods/chat.meMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_postEphemeral"><code class="name flex">
-<span>def <span class="ident">chat_postEphemeral</span></span>(<span>self,<br>*,<br>channel: str,<br>user: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_postEphemeral</span></span>(<span>self,<br>*,<br>channel: str,<br>user: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9784,10 +9858,11 @@ Each authorization represents an app installation that the event is visible to.
     link_names: Optional[bool] = None,
     username: Optional[str] = None,
     parse: Optional[str] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sends an ephemeral message to a user in a channel.
-    https://api.slack.com/methods/chat.postEphemeral
+    https://docs.slack.dev/reference/methods/chat.postEphemeral
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9803,19 +9878,20 @@ Each authorization represents an app installation that the event is visible to.
             &#34;link_names&#34;: link_names,
             &#34;username&#34;: username,
             &#34;parse&#34;: parse,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.postEphemeral&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends an ephemeral message to a user in a channel.
-<a href="https://api.slack.com/methods/chat.postEphemeral">https://api.slack.com/methods/chat.postEphemeral</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.postEphemeral">https://docs.slack.dev/reference/methods/chat.postEphemeral</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_postMessage"><code class="name flex">
-<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9842,10 +9918,11 @@ Each authorization represents an app installation that the event is visible to.
     username: Optional[str] = None,
     parse: Optional[str] = None,  # none, full
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sends a message to a channel.
-    https://api.slack.com/methods/chat.postMessage
+    https://docs.slack.dev/reference/methods/chat.postMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9866,19 +9943,20 @@ Each authorization represents an app installation that the event is visible to.
             &#34;username&#34;: username,
             &#34;parse&#34;: parse,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postMessage&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.postMessage&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.postMessage&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends a message to a channel.
-<a href="https://api.slack.com/methods/chat.postMessage">https://api.slack.com/methods/chat.postMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.postMessage">https://docs.slack.dev/reference/methods/chat.postMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_scheduleMessage"><code class="name flex">
-<span>def <span class="ident">chat_scheduleMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>post_at: str | int,<br>text: str,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>link_names: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_scheduleMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>post_at: str | int,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>link_names: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9890,7 +9968,7 @@ Each authorization represents an app installation that the event is visible to.
     *,
     channel: str,
     post_at: Union[str, int],
-    text: str,
+    text: Optional[str] = None,
     as_user: Optional[bool] = None,
     attachments: Optional[Union[str, Sequence[Union[Dict, Attachment]]]] = None,
     blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
@@ -9901,10 +9979,11 @@ Each authorization represents an app installation that the event is visible to.
     unfurl_media: Optional[bool] = None,
     link_names: Optional[bool] = None,
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Schedules a message.
-    https://api.slack.com/methods/chat.scheduleMessage
+    https://docs.slack.dev/reference/methods/chat.scheduleMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9921,16 +10000,17 @@ Each authorization represents an app installation that the event is visible to.
             &#34;unfurl_media&#34;: unfurl_media,
             &#34;link_names&#34;: link_names,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.scheduleMessage&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Schedules a message.
-<a href="https://api.slack.com/methods/chat.scheduleMessage">https://api.slack.com/methods/chat.scheduleMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.scheduleMessage">https://docs.slack.dev/reference/methods/chat.scheduleMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_scheduledMessages_list"><code class="name flex">
 <span>def <span class="ident">chat_scheduledMessages_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>cursor: str | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9952,7 +10032,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all scheduled messages.
-    https://api.slack.com/methods/chat.scheduledMessages.list
+    https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9967,7 +10047,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all scheduled messages.
-<a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.scheduledMessages.list">https://docs.slack.dev/reference/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_unfurl"><code class="name flex">
 <span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9992,7 +10072,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Provide custom unfurl behavior for user-posted URLs.
-    https://api.slack.com/methods/chat.unfurl
+    https://docs.slack.dev/reference/methods/chat.unfurl
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10013,10 +10093,10 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.unfurl&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Provide custom unfurl behavior for user-posted URLs.
-<a href="https://api.slack.com/methods/chat.unfurl">https://api.slack.com/methods/chat.unfurl</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.unfurl">https://docs.slack.dev/reference/methods/chat.unfurl</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_update"><code class="name flex">
-<span>def <span class="ident">chat_update</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>text: str | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>as_user: bool | None = None,<br>file_ids: str | Sequence[str] | None = None,<br>link_names: bool | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_update</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>text: str | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>as_user: bool | None = None,<br>file_ids: str | Sequence[str] | None = None,<br>link_names: bool | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10037,10 +10117,11 @@ Each authorization represents an app installation that the event is visible to.
     parse: Optional[str] = None,  # none, full
     reply_broadcast: Optional[bool] = None,
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Updates a message in a channel.
-    https://api.slack.com/methods/chat.update
+    https://docs.slack.dev/reference/methods/chat.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10054,6 +10135,7 @@ Each authorization represents an app installation that the event is visible to.
             &#34;parse&#34;: parse,
             &#34;reply_broadcast&#34;: reply_broadcast,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     if isinstance(file_ids, (list, tuple)):
@@ -10062,12 +10144,12 @@ Each authorization represents an app installation that the event is visible to.
         kwargs.update({&#34;file_ids&#34;: file_ids})
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.update&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.update&#34;, kwargs)
     # NOTE: intentionally using json over params for API methods using blocks/attachments
     return self.api_call(&#34;chat.update&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Updates a message in a channel.
-<a href="https://api.slack.com/methods/chat.update">https://api.slack.com/methods/chat.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.update">https://docs.slack.dev/reference/methods/chat.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_acceptSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_acceptSharedInvite</span></span>(<span>self,<br>*,<br>channel_name: str,<br>channel_id: str | None = None,<br>invite_id: str | None = None,<br>free_trial_accepted: bool | None = None,<br>is_private: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10089,7 +10171,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Accepts an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.acceptSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
     &#34;&#34;&#34;
     if channel_id is None and invite_id is None:
         raise e.SlackRequestError(&#34;Either channel_id or invite_id must be provided.&#34;)
@@ -10106,7 +10188,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.acceptSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Accepts an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.acceptSharedInvite">https://api.slack.com/methods/conversations.acceptSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite">https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_approveSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_approveSharedInvite</span></span>(<span>self, *, invite_id: str, target_team: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10124,13 +10206,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Approves an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.approveSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
     return self.api_call(&#34;conversations.approveSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approves an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.approveSharedInvite">https://api.slack.com/methods/conversations.approveSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.approveSharedInvite">https://docs.slack.dev/reference/methods/conversations.approveSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_archive"><code class="name flex">
 <span>def <span class="ident">conversations_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10147,13 +10229,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Archives a conversation.
-    https://api.slack.com/methods/conversations.archive
+    https://docs.slack.dev/reference/methods/conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.archive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archives a conversation.
-<a href="https://api.slack.com/methods/conversations.archive">https://api.slack.com/methods/conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.archive">https://docs.slack.dev/reference/methods/conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_canvases_create"><code class="name flex">
 <span>def <span class="ident">conversations_canvases_create</span></span>(<span>self, *, channel_id: str, document_content: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10171,13 +10253,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a Channel Canvas for a channel
-    https://api.slack.com/methods/conversations.canvases.create
+    https://docs.slack.dev/reference/methods/conversations.canvases.create
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;document_content&#34;: document_content})
     return self.api_call(&#34;conversations.canvases.create&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Channel Canvas for a channel
-<a href="https://api.slack.com/methods/conversations.canvases.create">https://api.slack.com/methods/conversations.canvases.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.canvases.create">https://docs.slack.dev/reference/methods/conversations.canvases.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_close"><code class="name flex">
 <span>def <span class="ident">conversations_close</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10194,13 +10276,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Closes a direct message or multi-person direct message.
-    https://api.slack.com/methods/conversations.close
+    https://docs.slack.dev/reference/methods/conversations.close
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.close&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Closes a direct message or multi-person direct message.
-<a href="https://api.slack.com/methods/conversations.close">https://api.slack.com/methods/conversations.close</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.close">https://docs.slack.dev/reference/methods/conversations.close</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_create"><code class="name flex">
 <span>def <span class="ident">conversations_create</span></span>(<span>self,<br>*,<br>name: str,<br>is_private: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10219,13 +10301,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Initiates a public or private channel-based conversation
-    https://api.slack.com/methods/conversations.create
+    https://docs.slack.dev/reference/methods/conversations.create
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;is_private&#34;: is_private, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;conversations.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Initiates a public or private channel-based conversation
-<a href="https://api.slack.com/methods/conversations.create">https://api.slack.com/methods/conversations.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.create">https://docs.slack.dev/reference/methods/conversations.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_declineSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_declineSharedInvite</span></span>(<span>self, *, invite_id: str, target_team: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10243,13 +10325,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Declines a Slack Connect channel invite.
-    https://api.slack.com/methods/conversations.declineSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
     return self.api_call(&#34;conversations.declineSharedInvite&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Declines a Slack Connect channel invite.
-<a href="https://api.slack.com/methods/conversations.declineSharedInvite">https://api.slack.com/methods/conversations.declineSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.declineSharedInvite">https://docs.slack.dev/reference/methods/conversations.declineSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_externalInvitePermissions_set"><code class="name flex">
 <span>def <span class="ident">conversations_externalInvitePermissions_set</span></span>(<span>self, *, action: str, channel: str, target_team: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10263,7 +10345,7 @@ Each authorization represents an app installation that the event is visible to.
     self, *, action: str, channel: str, target_team: str, **kwargs
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-    https://api.slack.com/methods/conversations.externalInvitePermissions.set
+    https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10275,7 +10357,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.externalInvitePermissions.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-<a href="https://api.slack.com/methods/conversations.externalInvitePermissions.set">https://api.slack.com/methods/conversations.externalInvitePermissions.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set">https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_history"><code class="name flex">
 <span>def <span class="ident">conversations_history</span></span>(<span>self,<br>*,<br>channel: str,<br>cursor: str | None = None,<br>inclusive: bool | None = None,<br>include_all_metadata: bool | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10298,7 +10380,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Fetches a conversation&#39;s history of messages and events.
-    https://api.slack.com/methods/conversations.history
+    https://docs.slack.dev/reference/methods/conversations.history
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10314,7 +10396,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.history&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetches a conversation's history of messages and events.
-<a href="https://api.slack.com/methods/conversations.history">https://api.slack.com/methods/conversations.history</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.history">https://docs.slack.dev/reference/methods/conversations.history</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_info"><code class="name flex">
 <span>def <span class="ident">conversations_info</span></span>(<span>self,<br>*,<br>channel: str,<br>include_locale: bool | None = None,<br>include_num_members: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10333,7 +10415,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve information about a conversation.
-    https://api.slack.com/methods/conversations.info
+    https://docs.slack.dev/reference/methods/conversations.info
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10345,7 +10427,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a conversation.
-<a href="https://api.slack.com/methods/conversations.info">https://api.slack.com/methods/conversations.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.info">https://docs.slack.dev/reference/methods/conversations.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_invite"><code class="name flex">
 <span>def <span class="ident">conversations_invite</span></span>(<span>self,<br>*,<br>channel: str,<br>users: str | Sequence[str],<br>force: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10364,7 +10446,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invites users to a channel.
-    https://api.slack.com/methods/conversations.invite
+    https://docs.slack.dev/reference/methods/conversations.invite
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10379,7 +10461,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invites users to a channel.
-<a href="https://api.slack.com/methods/conversations.invite">https://api.slack.com/methods/conversations.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.invite">https://docs.slack.dev/reference/methods/conversations.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_inviteShared"><code class="name flex">
 <span>def <span class="ident">conversations_inviteShared</span></span>(<span>self,<br>*,<br>channel: str,<br>emails: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10398,7 +10480,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sends an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.inviteShared
+    https://docs.slack.dev/reference/methods/conversations.inviteShared
     &#34;&#34;&#34;
     if emails is None and user_ids is None:
         raise e.SlackRequestError(&#34;Either emails or user ids must be provided.&#34;)
@@ -10414,7 +10496,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.inviteShared&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.inviteShared">https://api.slack.com/methods/conversations.inviteShared</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.inviteShared">https://docs.slack.dev/reference/methods/conversations.inviteShared</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_join"><code class="name flex">
 <span>def <span class="ident">conversations_join</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10431,13 +10513,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Joins an existing conversation.
-    https://api.slack.com/methods/conversations.join
+    https://docs.slack.dev/reference/methods/conversations.join
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.join&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Joins an existing conversation.
-<a href="https://api.slack.com/methods/conversations.join">https://api.slack.com/methods/conversations.join</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.join">https://docs.slack.dev/reference/methods/conversations.join</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_kick"><code class="name flex">
 <span>def <span class="ident">conversations_kick</span></span>(<span>self, *, channel: str, user: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10455,13 +10537,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a user from a conversation.
-    https://api.slack.com/methods/conversations.kick
+    https://docs.slack.dev/reference/methods/conversations.kick
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;user&#34;: user})
     return self.api_call(&#34;conversations.kick&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a user from a conversation.
-<a href="https://api.slack.com/methods/conversations.kick">https://api.slack.com/methods/conversations.kick</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.kick">https://docs.slack.dev/reference/methods/conversations.kick</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_leave"><code class="name flex">
 <span>def <span class="ident">conversations_leave</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10478,13 +10560,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Leaves a conversation.
-    https://api.slack.com/methods/conversations.leave
+    https://docs.slack.dev/reference/methods/conversations.leave
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.leave&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Leaves a conversation.
-<a href="https://api.slack.com/methods/conversations.leave">https://api.slack.com/methods/conversations.leave</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.leave">https://docs.slack.dev/reference/methods/conversations.leave</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_list"><code class="name flex">
 <span>def <span class="ident">conversations_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>exclude_archived: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>types: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10505,7 +10587,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all channels in a Slack team.
-    https://api.slack.com/methods/conversations.list
+    https://docs.slack.dev/reference/methods/conversations.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10522,7 +10604,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all channels in a Slack team.
-<a href="https://api.slack.com/methods/conversations.list">https://api.slack.com/methods/conversations.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.list">https://docs.slack.dev/reference/methods/conversations.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_listConnectInvites"><code class="name flex">
 <span>def <span class="ident">conversations_listConnectInvites</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10542,14 +10624,14 @@ Each authorization represents an app installation that the event is visible to.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List shared channel invites that have been generated
     or received but have not yet been approved by all parties.
-    https://api.slack.com/methods/conversations.listConnectInvites
+    https://docs.slack.dev/reference/methods/conversations.listConnectInvites
     &#34;&#34;&#34;
     kwargs.update({&#34;count&#34;: count, &#34;cursor&#34;: cursor, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;conversations.listConnectInvites&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List shared channel invites that have been generated
 or received but have not yet been approved by all parties.
-<a href="https://api.slack.com/methods/conversations.listConnectInvites">https://api.slack.com/methods/conversations.listConnectInvites</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.listConnectInvites">https://docs.slack.dev/reference/methods/conversations.listConnectInvites</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_mark"><code class="name flex">
 <span>def <span class="ident">conversations_mark</span></span>(<span>self, *, channel: str, ts: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10567,13 +10649,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the read cursor in a channel.
-    https://api.slack.com/methods/conversations.mark
+    https://docs.slack.dev/reference/methods/conversations.mark
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts})
     return self.api_call(&#34;conversations.mark&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the read cursor in a channel.
-<a href="https://api.slack.com/methods/conversations.mark">https://api.slack.com/methods/conversations.mark</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.mark">https://docs.slack.dev/reference/methods/conversations.mark</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_members"><code class="name flex">
 <span>def <span class="ident">conversations_members</span></span>(<span>self, *, channel: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10592,13 +10674,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve members of a conversation.
-    https://api.slack.com/methods/conversations.members
+    https://docs.slack.dev/reference/methods/conversations.members
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;conversations.members&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve members of a conversation.
-<a href="https://api.slack.com/methods/conversations.members">https://api.slack.com/methods/conversations.members</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.members">https://docs.slack.dev/reference/methods/conversations.members</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_open"><code class="name flex">
 <span>def <span class="ident">conversations_open</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>return_im: bool | None = None,<br>users: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10617,7 +10699,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Opens or resumes a direct message or multi-person direct message.
-    https://api.slack.com/methods/conversations.open
+    https://docs.slack.dev/reference/methods/conversations.open
     &#34;&#34;&#34;
     if channel is None and users is None:
         raise e.SlackRequestError(&#34;Either channel or users must be provided.&#34;)
@@ -10629,7 +10711,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.open&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Opens or resumes a direct message or multi-person direct message.
-<a href="https://api.slack.com/methods/conversations.open">https://api.slack.com/methods/conversations.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.open">https://docs.slack.dev/reference/methods/conversations.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_rename"><code class="name flex">
 <span>def <span class="ident">conversations_rename</span></span>(<span>self, *, channel: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10647,13 +10729,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Renames a conversation.
-    https://api.slack.com/methods/conversations.rename
+    https://docs.slack.dev/reference/methods/conversations.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name})
     return self.api_call(&#34;conversations.rename&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Renames a conversation.
-<a href="https://api.slack.com/methods/conversations.rename">https://api.slack.com/methods/conversations.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.rename">https://docs.slack.dev/reference/methods/conversations.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_replies"><code class="name flex">
 <span>def <span class="ident">conversations_replies</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>cursor: str | None = None,<br>inclusive: bool | None = None,<br>include_all_metadata: bool | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10677,7 +10759,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a thread of messages posted to a conversation
-    https://api.slack.com/methods/conversations.replies
+    https://docs.slack.dev/reference/methods/conversations.replies
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10694,7 +10776,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.replies&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a thread of messages posted to a conversation
-<a href="https://api.slack.com/methods/conversations.replies">https://api.slack.com/methods/conversations.replies</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.replies">https://docs.slack.dev/reference/methods/conversations.replies</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_requestSharedInvite_approve"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_approve</span></span>(<span>self,<br>*,<br>invite_id: str,<br>channel_id: str | None = None,<br>is_external_limited: str | None = None,<br>message: Dict[str, Any] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10714,7 +10796,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-    https://api.slack.com/methods/conversations.requestSharedInvite.approve
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10728,7 +10810,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.requestSharedInvite.approve&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.approve">https://api.slack.com/methods/conversations.requestSharedInvite.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_requestSharedInvite_deny"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_deny</span></span>(<span>self, *, invite_id: str, message: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10746,13 +10828,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deny a request to invite an external user to a channel.
-    https://api.slack.com/methods/conversations.requestSharedInvite.deny
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;message&#34;: message})
     return self.api_call(&#34;conversations.requestSharedInvite.deny&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deny a request to invite an external user to a channel.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.deny">https://api.slack.com/methods/conversations.requestSharedInvite.deny</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_requestSharedInvite_list"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>include_approved: bool | None = None,<br>include_denied: bool | None = None,<br>include_expired: bool | None = None,<br>invite_ids: str | Sequence[str] | None = None,<br>limit: int | None = None,<br>user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10775,7 +10857,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists requests to add external users to channels with ability to filter.
-    https://api.slack.com/methods/conversations.requestSharedInvite.list
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10795,7 +10877,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.requestSharedInvite.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists requests to add external users to channels with ability to filter.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.list">https://api.slack.com/methods/conversations.requestSharedInvite.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_setPurpose"><code class="name flex">
 <span>def <span class="ident">conversations_setPurpose</span></span>(<span>self, *, channel: str, purpose: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10813,13 +10895,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the purpose for a conversation.
-    https://api.slack.com/methods/conversations.setPurpose
+    https://docs.slack.dev/reference/methods/conversations.setPurpose
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;purpose&#34;: purpose})
     return self.api_call(&#34;conversations.setPurpose&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the purpose for a conversation.
-<a href="https://api.slack.com/methods/conversations.setPurpose">https://api.slack.com/methods/conversations.setPurpose</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.setPurpose">https://docs.slack.dev/reference/methods/conversations.setPurpose</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_setTopic"><code class="name flex">
 <span>def <span class="ident">conversations_setTopic</span></span>(<span>self, *, channel: str, topic: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10837,13 +10919,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the topic for a conversation.
-    https://api.slack.com/methods/conversations.setTopic
+    https://docs.slack.dev/reference/methods/conversations.setTopic
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;topic&#34;: topic})
     return self.api_call(&#34;conversations.setTopic&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the topic for a conversation.
-<a href="https://api.slack.com/methods/conversations.setTopic">https://api.slack.com/methods/conversations.setTopic</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.setTopic">https://docs.slack.dev/reference/methods/conversations.setTopic</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.conversations_unarchive"><code class="name flex">
 <span>def <span class="ident">conversations_unarchive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10860,13 +10942,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Reverses conversation archival.
-    https://api.slack.com/methods/conversations.unarchive
+    https://docs.slack.dev/reference/methods/conversations.unarchive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.unarchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Reverses conversation archival.
-<a href="https://api.slack.com/methods/conversations.unarchive">https://api.slack.com/methods/conversations.unarchive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.unarchive">https://docs.slack.dev/reference/methods/conversations.unarchive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.dialog_open"><code class="name flex">
 <span>def <span class="ident">dialog_open</span></span>(<span>self, *, dialog: Dict[str, Any], trigger_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10884,7 +10966,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Open a dialog with a user.
-    https://api.slack.com/methods/dialog.open
+    https://docs.slack.dev/reference/methods/dialog.open
     &#34;&#34;&#34;
     kwargs.update({&#34;dialog&#34;: dialog, &#34;trigger_id&#34;: trigger_id})
     kwargs = _remove_none_values(kwargs)
@@ -10892,7 +10974,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;dialog.open&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Open a dialog with a user.
-<a href="https://api.slack.com/methods/dialog.open">https://api.slack.com/methods/dialog.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dialog.open">https://docs.slack.dev/reference/methods/dialog.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.dnd_endDnd"><code class="name flex">
 <span>def <span class="ident">dnd_endDnd</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10907,12 +10989,12 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ends the current user&#39;s Do Not Disturb session immediately.
-    https://api.slack.com/methods/dnd.endDnd
+    https://docs.slack.dev/reference/methods/dnd.endDnd
     &#34;&#34;&#34;
     return self.api_call(&#34;dnd.endDnd&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends the current user's Do Not Disturb session immediately.
-<a href="https://api.slack.com/methods/dnd.endDnd">https://api.slack.com/methods/dnd.endDnd</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.endDnd">https://docs.slack.dev/reference/methods/dnd.endDnd</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.dnd_endSnooze"><code class="name flex">
 <span>def <span class="ident">dnd_endSnooze</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10927,12 +11009,12 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ends the current user&#39;s snooze mode immediately.
-    https://api.slack.com/methods/dnd.endSnooze
+    https://docs.slack.dev/reference/methods/dnd.endSnooze
     &#34;&#34;&#34;
     return self.api_call(&#34;dnd.endSnooze&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends the current user's snooze mode immediately.
-<a href="https://api.slack.com/methods/dnd.endSnooze">https://api.slack.com/methods/dnd.endSnooze</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.endSnooze">https://docs.slack.dev/reference/methods/dnd.endSnooze</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.dnd_info"><code class="name flex">
 <span>def <span class="ident">dnd_info</span></span>(<span>self, *, team_id: str | None = None, user: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10950,13 +11032,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieves a user&#39;s current Do Not Disturb status.
-    https://api.slack.com/methods/dnd.info
+    https://docs.slack.dev/reference/methods/dnd.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
     return self.api_call(&#34;dnd.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves a user's current Do Not Disturb status.
-<a href="https://api.slack.com/methods/dnd.info">https://api.slack.com/methods/dnd.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.info">https://docs.slack.dev/reference/methods/dnd.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.dnd_setSnooze"><code class="name flex">
 <span>def <span class="ident">dnd_setSnooze</span></span>(<span>self, *, num_minutes: str | int, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10973,13 +11055,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Turns on Do Not Disturb mode for the current user, or changes its duration.
-    https://api.slack.com/methods/dnd.setSnooze
+    https://docs.slack.dev/reference/methods/dnd.setSnooze
     &#34;&#34;&#34;
     kwargs.update({&#34;num_minutes&#34;: num_minutes})
     return self.api_call(&#34;dnd.setSnooze&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Turns on Do Not Disturb mode for the current user, or changes its duration.
-<a href="https://api.slack.com/methods/dnd.setSnooze">https://api.slack.com/methods/dnd.setSnooze</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.setSnooze">https://docs.slack.dev/reference/methods/dnd.setSnooze</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.dnd_teamInfo"><code class="name flex">
 <span>def <span class="ident">dnd_teamInfo</span></span>(<span>self, users: str | Sequence[str], team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10996,7 +11078,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieves the Do Not Disturb status for users on a team.
-    https://api.slack.com/methods/dnd.teamInfo
+    https://docs.slack.dev/reference/methods/dnd.teamInfo
     &#34;&#34;&#34;
     if isinstance(users, (list, tuple)):
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -11006,7 +11088,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;dnd.teamInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves the Do Not Disturb status for users on a team.
-<a href="https://api.slack.com/methods/dnd.teamInfo">https://api.slack.com/methods/dnd.teamInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.teamInfo">https://docs.slack.dev/reference/methods/dnd.teamInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.emoji_list"><code class="name flex">
 <span>def <span class="ident">emoji_list</span></span>(<span>self, include_categories: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11022,13 +11104,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists custom emoji for a team.
-    https://api.slack.com/methods/emoji.list
+    https://docs.slack.dev/reference/methods/emoji.list
     &#34;&#34;&#34;
     kwargs.update({&#34;include_categories&#34;: include_categories})
     return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists custom emoji for a team.
-<a href="https://api.slack.com/methods/emoji.list">https://api.slack.com/methods/emoji.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/emoji.list">https://docs.slack.dev/reference/methods/emoji.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_comments_delete"><code class="name flex">
 <span>def <span class="ident">files_comments_delete</span></span>(<span>self, *, file: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11046,13 +11128,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes an existing comment on a file.
-    https://api.slack.com/methods/files.comments.delete
+    https://docs.slack.dev/reference/methods/files.comments.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file, &#34;id&#34;: id})
     return self.api_call(&#34;files.comments.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes an existing comment on a file.
-<a href="https://api.slack.com/methods/files.comments.delete">https://api.slack.com/methods/files.comments.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.comments.delete">https://docs.slack.dev/reference/methods/files.comments.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_completeUploadExternal"><code class="name flex">
 <span>def <span class="ident">files_completeUploadExternal</span></span>(<span>self,<br>*,<br>files: List[Dict[str, str]],<br>channel_id: str | None = None,<br>channels: List[str] | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11073,7 +11155,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Finishes an upload started with files.getUploadURLExternal.
-    https://api.slack.com/methods/files.completeUploadExternal
+    https://docs.slack.dev/reference/methods/files.completeUploadExternal
     &#34;&#34;&#34;
     _files = [{k: v for k, v in f.items() if v is not None} for f in files]
     kwargs.update(
@@ -11089,7 +11171,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.completeUploadExternal&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Finishes an upload started with files.getUploadURLExternal.
-<a href="https://api.slack.com/methods/files.completeUploadExternal">https://api.slack.com/methods/files.completeUploadExternal</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.completeUploadExternal">https://docs.slack.dev/reference/methods/files.completeUploadExternal</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_delete"><code class="name flex">
 <span>def <span class="ident">files_delete</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11106,13 +11188,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a file.
-    https://api.slack.com/methods/files.delete
+    https://docs.slack.dev/reference/methods/files.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a file.
-<a href="https://api.slack.com/methods/files.delete">https://api.slack.com/methods/files.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.delete">https://docs.slack.dev/reference/methods/files.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_getUploadURLExternal"><code class="name flex">
 <span>def <span class="ident">files_getUploadURLExternal</span></span>(<span>self,<br>*,<br>filename: str,<br>length: int,<br>alt_txt: str | None = None,<br>snippet_type: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11132,7 +11214,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets a URL for an edge external upload.
-    https://api.slack.com/methods/files.getUploadURLExternal
+    https://docs.slack.dev/reference/methods/files.getUploadURLExternal
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11145,7 +11227,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.getUploadURLExternal&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets a URL for an edge external upload.
-<a href="https://api.slack.com/methods/files.getUploadURLExternal">https://api.slack.com/methods/files.getUploadURLExternal</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.getUploadURLExternal">https://docs.slack.dev/reference/methods/files.getUploadURLExternal</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_info"><code class="name flex">
 <span>def <span class="ident">files_info</span></span>(<span>self,<br>*,<br>file: str,<br>count: int | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11166,7 +11248,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a team file.
-    https://api.slack.com/methods/files.info
+    https://docs.slack.dev/reference/methods/files.info
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11180,7 +11262,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a team file.
-<a href="https://api.slack.com/methods/files.info">https://api.slack.com/methods/files.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.info">https://docs.slack.dev/reference/methods/files.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_list"><code class="name flex">
 <span>def <span class="ident">files_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>count: int | None = None,<br>page: int | None = None,<br>show_files_hidden_by_limit: bool | None = None,<br>team_id: str | None = None,<br>ts_from: str | None = None,<br>ts_to: str | None = None,<br>types: str | Sequence[str] | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11205,7 +11287,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists &amp; filters team files.
-    https://api.slack.com/methods/files.list
+    https://docs.slack.dev/reference/methods/files.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11226,7 +11308,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists &amp; filters team files.
-<a href="https://api.slack.com/methods/files.list">https://api.slack.com/methods/files.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.list">https://docs.slack.dev/reference/methods/files.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_remote_add"><code class="name flex">
 <span>def <span class="ident">files_remote_add</span></span>(<span>self,<br>*,<br>external_id: str,<br>external_url: str,<br>title: str,<br>filetype: str | None = None,<br>indexable_file_contents: str | bytes | io.IOBase | None = None,<br>preview_image: str | bytes | io.IOBase | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11248,7 +11330,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds a file from a remote service.
-    https://api.slack.com/methods/files.remote.add
+    https://docs.slack.dev/reference/methods/files.remote.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11275,7 +11357,7 @@ or received but have not yet been approved by all parties.
     )</code></pre>
 </details>
 <div class="desc"><p>Adds a file from a remote service.
-<a href="https://api.slack.com/methods/files.remote.add">https://api.slack.com/methods/files.remote.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.add">https://docs.slack.dev/reference/methods/files.remote.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_remote_info"><code class="name flex">
 <span>def <span class="ident">files_remote_info</span></span>(<span>self, *, external_id: str | None = None, file: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11293,13 +11375,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-    https://api.slack.com/methods/files.remote.info
+    https://docs.slack.dev/reference/methods/files.remote.info
     &#34;&#34;&#34;
     kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
     return self.api_call(&#34;files.remote.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a remote file added to Slack.
-<a href="https://api.slack.com/methods/files.remote.info">https://api.slack.com/methods/files.remote.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.info">https://docs.slack.dev/reference/methods/files.remote.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_remote_list"><code class="name flex">
 <span>def <span class="ident">files_remote_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>ts_from: str | None = None,<br>ts_to: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11320,7 +11402,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-    https://api.slack.com/methods/files.remote.list
+    https://docs.slack.dev/reference/methods/files.remote.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11334,7 +11416,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.remote.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a remote file added to Slack.
-<a href="https://api.slack.com/methods/files.remote.list">https://api.slack.com/methods/files.remote.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.list">https://docs.slack.dev/reference/methods/files.remote.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_remote_remove"><code class="name flex">
 <span>def <span class="ident">files_remote_remove</span></span>(<span>self, *, external_id: str | None = None, file: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11352,13 +11434,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a remote file.
-    https://api.slack.com/methods/files.remote.remove
+    https://docs.slack.dev/reference/methods/files.remote.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
     return self.api_call(&#34;files.remote.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a remote file.
-<a href="https://api.slack.com/methods/files.remote.remove">https://api.slack.com/methods/files.remote.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.remove">https://docs.slack.dev/reference/methods/files.remote.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_remote_share"><code class="name flex">
 <span>def <span class="ident">files_remote_share</span></span>(<span>self,<br>*,<br>channels: str | Sequence[str],<br>external_id: str | None = None,<br>file: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11377,7 +11459,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Share a remote file into a channel.
-    https://api.slack.com/methods/files.remote.share
+    https://docs.slack.dev/reference/methods/files.remote.share
     &#34;&#34;&#34;
     if external_id is None and file is None:
         raise e.SlackRequestError(&#34;Either external_id or file must be provided.&#34;)
@@ -11389,7 +11471,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.remote.share&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Share a remote file into a channel.
-<a href="https://api.slack.com/methods/files.remote.share">https://api.slack.com/methods/files.remote.share</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.share">https://docs.slack.dev/reference/methods/files.remote.share</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_remote_update"><code class="name flex">
 <span>def <span class="ident">files_remote_update</span></span>(<span>self,<br>*,<br>external_id: str | None = None,<br>external_url: str | None = None,<br>file: str | None = None,<br>title: str | None = None,<br>filetype: str | None = None,<br>indexable_file_contents: str | None = None,<br>preview_image: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11412,7 +11494,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Updates an existing remote file.
-    https://api.slack.com/methods/files.remote.update
+    https://docs.slack.dev/reference/methods/files.remote.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11440,7 +11522,7 @@ or received but have not yet been approved by all parties.
     )</code></pre>
 </details>
 <div class="desc"><p>Updates an existing remote file.
-<a href="https://api.slack.com/methods/files.remote.update">https://api.slack.com/methods/files.remote.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.update">https://docs.slack.dev/reference/methods/files.remote.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_revokePublicURL"><code class="name flex">
 <span>def <span class="ident">files_revokePublicURL</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11457,13 +11539,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes public/external sharing access for a file
-    https://api.slack.com/methods/files.revokePublicURL
+    https://docs.slack.dev/reference/methods/files.revokePublicURL
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.revokePublicURL&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes public/external sharing access for a file
-<a href="https://api.slack.com/methods/files.revokePublicURL">https://api.slack.com/methods/files.revokePublicURL</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.revokePublicURL">https://docs.slack.dev/reference/methods/files.revokePublicURL</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_sharedPublicURL"><code class="name flex">
 <span>def <span class="ident">files_sharedPublicURL</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11480,13 +11562,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Enables a file for public/external sharing.
-    https://api.slack.com/methods/files.sharedPublicURL
+    https://docs.slack.dev/reference/methods/files.sharedPublicURL
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.sharedPublicURL&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enables a file for public/external sharing.
-<a href="https://api.slack.com/methods/files.sharedPublicURL">https://api.slack.com/methods/files.sharedPublicURL</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.sharedPublicURL">https://docs.slack.dev/reference/methods/files.sharedPublicURL</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_upload"><code class="name flex">
 <span>def <span class="ident">files_upload</span></span>(<span>self,<br>*,<br>file: str | bytes | io.IOBase | None = None,<br>content: str | bytes | None = None,<br>filename: str | None = None,<br>filetype: str | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>title: str | None = None,<br>channels: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11510,7 +11592,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Uploads or creates a file.
-    https://api.slack.com/methods/files.upload
+    https://docs.slack.dev/reference/methods/files.upload
     &#34;&#34;&#34;
     _print_files_upload_v2_suggestion()
 
@@ -11543,7 +11625,7 @@ or received but have not yet been approved by all parties.
         return self.api_call(&#34;files.upload&#34;, data=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Uploads or creates a file.
-<a href="https://api.slack.com/methods/files.upload">https://api.slack.com/methods/files.upload</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.upload">https://docs.slack.dev/reference/methods/files.upload</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_upload_v2"><code class="name flex">
 <span>def <span class="ident">files_upload_v2</span></span>(<span>self,<br>*,<br>filename: str | None = None,<br>file: str | bytes | io.IOBase | os.PathLike | None = None,<br>content: str | bytes | None = None,<br>title: str | None = None,<br>alt_txt: str | None = None,<br>snippet_type: str | None = None,<br>file_uploads: List[Dict[str, Any]] | None = None,<br>channel: str | None = None,<br>channels: List[str] | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>request_file_info: bool = True,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11574,12 +11656,12 @@ or received but have not yet been approved by all parties.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;This wrapper method provides an easy way to upload files using the following endpoints:
 
-    - step1: https://api.slack.com/methods/files.getUploadURLExternal
+    - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
     - step2: &#34;https://files.slack.com/upload/v1/...&#34; URLs returned from files.getUploadURLExternal API
 
-    - step3: https://api.slack.com/methods/files.completeUploadExternal
-        and https://api.slack.com/methods/files.info
+    - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+        and https://docs.slack.dev/reference/methods/files.info
 
     &#34;&#34;&#34;
     if file is None and content is None and file_uploads is None:
@@ -11658,14 +11740,14 @@ or received but have not yet been approved by all parties.
 <div class="desc"><p>This wrapper method provides an easy way to upload files using the following endpoints:</p>
 <ul>
 <li>
-<p>step1: <a href="https://api.slack.com/methods/files.getUploadURLExternal">https://api.slack.com/methods/files.getUploadURLExternal</a></p>
+<p>step1: <a href="https://docs.slack.dev/reference/methods/files.getUploadURLExternal">https://docs.slack.dev/reference/methods/files.getUploadURLExternal</a></p>
 </li>
 <li>
 <p>step2: "https://files.slack.com/upload/v1/&hellip;" URLs returned from files.getUploadURLExternal API</p>
 </li>
 <li>
-<p>step3: <a href="https://api.slack.com/methods/files.completeUploadExternal">https://api.slack.com/methods/files.completeUploadExternal</a>
-and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/methods/files.info</a></p>
+<p>step3: <a href="https://docs.slack.dev/reference/methods/files.completeUploadExternal">https://docs.slack.dev/reference/methods/files.completeUploadExternal</a>
+and <a href="https://docs.slack.dev/reference/methods/files.info">https://docs.slack.dev/reference/methods/files.info</a></p>
 </li>
 </ul></div>
 </dd>
@@ -11685,13 +11767,13 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Signal the failure to execute a function
-    https://api.slack.com/methods/functions.completeError
+    https://docs.slack.dev/reference/methods/functions.completeError
     &#34;&#34;&#34;
     kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;error&#34;: error})
     return self.api_call(&#34;functions.completeError&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Signal the failure to execute a function
-<a href="https://api.slack.com/methods/functions.completeError">https://api.slack.com/methods/functions.completeError</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/functions.completeError">https://docs.slack.dev/reference/methods/functions.completeError</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.functions_completeSuccess"><code class="name flex">
 <span>def <span class="ident">functions_completeSuccess</span></span>(<span>self, *, function_execution_id: str, outputs: Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11709,13 +11791,13 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Signal the successful completion of a function
-    https://api.slack.com/methods/functions.completeSuccess
+    https://docs.slack.dev/reference/methods/functions.completeSuccess
     &#34;&#34;&#34;
     kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;outputs&#34;: json.dumps(outputs)})
     return self.api_call(&#34;functions.completeSuccess&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Signal the successful completion of a function
-<a href="https://api.slack.com/methods/functions.completeSuccess">https://api.slack.com/methods/functions.completeSuccess</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/functions.completeSuccess">https://docs.slack.dev/reference/methods/functions.completeSuccess</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.groups_archive"><code class="name flex">
 <span>def <span class="ident">groups_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12191,7 +12273,7 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;For Enterprise Grid workspaces, map local user IDs to global user IDs
-    https://api.slack.com/methods/migration.exchange
+    https://docs.slack.dev/reference/methods/migration.exchange
     &#34;&#34;&#34;
     if isinstance(users, (list, tuple)):
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -12201,7 +12283,7 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     return self.api_call(&#34;migration.exchange&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>For Enterprise Grid workspaces, map local user IDs to global user IDs
-<a href="https://api.slack.com/methods/migration.exchange">https://api.slack.com/methods/migration.exchange</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/migration.exchange">https://docs.slack.dev/reference/methods/migration.exchange</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.mpim_close"><code class="name flex">
 <span>def <span class="ident">mpim_close</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12348,7 +12430,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-    https://api.slack.com/methods/oauth.access
+    https://docs.slack.dev/reference/methods/oauth.access
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12360,7 +12442,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.
-<a href="https://api.slack.com/methods/oauth.access">https://api.slack.com/methods/oauth.access</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.access">https://docs.slack.dev/reference/methods/oauth.access</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.oauth_v2_access"><code class="name flex">
 <span>def <span class="ident">oauth_v2_access</span></span>(<span>self,<br>*,<br>client_id: str,<br>client_secret: str,<br>code: str | None = None,<br>redirect_uri: str | None = None,<br>grant_type: str | None = None,<br>refresh_token: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12386,7 +12468,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-    https://api.slack.com/methods/oauth.v2.access
+    https://docs.slack.dev/reference/methods/oauth.v2.access
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12403,7 +12485,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.
-<a href="https://api.slack.com/methods/oauth.v2.access">https://api.slack.com/methods/oauth.v2.access</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.v2.access">https://docs.slack.dev/reference/methods/oauth.v2.access</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.oauth_v2_exchange"><code class="name flex">
 <span>def <span class="ident">oauth_v2_exchange</span></span>(<span>self, *, token: str, client_id: str, client_secret: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12422,13 +12504,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
-    https://api.slack.com/methods/oauth.v2.exchange
+    https://docs.slack.dev/reference/methods/oauth.v2.exchange
     &#34;&#34;&#34;
     kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token})
     return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Exchanges a legacy access token for a new expiring access token and refresh token
-<a href="https://api.slack.com/methods/oauth.v2.exchange">https://api.slack.com/methods/oauth.v2.exchange</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.v2.exchange">https://docs.slack.dev/reference/methods/oauth.v2.exchange</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.openid_connect_token"><code class="name flex">
 <span>def <span class="ident">openid_connect_token</span></span>(<span>self,<br>client_id: str,<br>client_secret: str,<br>code: str | None = None,<br>redirect_uri: str | None = None,<br>grant_type: str | None = None,<br>refresh_token: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12449,7 +12531,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-    https://api.slack.com/methods/openid.connect.token
+    https://docs.slack.dev/reference/methods/openid.connect.token
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12466,7 +12548,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-<a href="https://api.slack.com/methods/openid.connect.token">https://api.slack.com/methods/openid.connect.token</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/openid.connect.token">https://docs.slack.dev/reference/methods/openid.connect.token</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.openid_connect_userInfo"><code class="name flex">
 <span>def <span class="ident">openid_connect_userInfo</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12481,12 +12563,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get the identity of a user who has authorized Sign in with Slack.
-    https://api.slack.com/methods/openid.connect.userInfo
+    https://docs.slack.dev/reference/methods/openid.connect.userInfo
     &#34;&#34;&#34;
     return self.api_call(&#34;openid.connect.userInfo&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get the identity of a user who has authorized Sign in with Slack.
-<a href="https://api.slack.com/methods/openid.connect.userInfo">https://api.slack.com/methods/openid.connect.userInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/openid.connect.userInfo">https://docs.slack.dev/reference/methods/openid.connect.userInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.pins_add"><code class="name flex">
 <span>def <span class="ident">pins_add</span></span>(<span>self, *, channel: str, timestamp: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12504,13 +12586,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Pins an item to a channel.
-    https://api.slack.com/methods/pins.add
+    https://docs.slack.dev/reference/methods/pins.add
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;pins.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Pins an item to a channel.
-<a href="https://api.slack.com/methods/pins.add">https://api.slack.com/methods/pins.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.add">https://docs.slack.dev/reference/methods/pins.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.pins_list"><code class="name flex">
 <span>def <span class="ident">pins_list</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12527,13 +12609,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists items pinned to a channel.
-    https://api.slack.com/methods/pins.list
+    https://docs.slack.dev/reference/methods/pins.list
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;pins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists items pinned to a channel.
-<a href="https://api.slack.com/methods/pins.list">https://api.slack.com/methods/pins.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.list">https://docs.slack.dev/reference/methods/pins.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.pins_remove"><code class="name flex">
 <span>def <span class="ident">pins_remove</span></span>(<span>self, *, channel: str, timestamp: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12551,13 +12633,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Un-pins an item from a channel.
-    https://api.slack.com/methods/pins.remove
+    https://docs.slack.dev/reference/methods/pins.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;pins.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Un-pins an item from a channel.
-<a href="https://api.slack.com/methods/pins.remove">https://api.slack.com/methods/pins.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.remove">https://docs.slack.dev/reference/methods/pins.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.reactions_add"><code class="name flex">
 <span>def <span class="ident">reactions_add</span></span>(<span>self, *, channel: str, name: str, timestamp: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12576,13 +12658,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds a reaction to an item.
-    https://api.slack.com/methods/reactions.add
+    https://docs.slack.dev/reference/methods/reactions.add
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;reactions.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds a reaction to an item.
-<a href="https://api.slack.com/methods/reactions.add">https://api.slack.com/methods/reactions.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.add">https://docs.slack.dev/reference/methods/reactions.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.reactions_get"><code class="name flex">
 <span>def <span class="ident">reactions_get</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>full: bool | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12603,7 +12685,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets reactions for an item.
-    https://api.slack.com/methods/reactions.get
+    https://docs.slack.dev/reference/methods/reactions.get
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12617,7 +12699,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets reactions for an item.
-<a href="https://api.slack.com/methods/reactions.get">https://api.slack.com/methods/reactions.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.get">https://docs.slack.dev/reference/methods/reactions.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.reactions_list"><code class="name flex">
 <span>def <span class="ident">reactions_list</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>full: bool | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>team_id: str | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12640,7 +12722,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists reactions made by a user.
-    https://api.slack.com/methods/reactions.list
+    https://docs.slack.dev/reference/methods/reactions.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12656,7 +12738,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists reactions made by a user.
-<a href="https://api.slack.com/methods/reactions.list">https://api.slack.com/methods/reactions.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.list">https://docs.slack.dev/reference/methods/reactions.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.reactions_remove"><code class="name flex">
 <span>def <span class="ident">reactions_remove</span></span>(<span>self,<br>*,<br>name: str,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12677,7 +12759,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a reaction from an item.
-    https://api.slack.com/methods/reactions.remove
+    https://docs.slack.dev/reference/methods/reactions.remove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12691,7 +12773,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a reaction from an item.
-<a href="https://api.slack.com/methods/reactions.remove">https://api.slack.com/methods/reactions.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.remove">https://docs.slack.dev/reference/methods/reactions.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.reminders_add"><code class="name flex">
 <span>def <span class="ident">reminders_add</span></span>(<span>self,<br>*,<br>text: str,<br>time: str,<br>team_id: str | None = None,<br>user: str | None = None,<br>recurrence: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12712,7 +12794,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Creates a reminder.
-    https://api.slack.com/methods/reminders.add
+    https://docs.slack.dev/reference/methods/reminders.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12726,7 +12808,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reminders.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Creates a reminder.
-<a href="https://api.slack.com/methods/reminders.add">https://api.slack.com/methods/reminders.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.add">https://docs.slack.dev/reference/methods/reminders.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.reminders_complete"><code class="name flex">
 <span>def <span class="ident">reminders_complete</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12744,13 +12826,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Marks a reminder as complete.
-    https://api.slack.com/methods/reminders.complete
+    https://docs.slack.dev/reference/methods/reminders.complete
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.complete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Marks a reminder as complete.
-<a href="https://api.slack.com/methods/reminders.complete">https://api.slack.com/methods/reminders.complete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.complete">https://docs.slack.dev/reference/methods/reminders.complete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.reminders_delete"><code class="name flex">
 <span>def <span class="ident">reminders_delete</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12768,13 +12850,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a reminder.
-    https://api.slack.com/methods/reminders.delete
+    https://docs.slack.dev/reference/methods/reminders.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a reminder.
-<a href="https://api.slack.com/methods/reminders.delete">https://api.slack.com/methods/reminders.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.delete">https://docs.slack.dev/reference/methods/reminders.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.reminders_info"><code class="name flex">
 <span>def <span class="ident">reminders_info</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12792,13 +12874,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a reminder.
-    https://api.slack.com/methods/reminders.info
+    https://docs.slack.dev/reference/methods/reminders.info
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a reminder.
-<a href="https://api.slack.com/methods/reminders.info">https://api.slack.com/methods/reminders.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.info">https://docs.slack.dev/reference/methods/reminders.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.reminders_list"><code class="name flex">
 <span>def <span class="ident">reminders_list</span></span>(<span>self, *, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12815,13 +12897,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all reminders created by or for a given user.
-    https://api.slack.com/methods/reminders.list
+    https://docs.slack.dev/reference/methods/reminders.list
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all reminders created by or for a given user.
-<a href="https://api.slack.com/methods/reminders.list">https://api.slack.com/methods/reminders.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.list">https://docs.slack.dev/reference/methods/reminders.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.rtm_connect"><code class="name flex">
 <span>def <span class="ident">rtm_connect</span></span>(<span>self,<br>*,<br>batch_presence_aware: bool | None = None,<br>presence_sub: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12839,13 +12921,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Starts a Real Time Messaging session.
-    https://api.slack.com/methods/rtm.connect
+    https://docs.slack.dev/reference/methods/rtm.connect
     &#34;&#34;&#34;
     kwargs.update({&#34;batch_presence_aware&#34;: batch_presence_aware, &#34;presence_sub&#34;: presence_sub})
     return self.api_call(&#34;rtm.connect&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Starts a Real Time Messaging session.
-<a href="https://api.slack.com/methods/rtm.connect">https://api.slack.com/methods/rtm.connect</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/rtm.connect">https://docs.slack.dev/reference/methods/rtm.connect</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.rtm_start"><code class="name flex">
 <span>def <span class="ident">rtm_start</span></span>(<span>self,<br>*,<br>batch_presence_aware: bool | None = None,<br>include_locale: bool | None = None,<br>mpim_aware: bool | None = None,<br>no_latest: bool | None = None,<br>no_unreads: bool | None = None,<br>presence_sub: bool | None = None,<br>simple_latest: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12868,7 +12950,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Starts a Real Time Messaging session.
-    https://api.slack.com/methods/rtm.start
+    https://docs.slack.dev/reference/methods/rtm.start
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12884,7 +12966,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;rtm.start&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Starts a Real Time Messaging session.
-<a href="https://api.slack.com/methods/rtm.start">https://api.slack.com/methods/rtm.start</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/rtm.start">https://docs.slack.dev/reference/methods/rtm.start</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.search_all"><code class="name flex">
 <span>def <span class="ident">search_all</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12907,7 +12989,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Searches for messages and files matching a query.
-    https://api.slack.com/methods/search.all
+    https://docs.slack.dev/reference/methods/search.all
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12923,7 +13005,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.all&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for messages and files matching a query.
-<a href="https://api.slack.com/methods/search.all">https://api.slack.com/methods/search.all</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.all">https://docs.slack.dev/reference/methods/search.all</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.search_files"><code class="name flex">
 <span>def <span class="ident">search_files</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12946,7 +13028,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Searches for files matching a query.
-    https://api.slack.com/methods/search.files
+    https://docs.slack.dev/reference/methods/search.files
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12962,7 +13044,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.files&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for files matching a query.
-<a href="https://api.slack.com/methods/search.files">https://api.slack.com/methods/search.files</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.files">https://docs.slack.dev/reference/methods/search.files</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.search_messages"><code class="name flex">
 <span>def <span class="ident">search_messages</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>cursor: str | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12986,7 +13068,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Searches for messages matching a query.
-    https://api.slack.com/methods/search.messages
+    https://docs.slack.dev/reference/methods/search.messages
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13003,7 +13085,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.messages&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for messages matching a query.
-<a href="https://api.slack.com/methods/search.messages">https://api.slack.com/methods/search.messages</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.messages">https://docs.slack.dev/reference/methods/search.messages</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.stars_add"><code class="name flex">
 <span>def <span class="ident">stars_add</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13023,7 +13105,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds a star to an item.
-    https://api.slack.com/methods/stars.add
+    https://docs.slack.dev/reference/methods/stars.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13036,7 +13118,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds a star to an item.
-<a href="https://api.slack.com/methods/stars.add">https://api.slack.com/methods/stars.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.add">https://docs.slack.dev/reference/methods/stars.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.stars_list"><code class="name flex">
 <span>def <span class="ident">stars_list</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13057,7 +13139,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists stars for a user.
-    https://api.slack.com/methods/stars.list
+    https://docs.slack.dev/reference/methods/stars.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13071,7 +13153,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists stars for a user.
-<a href="https://api.slack.com/methods/stars.list">https://api.slack.com/methods/stars.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.list">https://docs.slack.dev/reference/methods/stars.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.stars_remove"><code class="name flex">
 <span>def <span class="ident">stars_remove</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13091,7 +13173,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a star from an item.
-    https://api.slack.com/methods/stars.remove
+    https://docs.slack.dev/reference/methods/stars.remove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13104,7 +13186,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a star from an item.
-<a href="https://api.slack.com/methods/stars.remove">https://api.slack.com/methods/stars.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.remove">https://docs.slack.dev/reference/methods/stars.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.team_accessLogs"><code class="name flex">
 <span>def <span class="ident">team_accessLogs</span></span>(<span>self,<br>*,<br>before: str | int | None = None,<br>count: str | int | None = None,<br>page: str | int | None = None,<br>team_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13126,7 +13208,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets the access logs for the current team.
-    https://api.slack.com/methods/team.accessLogs
+    https://docs.slack.dev/reference/methods/team.accessLogs
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13141,7 +13223,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.accessLogs&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets the access logs for the current team.
-<a href="https://api.slack.com/methods/team.accessLogs">https://api.slack.com/methods/team.accessLogs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.accessLogs">https://docs.slack.dev/reference/methods/team.accessLogs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.team_billableInfo"><code class="name flex">
 <span>def <span class="ident">team_billableInfo</span></span>(<span>self, *, team_id: str | None = None, user: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13159,13 +13241,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets billable users information for the current team.
-    https://api.slack.com/methods/team.billableInfo
+    https://docs.slack.dev/reference/methods/team.billableInfo
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
     return self.api_call(&#34;team.billableInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets billable users information for the current team.
-<a href="https://api.slack.com/methods/team.billableInfo">https://api.slack.com/methods/team.billableInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.billableInfo">https://docs.slack.dev/reference/methods/team.billableInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.team_billing_info"><code class="name flex">
 <span>def <span class="ident">team_billing_info</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13180,12 +13262,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Reads a workspace&#39;s billing plan information.
-    https://api.slack.com/methods/team.billing.info
+    https://docs.slack.dev/reference/methods/team.billing.info
     &#34;&#34;&#34;
     return self.api_call(&#34;team.billing.info&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Reads a workspace's billing plan information.
-<a href="https://api.slack.com/methods/team.billing.info">https://api.slack.com/methods/team.billing.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.billing.info">https://docs.slack.dev/reference/methods/team.billing.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.team_externalTeams_disconnect"><code class="name flex">
 <span>def <span class="ident">team_externalTeams_disconnect</span></span>(<span>self, *, target_team: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13202,7 +13284,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Disconnects an external organization.
-    https://api.slack.com/methods/team.externalTeams.disconnect
+    https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13212,7 +13294,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.externalTeams.disconnect&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disconnects an external organization.
-<a href="https://api.slack.com/methods/team.externalTeams.disconnect">https://api.slack.com/methods/team.externalTeams.disconnect</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.externalTeams.disconnect">https://docs.slack.dev/reference/methods/team.externalTeams.disconnect</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.team_externalTeams_list"><code class="name flex">
 <span>def <span class="ident">team_externalTeams_list</span></span>(<span>self,<br>*,<br>connection_status_filter: str | None = None,<br>slack_connect_pref_filter: Sequence[str] | None = None,<br>sort_direction: str | None = None,<br>sort_field: str | None = None,<br>workspace_filter: Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13235,7 +13317,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
-    https://api.slack.com/methods/team.externalTeams.list
+    https://docs.slack.dev/reference/methods/team.externalTeams.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13259,7 +13341,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns a list of all the external teams connected and details about the connection.
-<a href="https://api.slack.com/methods/team.externalTeams.list">https://api.slack.com/methods/team.externalTeams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.externalTeams.list">https://docs.slack.dev/reference/methods/team.externalTeams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.team_info"><code class="name flex">
 <span>def <span class="ident">team_info</span></span>(<span>self, *, team: str | None = None, domain: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13277,13 +13359,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about the current team.
-    https://api.slack.com/methods/team.info
+    https://docs.slack.dev/reference/methods/team.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team&#34;: team, &#34;domain&#34;: domain})
     return self.api_call(&#34;team.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about the current team.
-<a href="https://api.slack.com/methods/team.info">https://api.slack.com/methods/team.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.info">https://docs.slack.dev/reference/methods/team.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.team_integrationLogs"><code class="name flex">
 <span>def <span class="ident">team_integrationLogs</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>change_type: str | None = None,<br>count: str | int | None = None,<br>page: str | int | None = None,<br>service_id: str | None = None,<br>team_id: str | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13306,7 +13388,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets the integration logs for the current team.
-    https://api.slack.com/methods/team.integrationLogs
+    https://docs.slack.dev/reference/methods/team.integrationLogs
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13322,7 +13404,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.integrationLogs&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets the integration logs for the current team.
-<a href="https://api.slack.com/methods/team.integrationLogs">https://api.slack.com/methods/team.integrationLogs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.integrationLogs">https://docs.slack.dev/reference/methods/team.integrationLogs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.team_preferences_list"><code class="name flex">
 <span>def <span class="ident">team_preferences_list</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13337,12 +13419,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a list of a workspace&#39;s team preferences.
-    https://api.slack.com/methods/team.preferences.list
+    https://docs.slack.dev/reference/methods/team.preferences.list
     &#34;&#34;&#34;
     return self.api_call(&#34;team.preferences.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a list of a workspace's team preferences.
-<a href="https://api.slack.com/methods/team.preferences.list">https://api.slack.com/methods/team.preferences.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.preferences.list">https://docs.slack.dev/reference/methods/team.preferences.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.team_profile_get"><code class="name flex">
 <span>def <span class="ident">team_profile_get</span></span>(<span>self, *, visibility: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13359,13 +13441,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a team&#39;s profile.
-    https://api.slack.com/methods/team.profile.get
+    https://docs.slack.dev/reference/methods/team.profile.get
     &#34;&#34;&#34;
     kwargs.update({&#34;visibility&#34;: visibility})
     return self.api_call(&#34;team.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a team's profile.
-<a href="https://api.slack.com/methods/team.profile.get">https://api.slack.com/methods/team.profile.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.profile.get">https://docs.slack.dev/reference/methods/team.profile.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.tooling_tokens_rotate"><code class="name flex">
 <span>def <span class="ident">tooling_tokens_rotate</span></span>(<span>self, *, refresh_token: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13382,13 +13464,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a refresh token for a new app configuration token
-    https://api.slack.com/methods/tooling.tokens.rotate
+    https://docs.slack.dev/reference/methods/tooling.tokens.rotate
     &#34;&#34;&#34;
     kwargs.update({&#34;refresh_token&#34;: refresh_token})
     return self.api_call(&#34;tooling.tokens.rotate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Exchanges a refresh token for a new app configuration token
-<a href="https://api.slack.com/methods/tooling.tokens.rotate">https://api.slack.com/methods/tooling.tokens.rotate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/tooling.tokens.rotate">https://docs.slack.dev/reference/methods/tooling.tokens.rotate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.usergroups_create"><code class="name flex">
 <span>def <span class="ident">usergroups_create</span></span>(<span>self,<br>*,<br>name: str,<br>channels: str | Sequence[str] | None = None,<br>description: str | None = None,<br>handle: str | None = None,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13410,7 +13492,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a User Group
-    https://api.slack.com/methods/usergroups.create
+    https://docs.slack.dev/reference/methods/usergroups.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13428,7 +13510,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a User Group
-<a href="https://api.slack.com/methods/usergroups.create">https://api.slack.com/methods/usergroups.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.create">https://docs.slack.dev/reference/methods/usergroups.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.usergroups_disable"><code class="name flex">
 <span>def <span class="ident">usergroups_disable</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13447,13 +13529,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Disable an existing User Group
-    https://api.slack.com/methods/usergroups.disable
+    https://docs.slack.dev/reference/methods/usergroups.disable
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;usergroups.disable&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disable an existing User Group
-<a href="https://api.slack.com/methods/usergroups.disable">https://api.slack.com/methods/usergroups.disable</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.disable">https://docs.slack.dev/reference/methods/usergroups.disable</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.usergroups_enable"><code class="name flex">
 <span>def <span class="ident">usergroups_enable</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13472,13 +13554,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Enable a User Group
-    https://api.slack.com/methods/usergroups.enable
+    https://docs.slack.dev/reference/methods/usergroups.enable
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;usergroups.enable&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enable a User Group
-<a href="https://api.slack.com/methods/usergroups.enable">https://api.slack.com/methods/usergroups.enable</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.enable">https://docs.slack.dev/reference/methods/usergroups.enable</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.usergroups_list"><code class="name flex">
 <span>def <span class="ident">usergroups_list</span></span>(<span>self,<br>*,<br>include_count: bool | None = None,<br>include_disabled: bool | None = None,<br>include_users: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13498,7 +13580,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all User Groups for a team
-    https://api.slack.com/methods/usergroups.list
+    https://docs.slack.dev/reference/methods/usergroups.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13511,7 +13593,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all User Groups for a team
-<a href="https://api.slack.com/methods/usergroups.list">https://api.slack.com/methods/usergroups.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.list">https://docs.slack.dev/reference/methods/usergroups.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.usergroups_update"><code class="name flex">
 <span>def <span class="ident">usergroups_update</span></span>(<span>self,<br>*,<br>usergroup: str,<br>channels: str | Sequence[str] | None = None,<br>description: str | None = None,<br>handle: str | None = None,<br>include_count: bool | None = None,<br>name: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13534,7 +13616,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an existing User Group
-    https://api.slack.com/methods/usergroups.update
+    https://docs.slack.dev/reference/methods/usergroups.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13553,7 +13635,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing User Group
-<a href="https://api.slack.com/methods/usergroups.update">https://api.slack.com/methods/usergroups.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.update">https://docs.slack.dev/reference/methods/usergroups.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.usergroups_users_list"><code class="name flex">
 <span>def <span class="ident">usergroups_users_list</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_disabled: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13572,7 +13654,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all users in a User Group
-    https://api.slack.com/methods/usergroups.users.list
+    https://docs.slack.dev/reference/methods/usergroups.users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13584,7 +13666,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.users.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all users in a User Group
-<a href="https://api.slack.com/methods/usergroups.users.list">https://api.slack.com/methods/usergroups.users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.users.list">https://docs.slack.dev/reference/methods/usergroups.users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.usergroups_users_update"><code class="name flex">
 <span>def <span class="ident">usergroups_users_update</span></span>(<span>self,<br>*,<br>usergroup: str,<br>users: str | Sequence[str],<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13604,7 +13686,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update the list of users for a User Group
-    https://api.slack.com/methods/usergroups.users.update
+    https://docs.slack.dev/reference/methods/usergroups.users.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13620,7 +13702,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update the list of users for a User Group
-<a href="https://api.slack.com/methods/usergroups.users.update">https://api.slack.com/methods/usergroups.users.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.users.update">https://docs.slack.dev/reference/methods/usergroups.users.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_conversations"><code class="name flex">
 <span>def <span class="ident">users_conversations</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>exclude_archived: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>types: str | Sequence[str] | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13642,7 +13724,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List conversations the calling user may access.
-    https://api.slack.com/methods/users.conversations
+    https://docs.slack.dev/reference/methods/users.conversations
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13660,7 +13742,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.conversations&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List conversations the calling user may access.
-<a href="https://api.slack.com/methods/users.conversations">https://api.slack.com/methods/users.conversations</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.conversations">https://docs.slack.dev/reference/methods/users.conversations</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_deletePhoto"><code class="name flex">
 <span>def <span class="ident">users_deletePhoto</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13675,12 +13757,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Delete the user profile photo
-    https://api.slack.com/methods/users.deletePhoto
+    https://docs.slack.dev/reference/methods/users.deletePhoto
     &#34;&#34;&#34;
     return self.api_call(&#34;users.deletePhoto&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete the user profile photo
-<a href="https://api.slack.com/methods/users.deletePhoto">https://api.slack.com/methods/users.deletePhoto</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.deletePhoto">https://docs.slack.dev/reference/methods/users.deletePhoto</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_discoverableContacts_lookup"><code class="name flex">
 <span>def <span class="ident">users_discoverableContacts_lookup</span></span>(<span>self, email: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13696,13 +13778,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lookup an email address to see if someone is on Slack
-    https://api.slack.com/methods/users.discoverableContacts.lookup
+    https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
     &#34;&#34;&#34;
     kwargs.update({&#34;email&#34;: email})
     return self.api_call(&#34;users.discoverableContacts.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lookup an email address to see if someone is on Slack
-<a href="https://api.slack.com/methods/users.discoverableContacts.lookup">https://api.slack.com/methods/users.discoverableContacts.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup">https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_getPresence"><code class="name flex">
 <span>def <span class="ident">users_getPresence</span></span>(<span>self, *, user: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13719,13 +13801,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets user presence information.
-    https://api.slack.com/methods/users.getPresence
+    https://docs.slack.dev/reference/methods/users.getPresence
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user})
     return self.api_call(&#34;users.getPresence&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets user presence information.
-<a href="https://api.slack.com/methods/users.getPresence">https://api.slack.com/methods/users.getPresence</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.getPresence">https://docs.slack.dev/reference/methods/users.getPresence</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_identity"><code class="name flex">
 <span>def <span class="ident">users_identity</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13740,12 +13822,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get a user&#39;s identity.
-    https://api.slack.com/methods/users.identity
+    https://docs.slack.dev/reference/methods/users.identity
     &#34;&#34;&#34;
     return self.api_call(&#34;users.identity&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a user's identity.
-<a href="https://api.slack.com/methods/users.identity">https://api.slack.com/methods/users.identity</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.identity">https://docs.slack.dev/reference/methods/users.identity</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_info"><code class="name flex">
 <span>def <span class="ident">users_info</span></span>(<span>self, *, user: str, include_locale: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13763,13 +13845,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a user.
-    https://api.slack.com/methods/users.info
+    https://docs.slack.dev/reference/methods/users.info
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user, &#34;include_locale&#34;: include_locale})
     return self.api_call(&#34;users.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a user.
-<a href="https://api.slack.com/methods/users.info">https://api.slack.com/methods/users.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.info">https://docs.slack.dev/reference/methods/users.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_list"><code class="name flex">
 <span>def <span class="ident">users_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>include_locale: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13789,7 +13871,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all users in a Slack team.
-    https://api.slack.com/methods/users.list
+    https://docs.slack.dev/reference/methods/users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13802,7 +13884,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all users in a Slack team.
-<a href="https://api.slack.com/methods/users.list">https://api.slack.com/methods/users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.list">https://docs.slack.dev/reference/methods/users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_lookupByEmail"><code class="name flex">
 <span>def <span class="ident">users_lookupByEmail</span></span>(<span>self, *, email: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13819,13 +13901,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Find a user with an email address.
-    https://api.slack.com/methods/users.lookupByEmail
+    https://docs.slack.dev/reference/methods/users.lookupByEmail
     &#34;&#34;&#34;
     kwargs.update({&#34;email&#34;: email})
     return self.api_call(&#34;users.lookupByEmail&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Find a user with an email address.
-<a href="https://api.slack.com/methods/users.lookupByEmail">https://api.slack.com/methods/users.lookupByEmail</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.lookupByEmail">https://docs.slack.dev/reference/methods/users.lookupByEmail</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_profile_get"><code class="name flex">
 <span>def <span class="ident">users_profile_get</span></span>(<span>self, *, user: str | None = None, include_labels: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13843,13 +13925,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieves a user&#39;s profile information.
-    https://api.slack.com/methods/users.profile.get
+    https://docs.slack.dev/reference/methods/users.profile.get
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user, &#34;include_labels&#34;: include_labels})
     return self.api_call(&#34;users.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves a user's profile information.
-<a href="https://api.slack.com/methods/users.profile.get">https://api.slack.com/methods/users.profile.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.profile.get">https://docs.slack.dev/reference/methods/users.profile.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_profile_set"><code class="name flex">
 <span>def <span class="ident">users_profile_set</span></span>(<span>self,<br>*,<br>name: str | None = None,<br>value: str | None = None,<br>user: str | None = None,<br>profile: Dict | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13869,7 +13951,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the profile information for a user.
-    https://api.slack.com/methods/users.profile.set
+    https://docs.slack.dev/reference/methods/users.profile.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13884,7 +13966,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.profile.set&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the profile information for a user.
-<a href="https://api.slack.com/methods/users.profile.set">https://api.slack.com/methods/users.profile.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.profile.set">https://docs.slack.dev/reference/methods/users.profile.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_setPhoto"><code class="name flex">
 <span>def <span class="ident">users_setPhoto</span></span>(<span>self,<br>*,<br>image: str | io.IOBase,<br>crop_w: str | int | None = None,<br>crop_x: str | int | None = None,<br>crop_y: str | int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13904,13 +13986,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the user profile photo
-    https://api.slack.com/methods/users.setPhoto
+    https://docs.slack.dev/reference/methods/users.setPhoto
     &#34;&#34;&#34;
     kwargs.update({&#34;crop_w&#34;: crop_w, &#34;crop_x&#34;: crop_x, &#34;crop_y&#34;: crop_y})
     return self.api_call(&#34;users.setPhoto&#34;, files={&#34;image&#34;: image}, data=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the user profile photo
-<a href="https://api.slack.com/methods/users.setPhoto">https://api.slack.com/methods/users.setPhoto</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.setPhoto">https://docs.slack.dev/reference/methods/users.setPhoto</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.users_setPresence"><code class="name flex">
 <span>def <span class="ident">users_setPresence</span></span>(<span>self, *, presence: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13927,13 +14009,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Manually sets user presence.
-    https://api.slack.com/methods/users.setPresence
+    https://docs.slack.dev/reference/methods/users.setPresence
     &#34;&#34;&#34;
     kwargs.update({&#34;presence&#34;: presence})
     return self.api_call(&#34;users.setPresence&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Manually sets user presence.
-<a href="https://api.slack.com/methods/users.setPresence">https://api.slack.com/methods/users.setPresence</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.setPresence">https://docs.slack.dev/reference/methods/users.setPresence</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.views_open"><code class="name flex">
 <span>def <span class="ident">views_open</span></span>(<span>self,<br>*,<br>trigger_id: str | None = None,<br>interactivity_pointer: str | None = None,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13952,8 +14034,8 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Open a view for a user.
-    https://api.slack.com/methods/views.open
-    See https://api.slack.com/surfaces/modals for details.
+    https://docs.slack.dev/reference/methods/views.open
+    See https://docs.slack.dev/surfaces/modals/ for details.
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
     if isinstance(view, View):
@@ -13965,8 +14047,8 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;views.open&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Open a view for a user.
-<a href="https://api.slack.com/methods/views.open">https://api.slack.com/methods/views.open</a>
-See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a> for details.</p></div>
+<a href="https://docs.slack.dev/reference/methods/views.open">https://docs.slack.dev/reference/methods/views.open</a>
+See <a href="https://docs.slack.dev/surfaces/modals/">https://docs.slack.dev/surfaces/modals/</a> for details.</p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.views_publish"><code class="name flex">
 <span>def <span class="ident">views_publish</span></span>(<span>self,<br>*,<br>user_id: str,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>hash: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13986,8 +14068,8 @@ See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfac
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Publish a static view for a User.
     Create or update the view that comprises an
-    app&#39;s Home tab (https://api.slack.com/surfaces/tabs)
-    https://api.slack.com/methods/views.publish
+    app&#39;s Home tab (https://docs.slack.dev/surfaces/app-home/)
+    https://docs.slack.dev/reference/methods/views.publish
     &#34;&#34;&#34;
     kwargs.update({&#34;user_id&#34;: user_id, &#34;hash&#34;: hash})
     if isinstance(view, View):
@@ -14000,8 +14082,8 @@ See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfac
 </details>
 <div class="desc"><p>Publish a static view for a User.
 Create or update the view that comprises an
-app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.com/surfaces/tabs</a>)
-<a href="https://api.slack.com/methods/views.publish">https://api.slack.com/methods/views.publish</a></p></div>
+app's Home tab (<a href="https://docs.slack.dev/surfaces/app-home/">https://docs.slack.dev/surfaces/app-home/</a>)
+<a href="https://docs.slack.dev/reference/methods/views.publish">https://docs.slack.dev/reference/methods/views.publish</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.views_push"><code class="name flex">
 <span>def <span class="ident">views_push</span></span>(<span>self,<br>*,<br>trigger_id: str | None = None,<br>interactivity_pointer: str | None = None,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14023,9 +14105,9 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
     Push a new view onto the existing view stack by passing a view
     payload and a valid trigger_id generated from an interaction
     within the existing modal.
-    Read the modals documentation (https://api.slack.com/surfaces/modals)
+    Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
     to learn more about the lifecycle and intricacies of views.
-    https://api.slack.com/methods/views.push
+    https://docs.slack.dev/reference/methods/views.push
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
     if isinstance(view, View):
@@ -14040,9 +14122,9 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
 Push a new view onto the existing view stack by passing a view
 payload and a valid trigger_id generated from an interaction
 within the existing modal.
-Read the modals documentation (<a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a>)
+Read the modals documentation (<a href="https://docs.slack.dev/surfaces/modals/">https://docs.slack.dev/surfaces/modals/</a>)
 to learn more about the lifecycle and intricacies of views.
-<a href="https://api.slack.com/methods/views.push">https://api.slack.com/methods/views.push</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/views.push">https://docs.slack.dev/reference/methods/views.push</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.views_update"><code class="name flex">
 <span>def <span class="ident">views_update</span></span>(<span>self,<br>*,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>external_id: str | None = None,<br>view_id: str | None = None,<br>hash: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14064,9 +14146,9 @@ to learn more about the lifecycle and intricacies of views.
     &#34;&#34;&#34;Update an existing view.
     Update a view by passing a new view definition along with the
     view_id returned in views.open or the external_id.
-    See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+    See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
     to learn more about updating views and avoiding race conditions with the hash argument.
-    https://api.slack.com/methods/views.update
+    https://docs.slack.dev/reference/methods/views.update
     &#34;&#34;&#34;
     if isinstance(view, View):
         kwargs.update({&#34;view&#34;: view.to_dict()})
@@ -14086,9 +14168,119 @@ to learn more about the lifecycle and intricacies of views.
 <div class="desc"><p>Update an existing view.
 Update a view by passing a new view definition along with the
 view_id returned in views.open or the external_id.
-See the modals documentation (<a href="https://api.slack.com/surfaces/modals#updating_views">https://api.slack.com/surfaces/modals#updating_views</a>)
+See the modals documentation (<a href="https://docs.slack.dev/surfaces/modals/#updating_views">https://docs.slack.dev/surfaces/modals/#updating_views</a>)
 to learn more about updating views and avoiding race conditions with the hash argument.
-<a href="https://api.slack.com/methods/views.update">https://api.slack.com/methods/views.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/views.update">https://docs.slack.dev/reference/methods/views.update</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.workflows_featured_add"><code class="name flex">
+<span>def <span class="ident">workflows_featured_add</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_add(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Add featured workflows to a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.add
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.add&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Add featured workflows to a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.add">https://docs.slack.dev/reference/methods/workflows.featured.add</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.workflows_featured_list"><code class="name flex">
+<span>def <span class="ident">workflows_featured_list</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_list(
+    self,
+    *,
+    channel_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;List the featured workflows for specified channels.
+    https://docs.slack.dev/reference/methods/workflows.featured.list
+    &#34;&#34;&#34;
+    if isinstance(channel_ids, (list, tuple)):
+        kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
+    else:
+        kwargs.update({&#34;channel_ids&#34;: channel_ids})
+    return self.api_call(&#34;workflows.featured.list&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>List the featured workflows for specified channels.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.list">https://docs.slack.dev/reference/methods/workflows.featured.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.workflows_featured_remove"><code class="name flex">
+<span>def <span class="ident">workflows_featured_remove</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_remove(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Remove featured workflows from a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.remove
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.remove&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Remove featured workflows from a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.remove">https://docs.slack.dev/reference/methods/workflows.featured.remove</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.workflows_featured_set"><code class="name flex">
+<span>def <span class="ident">workflows_featured_set</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_set(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Set featured workflows for a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.set
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.set&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Set featured workflows for a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.set">https://docs.slack.dev/reference/methods/workflows.featured.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.workflows_stepCompleted"><code class="name flex">
 <span>def <span class="ident">workflows_stepCompleted</span></span>(<span>self, *, workflow_step_execute_id: str, outputs: dict | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14106,7 +14298,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Indicate a successful outcome of a workflow step&#39;s execution.
-    https://api.slack.com/methods/workflows.stepCompleted
+    https://docs.slack.dev/reference/methods/workflows.stepCompleted
     &#34;&#34;&#34;
     kwargs.update({&#34;workflow_step_execute_id&#34;: workflow_step_execute_id})
     if outputs is not None:
@@ -14116,7 +14308,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.stepCompleted&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Indicate a successful outcome of a workflow step's execution.
-<a href="https://api.slack.com/methods/workflows.stepCompleted">https://api.slack.com/methods/workflows.stepCompleted</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.stepCompleted">https://docs.slack.dev/reference/methods/workflows.stepCompleted</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.workflows_stepFailed"><code class="name flex">
 <span>def <span class="ident">workflows_stepFailed</span></span>(<span>self, *, workflow_step_execute_id: str, error: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14134,7 +14326,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Indicate an unsuccessful outcome of a workflow step&#39;s execution.
-    https://api.slack.com/methods/workflows.stepFailed
+    https://docs.slack.dev/reference/methods/workflows.stepFailed
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -14147,7 +14339,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.stepFailed&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Indicate an unsuccessful outcome of a workflow step's execution.
-<a href="https://api.slack.com/methods/workflows.stepFailed">https://api.slack.com/methods/workflows.stepFailed</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.stepFailed">https://docs.slack.dev/reference/methods/workflows.stepFailed</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.workflows_updateStep"><code class="name flex">
 <span>def <span class="ident">workflows_updateStep</span></span>(<span>self,<br>*,<br>workflow_step_edit_id: str,<br>inputs: Dict[str, Any] | None = None,<br>outputs: List[Dict[str, str]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14166,7 +14358,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update the configuration for a workflow extension step.
-    https://api.slack.com/methods/workflows.updateStep
+    https://docs.slack.dev/reference/methods/workflows.updateStep
     &#34;&#34;&#34;
     kwargs.update({&#34;workflow_step_edit_id&#34;: workflow_step_edit_id})
     if inputs is not None:
@@ -14178,7 +14370,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.updateStep&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update the configuration for a workflow extension step.
-<a href="https://api.slack.com/methods/workflows.updateStep">https://api.slack.com/methods/workflows.updateStep</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.updateStep">https://docs.slack.dev/reference/methods/workflows.updateStep</a></p></div>
 </dd>
 </dl>
 <h3>Inherited members</h3>
@@ -14512,6 +14704,10 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.client.WebClient.views_publish" href="#slack_sdk.web.client.WebClient.views_publish">views_publish</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.views_push" href="#slack_sdk.web.client.WebClient.views_push">views_push</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.views_update" href="#slack_sdk.web.client.WebClient.views_update">views_update</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.workflows_featured_add" href="#slack_sdk.web.client.WebClient.workflows_featured_add">workflows_featured_add</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.workflows_featured_list" href="#slack_sdk.web.client.WebClient.workflows_featured_list">workflows_featured_list</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.workflows_featured_remove" href="#slack_sdk.web.client.WebClient.workflows_featured_remove">workflows_featured_remove</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.workflows_featured_set" href="#slack_sdk.web.client.WebClient.workflows_featured_set">workflows_featured_set</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.workflows_stepCompleted" href="#slack_sdk.web.client.WebClient.workflows_stepCompleted">workflows_stepCompleted</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.workflows_stepFailed" href="#slack_sdk.web.client.WebClient.workflows_stepFailed">workflows_stepFailed</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.workflows_updateStep" href="#slack_sdk.web.client.WebClient.workflows_updateStep">workflows_updateStep</a></code></li>

--- a/docs/reference/web/deprecation.html
+++ b/docs/reference/web/deprecation.html
@@ -67,7 +67,7 @@ el.replaceWith(d);
         message = (
             f&#34;{method_name} is deprecated. Please use the Conversations API instead. &#34;
             &#34;For more info, go to &#34;
-            &#34;https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api&#34;
+            &#34;https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/&#34;
         )
         warnings.warn(message)
 
@@ -76,7 +76,7 @@ el.replaceWith(d);
     if len(matched_prefixes) &gt; 0:
         message = (
             f&#34;{method_name} is deprecated. For more info, go to &#34;
-            &#34;https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders&#34;
+            &#34;https://docs.slack.dev/changelog/2023-07-its-later-already-for-stars-and-reminders/&#34;
         )
         warnings.warn(message)
 
@@ -85,7 +85,7 @@ el.replaceWith(d);
     if len(matched_prefixes) &gt; 0:
         message = (
             f&#34;{method_name} is deprecated. For more info, go to &#34;
-            &#34;https://api.slack.com/changelog/2023-08-workflow-steps-from-apps-step-back&#34;
+            &#34;https://docs.slack.dev/changelog/2023-08-workflow-steps-from-apps-step-back/&#34;
         )
         warnings.warn(message)</code></pre>
 </details>

--- a/docs/reference/web/index.html
+++ b/docs/reference/web/index.html
@@ -420,7 +420,7 @@ This method returns it's own object. e.g. 'self'</p>
 <pre><code class="python">class WebClient(BaseClient):
     &#34;&#34;&#34;A WebClient allows apps to communicate with the Slack Platform&#39;s Web API.
 
-    https://api.slack.com/methods
+    https://docs.slack.dev/reference/methods
 
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
@@ -491,7 +491,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve analytics data for a given date, presented as a compressed JSON file
-        https://api.slack.com/methods/admin.analytics.getFile
+        https://docs.slack.dev/reference/methods/admin.analytics.getFile
         &#34;&#34;&#34;
         kwargs.update({&#34;type&#34;: type})
         if date is not None:
@@ -513,7 +513,7 @@ This method returns it's own object. e.g. 'self'</p>
         Either app_id or request_id is required.
         These IDs can be obtained either directly via the app_requested event,
         or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.approve
+        https://docs.slack.dev/reference/methods/admin.apps.approve
         &#34;&#34;&#34;
         if app_id:
             kwargs.update({&#34;app_id&#34;: app_id})
@@ -540,7 +540,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List approved apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.approved.list
+        https://docs.slack.dev/reference/methods/admin.apps.approved.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -561,7 +561,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Clear an app resolution
-        https://api.slack.com/methods/admin.apps.clearResolution
+        https://docs.slack.dev/reference/methods/admin.apps.clearResolution
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -581,7 +581,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.cancel
+        https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -601,7 +601,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.list
+        https://docs.slack.dev/reference/methods/admin.apps.requests.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -625,7 +625,7 @@ This method returns it's own object. e.g. 'self'</p>
         Exactly one of the team_id or enterprise_id arguments is required, not both.
         Either app_id or request_id is required. These IDs can be obtained either directly
         via the app_requested event, or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.restrict
+        https://docs.slack.dev/reference/methods/admin.apps.restrict
         &#34;&#34;&#34;
         if app_id:
             kwargs.update({&#34;app_id&#34;: app_id})
@@ -652,7 +652,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List restricted apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.restricted.list
+        https://docs.slack.dev/reference/methods/admin.apps.restricted.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -674,7 +674,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Uninstall an app from one or many workspaces, or an entire enterprise organization.
         With an org-level token, enterprise_id or team_ids is required.
-        https://api.slack.com/methods/admin.apps.uninstall
+        https://docs.slack.dev/reference/methods/admin.apps.uninstall
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         if enterprise_id is not None:
@@ -705,7 +705,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get logs for a specified team/org
-        https://api.slack.com/methods/admin.apps.activities.list
+        https://docs.slack.dev/reference/methods/admin.apps.activities.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -733,7 +733,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Look up the app config for connectors by their IDs
-        https://api.slack.com/methods/admin.apps.config.lookup
+        https://docs.slack.dev/reference/methods/admin.apps.config.lookup
         &#34;&#34;&#34;
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -750,7 +750,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the app config for a connector
-        https://api.slack.com/methods/admin.apps.config.set
+        https://docs.slack.dev/reference/methods/admin.apps.config.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -772,7 +772,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.
-        https://api.slack.com/methods/admin.auth.policy.getEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
         &#34;&#34;&#34;
         kwargs.update({&#34;policy_name&#34;: policy_name})
         if cursor is not None:
@@ -792,7 +792,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Assign entities to a particular authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.assignEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
         &#34;&#34;&#34;
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -811,7 +811,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove specified entities from a specified authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.removeEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
         &#34;&#34;&#34;
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -830,7 +830,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a Salesforce channel for the corresponding object provided.
-        https://api.slack.com/methods/admin.conversations.createForObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
         &#34;&#34;&#34;
         kwargs.update(
             {&#34;object_id&#34;: object_id, &#34;salesforce_org_id&#34;: salesforce_org_id, &#34;invite_object_team&#34;: invite_object_team}
@@ -846,7 +846,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Link a Salesforce record to a channel.
-        https://api.slack.com/methods/admin.conversations.linkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -865,7 +865,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Unlink a Salesforce record from a channel.
-        https://api.slack.com/methods/admin.conversations.unlinkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -884,7 +884,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create an Information Barrier
-        https://api.slack.com/methods/admin.barriers.create
+        https://docs.slack.dev/reference/methods/admin.barriers.create
         &#34;&#34;&#34;
         kwargs.update({&#34;primary_usergroup_id&#34;: primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -904,7 +904,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Delete an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.delete
+        https://docs.slack.dev/reference/methods/admin.barriers.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;barrier_id&#34;: barrier_id})
         return self.api_call(&#34;admin.barriers.delete&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -919,7 +919,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.update
+        https://docs.slack.dev/reference/methods/admin.barriers.update
         &#34;&#34;&#34;
         kwargs.update({&#34;barrier_id&#34;: barrier_id, &#34;primary_usergroup_id&#34;: primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -940,7 +940,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get all Information Barriers for your organization
-        https://api.slack.com/methods/admin.barriers.list&#34;&#34;&#34;
+        https://docs.slack.dev/reference/methods/admin.barriers.list&#34;&#34;&#34;
         kwargs.update(
             {
                 &#34;cursor&#34;: cursor,
@@ -960,7 +960,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a public or private channel-based conversation.
-        https://api.slack.com/methods/admin.conversations.create
+        https://docs.slack.dev/reference/methods/admin.conversations.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -980,7 +980,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Delete a public or private channel.
-        https://api.slack.com/methods/admin.conversations.delete
+        https://docs.slack.dev/reference/methods/admin.conversations.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.delete&#34;, params=kwargs)
@@ -993,7 +993,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invite a user to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.invite
+        https://docs.slack.dev/reference/methods/admin.conversations.invite
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(user_ids, (list, tuple)):
@@ -1010,7 +1010,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Archive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.archive&#34;, params=kwargs)
@@ -1022,7 +1022,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Unarchive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.unarchive&#34;, params=kwargs)
@@ -1035,7 +1035,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Rename a public or private channel.
-        https://api.slack.com/methods/admin.conversations.rename
+        https://docs.slack.dev/reference/methods/admin.conversations.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;name&#34;: name})
         return self.api_call(&#34;admin.conversations.rename&#34;, params=kwargs)
@@ -1053,7 +1053,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.
-        https://api.slack.com/methods/admin.conversations.search
+        https://docs.slack.dev/reference/methods/admin.conversations.search
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1084,7 +1084,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Convert a public channel to a private channel.
-        https://api.slack.com/methods/admin.conversations.convertToPrivate
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.convertToPrivate&#34;, params=kwargs)
@@ -1096,7 +1096,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Convert a privte channel to a public channel.
-        https://api.slack.com/methods/admin.conversations.convertToPublic
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.convertToPublic&#34;, params=kwargs)
@@ -1109,7 +1109,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the posting permissions for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(prefs, dict):
@@ -1125,7 +1125,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get conversation preferences for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.getConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.getConversationPrefs&#34;, params=kwargs)
@@ -1138,7 +1138,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Disconnect a connected channel from one or more workspaces.
-        https://api.slack.com/methods/admin.conversations.disconnectShared
+        https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(leaving_team_ids, (list, tuple)):
@@ -1158,7 +1158,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Returns channels on the given team using the filters.
-        https://api.slack.com/methods/admin.conversations.lookup
+        https://docs.slack.dev/reference/methods/admin.conversations.lookup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1186,7 +1186,7 @@ This method returns it's own object. e.g. 'self'</p>
         &#34;&#34;&#34;List all disconnected channels—i.e.,
         channels that were once connected to other workspaces and then disconnected—and
         the corresponding original channel IDs for key revocation with EKM.
-        https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+        https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1213,7 +1213,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an allowlist of IDP groups for accessing a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1236,7 +1236,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all IDP Groups linked to a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1259,7 +1259,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a linked IDP group linked from a private channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1284,7 +1284,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.setTeams
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1308,7 +1308,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a channel.
-        https://api.slack.com/methods/admin.conversations.getTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.getTeams
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1326,7 +1326,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.getCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.getCustomRetention&#34;, params=kwargs)
@@ -1338,7 +1338,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.removeCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.removeCustomRetention&#34;, params=kwargs)
@@ -1351,7 +1351,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.setCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;duration_days&#34;: duration_days})
         return self.api_call(&#34;admin.conversations.setCustomRetention&#34;, params=kwargs)
@@ -1363,7 +1363,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Archive public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkArchive
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
         return self.api_call(&#34;admin.conversations.bulkArchive&#34;, params=kwargs)
@@ -1388,7 +1388,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Move public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkMove
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1406,7 +1406,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an emoji.
-        https://api.slack.com/methods/admin.emoji.add
+        https://docs.slack.dev/reference/methods/admin.emoji.add
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;url&#34;: url})
         return self.api_call(&#34;admin.emoji.add&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1419,7 +1419,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an emoji alias.
-        https://api.slack.com/methods/admin.emoji.addAlias
+        https://docs.slack.dev/reference/methods/admin.emoji.addAlias
         &#34;&#34;&#34;
         kwargs.update({&#34;alias_for&#34;: alias_for, &#34;name&#34;: name})
         return self.api_call(&#34;admin.emoji.addAlias&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1432,7 +1432,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List emoji for an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.list
+        https://docs.slack.dev/reference/methods/admin.emoji.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1444,7 +1444,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove an emoji across an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.remove
+        https://docs.slack.dev/reference/methods/admin.emoji.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name})
         return self.api_call(&#34;admin.emoji.remove&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1457,7 +1457,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Rename an emoji.
-        https://api.slack.com/methods/admin.emoji.rename
+        https://docs.slack.dev/reference/methods/admin.emoji.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;new_name&#34;: new_name})
         return self.api_call(&#34;admin.emoji.rename&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1472,7 +1472,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Look up functions by a set of apps
-        https://api.slack.com/methods/admin.functions.list
+        https://docs.slack.dev/reference/methods/admin.functions.list
         &#34;&#34;&#34;
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -1495,7 +1495,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lookup the visibility of multiple Slack functions
         and include the users if it is limited to particular named entities.
-        https://api.slack.com/methods/admin.functions.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
         &#34;&#34;&#34;
         if isinstance(function_ids, (list, tuple)):
             kwargs.update({&#34;function_ids&#34;: &#34;,&#34;.join(function_ids)})
@@ -1513,7 +1513,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the visibility of a Slack function
         and define the users or workspaces if it is set to named_entities
-        https://api.slack.com/methods/admin.functions.permissions.set
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1537,7 +1537,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds members to the specified role with the specified scopes
-        https://api.slack.com/methods/admin.roles.addAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.addAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;role_id&#34;: role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1562,7 +1562,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists assignments for all roles across entities.
             Options to scope results by any combination of roles or entities
-        https://api.slack.com/methods/admin.roles.listAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.listAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;sort_dir&#34;: sort_dir})
         if isinstance(entity_ids, (list, tuple)):
@@ -1584,7 +1584,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a set of users from a role for the given scopes and entities
-        https://api.slack.com/methods/admin.roles.removeAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;role_id&#34;: role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1606,7 +1606,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Wipes all valid sessions on all devices for a given user.
-        https://api.slack.com/methods/admin.users.session.reset
+        https://docs.slack.dev/reference/methods/admin.users.session.reset
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1626,7 +1626,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-        https://api.slack.com/methods/admin.users.session.resetBulk
+        https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1648,7 +1648,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invalidate a single session for a user by session_id.
-        https://api.slack.com/methods/admin.users.session.invalidate
+        https://docs.slack.dev/reference/methods/admin.users.session.invalidate
         &#34;&#34;&#34;
         kwargs.update({&#34;session_id&#34;: session_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.users.session.invalidate&#34;, params=kwargs)
@@ -1663,7 +1663,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all active user sessions for an organization
-        https://api.slack.com/methods/admin.users.session.list
+        https://docs.slack.dev/reference/methods/admin.users.session.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1683,7 +1683,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the default channels of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1700,7 +1700,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get user-specific session settings—the session duration
         and what happens when the client closes—given a list of users.
-        https://api.slack.com/methods/admin.users.session.getSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.getSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1718,7 +1718,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Configure the user-level session settings—the session duration
         and what happens when the client closes—for one or more users.
-        https://api.slack.com/methods/admin.users.session.setSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.setSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1740,7 +1740,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Clear user-specific session settings—the session duration
         and what happens when the client closes—for a list of users.
-        https://api.slack.com/methods/admin.users.session.clearSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1757,7 +1757,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ask Slackbot to send you an export listing all workspace members using unsupported software,
         presented as a zipped CSV file.
-        https://api.slack.com/methods/admin.users.unsupportedVersions.export
+        https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1775,7 +1775,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Approve a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.approve
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.inviteRequests.approve&#34;, params=kwargs)
@@ -1789,7 +1789,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all approved workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.approved.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1809,7 +1809,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all denied workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.denied.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1828,7 +1828,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deny a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.deny
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.inviteRequests.deny&#34;, params=kwargs)
@@ -1849,7 +1849,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.inviteRequests.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1870,7 +1870,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create an Enterprise team.
-        https://api.slack.com/methods/admin.teams.create
+        https://docs.slack.dev/reference/methods/admin.teams.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1890,7 +1890,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all teams on an Enterprise organization.
-        https://api.slack.com/methods/admin.teams.list
+        https://docs.slack.dev/reference/methods/admin.teams.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
@@ -1904,7 +1904,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.teams.owners.list
+        https://docs.slack.dev/reference/methods/admin.teams.owners.list
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.teams.owners.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1916,7 +1916,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Fetch information about settings in a workspace
-        https://api.slack.com/methods/admin.teams.settings.info
+        https://docs.slack.dev/reference/methods/admin.teams.settings.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.teams.settings.info&#34;, params=kwargs)
@@ -1929,7 +1929,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the description of a given workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDescription
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;description&#34;: description})
         return self.api_call(&#34;admin.teams.settings.setDescription&#34;, params=kwargs)
@@ -1942,7 +1942,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;discoverability&#34;: discoverability})
         return self.api_call(&#34;admin.teams.settings.setDiscoverability&#34;, params=kwargs)
@@ -1955,7 +1955,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setIcon
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;image_url&#34;: image_url})
         return self.api_call(&#34;admin.teams.settings.setIcon&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1968,7 +1968,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setName
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setName
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;name&#34;: name})
         return self.api_call(&#34;admin.teams.settings.setName&#34;, params=kwargs)
@@ -1982,7 +1982,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.addChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;usergroup_id&#34;: usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -2000,7 +2000,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Associate one or more default workspaces with an organization-wide IDP group.
-        https://api.slack.com/methods/admin.usergroups.addTeams
+        https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup_id&#34;: usergroup_id, &#34;auto_provision&#34;: auto_provision})
         if isinstance(team_ids, (list, tuple)):
@@ -2018,7 +2018,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.listChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2037,7 +2037,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.removeChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup_id&#34;: usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -2057,7 +2057,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add an Enterprise user to a workspace.
-        https://api.slack.com/methods/admin.users.assign
+        https://docs.slack.dev/reference/methods/admin.users.assign
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2089,7 +2089,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invite a user to a workspace.
-        https://api.slack.com/methods/admin.users.invite
+        https://docs.slack.dev/reference/methods/admin.users.invite
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2113,7 +2113,7 @@ This method returns it's own object. e.g. 'self'</p>
     def admin_users_list(
         self,
         *,
-        team_id: str,
+        team_id: Optional[str] = None,
         include_deactivated_user_workspaces: Optional[bool] = None,
         is_active: Optional[bool] = None,
         cursor: Optional[str] = None,
@@ -2121,7 +2121,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List users on a workspace
-        https://api.slack.com/methods/admin.users.list
+        https://docs.slack.dev/reference/methods/admin.users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2142,7 +2142,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a user from a workspace.
-        https://api.slack.com/methods/admin.users.remove
+        https://docs.slack.dev/reference/methods/admin.users.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.remove&#34;, params=kwargs)
@@ -2155,7 +2155,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an existing guest, regular user, or owner to be an admin user.
-        https://api.slack.com/methods/admin.users.setAdmin
+        https://docs.slack.dev/reference/methods/admin.users.setAdmin
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setAdmin&#34;, params=kwargs)
@@ -2169,7 +2169,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an expiration for a guest user.
-        https://api.slack.com/methods/admin.users.setExpiration
+        https://docs.slack.dev/reference/methods/admin.users.setExpiration
         &#34;&#34;&#34;
         kwargs.update({&#34;expiration_ts&#34;: expiration_ts, &#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setExpiration&#34;, params=kwargs)
@@ -2182,7 +2182,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an existing guest, regular user, or admin user to be a workspace owner.
-        https://api.slack.com/methods/admin.users.setOwner
+        https://docs.slack.dev/reference/methods/admin.users.setOwner
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setOwner&#34;, params=kwargs)
@@ -2195,7 +2195,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set an existing guest user, admin user, or owner to be a regular user.
-        https://api.slack.com/methods/admin.users.setRegular
+        https://docs.slack.dev/reference/methods/admin.users.setRegular
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setRegular&#34;, params=kwargs)
@@ -2216,7 +2216,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Search workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.search
+        https://docs.slack.dev/reference/methods/admin.workflows.search
         &#34;&#34;&#34;
         if collaborator_ids is not None:
             if isinstance(collaborator_ids, (list, tuple)):
@@ -2246,7 +2246,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Look up the permissions for a set of workflows
-        https://api.slack.com/methods/admin.workflows.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
         &#34;&#34;&#34;
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -2267,7 +2267,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add collaborators to workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.add
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
         &#34;&#34;&#34;
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -2287,7 +2287,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove collaborators from workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.remove
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
         &#34;&#34;&#34;
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -2306,7 +2306,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Unpublish workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.unpublish
+        https://docs.slack.dev/reference/methods/admin.workflows.unpublish
         &#34;&#34;&#34;
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -2321,7 +2321,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Checks API calling code.
-        https://api.slack.com/methods/api.test
+        https://docs.slack.dev/reference/methods/api.test
         &#34;&#34;&#34;
         kwargs.update({&#34;error&#34;: error})
         return self.api_call(&#34;api.test&#34;, params=kwargs)
@@ -2334,7 +2334,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Generate a temporary Socket Mode WebSocket URL that your app can connect to
         in order to receive events and interactive payloads
-        https://api.slack.com/methods/apps.connections.open
+        https://docs.slack.dev/reference/methods/apps.connections.open
         &#34;&#34;&#34;
         kwargs.update({&#34;token&#34;: app_token})
         return self.api_call(&#34;apps.connections.open&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2349,7 +2349,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get a list of authorizations for the given event context.
         Each authorization represents an app installation that the event is visible to.
-        https://api.slack.com/methods/apps.event.authorizations.list
+        https://docs.slack.dev/reference/methods/apps.event.authorizations.list
         &#34;&#34;&#34;
         kwargs.update({&#34;event_context&#34;: event_context, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;apps.event.authorizations.list&#34;, params=kwargs)
@@ -2362,7 +2362,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Uninstalls your app from a workspace.
-        https://api.slack.com/methods/apps.uninstall
+        https://docs.slack.dev/reference/methods/apps.uninstall
         &#34;&#34;&#34;
         kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret})
         return self.api_call(&#34;apps.uninstall&#34;, params=kwargs)
@@ -2374,7 +2374,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.create
+        https://docs.slack.dev/reference/methods/apps.manifest.create
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2389,7 +2389,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Permanently deletes an app created through app manifests
-        https://api.slack.com/methods/apps.manifest.delete
+        https://docs.slack.dev/reference/methods/apps.manifest.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         return self.api_call(&#34;apps.manifest.delete&#34;, params=kwargs)
@@ -2401,7 +2401,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Export an app manifest from an existing app
-        https://api.slack.com/methods/apps.manifest.export
+        https://docs.slack.dev/reference/methods/apps.manifest.export
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         return self.api_call(&#34;apps.manifest.export&#34;, params=kwargs)
@@ -2414,7 +2414,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.update
+        https://docs.slack.dev/reference/methods/apps.manifest.update
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2431,7 +2431,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Validate an app manifest
-        https://api.slack.com/methods/apps.manifest.validate
+        https://docs.slack.dev/reference/methods/apps.manifest.validate
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2447,7 +2447,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a refresh token for a new app configuration token
-        https://api.slack.com/methods/tooling.tokens.rotate
+        https://docs.slack.dev/reference/methods/tooling.tokens.rotate
         &#34;&#34;&#34;
         kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return self.api_call(&#34;tooling.tokens.rotate&#34;, params=kwargs)
@@ -2461,7 +2461,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setStatus
+        https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status})
         return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)
@@ -2475,7 +2475,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setTitle
+        https://docs.slack.dev/reference/methods/assistant.threads.setTitle
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;title&#34;: title})
         return self.api_call(&#34;assistant.threads.setTitle&#34;, params=kwargs)
@@ -2490,7 +2490,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+        https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
         if title is not None:
@@ -2504,7 +2504,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/auth.revoke
+        https://docs.slack.dev/reference/methods/auth.revoke
         &#34;&#34;&#34;
         kwargs.update({&#34;test&#34;: test})
         return self.api_call(&#34;auth.revoke&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2514,7 +2514,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Checks authentication &amp; identity.
-        https://api.slack.com/methods/auth.test
+        https://docs.slack.dev/reference/methods/auth.test
         &#34;&#34;&#34;
         return self.api_call(&#34;auth.test&#34;, params=kwargs)
 
@@ -2526,7 +2526,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List the workspaces a token can access.
-        https://api.slack.com/methods/auth.teams.list
+        https://docs.slack.dev/reference/methods/auth.teams.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;include_icon&#34;: include_icon})
         return self.api_call(&#34;auth.teams.list&#34;, params=kwargs)
@@ -2544,7 +2544,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Add bookmark to a channel.
-        https://api.slack.com/methods/bookmarks.add
+        https://docs.slack.dev/reference/methods/bookmarks.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2570,7 +2570,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Edit bookmark.
-        https://api.slack.com/methods/bookmarks.edit
+        https://docs.slack.dev/reference/methods/bookmarks.edit
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2590,7 +2590,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List bookmark for the channel.
-        https://api.slack.com/methods/bookmarks.list
+        https://docs.slack.dev/reference/methods/bookmarks.list
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;bookmarks.list&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2603,7 +2603,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove bookmark from the channel.
-        https://api.slack.com/methods/bookmarks.remove
+        https://docs.slack.dev/reference/methods/bookmarks.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;bookmark_id&#34;: bookmark_id, &#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;bookmarks.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2616,7 +2616,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a bot user.
-        https://api.slack.com/methods/bots.info
+        https://docs.slack.dev/reference/methods/bots.info
         &#34;&#34;&#34;
         kwargs.update({&#34;bot&#34;: bot, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;bots.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2635,7 +2635,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Registers a new Call.
-        https://api.slack.com/methods/calls.add
+        https://docs.slack.dev/reference/methods/calls.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2662,7 +2662,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ends a Call.
-        https://api.slack.com/methods/calls.end
+        https://docs.slack.dev/reference/methods/calls.end
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id, &#34;duration&#34;: duration})
         return self.api_call(&#34;calls.end&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2674,7 +2674,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Returns information about a Call.
-        https://api.slack.com/methods/calls.info
+        https://docs.slack.dev/reference/methods/calls.info
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         return self.api_call(&#34;calls.info&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2687,7 +2687,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Registers new participants added to a Call.
-        https://api.slack.com/methods/calls.participants.add
+        https://docs.slack.dev/reference/methods/calls.participants.add
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         _update_call_participants(kwargs, users)
@@ -2701,7 +2701,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Registers participants removed from a Call.
-        https://api.slack.com/methods/calls.participants.remove
+        https://docs.slack.dev/reference/methods/calls.participants.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         _update_call_participants(kwargs, users)
@@ -2717,7 +2717,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Updates information about a Call.
-        https://api.slack.com/methods/calls.update
+        https://docs.slack.dev/reference/methods/calls.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2737,7 +2737,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create Canvas for a user
-        https://api.slack.com/methods/canvases.create
+        https://docs.slack.dev/reference/methods/canvases.create
         &#34;&#34;&#34;
         kwargs.update({&#34;title&#34;: title, &#34;document_content&#34;: document_content})
         return self.api_call(&#34;canvases.create&#34;, json=kwargs)
@@ -2750,7 +2750,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an existing canvas
-        https://api.slack.com/methods/canvases.edit
+        https://docs.slack.dev/reference/methods/canvases.edit
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;changes&#34;: changes})
         return self.api_call(&#34;canvases.edit&#34;, json=kwargs)
@@ -2762,7 +2762,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a canvas
-        https://api.slack.com/methods/canvases.delete
+        https://docs.slack.dev/reference/methods/canvases.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id})
         return self.api_call(&#34;canvases.delete&#34;, params=kwargs)
@@ -2777,7 +2777,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the access level to a canvas for specified entities
-        https://api.slack.com/methods/canvases.access.set
+        https://docs.slack.dev/reference/methods/canvases.access.set
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;access_level&#34;: access_level})
         if channel_ids is not None:
@@ -2802,7 +2802,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a Channel Canvas for a channel
-        https://api.slack.com/methods/canvases.access.delete
+        https://docs.slack.dev/reference/methods/canvases.access.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id})
         if channel_ids is not None:
@@ -2825,7 +2825,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Find sections matching the provided criteria
-        https://api.slack.com/methods/canvases.sections.lookup
+        https://docs.slack.dev/reference/methods/canvases.sections.lookup
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;criteria&#34;: json.dumps(criteria)})
         return self.api_call(&#34;canvases.sections.lookup&#34;, params=kwargs)
@@ -2833,7 +2833,7 @@ This method returns it's own object. e.g. 'self'</p>
     # --------------------------
     # Deprecated: channels.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def channels_archive(
@@ -3012,7 +3012,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a message.
-        https://api.slack.com/methods/chat.delete
+        https://docs.slack.dev/reference/methods/chat.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts, &#34;as_user&#34;: as_user})
         return self.api_call(&#34;chat.delete&#34;, params=kwargs)
@@ -3026,7 +3026,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a scheduled message.
-        https://api.slack.com/methods/chat.deleteScheduledMessage
+        https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3045,7 +3045,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a permalink URL for a specific extant message
-        https://api.slack.com/methods/chat.getPermalink
+        https://docs.slack.dev/reference/methods/chat.getPermalink
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;message_ts&#34;: message_ts})
         return self.api_call(&#34;chat.getPermalink&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3058,7 +3058,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Share a me message into a channel.
-        https://api.slack.com/methods/chat.meMessage
+        https://docs.slack.dev/reference/methods/chat.meMessage
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;text&#34;: text})
         return self.api_call(&#34;chat.meMessage&#34;, params=kwargs)
@@ -3078,10 +3078,11 @@ This method returns it's own object. e.g. 'self'</p>
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sends an ephemeral message to a user in a channel.
-        https://api.slack.com/methods/chat.postEphemeral
+        https://docs.slack.dev/reference/methods/chat.postEphemeral
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3097,11 +3098,12 @@ This method returns it's own object. e.g. 'self'</p>
                 &#34;link_names&#34;: link_names,
                 &#34;username&#34;: username,
                 &#34;parse&#34;: parse,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.postEphemeral&#34;, json=kwargs)
 
@@ -3125,10 +3127,11 @@ This method returns it's own object. e.g. 'self'</p>
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sends a message to a channel.
-        https://api.slack.com/methods/chat.postMessage
+        https://docs.slack.dev/reference/methods/chat.postMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3149,11 +3152,12 @@ This method returns it's own object. e.g. 'self'</p>
                 &#34;username&#34;: username,
                 &#34;parse&#34;: parse,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postMessage&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.postMessage&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.postMessage&#34;, json=kwargs)
 
@@ -3162,7 +3166,7 @@ This method returns it's own object. e.g. 'self'</p>
         *,
         channel: str,
         post_at: Union[str, int],
-        text: str,
+        text: Optional[str] = None,
         as_user: Optional[bool] = None,
         attachments: Optional[Union[str, Sequence[Union[Dict, Attachment]]]] = None,
         blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
@@ -3173,10 +3177,11 @@ This method returns it's own object. e.g. 'self'</p>
         unfurl_media: Optional[bool] = None,
         link_names: Optional[bool] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Schedules a message.
-        https://api.slack.com/methods/chat.scheduleMessage
+        https://docs.slack.dev/reference/methods/chat.scheduleMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3193,11 +3198,12 @@ This method returns it's own object. e.g. 'self'</p>
                 &#34;unfurl_media&#34;: unfurl_media,
                 &#34;link_names&#34;: link_names,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.scheduleMessage&#34;, json=kwargs)
 
@@ -3216,7 +3222,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Provide custom unfurl behavior for user-posted URLs.
-        https://api.slack.com/methods/chat.unfurl
+        https://docs.slack.dev/reference/methods/chat.unfurl
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3250,10 +3256,11 @@ This method returns it's own object. e.g. 'self'</p>
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Updates a message in a channel.
-        https://api.slack.com/methods/chat.update
+        https://docs.slack.dev/reference/methods/chat.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3267,6 +3274,7 @@ This method returns it's own object. e.g. 'self'</p>
                 &#34;parse&#34;: parse,
                 &#34;reply_broadcast&#34;: reply_broadcast,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         if isinstance(file_ids, (list, tuple)):
@@ -3275,7 +3283,7 @@ This method returns it's own object. e.g. 'self'</p>
             kwargs.update({&#34;file_ids&#34;: file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.update&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.update&#34;, kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return self.api_call(&#34;chat.update&#34;, json=kwargs)
 
@@ -3291,7 +3299,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all scheduled messages.
-        https://api.slack.com/methods/chat.scheduledMessages.list
+        https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3317,7 +3325,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Accepts an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.acceptSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
         &#34;&#34;&#34;
         if channel_id is None and invite_id is None:
             raise e.SlackRequestError(&#34;Either channel_id or invite_id must be provided.&#34;)
@@ -3341,7 +3349,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Approves an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.approveSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
         return self.api_call(&#34;conversations.approveSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -3353,7 +3361,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Archives a conversation.
-        https://api.slack.com/methods/conversations.archive
+        https://docs.slack.dev/reference/methods/conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.archive&#34;, params=kwargs)
@@ -3365,7 +3373,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Closes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.close
+        https://docs.slack.dev/reference/methods/conversations.close
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.close&#34;, params=kwargs)
@@ -3379,7 +3387,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Initiates a public or private channel-based conversation
-        https://api.slack.com/methods/conversations.create
+        https://docs.slack.dev/reference/methods/conversations.create
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;is_private&#34;: is_private, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;conversations.create&#34;, params=kwargs)
@@ -3392,7 +3400,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Declines a Slack Connect channel invite.
-        https://api.slack.com/methods/conversations.declineSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
         return self.api_call(&#34;conversations.declineSharedInvite&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3401,7 +3409,7 @@ This method returns it's own object. e.g. 'self'</p>
         self, *, action: str, channel: str, target_team: str, **kwargs
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-        https://api.slack.com/methods/conversations.externalInvitePermissions.set
+        https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3425,7 +3433,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Fetches a conversation&#39;s history of messages and events.
-        https://api.slack.com/methods/conversations.history
+        https://docs.slack.dev/reference/methods/conversations.history
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3449,7 +3457,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve information about a conversation.
-        https://api.slack.com/methods/conversations.info
+        https://docs.slack.dev/reference/methods/conversations.info
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3469,7 +3477,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Invites users to a channel.
-        https://api.slack.com/methods/conversations.invite
+        https://docs.slack.dev/reference/methods/conversations.invite
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3492,7 +3500,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sends an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.inviteShared
+        https://docs.slack.dev/reference/methods/conversations.inviteShared
         &#34;&#34;&#34;
         if emails is None and user_ids is None:
             raise e.SlackRequestError(&#34;Either emails or user ids must be provided.&#34;)
@@ -3514,7 +3522,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Joins an existing conversation.
-        https://api.slack.com/methods/conversations.join
+        https://docs.slack.dev/reference/methods/conversations.join
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.join&#34;, params=kwargs)
@@ -3527,7 +3535,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a user from a conversation.
-        https://api.slack.com/methods/conversations.kick
+        https://docs.slack.dev/reference/methods/conversations.kick
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;user&#34;: user})
         return self.api_call(&#34;conversations.kick&#34;, params=kwargs)
@@ -3539,7 +3547,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Leaves a conversation.
-        https://api.slack.com/methods/conversations.leave
+        https://docs.slack.dev/reference/methods/conversations.leave
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.leave&#34;, params=kwargs)
@@ -3555,7 +3563,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all channels in a Slack team.
-        https://api.slack.com/methods/conversations.list
+        https://docs.slack.dev/reference/methods/conversations.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3581,7 +3589,7 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List shared channel invites that have been generated
         or received but have not yet been approved by all parties.
-        https://api.slack.com/methods/conversations.listConnectInvites
+        https://docs.slack.dev/reference/methods/conversations.listConnectInvites
         &#34;&#34;&#34;
         kwargs.update({&#34;count&#34;: count, &#34;cursor&#34;: cursor, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;conversations.listConnectInvites&#34;, params=kwargs)
@@ -3594,7 +3602,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the read cursor in a channel.
-        https://api.slack.com/methods/conversations.mark
+        https://docs.slack.dev/reference/methods/conversations.mark
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts})
         return self.api_call(&#34;conversations.mark&#34;, params=kwargs)
@@ -3608,7 +3616,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve members of a conversation.
-        https://api.slack.com/methods/conversations.members
+        https://docs.slack.dev/reference/methods/conversations.members
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;conversations.members&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3622,7 +3630,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Opens or resumes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.open
+        https://docs.slack.dev/reference/methods/conversations.open
         &#34;&#34;&#34;
         if channel is None and users is None:
             raise e.SlackRequestError(&#34;Either channel or users must be provided.&#34;)
@@ -3641,7 +3649,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Renames a conversation.
-        https://api.slack.com/methods/conversations.rename
+        https://docs.slack.dev/reference/methods/conversations.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name})
         return self.api_call(&#34;conversations.rename&#34;, params=kwargs)
@@ -3660,7 +3668,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a thread of messages posted to a conversation
-        https://api.slack.com/methods/conversations.replies
+        https://docs.slack.dev/reference/methods/conversations.replies
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3686,7 +3694,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-        https://api.slack.com/methods/conversations.requestSharedInvite.approve
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3707,7 +3715,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deny a request to invite an external user to a channel.
-        https://api.slack.com/methods/conversations.requestSharedInvite.deny
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;message&#34;: message})
         return self.api_call(&#34;conversations.requestSharedInvite.deny&#34;, params=kwargs)
@@ -3725,7 +3733,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists requests to add external users to channels with ability to filter.
-        https://api.slack.com/methods/conversations.requestSharedInvite.list
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3752,7 +3760,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the purpose for a conversation.
-        https://api.slack.com/methods/conversations.setPurpose
+        https://docs.slack.dev/reference/methods/conversations.setPurpose
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;purpose&#34;: purpose})
         return self.api_call(&#34;conversations.setPurpose&#34;, params=kwargs)
@@ -3765,7 +3773,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Sets the topic for a conversation.
-        https://api.slack.com/methods/conversations.setTopic
+        https://docs.slack.dev/reference/methods/conversations.setTopic
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;topic&#34;: topic})
         return self.api_call(&#34;conversations.setTopic&#34;, params=kwargs)
@@ -3777,7 +3785,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Reverses conversation archival.
-        https://api.slack.com/methods/conversations.unarchive
+        https://docs.slack.dev/reference/methods/conversations.unarchive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.unarchive&#34;, params=kwargs)
@@ -3790,7 +3798,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a Channel Canvas for a channel
-        https://api.slack.com/methods/conversations.canvases.create
+        https://docs.slack.dev/reference/methods/conversations.canvases.create
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;document_content&#34;: document_content})
         return self.api_call(&#34;conversations.canvases.create&#34;, json=kwargs)
@@ -3803,7 +3811,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Open a dialog with a user.
-        https://api.slack.com/methods/dialog.open
+        https://docs.slack.dev/reference/methods/dialog.open
         &#34;&#34;&#34;
         kwargs.update({&#34;dialog&#34;: dialog, &#34;trigger_id&#34;: trigger_id})
         kwargs = _remove_none_values(kwargs)
@@ -3815,7 +3823,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ends the current user&#39;s Do Not Disturb session immediately.
-        https://api.slack.com/methods/dnd.endDnd
+        https://docs.slack.dev/reference/methods/dnd.endDnd
         &#34;&#34;&#34;
         return self.api_call(&#34;dnd.endDnd&#34;, params=kwargs)
 
@@ -3824,7 +3832,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Ends the current user&#39;s snooze mode immediately.
-        https://api.slack.com/methods/dnd.endSnooze
+        https://docs.slack.dev/reference/methods/dnd.endSnooze
         &#34;&#34;&#34;
         return self.api_call(&#34;dnd.endSnooze&#34;, params=kwargs)
 
@@ -3836,7 +3844,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieves a user&#39;s current Do Not Disturb status.
-        https://api.slack.com/methods/dnd.info
+        https://docs.slack.dev/reference/methods/dnd.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
         return self.api_call(&#34;dnd.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3848,7 +3856,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Turns on Do Not Disturb mode for the current user, or changes its duration.
-        https://api.slack.com/methods/dnd.setSnooze
+        https://docs.slack.dev/reference/methods/dnd.setSnooze
         &#34;&#34;&#34;
         kwargs.update({&#34;num_minutes&#34;: num_minutes})
         return self.api_call(&#34;dnd.setSnooze&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3860,7 +3868,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieves the Do Not Disturb status for users on a team.
-        https://api.slack.com/methods/dnd.teamInfo
+        https://docs.slack.dev/reference/methods/dnd.teamInfo
         &#34;&#34;&#34;
         if isinstance(users, (list, tuple)):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -3875,7 +3883,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists custom emoji for a team.
-        https://api.slack.com/methods/emoji.list
+        https://docs.slack.dev/reference/methods/emoji.list
         &#34;&#34;&#34;
         kwargs.update({&#34;include_categories&#34;: include_categories})
         return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3888,7 +3896,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes an existing comment on a file.
-        https://api.slack.com/methods/files.comments.delete
+        https://docs.slack.dev/reference/methods/files.comments.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file, &#34;id&#34;: id})
         return self.api_call(&#34;files.comments.delete&#34;, params=kwargs)
@@ -3900,7 +3908,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a file.
-        https://api.slack.com/methods/files.delete
+        https://docs.slack.dev/reference/methods/files.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.delete&#34;, params=kwargs)
@@ -3916,7 +3924,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a team file.
-        https://api.slack.com/methods/files.info
+        https://docs.slack.dev/reference/methods/files.info
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3944,7 +3952,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists &amp; filters team files.
-        https://api.slack.com/methods/files.list
+        https://docs.slack.dev/reference/methods/files.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3972,7 +3980,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.info
+        https://docs.slack.dev/reference/methods/files.remote.info
         &#34;&#34;&#34;
         kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
         return self.api_call(&#34;files.remote.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3988,7 +3996,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.list
+        https://docs.slack.dev/reference/methods/files.remote.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4013,7 +4021,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds a file from a remote service.
-        https://api.slack.com/methods/files.remote.add
+        https://docs.slack.dev/reference/methods/files.remote.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4052,7 +4060,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Updates an existing remote file.
-        https://api.slack.com/methods/files.remote.update
+        https://docs.slack.dev/reference/methods/files.remote.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4087,7 +4095,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Remove a remote file.
-        https://api.slack.com/methods/files.remote.remove
+        https://docs.slack.dev/reference/methods/files.remote.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
         return self.api_call(&#34;files.remote.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -4101,7 +4109,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Share a remote file into a channel.
-        https://api.slack.com/methods/files.remote.share
+        https://docs.slack.dev/reference/methods/files.remote.share
         &#34;&#34;&#34;
         if external_id is None and file is None:
             raise e.SlackRequestError(&#34;Either external_id or file must be provided.&#34;)
@@ -4119,7 +4127,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Revokes public/external sharing access for a file
-        https://api.slack.com/methods/files.revokePublicURL
+        https://docs.slack.dev/reference/methods/files.revokePublicURL
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.revokePublicURL&#34;, params=kwargs)
@@ -4131,7 +4139,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Enables a file for public/external sharing.
-        https://api.slack.com/methods/files.sharedPublicURL
+        https://docs.slack.dev/reference/methods/files.sharedPublicURL
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.sharedPublicURL&#34;, params=kwargs)
@@ -4150,7 +4158,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Uploads or creates a file.
-        https://api.slack.com/methods/files.upload
+        https://docs.slack.dev/reference/methods/files.upload
         &#34;&#34;&#34;
         _print_files_upload_v2_suggestion()
 
@@ -4203,12 +4211,12 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;This wrapper method provides an easy way to upload files using the following endpoints:
 
-        - step1: https://api.slack.com/methods/files.getUploadURLExternal
+        - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
         - step2: &#34;https://files.slack.com/upload/v1/...&#34; URLs returned from files.getUploadURLExternal API
 
-        - step3: https://api.slack.com/methods/files.completeUploadExternal
-            and https://api.slack.com/methods/files.info
+        - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+            and https://docs.slack.dev/reference/methods/files.info
 
         &#34;&#34;&#34;
         if file is None and content is None and file_uploads is None:
@@ -4294,7 +4302,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets a URL for an edge external upload.
-        https://api.slack.com/methods/files.getUploadURLExternal
+        https://docs.slack.dev/reference/methods/files.getUploadURLExternal
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4317,7 +4325,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Finishes an upload started with files.getUploadURLExternal.
-        https://api.slack.com/methods/files.completeUploadExternal
+        https://docs.slack.dev/reference/methods/files.completeUploadExternal
         &#34;&#34;&#34;
         _files = [{k: v for k, v in f.items() if v is not None} for f in files]
         kwargs.update(
@@ -4340,7 +4348,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Signal the successful completion of a function
-        https://api.slack.com/methods/functions.completeSuccess
+        https://docs.slack.dev/reference/methods/functions.completeSuccess
         &#34;&#34;&#34;
         kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;outputs&#34;: json.dumps(outputs)})
         return self.api_call(&#34;functions.completeSuccess&#34;, params=kwargs)
@@ -4353,7 +4361,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Signal the failure to execute a function
-        https://api.slack.com/methods/functions.completeError
+        https://docs.slack.dev/reference/methods/functions.completeError
         &#34;&#34;&#34;
         kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;error&#34;: error})
         return self.api_call(&#34;functions.completeError&#34;, params=kwargs)
@@ -4361,7 +4369,7 @@ This method returns it's own object. e.g. 'self'</p>
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def groups_archive(
@@ -4542,7 +4550,7 @@ This method returns it's own object. e.g. 'self'</p>
     # --------------------------
     # Deprecated: im.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def im_close(
@@ -4618,7 +4626,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;For Enterprise Grid workspaces, map local user IDs to global user IDs
-        https://api.slack.com/methods/migration.exchange
+        https://docs.slack.dev/reference/methods/migration.exchange
         &#34;&#34;&#34;
         if isinstance(users, (list, tuple)):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -4630,7 +4638,7 @@ This method returns it's own object. e.g. 'self'</p>
     # --------------------------
     # Deprecated: mpim.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def mpim_close(
@@ -4717,7 +4725,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.v2.access
+        https://docs.slack.dev/reference/methods/oauth.v2.access
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4743,7 +4751,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.access
+        https://docs.slack.dev/reference/methods/oauth.access
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4763,7 +4771,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
-        https://api.slack.com/methods/oauth.v2.exchange
+        https://docs.slack.dev/reference/methods/oauth.v2.exchange
         &#34;&#34;&#34;
         kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token})
         return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
@@ -4779,7 +4787,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.token
+        https://docs.slack.dev/reference/methods/openid.connect.token
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4800,7 +4808,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get the identity of a user who has authorized Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.userInfo
+        https://docs.slack.dev/reference/methods/openid.connect.userInfo
         &#34;&#34;&#34;
         return self.api_call(&#34;openid.connect.userInfo&#34;, params=kwargs)
 
@@ -4812,7 +4820,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Pins an item to a channel.
-        https://api.slack.com/methods/pins.add
+        https://docs.slack.dev/reference/methods/pins.add
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;pins.add&#34;, params=kwargs)
@@ -4824,7 +4832,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists items pinned to a channel.
-        https://api.slack.com/methods/pins.list
+        https://docs.slack.dev/reference/methods/pins.list
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;pins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4837,7 +4845,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Un-pins an item from a channel.
-        https://api.slack.com/methods/pins.remove
+        https://docs.slack.dev/reference/methods/pins.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;pins.remove&#34;, params=kwargs)
@@ -4851,7 +4859,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds a reaction to an item.
-        https://api.slack.com/methods/reactions.add
+        https://docs.slack.dev/reference/methods/reactions.add
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;reactions.add&#34;, params=kwargs)
@@ -4867,7 +4875,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets reactions for an item.
-        https://api.slack.com/methods/reactions.get
+        https://docs.slack.dev/reference/methods/reactions.get
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4893,7 +4901,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists reactions made by a user.
-        https://api.slack.com/methods/reactions.list
+        https://docs.slack.dev/reference/methods/reactions.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4919,7 +4927,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a reaction from an item.
-        https://api.slack.com/methods/reactions.remove
+        https://docs.slack.dev/reference/methods/reactions.remove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4943,7 +4951,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Creates a reminder.
-        https://api.slack.com/methods/reminders.add
+        https://docs.slack.dev/reference/methods/reminders.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4964,7 +4972,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Marks a reminder as complete.
-        https://api.slack.com/methods/reminders.complete
+        https://docs.slack.dev/reference/methods/reminders.complete
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.complete&#34;, params=kwargs)
@@ -4977,7 +4985,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Deletes a reminder.
-        https://api.slack.com/methods/reminders.delete
+        https://docs.slack.dev/reference/methods/reminders.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.delete&#34;, params=kwargs)
@@ -4990,7 +4998,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a reminder.
-        https://api.slack.com/methods/reminders.info
+        https://docs.slack.dev/reference/methods/reminders.info
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5002,7 +5010,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all reminders created by or for a given user.
-        https://api.slack.com/methods/reminders.list
+        https://docs.slack.dev/reference/methods/reminders.list
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5015,7 +5023,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.connect
+        https://docs.slack.dev/reference/methods/rtm.connect
         &#34;&#34;&#34;
         kwargs.update({&#34;batch_presence_aware&#34;: batch_presence_aware, &#34;presence_sub&#34;: presence_sub})
         return self.api_call(&#34;rtm.connect&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5033,7 +5041,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.start
+        https://docs.slack.dev/reference/methods/rtm.start
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5061,7 +5069,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Searches for messages and files matching a query.
-        https://api.slack.com/methods/search.all
+        https://docs.slack.dev/reference/methods/search.all
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5089,7 +5097,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Searches for files matching a query.
-        https://api.slack.com/methods/search.files
+        https://docs.slack.dev/reference/methods/search.files
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5118,7 +5126,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Searches for messages matching a query.
-        https://api.slack.com/methods/search.messages
+        https://docs.slack.dev/reference/methods/search.messages
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5144,7 +5152,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Adds a star to an item.
-        https://api.slack.com/methods/stars.add
+        https://docs.slack.dev/reference/methods/stars.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5167,7 +5175,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists stars for a user.
-        https://api.slack.com/methods/stars.list
+        https://docs.slack.dev/reference/methods/stars.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5190,7 +5198,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Removes a star from an item.
-        https://api.slack.com/methods/stars.remove
+        https://docs.slack.dev/reference/methods/stars.remove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5214,7 +5222,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets the access logs for the current team.
-        https://api.slack.com/methods/team.accessLogs
+        https://docs.slack.dev/reference/methods/team.accessLogs
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5236,7 +5244,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets billable users information for the current team.
-        https://api.slack.com/methods/team.billableInfo
+        https://docs.slack.dev/reference/methods/team.billableInfo
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
         return self.api_call(&#34;team.billableInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5246,7 +5254,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Reads a workspace&#39;s billing plan information.
-        https://api.slack.com/methods/team.billing.info
+        https://docs.slack.dev/reference/methods/team.billing.info
         &#34;&#34;&#34;
         return self.api_call(&#34;team.billing.info&#34;, params=kwargs)
 
@@ -5257,7 +5265,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Disconnects an external organization.
-        https://api.slack.com/methods/team.externalTeams.disconnect
+        https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5279,7 +5287,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
-        https://api.slack.com/methods/team.externalTeams.list
+        https://docs.slack.dev/reference/methods/team.externalTeams.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5310,7 +5318,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about the current team.
-        https://api.slack.com/methods/team.info
+        https://docs.slack.dev/reference/methods/team.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team&#34;: team, &#34;domain&#34;: domain})
         return self.api_call(&#34;team.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5328,7 +5336,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets the integration logs for the current team.
-        https://api.slack.com/methods/team.integrationLogs
+        https://docs.slack.dev/reference/methods/team.integrationLogs
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5350,7 +5358,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a team&#39;s profile.
-        https://api.slack.com/methods/team.profile.get
+        https://docs.slack.dev/reference/methods/team.profile.get
         &#34;&#34;&#34;
         kwargs.update({&#34;visibility&#34;: visibility})
         return self.api_call(&#34;team.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5360,7 +5368,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieve a list of a workspace&#39;s team preferences.
-        https://api.slack.com/methods/team.preferences.list
+        https://docs.slack.dev/reference/methods/team.preferences.list
         &#34;&#34;&#34;
         return self.api_call(&#34;team.preferences.list&#34;, params=kwargs)
 
@@ -5376,7 +5384,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Create a User Group
-        https://api.slack.com/methods/usergroups.create
+        https://docs.slack.dev/reference/methods/usergroups.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5402,7 +5410,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Disable an existing User Group
-        https://api.slack.com/methods/usergroups.disable
+        https://docs.slack.dev/reference/methods/usergroups.disable
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;usergroups.disable&#34;, params=kwargs)
@@ -5416,7 +5424,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Enable a User Group
-        https://api.slack.com/methods/usergroups.enable
+        https://docs.slack.dev/reference/methods/usergroups.enable
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;usergroups.enable&#34;, params=kwargs)
@@ -5431,7 +5439,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all User Groups for a team
-        https://api.slack.com/methods/usergroups.list
+        https://docs.slack.dev/reference/methods/usergroups.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5456,7 +5464,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update an existing User Group
-        https://api.slack.com/methods/usergroups.update
+        https://docs.slack.dev/reference/methods/usergroups.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5483,7 +5491,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List all users in a User Group
-        https://api.slack.com/methods/usergroups.users.list
+        https://docs.slack.dev/reference/methods/usergroups.users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5504,7 +5512,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update the list of users for a User Group
-        https://api.slack.com/methods/usergroups.users.update
+        https://docs.slack.dev/reference/methods/usergroups.users.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5531,7 +5539,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;List conversations the calling user may access.
-        https://api.slack.com/methods/users.conversations
+        https://docs.slack.dev/reference/methods/users.conversations
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5553,7 +5561,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Delete the user profile photo
-        https://api.slack.com/methods/users.deletePhoto
+        https://docs.slack.dev/reference/methods/users.deletePhoto
         &#34;&#34;&#34;
         return self.api_call(&#34;users.deletePhoto&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
@@ -5564,7 +5572,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets user presence information.
-        https://api.slack.com/methods/users.getPresence
+        https://docs.slack.dev/reference/methods/users.getPresence
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user})
         return self.api_call(&#34;users.getPresence&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5574,7 +5582,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Get a user&#39;s identity.
-        https://api.slack.com/methods/users.identity
+        https://docs.slack.dev/reference/methods/users.identity
         &#34;&#34;&#34;
         return self.api_call(&#34;users.identity&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
@@ -5586,7 +5594,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Gets information about a user.
-        https://api.slack.com/methods/users.info
+        https://docs.slack.dev/reference/methods/users.info
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user, &#34;include_locale&#34;: include_locale})
         return self.api_call(&#34;users.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5601,7 +5609,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lists all users in a Slack team.
-        https://api.slack.com/methods/users.list
+        https://docs.slack.dev/reference/methods/users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5620,7 +5628,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Find a user with an email address.
-        https://api.slack.com/methods/users.lookupByEmail
+        https://docs.slack.dev/reference/methods/users.lookupByEmail
         &#34;&#34;&#34;
         kwargs.update({&#34;email&#34;: email})
         return self.api_call(&#34;users.lookupByEmail&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5635,7 +5643,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the user profile photo
-        https://api.slack.com/methods/users.setPhoto
+        https://docs.slack.dev/reference/methods/users.setPhoto
         &#34;&#34;&#34;
         kwargs.update({&#34;crop_w&#34;: crop_w, &#34;crop_x&#34;: crop_x, &#34;crop_y&#34;: crop_y})
         return self.api_call(&#34;users.setPhoto&#34;, files={&#34;image&#34;: image}, data=kwargs)
@@ -5647,7 +5655,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Manually sets user presence.
-        https://api.slack.com/methods/users.setPresence
+        https://docs.slack.dev/reference/methods/users.setPresence
         &#34;&#34;&#34;
         kwargs.update({&#34;presence&#34;: presence})
         return self.api_call(&#34;users.setPresence&#34;, params=kwargs)
@@ -5658,7 +5666,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Lookup an email address to see if someone is on Slack
-        https://api.slack.com/methods/users.discoverableContacts.lookup
+        https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
         &#34;&#34;&#34;
         kwargs.update({&#34;email&#34;: email})
         return self.api_call(&#34;users.discoverableContacts.lookup&#34;, params=kwargs)
@@ -5671,7 +5679,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Retrieves a user&#39;s profile information.
-        https://api.slack.com/methods/users.profile.get
+        https://docs.slack.dev/reference/methods/users.profile.get
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user, &#34;include_labels&#34;: include_labels})
         return self.api_call(&#34;users.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5686,7 +5694,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Set the profile information for a user.
-        https://api.slack.com/methods/users.profile.set
+        https://docs.slack.dev/reference/methods/users.profile.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5709,8 +5717,8 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Open a view for a user.
-        https://api.slack.com/methods/views.open
-        See https://api.slack.com/surfaces/modals for details.
+        https://docs.slack.dev/reference/methods/views.open
+        See https://docs.slack.dev/surfaces/modals/ for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
         if isinstance(view, View):
@@ -5733,9 +5741,9 @@ This method returns it's own object. e.g. 'self'</p>
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/surfaces/modals)
+        Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
         to learn more about the lifecycle and intricacies of views.
-        https://api.slack.com/methods/views.push
+        https://docs.slack.dev/reference/methods/views.push
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
         if isinstance(view, View):
@@ -5758,9 +5766,9 @@ This method returns it's own object. e.g. 'self'</p>
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+        See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
-        https://api.slack.com/methods/views.update
+        https://docs.slack.dev/reference/methods/views.update
         &#34;&#34;&#34;
         if isinstance(view, View):
             kwargs.update({&#34;view&#34;: view.to_dict()})
@@ -5787,8 +5795,8 @@ This method returns it's own object. e.g. 'self'</p>
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Publish a static view for a User.
         Create or update the view that comprises an
-        app&#39;s Home tab (https://api.slack.com/surfaces/tabs)
-        https://api.slack.com/methods/views.publish
+        app&#39;s Home tab (https://docs.slack.dev/surfaces/app-home/)
+        https://docs.slack.dev/reference/methods/views.publish
         &#34;&#34;&#34;
         kwargs.update({&#34;user_id&#34;: user_id, &#34;hash&#34;: hash})
         if isinstance(view, View):
@@ -5799,6 +5807,72 @@ This method returns it's own object. e.g. 'self'</p>
         # NOTE: Intentionally using json for the &#34;view&#34; parameter
         return self.api_call(&#34;views.publish&#34;, json=kwargs)
 
+    def workflows_featured_add(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Add featured workflows to a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.add
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.add&#34;, params=kwargs)
+
+    def workflows_featured_list(
+        self,
+        *,
+        channel_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;List the featured workflows for specified channels.
+        https://docs.slack.dev/reference/methods/workflows.featured.list
+        &#34;&#34;&#34;
+        if isinstance(channel_ids, (list, tuple)):
+            kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
+        else:
+            kwargs.update({&#34;channel_ids&#34;: channel_ids})
+        return self.api_call(&#34;workflows.featured.list&#34;, params=kwargs)
+
+    def workflows_featured_remove(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Remove featured workflows from a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.remove
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.remove&#34;, params=kwargs)
+
+    def workflows_featured_set(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Set featured workflows for a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.set
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.set&#34;, params=kwargs)
+
     def workflows_stepCompleted(
         self,
         *,
@@ -5807,7 +5881,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Indicate a successful outcome of a workflow step&#39;s execution.
-        https://api.slack.com/methods/workflows.stepCompleted
+        https://docs.slack.dev/reference/methods/workflows.stepCompleted
         &#34;&#34;&#34;
         kwargs.update({&#34;workflow_step_execute_id&#34;: workflow_step_execute_id})
         if outputs is not None:
@@ -5824,7 +5898,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Indicate an unsuccessful outcome of a workflow step&#39;s execution.
-        https://api.slack.com/methods/workflows.stepFailed
+        https://docs.slack.dev/reference/methods/workflows.stepFailed
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5845,7 +5919,7 @@ This method returns it's own object. e.g. 'self'</p>
         **kwargs,
     ) -&gt; SlackResponse:
         &#34;&#34;&#34;Update the configuration for a workflow extension step.
-        https://api.slack.com/methods/workflows.updateStep
+        https://docs.slack.dev/reference/methods/workflows.updateStep
         &#34;&#34;&#34;
         kwargs.update({&#34;workflow_step_edit_id&#34;: workflow_step_edit_id})
         if inputs is not None:
@@ -5857,7 +5931,7 @@ This method returns it's own object. e.g. 'self'</p>
         return self.api_call(&#34;workflows.updateStep&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>A WebClient allows apps to communicate with the Slack Platform's Web API.</p>
-<p><a href="https://api.slack.com/methods">https://api.slack.com/methods</a></p>
+<p><a href="https://docs.slack.dev/reference/methods">https://docs.slack.dev/reference/methods</a></p>
 <p>The Slack Web API is an interface for querying information from
 and enacting change in a Slack workspace.</p>
 <p>This client handles constructing and sending HTTP requests to Slack
@@ -5937,7 +6011,7 @@ removed at anytime.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve analytics data for a given date, presented as a compressed JSON file
-    https://api.slack.com/methods/admin.analytics.getFile
+    https://docs.slack.dev/reference/methods/admin.analytics.getFile
     &#34;&#34;&#34;
     kwargs.update({&#34;type&#34;: type})
     if date is not None:
@@ -5947,7 +6021,7 @@ removed at anytime.</p></div>
     return self.api_call(&#34;admin.analytics.getFile&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve analytics data for a given date, presented as a compressed JSON file
-<a href="https://api.slack.com/methods/admin.analytics.getFile">https://api.slack.com/methods/admin.analytics.getFile</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.analytics.getFile">https://docs.slack.dev/reference/methods/admin.analytics.getFile</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_activities_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_activities_list</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>component_id: str | None = None,<br>component_type: str | None = None,<br>log_event_type: str | None = None,<br>max_date_created: int | None = None,<br>min_date_created: int | None = None,<br>min_log_level: str | None = None,<br>sort_direction: str | None = None,<br>source: str | None = None,<br>team_id: str | None = None,<br>trace_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -5976,7 +6050,7 @@ removed at anytime.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get logs for a specified team/org
-    https://api.slack.com/methods/admin.apps.activities.list
+    https://docs.slack.dev/reference/methods/admin.apps.activities.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5998,7 +6072,7 @@ removed at anytime.</p></div>
     return self.api_call(&#34;admin.apps.activities.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get logs for a specified team/org
-<a href="https://api.slack.com/methods/admin.apps.activities.list">https://api.slack.com/methods/admin.apps.activities.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.activities.list">https://docs.slack.dev/reference/methods/admin.apps.activities.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_approve"><code class="name flex">
 <span>def <span class="ident">admin_apps_approve</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>request_id: str | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6021,7 +6095,7 @@ removed at anytime.</p></div>
     Either app_id or request_id is required.
     These IDs can be obtained either directly via the app_requested event,
     or by the admin.apps.requests.list method.
-    https://api.slack.com/methods/admin.apps.approve
+    https://docs.slack.dev/reference/methods/admin.apps.approve
     &#34;&#34;&#34;
     if app_id:
         kwargs.update({&#34;app_id&#34;: app_id})
@@ -6042,7 +6116,7 @@ removed at anytime.</p></div>
 Either app_id or request_id is required.
 These IDs can be obtained either directly via the app_requested event,
 or by the admin.apps.requests.list method.
-<a href="https://api.slack.com/methods/admin.apps.approve">https://api.slack.com/methods/admin.apps.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.approve">https://docs.slack.dev/reference/methods/admin.apps.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_approved_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_approved_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6062,7 +6136,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List approved apps for an org or workspace.
-    https://api.slack.com/methods/admin.apps.approved.list
+    https://docs.slack.dev/reference/methods/admin.apps.approved.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6075,7 +6149,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.approved.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List approved apps for an org or workspace.
-<a href="https://api.slack.com/methods/admin.apps.approved.list">https://api.slack.com/methods/admin.apps.approved.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.approved.list">https://docs.slack.dev/reference/methods/admin.apps.approved.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_clearResolution"><code class="name flex">
 <span>def <span class="ident">admin_apps_clearResolution</span></span>(<span>self,<br>*,<br>app_id: str,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6094,7 +6168,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Clear an app resolution
-    https://api.slack.com/methods/admin.apps.clearResolution
+    https://docs.slack.dev/reference/methods/admin.apps.clearResolution
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6106,7 +6180,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.clearResolution&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Clear an app resolution
-<a href="https://api.slack.com/methods/admin.apps.clearResolution">https://api.slack.com/methods/admin.apps.clearResolution</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.clearResolution">https://docs.slack.dev/reference/methods/admin.apps.clearResolution</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_config_lookup"><code class="name flex">
 <span>def <span class="ident">admin_apps_config_lookup</span></span>(<span>self, *, app_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6123,7 +6197,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Look up the app config for connectors by their IDs
-    https://api.slack.com/methods/admin.apps.config.lookup
+    https://docs.slack.dev/reference/methods/admin.apps.config.lookup
     &#34;&#34;&#34;
     if isinstance(app_ids, (list, tuple)):
         kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -6132,7 +6206,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.config.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up the app config for connectors by their IDs
-<a href="https://api.slack.com/methods/admin.apps.config.lookup">https://api.slack.com/methods/admin.apps.config.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.config.lookup">https://docs.slack.dev/reference/methods/admin.apps.config.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_config_set"><code class="name flex">
 <span>def <span class="ident">admin_apps_config_set</span></span>(<span>self,<br>*,<br>app_id: str,<br>domain_restrictions: Dict[str, Any] | None = None,<br>workflow_auth_strategy: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6151,7 +6225,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the app config for a connector
-    https://api.slack.com/methods/admin.apps.config.set
+    https://docs.slack.dev/reference/methods/admin.apps.config.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6164,7 +6238,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.config.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the app config for a connector
-<a href="https://api.slack.com/methods/admin.apps.config.set">https://api.slack.com/methods/admin.apps.config.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.config.set">https://docs.slack.dev/reference/methods/admin.apps.config.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_requests_cancel"><code class="name flex">
 <span>def <span class="ident">admin_apps_requests_cancel</span></span>(<span>self,<br>*,<br>request_id: str,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6183,7 +6257,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List app requests for a team/workspace.
-    https://api.slack.com/methods/admin.apps.requests.cancel
+    https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6195,7 +6269,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.requests.cancel&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List app requests for a team/workspace.
-<a href="https://api.slack.com/methods/admin.apps.requests.cancel">https://api.slack.com/methods/admin.apps.requests.cancel</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.requests.cancel">https://docs.slack.dev/reference/methods/admin.apps.requests.cancel</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_requests_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_requests_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6214,7 +6288,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List app requests for a team/workspace.
-    https://api.slack.com/methods/admin.apps.requests.list
+    https://docs.slack.dev/reference/methods/admin.apps.requests.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6226,7 +6300,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.requests.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List app requests for a team/workspace.
-<a href="https://api.slack.com/methods/admin.apps.requests.list">https://api.slack.com/methods/admin.apps.requests.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.requests.list">https://docs.slack.dev/reference/methods/admin.apps.requests.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_restrict"><code class="name flex">
 <span>def <span class="ident">admin_apps_restrict</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>request_id: str | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6249,7 +6323,7 @@ or by the admin.apps.requests.list method.
     Exactly one of the team_id or enterprise_id arguments is required, not both.
     Either app_id or request_id is required. These IDs can be obtained either directly
     via the app_requested event, or by the admin.apps.requests.list method.
-    https://api.slack.com/methods/admin.apps.restrict
+    https://docs.slack.dev/reference/methods/admin.apps.restrict
     &#34;&#34;&#34;
     if app_id:
         kwargs.update({&#34;app_id&#34;: app_id})
@@ -6270,7 +6344,7 @@ or by the admin.apps.requests.list method.
 Exactly one of the team_id or enterprise_id arguments is required, not both.
 Either app_id or request_id is required. These IDs can be obtained either directly
 via the app_requested event, or by the admin.apps.requests.list method.
-<a href="https://api.slack.com/methods/admin.apps.restrict">https://api.slack.com/methods/admin.apps.restrict</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.restrict">https://docs.slack.dev/reference/methods/admin.apps.restrict</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_restricted_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_restricted_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6290,7 +6364,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List restricted apps for an org or workspace.
-    https://api.slack.com/methods/admin.apps.restricted.list
+    https://docs.slack.dev/reference/methods/admin.apps.restricted.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6303,7 +6377,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.restricted.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List restricted apps for an org or workspace.
-<a href="https://api.slack.com/methods/admin.apps.restricted.list">https://api.slack.com/methods/admin.apps.restricted.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.restricted.list">https://docs.slack.dev/reference/methods/admin.apps.restricted.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_apps_uninstall"><code class="name flex">
 <span>def <span class="ident">admin_apps_uninstall</span></span>(<span>self,<br>*,<br>app_id: str,<br>enterprise_id: str | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6323,7 +6397,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Uninstall an app from one or many workspaces, or an entire enterprise organization.
     With an org-level token, enterprise_id or team_ids is required.
-    https://api.slack.com/methods/admin.apps.uninstall
+    https://docs.slack.dev/reference/methods/admin.apps.uninstall
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     if enterprise_id is not None:
@@ -6337,7 +6411,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
 </details>
 <div class="desc"><p>Uninstall an app from one or many workspaces, or an entire enterprise organization.
 With an org-level token, enterprise_id or team_ids is required.
-<a href="https://api.slack.com/methods/admin.apps.uninstall">https://api.slack.com/methods/admin.apps.uninstall</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.uninstall">https://docs.slack.dev/reference/methods/admin.apps.uninstall</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_auth_policy_assignEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_assignEntities</span></span>(<span>self,<br>*,<br>entity_ids: str | Sequence[str],<br>policy_name: str,<br>entity_type: str,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6356,7 +6430,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Assign entities to a particular authentication policy.
-    https://api.slack.com/methods/admin.auth.policy.assignEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
     &#34;&#34;&#34;
     if isinstance(entity_ids, (list, tuple)):
         kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -6367,7 +6441,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Assign entities to a particular authentication policy.
-<a href="https://api.slack.com/methods/admin.auth.policy.assignEntities">https://api.slack.com/methods/admin.auth.policy.assignEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_auth_policy_getEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_getEntities</span></span>(<span>self,<br>*,<br>policy_name: str,<br>cursor: str | None = None,<br>entity_type: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6387,7 +6461,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.
-    https://api.slack.com/methods/admin.auth.policy.getEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
     &#34;&#34;&#34;
     kwargs.update({&#34;policy_name&#34;: policy_name})
     if cursor is not None:
@@ -6399,7 +6473,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetch all the entities assigned to a particular authentication policy by name.
-<a href="https://api.slack.com/methods/admin.auth.policy.getEntities">https://api.slack.com/methods/admin.auth.policy.getEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_auth_policy_removeEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_removeEntities</span></span>(<span>self,<br>*,<br>entity_ids: str | Sequence[str],<br>policy_name: str,<br>entity_type: str,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6418,7 +6492,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove specified entities from a specified authentication policy.
-    https://api.slack.com/methods/admin.auth.policy.removeEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
     &#34;&#34;&#34;
     if isinstance(entity_ids, (list, tuple)):
         kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -6429,7 +6503,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove specified entities from a specified authentication policy.
-<a href="https://api.slack.com/methods/admin.auth.policy.removeEntities">https://api.slack.com/methods/admin.auth.policy.removeEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_barriers_create"><code class="name flex">
 <span>def <span class="ident">admin_barriers_create</span></span>(<span>self,<br>*,<br>barriered_from_usergroup_ids: str | Sequence[str],<br>primary_usergroup_id: str,<br>restricted_subjects: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6448,7 +6522,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create an Information Barrier
-    https://api.slack.com/methods/admin.barriers.create
+    https://docs.slack.dev/reference/methods/admin.barriers.create
     &#34;&#34;&#34;
     kwargs.update({&#34;primary_usergroup_id&#34;: primary_usergroup_id})
     if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -6462,7 +6536,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.create&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.create">https://api.slack.com/methods/admin.barriers.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.create">https://docs.slack.dev/reference/methods/admin.barriers.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_barriers_delete"><code class="name flex">
 <span>def <span class="ident">admin_barriers_delete</span></span>(<span>self, *, barrier_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6479,13 +6553,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Delete an existing Information Barrier
-    https://api.slack.com/methods/admin.barriers.delete
+    https://docs.slack.dev/reference/methods/admin.barriers.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;barrier_id&#34;: barrier_id})
     return self.api_call(&#34;admin.barriers.delete&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete an existing Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.delete">https://api.slack.com/methods/admin.barriers.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.delete">https://docs.slack.dev/reference/methods/admin.barriers.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_barriers_list"><code class="name flex">
 <span>def <span class="ident">admin_barriers_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6503,7 +6577,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get all Information Barriers for your organization
-    https://api.slack.com/methods/admin.barriers.list&#34;&#34;&#34;
+    https://docs.slack.dev/reference/methods/admin.barriers.list&#34;&#34;&#34;
     kwargs.update(
         {
             &#34;cursor&#34;: cursor,
@@ -6513,7 +6587,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get all Information Barriers for your organization
-<a href="https://api.slack.com/methods/admin.barriers.list">https://api.slack.com/methods/admin.barriers.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.list">https://docs.slack.dev/reference/methods/admin.barriers.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_barriers_update"><code class="name flex">
 <span>def <span class="ident">admin_barriers_update</span></span>(<span>self,<br>*,<br>barrier_id: str,<br>barriered_from_usergroup_ids: str | Sequence[str],<br>primary_usergroup_id: str,<br>restricted_subjects: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6533,7 +6607,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an existing Information Barrier
-    https://api.slack.com/methods/admin.barriers.update
+    https://docs.slack.dev/reference/methods/admin.barriers.update
     &#34;&#34;&#34;
     kwargs.update({&#34;barrier_id&#34;: barrier_id, &#34;primary_usergroup_id&#34;: primary_usergroup_id})
     if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -6547,7 +6621,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.update&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.update">https://api.slack.com/methods/admin.barriers.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.update">https://docs.slack.dev/reference/methods/admin.barriers.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_archive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_archive</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6564,13 +6638,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Archive a public or private channel.
-    https://api.slack.com/methods/admin.conversations.archive
+    https://docs.slack.dev/reference/methods/admin.conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.archive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archive a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.archive">https://api.slack.com/methods/admin.conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.archive">https://docs.slack.dev/reference/methods/admin.conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_bulkArchive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_bulkArchive</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6587,13 +6661,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Archive public or private channels in bulk.
-    https://api.slack.com/methods/admin.conversations.bulkArchive
+    https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
     return self.api_call(&#34;admin.conversations.bulkArchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archive public or private channels in bulk.
-<a href="https://api.slack.com/methods/admin.conversations.bulkArchive">https://api.slack.com/methods/admin.conversations.bulkArchive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive">https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_bulkDelete"><code class="name flex">
 <span>def <span class="ident">admin_conversations_bulkDelete</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6634,7 +6708,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Move public or private channels in bulk.
-    https://api.slack.com/methods/admin.conversations.bulkMove
+    https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6645,7 +6719,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.bulkMove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Move public or private channels in bulk.
-<a href="https://api.slack.com/methods/admin.conversations.bulkMove">https://api.slack.com/methods/admin.conversations.bulkMove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.bulkMove">https://docs.slack.dev/reference/methods/admin.conversations.bulkMove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_convertToPrivate"><code class="name flex">
 <span>def <span class="ident">admin_conversations_convertToPrivate</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6662,13 +6736,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Convert a public channel to a private channel.
-    https://api.slack.com/methods/admin.conversations.convertToPrivate
+    https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.convertToPrivate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Convert a public channel to a private channel.
-<a href="https://api.slack.com/methods/admin.conversations.convertToPrivate">https://api.slack.com/methods/admin.conversations.convertToPrivate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate">https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_convertToPublic"><code class="name flex">
 <span>def <span class="ident">admin_conversations_convertToPublic</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6685,13 +6759,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Convert a privte channel to a public channel.
-    https://api.slack.com/methods/admin.conversations.convertToPublic
+    https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.convertToPublic&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Convert a privte channel to a public channel.
-<a href="https://api.slack.com/methods/admin.conversations.convertToPublic">https://api.slack.com/methods/admin.conversations.convertToPublic</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic">https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_create"><code class="name flex">
 <span>def <span class="ident">admin_conversations_create</span></span>(<span>self,<br>*,<br>is_private: bool,<br>name: str,<br>description: str | None = None,<br>org_wide: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6712,7 +6786,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a public or private channel-based conversation.
-    https://api.slack.com/methods/admin.conversations.create
+    https://docs.slack.dev/reference/methods/admin.conversations.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6726,7 +6800,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a public or private channel-based conversation.
-<a href="https://api.slack.com/methods/admin.conversations.create">https://api.slack.com/methods/admin.conversations.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.create">https://docs.slack.dev/reference/methods/admin.conversations.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_createForObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_createForObjects</span></span>(<span>self,<br>*,<br>object_id: str,<br>salesforce_org_id: str,<br>invite_object_team: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6745,7 +6819,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a Salesforce channel for the corresponding object provided.
-    https://api.slack.com/methods/admin.conversations.createForObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
     &#34;&#34;&#34;
     kwargs.update(
         {&#34;object_id&#34;: object_id, &#34;salesforce_org_id&#34;: salesforce_org_id, &#34;invite_object_team&#34;: invite_object_team}
@@ -6753,7 +6827,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.createForObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Salesforce channel for the corresponding object provided.
-<a href="https://api.slack.com/methods/admin.conversations.createForObjects">https://api.slack.com/methods/admin.conversations.createForObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.createForObjects">https://docs.slack.dev/reference/methods/admin.conversations.createForObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_delete"><code class="name flex">
 <span>def <span class="ident">admin_conversations_delete</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6770,13 +6844,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Delete a public or private channel.
-    https://api.slack.com/methods/admin.conversations.delete
+    https://docs.slack.dev/reference/methods/admin.conversations.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.delete">https://api.slack.com/methods/admin.conversations.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.delete">https://docs.slack.dev/reference/methods/admin.conversations.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_disconnectShared"><code class="name flex">
 <span>def <span class="ident">admin_conversations_disconnectShared</span></span>(<span>self,<br>*,<br>channel_id: str,<br>leaving_team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6794,7 +6868,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Disconnect a connected channel from one or more workspaces.
-    https://api.slack.com/methods/admin.conversations.disconnectShared
+    https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(leaving_team_ids, (list, tuple)):
@@ -6804,7 +6878,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.disconnectShared&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disconnect a connected channel from one or more workspaces.
-<a href="https://api.slack.com/methods/admin.conversations.disconnectShared">https://api.slack.com/methods/admin.conversations.disconnectShared</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared">https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_ekm_listOriginalConnectedChannelInfo"><code class="name flex">
 <span>def <span class="ident">admin_conversations_ekm_listOriginalConnectedChannelInfo</span></span>(<span>self,<br>*,<br>channel_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6826,7 +6900,7 @@ With an org-level token, enterprise_id or team_ids is required.
     &#34;&#34;&#34;List all disconnected channels—i.e.,
     channels that were once connected to other workspaces and then disconnected—and
     the corresponding original channel IDs for key revocation with EKM.
-    https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+    https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6847,7 +6921,7 @@ With an org-level token, enterprise_id or team_ids is required.
 <div class="desc"><p>List all disconnected channels—i.e.,
 channels that were once connected to other workspaces and then disconnected—and
 the corresponding original channel IDs for key revocation with EKM.
-<a href="https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo">https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo">https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_getConversationPrefs"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getConversationPrefs</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6864,13 +6938,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get conversation preferences for a public or private channel.
-    https://api.slack.com/methods/admin.conversations.getConversationPrefs
+    https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.getConversationPrefs&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get conversation preferences for a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.getConversationPrefs">https://api.slack.com/methods/admin.conversations.getConversationPrefs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs">https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_getCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getCustomRetention</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6887,13 +6961,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.getCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.getCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.getCustomRetention">https://api.slack.com/methods/admin.conversations.getCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_getTeams"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getTeams</span></span>(<span>self,<br>*,<br>channel_id: str,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6912,7 +6986,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a channel.
-    https://api.slack.com/methods/admin.conversations.getTeams
+    https://docs.slack.dev/reference/methods/admin.conversations.getTeams
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6924,7 +6998,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the workspaces in an Enterprise grid org that connect to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.getTeams">https://api.slack.com/methods/admin.conversations.getTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getTeams">https://docs.slack.dev/reference/methods/admin.conversations.getTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_invite"><code class="name flex">
 <span>def <span class="ident">admin_conversations_invite</span></span>(<span>self, *, channel_id: str, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6942,7 +7016,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invite a user to a public or private channel.
-    https://api.slack.com/methods/admin.conversations.invite
+    https://docs.slack.dev/reference/methods/admin.conversations.invite
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(user_ids, (list, tuple)):
@@ -6953,7 +7027,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invite a user to a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.invite">https://api.slack.com/methods/admin.conversations.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.invite">https://docs.slack.dev/reference/methods/admin.conversations.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_linkObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_linkObjects</span></span>(<span>self, *, channel: str, record_id: str, salesforce_org_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -6972,7 +7046,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Link a Salesforce record to a channel.
-    https://api.slack.com/methods/admin.conversations.linkObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6984,7 +7058,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.linkObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Link a Salesforce record to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.linkObjects">https://api.slack.com/methods/admin.conversations.linkObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.linkObjects">https://docs.slack.dev/reference/methods/admin.conversations.linkObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_lookup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_lookup</span></span>(<span>self,<br>*,<br>last_message_activity_before: int,<br>team_ids: str | Sequence[str],<br>cursor: str | None = None,<br>limit: int | None = None,<br>max_member_count: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7005,7 +7079,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Returns channels on the given team using the filters.
-    https://api.slack.com/methods/admin.conversations.lookup
+    https://docs.slack.dev/reference/methods/admin.conversations.lookup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7022,7 +7096,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns channels on the given team using the filters.
-<a href="https://api.slack.com/methods/admin.conversations.lookup">https://api.slack.com/methods/admin.conversations.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.lookup">https://docs.slack.dev/reference/methods/admin.conversations.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_removeCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_removeCustomRetention</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7039,13 +7113,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.removeCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.removeCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.removeCustomRetention">https://api.slack.com/methods/admin.conversations.removeCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_rename"><code class="name flex">
 <span>def <span class="ident">admin_conversations_rename</span></span>(<span>self, *, channel_id: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7063,13 +7137,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Rename a public or private channel.
-    https://api.slack.com/methods/admin.conversations.rename
+    https://docs.slack.dev/reference/methods/admin.conversations.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;name&#34;: name})
     return self.api_call(&#34;admin.conversations.rename&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Rename a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.rename">https://api.slack.com/methods/admin.conversations.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.rename">https://docs.slack.dev/reference/methods/admin.conversations.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_restrictAccess_addGroup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_addGroup</span></span>(<span>self, *, channel_id: str, group_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7088,7 +7162,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an allowlist of IDP groups for accessing a channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7104,7 +7178,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>Add an allowlist of IDP groups for accessing a channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup">https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_restrictAccess_listGroups"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_listGroups</span></span>(<span>self, *, channel_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7122,7 +7196,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all IDP Groups linked to a channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7137,7 +7211,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>List all IDP Groups linked to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups">https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_restrictAccess_removeGroup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_removeGroup</span></span>(<span>self, *, channel_id: str, group_id: str, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7156,7 +7230,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a linked IDP group linked from a private channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7172,7 +7246,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>Remove a linked IDP group linked from a private channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup">https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_search"><code class="name flex">
 <span>def <span class="ident">admin_conversations_search</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>query: str | None = None,<br>search_channel_types: str | Sequence[str] | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7195,7 +7269,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.
-    https://api.slack.com/methods/admin.conversations.search
+    https://docs.slack.dev/reference/methods/admin.conversations.search
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7220,7 +7294,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Search for public or private channels in an Enterprise organization.
-<a href="https://api.slack.com/methods/admin.conversations.search">https://api.slack.com/methods/admin.conversations.search</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.search">https://docs.slack.dev/reference/methods/admin.conversations.search</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_setConversationPrefs"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setConversationPrefs</span></span>(<span>self, *, channel_id: str, prefs: str | Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7238,7 +7312,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the posting permissions for a public or private channel.
-    https://api.slack.com/methods/admin.conversations.setConversationPrefs
+    https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(prefs, dict):
@@ -7248,7 +7322,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.setConversationPrefs&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the posting permissions for a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.setConversationPrefs">https://api.slack.com/methods/admin.conversations.setConversationPrefs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs">https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_setCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setCustomRetention</span></span>(<span>self, *, channel_id: str, duration_days: int, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7266,13 +7340,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.setCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;duration_days&#34;: duration_days})
     return self.api_call(&#34;admin.conversations.setCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.setCustomRetention">https://api.slack.com/methods/admin.conversations.setCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_setTeams"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setTeams</span></span>(<span>self,<br>*,<br>channel_id: str,<br>org_channel: bool | None = None,<br>target_team_ids: str | Sequence[str] | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7292,7 +7366,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-    https://api.slack.com/methods/admin.conversations.setTeams
+    https://docs.slack.dev/reference/methods/admin.conversations.setTeams
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7308,7 +7382,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.setTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.setTeams">https://api.slack.com/methods/admin.conversations.setTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setTeams">https://docs.slack.dev/reference/methods/admin.conversations.setTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_unarchive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_unarchive</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7325,13 +7399,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Unarchive a public or private channel.
-    https://api.slack.com/methods/admin.conversations.archive
+    https://docs.slack.dev/reference/methods/admin.conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.unarchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unarchive a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.archive">https://api.slack.com/methods/admin.conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.archive">https://docs.slack.dev/reference/methods/admin.conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_conversations_unlinkObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_unlinkObjects</span></span>(<span>self, *, channel: str, new_name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7349,7 +7423,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Unlink a Salesforce record from a channel.
-    https://api.slack.com/methods/admin.conversations.unlinkObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7360,7 +7434,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.unlinkObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unlink a Salesforce record from a channel.
-<a href="https://api.slack.com/methods/admin.conversations.unlinkObjects">https://api.slack.com/methods/admin.conversations.unlinkObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects">https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_emoji_add"><code class="name flex">
 <span>def <span class="ident">admin_emoji_add</span></span>(<span>self, *, name: str, url: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7378,13 +7452,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an emoji.
-    https://api.slack.com/methods/admin.emoji.add
+    https://docs.slack.dev/reference/methods/admin.emoji.add
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;url&#34;: url})
     return self.api_call(&#34;admin.emoji.add&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an emoji.
-<a href="https://api.slack.com/methods/admin.emoji.add">https://api.slack.com/methods/admin.emoji.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.add">https://docs.slack.dev/reference/methods/admin.emoji.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_emoji_addAlias"><code class="name flex">
 <span>def <span class="ident">admin_emoji_addAlias</span></span>(<span>self, *, alias_for: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7402,13 +7476,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an emoji alias.
-    https://api.slack.com/methods/admin.emoji.addAlias
+    https://docs.slack.dev/reference/methods/admin.emoji.addAlias
     &#34;&#34;&#34;
     kwargs.update({&#34;alias_for&#34;: alias_for, &#34;name&#34;: name})
     return self.api_call(&#34;admin.emoji.addAlias&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an emoji alias.
-<a href="https://api.slack.com/methods/admin.emoji.addAlias">https://api.slack.com/methods/admin.emoji.addAlias</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.addAlias">https://docs.slack.dev/reference/methods/admin.emoji.addAlias</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_emoji_list"><code class="name flex">
 <span>def <span class="ident">admin_emoji_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7426,13 +7500,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List emoji for an Enterprise Grid organization.
-    https://api.slack.com/methods/admin.emoji.list
+    https://docs.slack.dev/reference/methods/admin.emoji.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List emoji for an Enterprise Grid organization.
-<a href="https://api.slack.com/methods/admin.emoji.list">https://api.slack.com/methods/admin.emoji.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.list">https://docs.slack.dev/reference/methods/admin.emoji.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_emoji_remove"><code class="name flex">
 <span>def <span class="ident">admin_emoji_remove</span></span>(<span>self, *, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7449,13 +7523,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove an emoji across an Enterprise Grid organization.
-    https://api.slack.com/methods/admin.emoji.remove
+    https://docs.slack.dev/reference/methods/admin.emoji.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name})
     return self.api_call(&#34;admin.emoji.remove&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove an emoji across an Enterprise Grid organization.
-<a href="https://api.slack.com/methods/admin.emoji.remove">https://api.slack.com/methods/admin.emoji.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.remove">https://docs.slack.dev/reference/methods/admin.emoji.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_emoji_rename"><code class="name flex">
 <span>def <span class="ident">admin_emoji_rename</span></span>(<span>self, *, name: str, new_name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7473,13 +7547,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Rename an emoji.
-    https://api.slack.com/methods/admin.emoji.rename
+    https://docs.slack.dev/reference/methods/admin.emoji.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;new_name&#34;: new_name})
     return self.api_call(&#34;admin.emoji.rename&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Rename an emoji.
-<a href="https://api.slack.com/methods/admin.emoji.rename">https://api.slack.com/methods/admin.emoji.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.rename">https://docs.slack.dev/reference/methods/admin.emoji.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_functions_list"><code class="name flex">
 <span>def <span class="ident">admin_functions_list</span></span>(<span>self,<br>*,<br>app_ids: str | Sequence[str],<br>team_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7499,7 +7573,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Look up functions by a set of apps
-    https://api.slack.com/methods/admin.functions.list
+    https://docs.slack.dev/reference/methods/admin.functions.list
     &#34;&#34;&#34;
     if isinstance(app_ids, (list, tuple)):
         kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -7515,7 +7589,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.functions.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up functions by a set of apps
-<a href="https://api.slack.com/methods/admin.functions.list">https://api.slack.com/methods/admin.functions.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.list">https://docs.slack.dev/reference/methods/admin.functions.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_functions_permissions_lookup"><code class="name flex">
 <span>def <span class="ident">admin_functions_permissions_lookup</span></span>(<span>self, *, function_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7533,7 +7607,7 @@ the corresponding original channel IDs for key revocation with EKM.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lookup the visibility of multiple Slack functions
     and include the users if it is limited to particular named entities.
-    https://api.slack.com/methods/admin.functions.permissions.lookup
+    https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
     &#34;&#34;&#34;
     if isinstance(function_ids, (list, tuple)):
         kwargs.update({&#34;function_ids&#34;: &#34;,&#34;.join(function_ids)})
@@ -7543,7 +7617,7 @@ the corresponding original channel IDs for key revocation with EKM.
 </details>
 <div class="desc"><p>Lookup the visibility of multiple Slack functions
 and include the users if it is limited to particular named entities.
-<a href="https://api.slack.com/methods/admin.functions.permissions.lookup">https://api.slack.com/methods/admin.functions.permissions.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup">https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_functions_permissions_set"><code class="name flex">
 <span>def <span class="ident">admin_functions_permissions_set</span></span>(<span>self,<br>*,<br>function_id: str,<br>visibility: str,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7563,7 +7637,7 @@ and include the users if it is limited to particular named entities.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the visibility of a Slack function
     and define the users or workspaces if it is set to named_entities
-    https://api.slack.com/methods/admin.functions.permissions.set
+    https://docs.slack.dev/reference/methods/admin.functions.permissions.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7580,7 +7654,7 @@ and include the users if it is limited to particular named entities.
 </details>
 <div class="desc"><p>Set the visibility of a Slack function
 and define the users or workspaces if it is set to named_entities
-<a href="https://api.slack.com/methods/admin.functions.permissions.set">https://api.slack.com/methods/admin.functions.permissions.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.permissions.set">https://docs.slack.dev/reference/methods/admin.functions.permissions.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_inviteRequests_approve"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_approve</span></span>(<span>self, *, invite_request_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7598,13 +7672,13 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Approve a workspace invite request.
-    https://api.slack.com/methods/admin.inviteRequests.approve
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.inviteRequests.approve&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approve a workspace invite request.
-<a href="https://api.slack.com/methods/admin.inviteRequests.approve">https://api.slack.com/methods/admin.inviteRequests.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.approve">https://docs.slack.dev/reference/methods/admin.inviteRequests.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_inviteRequests_approved_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_approved_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7623,7 +7697,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all approved workspace invite requests.
-    https://api.slack.com/methods/admin.inviteRequests.approved.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7635,7 +7709,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all approved workspace invite requests.
-<a href="https://api.slack.com/methods/admin.inviteRequests.approved.list">https://api.slack.com/methods/admin.inviteRequests.approved.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_inviteRequests_denied_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_denied_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7654,7 +7728,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all denied workspace invite requests.
-    https://api.slack.com/methods/admin.inviteRequests.denied.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7666,7 +7740,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all denied workspace invite requests.
-<a href="https://api.slack.com/methods/admin.inviteRequests.denied.list">https://api.slack.com/methods/admin.inviteRequests.denied.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_inviteRequests_deny"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_deny</span></span>(<span>self, *, invite_request_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7684,13 +7758,13 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deny a workspace invite request.
-    https://api.slack.com/methods/admin.inviteRequests.deny
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.inviteRequests.deny&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deny a workspace invite request.
-<a href="https://api.slack.com/methods/admin.inviteRequests.deny">https://api.slack.com/methods/admin.inviteRequests.deny</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.deny">https://docs.slack.dev/reference/methods/admin.inviteRequests.deny</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_inviteRequests_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_list</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7726,7 +7800,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds members to the specified role with the specified scopes
-    https://api.slack.com/methods/admin.roles.addAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.addAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;role_id&#34;: role_id})
     if isinstance(entity_ids, (list, tuple)):
@@ -7740,7 +7814,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.roles.addAssignments&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds members to the specified role with the specified scopes
-<a href="https://api.slack.com/methods/admin.roles.addAssignments">https://api.slack.com/methods/admin.roles.addAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.addAssignments">https://docs.slack.dev/reference/methods/admin.roles.addAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_roles_listAssignments"><code class="name flex">
 <span>def <span class="ident">admin_roles_listAssignments</span></span>(<span>self,<br>*,<br>role_ids: str | Sequence[str] | None = None,<br>entity_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: str | int | None = None,<br>sort_dir: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7762,7 +7836,7 @@ and define the users or workspaces if it is set to named_entities
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists assignments for all roles across entities.
         Options to scope results by any combination of roles or entities
-    https://api.slack.com/methods/admin.roles.listAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.listAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;sort_dir&#34;: sort_dir})
     if isinstance(entity_ids, (list, tuple)):
@@ -7777,7 +7851,7 @@ and define the users or workspaces if it is set to named_entities
 </details>
 <div class="desc"><p>Lists assignments for all roles across entities.
 Options to scope results by any combination of roles or entities
-<a href="https://api.slack.com/methods/admin.roles.listAssignments">https://api.slack.com/methods/admin.roles.listAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.listAssignments">https://docs.slack.dev/reference/methods/admin.roles.listAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_roles_removeAssignments"><code class="name flex">
 <span>def <span class="ident">admin_roles_removeAssignments</span></span>(<span>self,<br>*,<br>role_id: str,<br>entity_ids: str | Sequence[str],<br>user_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7796,7 +7870,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a set of users from a role for the given scopes and entities
-    https://api.slack.com/methods/admin.roles.removeAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;role_id&#34;: role_id})
     if isinstance(entity_ids, (list, tuple)):
@@ -7810,7 +7884,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.roles.removeAssignments&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a set of users from a role for the given scopes and entities
-<a href="https://api.slack.com/methods/admin.roles.removeAssignments">https://api.slack.com/methods/admin.roles.removeAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.removeAssignments">https://docs.slack.dev/reference/methods/admin.roles.removeAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_teams_admins_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_admins_list</span></span>(<span>self, *, team_id: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7829,7 +7903,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all of the admins on a given workspace.
-    https://api.slack.com/methods/admin.inviteRequests.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7841,7 +7915,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.admins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all of the admins on a given workspace.
-<a href="https://api.slack.com/methods/admin.inviteRequests.list">https://api.slack.com/methods/admin.inviteRequests.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_teams_create"><code class="name flex">
 <span>def <span class="ident">admin_teams_create</span></span>(<span>self,<br>*,<br>team_domain: str,<br>team_name: str,<br>team_description: str | None = None,<br>team_discoverability: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7861,7 +7935,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create an Enterprise team.
-    https://api.slack.com/methods/admin.teams.create
+    https://docs.slack.dev/reference/methods/admin.teams.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7874,7 +7948,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an Enterprise team.
-<a href="https://api.slack.com/methods/admin.teams.create">https://api.slack.com/methods/admin.teams.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.create">https://docs.slack.dev/reference/methods/admin.teams.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_teams_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7892,13 +7966,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all teams on an Enterprise organization.
-    https://api.slack.com/methods/admin.teams.list
+    https://docs.slack.dev/reference/methods/admin.teams.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all teams on an Enterprise organization.
-<a href="https://api.slack.com/methods/admin.teams.list">https://api.slack.com/methods/admin.teams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.list">https://docs.slack.dev/reference/methods/admin.teams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_teams_owners_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_owners_list</span></span>(<span>self, *, team_id: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7917,13 +7991,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all of the admins on a given workspace.
-    https://api.slack.com/methods/admin.teams.owners.list
+    https://docs.slack.dev/reference/methods/admin.teams.owners.list
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.teams.owners.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all of the admins on a given workspace.
-<a href="https://api.slack.com/methods/admin.teams.owners.list">https://api.slack.com/methods/admin.teams.owners.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.owners.list">https://docs.slack.dev/reference/methods/admin.teams.owners.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_teams_settings_info"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_info</span></span>(<span>self, *, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7940,13 +8014,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Fetch information about settings in a workspace
-    https://api.slack.com/methods/admin.teams.settings.info
+    https://docs.slack.dev/reference/methods/admin.teams.settings.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.teams.settings.info&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetch information about settings in a workspace
-<a href="https://api.slack.com/methods/admin.teams.settings.info">https://api.slack.com/methods/admin.teams.settings.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.info">https://docs.slack.dev/reference/methods/admin.teams.settings.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_teams_settings_setDefaultChannels"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDefaultChannels</span></span>(<span>self, *, team_id: str, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7964,7 +8038,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the default channels of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7974,7 +8048,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.settings.setDefaultChannels&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the default channels of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDefaultChannels">https://api.slack.com/methods/admin.teams.settings.setDefaultChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels">https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_teams_settings_setDescription"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDescription</span></span>(<span>self, *, team_id: str, description: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -7992,13 +8066,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the description of a given workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDescription
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;description&#34;: description})
     return self.api_call(&#34;admin.teams.settings.setDescription&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the description of a given workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDescription">https://api.slack.com/methods/admin.teams.settings.setDescription</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription">https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_teams_settings_setDiscoverability"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDiscoverability</span></span>(<span>self, *, team_id: str, discoverability: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8016,13 +8090,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;discoverability&#34;: discoverability})
     return self.api_call(&#34;admin.teams.settings.setDiscoverability&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDiscoverability">https://api.slack.com/methods/admin.teams.settings.setDiscoverability</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability">https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_teams_settings_setIcon"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setIcon</span></span>(<span>self, *, team_id: str, image_url: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8040,13 +8114,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setIcon
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;image_url&#34;: image_url})
     return self.api_call(&#34;admin.teams.settings.setIcon&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setIcon">https://api.slack.com/methods/admin.teams.settings.setIcon</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon">https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_teams_settings_setName"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setName</span></span>(<span>self, *, team_id: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8064,13 +8138,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setName
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setName
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;name&#34;: name})
     return self.api_call(&#34;admin.teams.settings.setName&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setName">https://api.slack.com/methods/admin.teams.settings.setName</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setName">https://docs.slack.dev/reference/methods/admin.teams.settings.setName</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_usergroups_addChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_addChannels</span></span>(<span>self,<br>*,<br>channel_ids: str | Sequence[str],<br>usergroup_id: str,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8089,7 +8163,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.addChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;usergroup_id&#34;: usergroup_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -8099,7 +8173,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.addChannels">https://api.slack.com/methods/admin.usergroups.addChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.addChannels">https://docs.slack.dev/reference/methods/admin.usergroups.addChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_usergroups_addTeams"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_addTeams</span></span>(<span>self,<br>*,<br>usergroup_id: str,<br>team_ids: str | Sequence[str],<br>auto_provision: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8118,7 +8192,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Associate one or more default workspaces with an organization-wide IDP group.
-    https://api.slack.com/methods/admin.usergroups.addTeams
+    https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup_id&#34;: usergroup_id, &#34;auto_provision&#34;: auto_provision})
     if isinstance(team_ids, (list, tuple)):
@@ -8128,7 +8202,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Associate one or more default workspaces with an organization-wide IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.addTeams">https://api.slack.com/methods/admin.usergroups.addTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.addTeams">https://docs.slack.dev/reference/methods/admin.usergroups.addTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_usergroups_listChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_listChannels</span></span>(<span>self,<br>*,<br>usergroup_id: str,<br>include_num_members: bool | None = None,<br>team_id: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8147,7 +8221,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.listChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8159,7 +8233,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.listChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.listChannels">https://api.slack.com/methods/admin.usergroups.listChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.listChannels">https://docs.slack.dev/reference/methods/admin.usergroups.listChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_usergroups_removeChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_removeChannels</span></span>(<span>self, *, usergroup_id: str, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8177,7 +8251,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.removeChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup_id&#34;: usergroup_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -8187,7 +8261,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.removeChannels">https://api.slack.com/methods/admin.usergroups.removeChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels">https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_assign"><code class="name flex">
 <span>def <span class="ident">admin_users_assign</span></span>(<span>self,<br>*,<br>team_id: str,<br>user_id: str,<br>channel_ids: str | Sequence[str] | None = None,<br>is_restricted: bool | None = None,<br>is_ultra_restricted: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8208,7 +8282,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add an Enterprise user to a workspace.
-    https://api.slack.com/methods/admin.users.assign
+    https://docs.slack.dev/reference/methods/admin.users.assign
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8225,7 +8299,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.assign&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an Enterprise user to a workspace.
-<a href="https://api.slack.com/methods/admin.users.assign">https://api.slack.com/methods/admin.users.assign</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.assign">https://docs.slack.dev/reference/methods/admin.users.assign</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_invite"><code class="name flex">
 <span>def <span class="ident">admin_users_invite</span></span>(<span>self,<br>*,<br>team_id: str,<br>email: str,<br>channel_ids: str | Sequence[str],<br>custom_message: str | None = None,<br>email_password_policy_enabled: bool | None = None,<br>guest_expiration_ts: str | float | None = None,<br>is_restricted: bool | None = None,<br>is_ultra_restricted: bool | None = None,<br>real_name: str | None = None,<br>resend: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8251,7 +8325,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invite a user to a workspace.
-    https://api.slack.com/methods/admin.users.invite
+    https://docs.slack.dev/reference/methods/admin.users.invite
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8273,10 +8347,10 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invite a user to a workspace.
-<a href="https://api.slack.com/methods/admin.users.invite">https://api.slack.com/methods/admin.users.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.invite">https://docs.slack.dev/reference/methods/admin.users.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_list"><code class="name flex">
-<span>def <span class="ident">admin_users_list</span></span>(<span>self,<br>*,<br>team_id: str,<br>include_deactivated_user_workspaces: bool | None = None,<br>is_active: bool | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">admin_users_list</span></span>(<span>self,<br>*,<br>team_id: str | None = None,<br>include_deactivated_user_workspaces: bool | None = None,<br>is_active: bool | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -8286,7 +8360,7 @@ Options to scope results by any combination of roles or entities
 <pre><code class="python">def admin_users_list(
     self,
     *,
-    team_id: str,
+    team_id: Optional[str] = None,
     include_deactivated_user_workspaces: Optional[bool] = None,
     is_active: Optional[bool] = None,
     cursor: Optional[str] = None,
@@ -8294,7 +8368,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List users on a workspace
-    https://api.slack.com/methods/admin.users.list
+    https://docs.slack.dev/reference/methods/admin.users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8308,7 +8382,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List users on a workspace
-<a href="https://api.slack.com/methods/admin.users.list">https://api.slack.com/methods/admin.users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.list">https://docs.slack.dev/reference/methods/admin.users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_remove"><code class="name flex">
 <span>def <span class="ident">admin_users_remove</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8326,13 +8400,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a user from a workspace.
-    https://api.slack.com/methods/admin.users.remove
+    https://docs.slack.dev/reference/methods/admin.users.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a user from a workspace.
-<a href="https://api.slack.com/methods/admin.users.remove">https://api.slack.com/methods/admin.users.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.remove">https://docs.slack.dev/reference/methods/admin.users.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_session_clearSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_clearSettings</span></span>(<span>self, *, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8350,7 +8424,7 @@ Options to scope results by any combination of roles or entities
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Clear user-specific session settings—the session duration
     and what happens when the client closes—for a list of users.
-    https://api.slack.com/methods/admin.users.session.clearSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8360,7 +8434,7 @@ Options to scope results by any combination of roles or entities
 </details>
 <div class="desc"><p>Clear user-specific session settings—the session duration
 and what happens when the client closes—for a list of users.
-<a href="https://api.slack.com/methods/admin.users.session.clearSettings">https://api.slack.com/methods/admin.users.session.clearSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.clearSettings">https://docs.slack.dev/reference/methods/admin.users.session.clearSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_session_getSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_getSettings</span></span>(<span>self, *, user_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8378,7 +8452,7 @@ and what happens when the client closes—for a list of users.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get user-specific session settings—the session duration
     and what happens when the client closes—given a list of users.
-    https://api.slack.com/methods/admin.users.session.getSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.getSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8388,7 +8462,7 @@ and what happens when the client closes—for a list of users.
 </details>
 <div class="desc"><p>Get user-specific session settings—the session duration
 and what happens when the client closes—given a list of users.
-<a href="https://api.slack.com/methods/admin.users.session.getSettings">https://api.slack.com/methods/admin.users.session.getSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.getSettings">https://docs.slack.dev/reference/methods/admin.users.session.getSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_session_invalidate"><code class="name flex">
 <span>def <span class="ident">admin_users_session_invalidate</span></span>(<span>self, *, session_id: str, team_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8406,13 +8480,13 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invalidate a single session for a user by session_id.
-    https://api.slack.com/methods/admin.users.session.invalidate
+    https://docs.slack.dev/reference/methods/admin.users.session.invalidate
     &#34;&#34;&#34;
     kwargs.update({&#34;session_id&#34;: session_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.users.session.invalidate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invalidate a single session for a user by session_id.
-<a href="https://api.slack.com/methods/admin.users.session.invalidate">https://api.slack.com/methods/admin.users.session.invalidate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.invalidate">https://docs.slack.dev/reference/methods/admin.users.session.invalidate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_session_list"><code class="name flex">
 <span>def <span class="ident">admin_users_session_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8432,7 +8506,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all active user sessions for an organization
-    https://api.slack.com/methods/admin.users.session.list
+    https://docs.slack.dev/reference/methods/admin.users.session.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8445,7 +8519,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all active user sessions for an organization
-<a href="https://api.slack.com/methods/admin.users.session.list">https://api.slack.com/methods/admin.users.session.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.list">https://docs.slack.dev/reference/methods/admin.users.session.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_session_reset"><code class="name flex">
 <span>def <span class="ident">admin_users_session_reset</span></span>(<span>self,<br>*,<br>user_id: str,<br>mobile_only: bool | None = None,<br>web_only: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8464,7 +8538,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Wipes all valid sessions on all devices for a given user.
-    https://api.slack.com/methods/admin.users.session.reset
+    https://docs.slack.dev/reference/methods/admin.users.session.reset
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8476,7 +8550,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.reset&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Wipes all valid sessions on all devices for a given user.
-<a href="https://api.slack.com/methods/admin.users.session.reset">https://api.slack.com/methods/admin.users.session.reset</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.reset">https://docs.slack.dev/reference/methods/admin.users.session.reset</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_session_resetBulk"><code class="name flex">
 <span>def <span class="ident">admin_users_session_resetBulk</span></span>(<span>self,<br>*,<br>user_ids: str | Sequence[str],<br>mobile_only: bool | None = None,<br>web_only: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8495,7 +8569,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-    https://api.slack.com/methods/admin.users.session.resetBulk
+    https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8510,7 +8584,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.resetBulk&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-<a href="https://api.slack.com/methods/admin.users.session.resetBulk">https://api.slack.com/methods/admin.users.session.resetBulk</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.resetBulk">https://docs.slack.dev/reference/methods/admin.users.session.resetBulk</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_session_setSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_setSettings</span></span>(<span>self,<br>*,<br>user_ids: str | Sequence[str],<br>desktop_app_browser_quit: bool | None = None,<br>duration: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8530,7 +8604,7 @@ and what happens when the client closes—given a list of users.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Configure the user-level session settings—the session duration
     and what happens when the client closes—for one or more users.
-    https://api.slack.com/methods/admin.users.session.setSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.setSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8546,7 +8620,7 @@ and what happens when the client closes—given a list of users.
 </details>
 <div class="desc"><p>Configure the user-level session settings—the session duration
 and what happens when the client closes—for one or more users.
-<a href="https://api.slack.com/methods/admin.users.session.setSettings">https://api.slack.com/methods/admin.users.session.setSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.setSettings">https://docs.slack.dev/reference/methods/admin.users.session.setSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_setAdmin"><code class="name flex">
 <span>def <span class="ident">admin_users_setAdmin</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8564,13 +8638,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an existing guest, regular user, or owner to be an admin user.
-    https://api.slack.com/methods/admin.users.setAdmin
+    https://docs.slack.dev/reference/methods/admin.users.setAdmin
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setAdmin&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest, regular user, or owner to be an admin user.
-<a href="https://api.slack.com/methods/admin.users.setAdmin">https://api.slack.com/methods/admin.users.setAdmin</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setAdmin">https://docs.slack.dev/reference/methods/admin.users.setAdmin</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_setExpiration"><code class="name flex">
 <span>def <span class="ident">admin_users_setExpiration</span></span>(<span>self, *, expiration_ts: int, user_id: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8589,13 +8663,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an expiration for a guest user.
-    https://api.slack.com/methods/admin.users.setExpiration
+    https://docs.slack.dev/reference/methods/admin.users.setExpiration
     &#34;&#34;&#34;
     kwargs.update({&#34;expiration_ts&#34;: expiration_ts, &#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setExpiration&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an expiration for a guest user.
-<a href="https://api.slack.com/methods/admin.users.setExpiration">https://api.slack.com/methods/admin.users.setExpiration</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setExpiration">https://docs.slack.dev/reference/methods/admin.users.setExpiration</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_setOwner"><code class="name flex">
 <span>def <span class="ident">admin_users_setOwner</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8613,13 +8687,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an existing guest, regular user, or admin user to be a workspace owner.
-    https://api.slack.com/methods/admin.users.setOwner
+    https://docs.slack.dev/reference/methods/admin.users.setOwner
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setOwner&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest, regular user, or admin user to be a workspace owner.
-<a href="https://api.slack.com/methods/admin.users.setOwner">https://api.slack.com/methods/admin.users.setOwner</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setOwner">https://docs.slack.dev/reference/methods/admin.users.setOwner</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_setRegular"><code class="name flex">
 <span>def <span class="ident">admin_users_setRegular</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8637,13 +8711,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set an existing guest user, admin user, or owner to be a regular user.
-    https://api.slack.com/methods/admin.users.setRegular
+    https://docs.slack.dev/reference/methods/admin.users.setRegular
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setRegular&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest user, admin user, or owner to be a regular user.
-<a href="https://api.slack.com/methods/admin.users.setRegular">https://api.slack.com/methods/admin.users.setRegular</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setRegular">https://docs.slack.dev/reference/methods/admin.users.setRegular</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_users_unsupportedVersions_export"><code class="name flex">
 <span>def <span class="ident">admin_users_unsupportedVersions_export</span></span>(<span>self,<br>*,<br>date_end_of_support: str | int | None = None,<br>date_sessions_started: str | int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8662,7 +8736,7 @@ and what happens when the client closes—for one or more users.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ask Slackbot to send you an export listing all workspace members using unsupported software,
     presented as a zipped CSV file.
-    https://api.slack.com/methods/admin.users.unsupportedVersions.export
+    https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8674,7 +8748,7 @@ and what happens when the client closes—for one or more users.
 </details>
 <div class="desc"><p>Ask Slackbot to send you an export listing all workspace members using unsupported software,
 presented as a zipped CSV file.
-<a href="https://api.slack.com/methods/admin.users.unsupportedVersions.export">https://api.slack.com/methods/admin.users.unsupportedVersions.export</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export">https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_workflows_collaborators_add"><code class="name flex">
 <span>def <span class="ident">admin_workflows_collaborators_add</span></span>(<span>self,<br>*,<br>collaborator_ids: str | Sequence[str],<br>workflow_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8692,7 +8766,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add collaborators to workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.collaborators.add
+    https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
     &#34;&#34;&#34;
     if isinstance(collaborator_ids, (list, tuple)):
         kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -8705,7 +8779,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.collaborators.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add collaborators to workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.collaborators.add">https://api.slack.com/methods/admin.workflows.collaborators.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add">https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_workflows_collaborators_remove"><code class="name flex">
 <span>def <span class="ident">admin_workflows_collaborators_remove</span></span>(<span>self,<br>*,<br>collaborator_ids: str | Sequence[str],<br>workflow_ids: str | Sequence[str],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8723,7 +8797,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove collaborators from workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.collaborators.remove
+    https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
     &#34;&#34;&#34;
     if isinstance(collaborator_ids, (list, tuple)):
         kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -8736,7 +8810,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.collaborators.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove collaborators from workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.collaborators.remove">https://api.slack.com/methods/admin.workflows.collaborators.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove">https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_workflows_permissions_lookup"><code class="name flex">
 <span>def <span class="ident">admin_workflows_permissions_lookup</span></span>(<span>self,<br>*,<br>workflow_ids: str | Sequence[str],<br>max_workflow_triggers: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8754,7 +8828,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Look up the permissions for a set of workflows
-    https://api.slack.com/methods/admin.workflows.permissions.lookup
+    https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
     &#34;&#34;&#34;
     if isinstance(workflow_ids, (list, tuple)):
         kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -8768,7 +8842,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.permissions.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up the permissions for a set of workflows
-<a href="https://api.slack.com/methods/admin.workflows.permissions.lookup">https://api.slack.com/methods/admin.workflows.permissions.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup">https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_workflows_search"><code class="name flex">
 <span>def <span class="ident">admin_workflows_search</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>collaborator_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>no_collaborators: bool | None = None,<br>num_trigger_ids: int | None = None,<br>query: str | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>source: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8794,7 +8868,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Search workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.search
+    https://docs.slack.dev/reference/methods/admin.workflows.search
     &#34;&#34;&#34;
     if collaborator_ids is not None:
         if isinstance(collaborator_ids, (list, tuple)):
@@ -8817,7 +8891,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.search&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Search workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.search">https://api.slack.com/methods/admin.workflows.search</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.search">https://docs.slack.dev/reference/methods/admin.workflows.search</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.admin_workflows_unpublish"><code class="name flex">
 <span>def <span class="ident">admin_workflows_unpublish</span></span>(<span>self, *, workflow_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8834,7 +8908,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Unpublish workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.unpublish
+    https://docs.slack.dev/reference/methods/admin.workflows.unpublish
     &#34;&#34;&#34;
     if isinstance(workflow_ids, (list, tuple)):
         kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -8843,7 +8917,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.unpublish&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unpublish workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.unpublish">https://api.slack.com/methods/admin.workflows.unpublish</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.unpublish">https://docs.slack.dev/reference/methods/admin.workflows.unpublish</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.api_test"><code class="name flex">
 <span>def <span class="ident">api_test</span></span>(<span>self, *, error: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8860,13 +8934,13 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Checks API calling code.
-    https://api.slack.com/methods/api.test
+    https://docs.slack.dev/reference/methods/api.test
     &#34;&#34;&#34;
     kwargs.update({&#34;error&#34;: error})
     return self.api_call(&#34;api.test&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Checks API calling code.
-<a href="https://api.slack.com/methods/api.test">https://api.slack.com/methods/api.test</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/api.test">https://docs.slack.dev/reference/methods/api.test</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.apps_connections_open"><code class="name flex">
 <span>def <span class="ident">apps_connections_open</span></span>(<span>self, *, app_token: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8884,14 +8958,14 @@ presented as a zipped CSV file.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Generate a temporary Socket Mode WebSocket URL that your app can connect to
     in order to receive events and interactive payloads
-    https://api.slack.com/methods/apps.connections.open
+    https://docs.slack.dev/reference/methods/apps.connections.open
     &#34;&#34;&#34;
     kwargs.update({&#34;token&#34;: app_token})
     return self.api_call(&#34;apps.connections.open&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Generate a temporary Socket Mode WebSocket URL that your app can connect to
 in order to receive events and interactive payloads
-<a href="https://api.slack.com/methods/apps.connections.open">https://api.slack.com/methods/apps.connections.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.connections.open">https://docs.slack.dev/reference/methods/apps.connections.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.apps_event_authorizations_list"><code class="name flex">
 <span>def <span class="ident">apps_event_authorizations_list</span></span>(<span>self,<br>*,<br>event_context: str,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8911,14 +8985,14 @@ in order to receive events and interactive payloads
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get a list of authorizations for the given event context.
     Each authorization represents an app installation that the event is visible to.
-    https://api.slack.com/methods/apps.event.authorizations.list
+    https://docs.slack.dev/reference/methods/apps.event.authorizations.list
     &#34;&#34;&#34;
     kwargs.update({&#34;event_context&#34;: event_context, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;apps.event.authorizations.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a list of authorizations for the given event context.
 Each authorization represents an app installation that the event is visible to.
-<a href="https://api.slack.com/methods/apps.event.authorizations.list">https://api.slack.com/methods/apps.event.authorizations.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.event.authorizations.list">https://docs.slack.dev/reference/methods/apps.event.authorizations.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.apps_manifest_create"><code class="name flex">
 <span>def <span class="ident">apps_manifest_create</span></span>(<span>self, *, manifest: str | Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8935,7 +9009,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create an app from an app manifest
-    https://api.slack.com/methods/apps.manifest.create
+    https://docs.slack.dev/reference/methods/apps.manifest.create
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8944,7 +9018,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an app from an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.create">https://api.slack.com/methods/apps.manifest.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.create">https://docs.slack.dev/reference/methods/apps.manifest.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.apps_manifest_delete"><code class="name flex">
 <span>def <span class="ident">apps_manifest_delete</span></span>(<span>self, *, app_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8961,13 +9035,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Permanently deletes an app created through app manifests
-    https://api.slack.com/methods/apps.manifest.delete
+    https://docs.slack.dev/reference/methods/apps.manifest.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     return self.api_call(&#34;apps.manifest.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Permanently deletes an app created through app manifests
-<a href="https://api.slack.com/methods/apps.manifest.delete">https://api.slack.com/methods/apps.manifest.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.delete">https://docs.slack.dev/reference/methods/apps.manifest.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.apps_manifest_export"><code class="name flex">
 <span>def <span class="ident">apps_manifest_export</span></span>(<span>self, *, app_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -8984,13 +9058,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Export an app manifest from an existing app
-    https://api.slack.com/methods/apps.manifest.export
+    https://docs.slack.dev/reference/methods/apps.manifest.export
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     return self.api_call(&#34;apps.manifest.export&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Export an app manifest from an existing app
-<a href="https://api.slack.com/methods/apps.manifest.export">https://api.slack.com/methods/apps.manifest.export</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.export">https://docs.slack.dev/reference/methods/apps.manifest.export</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.apps_manifest_update"><code class="name flex">
 <span>def <span class="ident">apps_manifest_update</span></span>(<span>self, *, app_id: str, manifest: str | Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9008,7 +9082,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an app from an app manifest
-    https://api.slack.com/methods/apps.manifest.update
+    https://docs.slack.dev/reference/methods/apps.manifest.update
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -9018,7 +9092,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an app from an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.update">https://api.slack.com/methods/apps.manifest.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.update">https://docs.slack.dev/reference/methods/apps.manifest.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.apps_manifest_validate"><code class="name flex">
 <span>def <span class="ident">apps_manifest_validate</span></span>(<span>self, *, manifest: str | Dict[str, Any], app_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9036,7 +9110,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Validate an app manifest
-    https://api.slack.com/methods/apps.manifest.validate
+    https://docs.slack.dev/reference/methods/apps.manifest.validate
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -9046,7 +9120,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.validate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Validate an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.validate">https://api.slack.com/methods/apps.manifest.validate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.validate">https://docs.slack.dev/reference/methods/apps.manifest.validate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.apps_uninstall"><code class="name flex">
 <span>def <span class="ident">apps_uninstall</span></span>(<span>self, *, client_id: str, client_secret: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9064,13 +9138,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Uninstalls your app from a workspace.
-    https://api.slack.com/methods/apps.uninstall
+    https://docs.slack.dev/reference/methods/apps.uninstall
     &#34;&#34;&#34;
     kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret})
     return self.api_call(&#34;apps.uninstall&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Uninstalls your app from a workspace.
-<a href="https://api.slack.com/methods/apps.uninstall">https://api.slack.com/methods/apps.uninstall</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.uninstall">https://docs.slack.dev/reference/methods/apps.uninstall</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.assistant_threads_setStatus"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setStatus</span></span>(<span>self, *, channel_id: str, thread_ts: str, status: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9089,13 +9163,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setStatus
+    https://docs.slack.dev/reference/methods/assistant.threads.setStatus
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status})
     return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setStatus">https://api.slack.com/methods/assistant.threads.setStatus</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setStatus">https://docs.slack.dev/reference/methods/assistant.threads.setStatus</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.assistant_threads_setSuggestedPrompts"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9115,7 +9189,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+    https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
     if title is not None:
@@ -9123,7 +9197,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setSuggestedPrompts">https://api.slack.com/methods/assistant.threads.setSuggestedPrompts</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts">https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.assistant_threads_setTitle"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setTitle</span></span>(<span>self, *, channel_id: str, thread_ts: str, title: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9142,13 +9216,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setTitle
+    https://docs.slack.dev/reference/methods/assistant.threads.setTitle
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;title&#34;: title})
     return self.api_call(&#34;assistant.threads.setTitle&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setTitle">https://api.slack.com/methods/assistant.threads.setTitle</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setTitle">https://docs.slack.dev/reference/methods/assistant.threads.setTitle</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.auth_revoke"><code class="name flex">
 <span>def <span class="ident">auth_revoke</span></span>(<span>self, *, test: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9165,13 +9239,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/auth.revoke
+    https://docs.slack.dev/reference/methods/auth.revoke
     &#34;&#34;&#34;
     kwargs.update({&#34;test&#34;: test})
     return self.api_call(&#34;auth.revoke&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/auth.revoke">https://api.slack.com/methods/auth.revoke</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.revoke">https://docs.slack.dev/reference/methods/auth.revoke</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.auth_teams_list"><code class="name flex">
 <span>def <span class="ident">auth_teams_list</span></span>(<span>self,<br>cursor: str | None = None,<br>limit: int | None = None,<br>include_icon: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9189,13 +9263,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List the workspaces a token can access.
-    https://api.slack.com/methods/auth.teams.list
+    https://docs.slack.dev/reference/methods/auth.teams.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;include_icon&#34;: include_icon})
     return self.api_call(&#34;auth.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List the workspaces a token can access.
-<a href="https://api.slack.com/methods/auth.teams.list">https://api.slack.com/methods/auth.teams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.teams.list">https://docs.slack.dev/reference/methods/auth.teams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.auth_test"><code class="name flex">
 <span>def <span class="ident">auth_test</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9210,12 +9284,12 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Checks authentication &amp; identity.
-    https://api.slack.com/methods/auth.test
+    https://docs.slack.dev/reference/methods/auth.test
     &#34;&#34;&#34;
     return self.api_call(&#34;auth.test&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Checks authentication &amp; identity.
-<a href="https://api.slack.com/methods/auth.test">https://api.slack.com/methods/auth.test</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.test">https://docs.slack.dev/reference/methods/auth.test</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.bookmarks_add"><code class="name flex">
 <span>def <span class="ident">bookmarks_add</span></span>(<span>self,<br>*,<br>channel_id: str,<br>title: str,<br>type: str,<br>emoji: str | None = None,<br>entity_id: str | None = None,<br>link: str | None = None,<br>parent_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9238,7 +9312,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Add bookmark to a channel.
-    https://api.slack.com/methods/bookmarks.add
+    https://docs.slack.dev/reference/methods/bookmarks.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9254,7 +9328,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;bookmarks.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add bookmark to a channel.
-<a href="https://api.slack.com/methods/bookmarks.add">https://api.slack.com/methods/bookmarks.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.add">https://docs.slack.dev/reference/methods/bookmarks.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.bookmarks_edit"><code class="name flex">
 <span>def <span class="ident">bookmarks_edit</span></span>(<span>self,<br>*,<br>bookmark_id: str,<br>channel_id: str,<br>emoji: str | None = None,<br>link: str | None = None,<br>title: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9275,7 +9349,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Edit bookmark.
-    https://api.slack.com/methods/bookmarks.edit
+    https://docs.slack.dev/reference/methods/bookmarks.edit
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9289,7 +9363,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;bookmarks.edit&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Edit bookmark.
-<a href="https://api.slack.com/methods/bookmarks.edit">https://api.slack.com/methods/bookmarks.edit</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.edit">https://docs.slack.dev/reference/methods/bookmarks.edit</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.bookmarks_list"><code class="name flex">
 <span>def <span class="ident">bookmarks_list</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9306,13 +9380,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List bookmark for the channel.
-    https://api.slack.com/methods/bookmarks.list
+    https://docs.slack.dev/reference/methods/bookmarks.list
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;bookmarks.list&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List bookmark for the channel.
-<a href="https://api.slack.com/methods/bookmarks.list">https://api.slack.com/methods/bookmarks.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.list">https://docs.slack.dev/reference/methods/bookmarks.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.bookmarks_remove"><code class="name flex">
 <span>def <span class="ident">bookmarks_remove</span></span>(<span>self, *, bookmark_id: str, channel_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9330,13 +9404,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove bookmark from the channel.
-    https://api.slack.com/methods/bookmarks.remove
+    https://docs.slack.dev/reference/methods/bookmarks.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;bookmark_id&#34;: bookmark_id, &#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;bookmarks.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove bookmark from the channel.
-<a href="https://api.slack.com/methods/bookmarks.remove">https://api.slack.com/methods/bookmarks.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.remove">https://docs.slack.dev/reference/methods/bookmarks.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.bots_info"><code class="name flex">
 <span>def <span class="ident">bots_info</span></span>(<span>self, *, bot: str | None = None, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9354,13 +9428,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a bot user.
-    https://api.slack.com/methods/bots.info
+    https://docs.slack.dev/reference/methods/bots.info
     &#34;&#34;&#34;
     kwargs.update({&#34;bot&#34;: bot, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;bots.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a bot user.
-<a href="https://api.slack.com/methods/bots.info">https://api.slack.com/methods/bots.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bots.info">https://docs.slack.dev/reference/methods/bots.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.calls_add"><code class="name flex">
 <span>def <span class="ident">calls_add</span></span>(<span>self,<br>*,<br>external_unique_id: str,<br>join_url: str,<br>created_by: str | None = None,<br>date_start: int | None = None,<br>desktop_app_join_url: str | None = None,<br>external_display_id: str | None = None,<br>title: str | None = None,<br>users: str | Sequence[Dict[str, str]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9384,7 +9458,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Registers a new Call.
-    https://api.slack.com/methods/calls.add
+    https://docs.slack.dev/reference/methods/calls.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9404,7 +9478,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;calls.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers a new Call.
-<a href="https://api.slack.com/methods/calls.add">https://api.slack.com/methods/calls.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.add">https://docs.slack.dev/reference/methods/calls.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.calls_end"><code class="name flex">
 <span>def <span class="ident">calls_end</span></span>(<span>self, *, id: str, duration: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9422,13 +9496,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ends a Call.
-    https://api.slack.com/methods/calls.end
+    https://docs.slack.dev/reference/methods/calls.end
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id, &#34;duration&#34;: duration})
     return self.api_call(&#34;calls.end&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends a Call.
-<a href="https://api.slack.com/methods/calls.end">https://api.slack.com/methods/calls.end</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.end">https://docs.slack.dev/reference/methods/calls.end</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.calls_info"><code class="name flex">
 <span>def <span class="ident">calls_info</span></span>(<span>self, *, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9445,13 +9519,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Returns information about a Call.
-    https://api.slack.com/methods/calls.info
+    https://docs.slack.dev/reference/methods/calls.info
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     return self.api_call(&#34;calls.info&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns information about a Call.
-<a href="https://api.slack.com/methods/calls.info">https://api.slack.com/methods/calls.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.info">https://docs.slack.dev/reference/methods/calls.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.calls_participants_add"><code class="name flex">
 <span>def <span class="ident">calls_participants_add</span></span>(<span>self, *, id: str, users: str | Sequence[Dict[str, str]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9469,14 +9543,14 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Registers new participants added to a Call.
-    https://api.slack.com/methods/calls.participants.add
+    https://docs.slack.dev/reference/methods/calls.participants.add
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     _update_call_participants(kwargs, users)
     return self.api_call(&#34;calls.participants.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers new participants added to a Call.
-<a href="https://api.slack.com/methods/calls.participants.add">https://api.slack.com/methods/calls.participants.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.participants.add">https://docs.slack.dev/reference/methods/calls.participants.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.calls_participants_remove"><code class="name flex">
 <span>def <span class="ident">calls_participants_remove</span></span>(<span>self, *, id: str, users: str | Sequence[Dict[str, str]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9494,14 +9568,14 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Registers participants removed from a Call.
-    https://api.slack.com/methods/calls.participants.remove
+    https://docs.slack.dev/reference/methods/calls.participants.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     _update_call_participants(kwargs, users)
     return self.api_call(&#34;calls.participants.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers participants removed from a Call.
-<a href="https://api.slack.com/methods/calls.participants.remove">https://api.slack.com/methods/calls.participants.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.participants.remove">https://docs.slack.dev/reference/methods/calls.participants.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.calls_update"><code class="name flex">
 <span>def <span class="ident">calls_update</span></span>(<span>self,<br>*,<br>id: str,<br>desktop_app_join_url: str | None = None,<br>join_url: str | None = None,<br>title: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9521,7 +9595,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Updates information about a Call.
-    https://api.slack.com/methods/calls.update
+    https://docs.slack.dev/reference/methods/calls.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9534,7 +9608,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;calls.update&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Updates information about a Call.
-<a href="https://api.slack.com/methods/calls.update">https://api.slack.com/methods/calls.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.update">https://docs.slack.dev/reference/methods/calls.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.canvases_access_delete"><code class="name flex">
 <span>def <span class="ident">canvases_access_delete</span></span>(<span>self,<br>*,<br>canvas_id: str,<br>channel_ids: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9553,7 +9627,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a Channel Canvas for a channel
-    https://api.slack.com/methods/canvases.access.delete
+    https://docs.slack.dev/reference/methods/canvases.access.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id})
     if channel_ids is not None:
@@ -9569,7 +9643,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;canvases.access.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Channel Canvas for a channel
-<a href="https://api.slack.com/methods/canvases.access.delete">https://api.slack.com/methods/canvases.access.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.access.delete">https://docs.slack.dev/reference/methods/canvases.access.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.canvases_access_set"><code class="name flex">
 <span>def <span class="ident">canvases_access_set</span></span>(<span>self,<br>*,<br>canvas_id: str,<br>access_level: str,<br>channel_ids: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9589,7 +9663,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the access level to a canvas for specified entities
-    https://api.slack.com/methods/canvases.access.set
+    https://docs.slack.dev/reference/methods/canvases.access.set
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;access_level&#34;: access_level})
     if channel_ids is not None:
@@ -9606,7 +9680,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;canvases.access.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the access level to a canvas for specified entities
-<a href="https://api.slack.com/methods/canvases.access.set">https://api.slack.com/methods/canvases.access.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.access.set">https://docs.slack.dev/reference/methods/canvases.access.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.canvases_create"><code class="name flex">
 <span>def <span class="ident">canvases_create</span></span>(<span>self, *, title: str | None = None, document_content: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9624,13 +9698,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create Canvas for a user
-    https://api.slack.com/methods/canvases.create
+    https://docs.slack.dev/reference/methods/canvases.create
     &#34;&#34;&#34;
     kwargs.update({&#34;title&#34;: title, &#34;document_content&#34;: document_content})
     return self.api_call(&#34;canvases.create&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create Canvas for a user
-<a href="https://api.slack.com/methods/canvases.create">https://api.slack.com/methods/canvases.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.create">https://docs.slack.dev/reference/methods/canvases.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.canvases_delete"><code class="name flex">
 <span>def <span class="ident">canvases_delete</span></span>(<span>self, *, canvas_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9647,13 +9721,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a canvas
-    https://api.slack.com/methods/canvases.delete
+    https://docs.slack.dev/reference/methods/canvases.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id})
     return self.api_call(&#34;canvases.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a canvas
-<a href="https://api.slack.com/methods/canvases.delete">https://api.slack.com/methods/canvases.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.delete">https://docs.slack.dev/reference/methods/canvases.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.canvases_edit"><code class="name flex">
 <span>def <span class="ident">canvases_edit</span></span>(<span>self, *, canvas_id: str, changes: Sequence[Dict[str, Any]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9671,13 +9745,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an existing canvas
-    https://api.slack.com/methods/canvases.edit
+    https://docs.slack.dev/reference/methods/canvases.edit
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;changes&#34;: changes})
     return self.api_call(&#34;canvases.edit&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing canvas
-<a href="https://api.slack.com/methods/canvases.edit">https://api.slack.com/methods/canvases.edit</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.edit">https://docs.slack.dev/reference/methods/canvases.edit</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.canvases_sections_lookup"><code class="name flex">
 <span>def <span class="ident">canvases_sections_lookup</span></span>(<span>self, *, canvas_id: str, criteria: Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -9695,13 +9769,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Find sections matching the provided criteria
-    https://api.slack.com/methods/canvases.sections.lookup
+    https://docs.slack.dev/reference/methods/canvases.sections.lookup
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;criteria&#34;: json.dumps(criteria)})
     return self.api_call(&#34;canvases.sections.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Find sections matching the provided criteria
-<a href="https://api.slack.com/methods/canvases.sections.lookup">https://api.slack.com/methods/canvases.sections.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.sections.lookup">https://docs.slack.dev/reference/methods/canvases.sections.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.channels_archive"><code class="name flex">
 <span>def <span class="ident">channels_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10035,13 +10109,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a message.
-    https://api.slack.com/methods/chat.delete
+    https://docs.slack.dev/reference/methods/chat.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts, &#34;as_user&#34;: as_user})
     return self.api_call(&#34;chat.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a message.
-<a href="https://api.slack.com/methods/chat.delete">https://api.slack.com/methods/chat.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.delete">https://docs.slack.dev/reference/methods/chat.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_deleteScheduledMessage"><code class="name flex">
 <span>def <span class="ident">chat_deleteScheduledMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>scheduled_message_id: str,<br>as_user: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10060,7 +10134,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a scheduled message.
-    https://api.slack.com/methods/chat.deleteScheduledMessage
+    https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10072,7 +10146,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.deleteScheduledMessage&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a scheduled message.
-<a href="https://api.slack.com/methods/chat.deleteScheduledMessage">https://api.slack.com/methods/chat.deleteScheduledMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage">https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_getPermalink"><code class="name flex">
 <span>def <span class="ident">chat_getPermalink</span></span>(<span>self, *, channel: str, message_ts: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10090,13 +10164,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a permalink URL for a specific extant message
-    https://api.slack.com/methods/chat.getPermalink
+    https://docs.slack.dev/reference/methods/chat.getPermalink
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;message_ts&#34;: message_ts})
     return self.api_call(&#34;chat.getPermalink&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a permalink URL for a specific extant message
-<a href="https://api.slack.com/methods/chat.getPermalink">https://api.slack.com/methods/chat.getPermalink</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.getPermalink">https://docs.slack.dev/reference/methods/chat.getPermalink</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_meMessage"><code class="name flex">
 <span>def <span class="ident">chat_meMessage</span></span>(<span>self, *, channel: str, text: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10114,16 +10188,16 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Share a me message into a channel.
-    https://api.slack.com/methods/chat.meMessage
+    https://docs.slack.dev/reference/methods/chat.meMessage
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;text&#34;: text})
     return self.api_call(&#34;chat.meMessage&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Share a me message into a channel.
-<a href="https://api.slack.com/methods/chat.meMessage">https://api.slack.com/methods/chat.meMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.meMessage">https://docs.slack.dev/reference/methods/chat.meMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_postEphemeral"><code class="name flex">
-<span>def <span class="ident">chat_postEphemeral</span></span>(<span>self,<br>*,<br>channel: str,<br>user: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_postEphemeral</span></span>(<span>self,<br>*,<br>channel: str,<br>user: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10145,10 +10219,11 @@ Each authorization represents an app installation that the event is visible to.
     link_names: Optional[bool] = None,
     username: Optional[str] = None,
     parse: Optional[str] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sends an ephemeral message to a user in a channel.
-    https://api.slack.com/methods/chat.postEphemeral
+    https://docs.slack.dev/reference/methods/chat.postEphemeral
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10164,19 +10239,20 @@ Each authorization represents an app installation that the event is visible to.
             &#34;link_names&#34;: link_names,
             &#34;username&#34;: username,
             &#34;parse&#34;: parse,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.postEphemeral&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends an ephemeral message to a user in a channel.
-<a href="https://api.slack.com/methods/chat.postEphemeral">https://api.slack.com/methods/chat.postEphemeral</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.postEphemeral">https://docs.slack.dev/reference/methods/chat.postEphemeral</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_postMessage"><code class="name flex">
-<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10203,10 +10279,11 @@ Each authorization represents an app installation that the event is visible to.
     username: Optional[str] = None,
     parse: Optional[str] = None,  # none, full
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sends a message to a channel.
-    https://api.slack.com/methods/chat.postMessage
+    https://docs.slack.dev/reference/methods/chat.postMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10227,19 +10304,20 @@ Each authorization represents an app installation that the event is visible to.
             &#34;username&#34;: username,
             &#34;parse&#34;: parse,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postMessage&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.postMessage&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.postMessage&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends a message to a channel.
-<a href="https://api.slack.com/methods/chat.postMessage">https://api.slack.com/methods/chat.postMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.postMessage">https://docs.slack.dev/reference/methods/chat.postMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_scheduleMessage"><code class="name flex">
-<span>def <span class="ident">chat_scheduleMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>post_at: str | int,<br>text: str,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>link_names: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_scheduleMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>post_at: str | int,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>link_names: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10251,7 +10329,7 @@ Each authorization represents an app installation that the event is visible to.
     *,
     channel: str,
     post_at: Union[str, int],
-    text: str,
+    text: Optional[str] = None,
     as_user: Optional[bool] = None,
     attachments: Optional[Union[str, Sequence[Union[Dict, Attachment]]]] = None,
     blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
@@ -10262,10 +10340,11 @@ Each authorization represents an app installation that the event is visible to.
     unfurl_media: Optional[bool] = None,
     link_names: Optional[bool] = None,
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Schedules a message.
-    https://api.slack.com/methods/chat.scheduleMessage
+    https://docs.slack.dev/reference/methods/chat.scheduleMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10282,16 +10361,17 @@ Each authorization represents an app installation that the event is visible to.
             &#34;unfurl_media&#34;: unfurl_media,
             &#34;link_names&#34;: link_names,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.scheduleMessage&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Schedules a message.
-<a href="https://api.slack.com/methods/chat.scheduleMessage">https://api.slack.com/methods/chat.scheduleMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.scheduleMessage">https://docs.slack.dev/reference/methods/chat.scheduleMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_scheduledMessages_list"><code class="name flex">
 <span>def <span class="ident">chat_scheduledMessages_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>cursor: str | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10313,7 +10393,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all scheduled messages.
-    https://api.slack.com/methods/chat.scheduledMessages.list
+    https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10328,7 +10408,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all scheduled messages.
-<a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.scheduledMessages.list">https://docs.slack.dev/reference/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_unfurl"><code class="name flex">
 <span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10353,7 +10433,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Provide custom unfurl behavior for user-posted URLs.
-    https://api.slack.com/methods/chat.unfurl
+    https://docs.slack.dev/reference/methods/chat.unfurl
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10374,10 +10454,10 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.unfurl&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Provide custom unfurl behavior for user-posted URLs.
-<a href="https://api.slack.com/methods/chat.unfurl">https://api.slack.com/methods/chat.unfurl</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.unfurl">https://docs.slack.dev/reference/methods/chat.unfurl</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_update"><code class="name flex">
-<span>def <span class="ident">chat_update</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>text: str | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>as_user: bool | None = None,<br>file_ids: str | Sequence[str] | None = None,<br>link_names: bool | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_update</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>text: str | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>as_user: bool | None = None,<br>file_ids: str | Sequence[str] | None = None,<br>link_names: bool | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10398,10 +10478,11 @@ Each authorization represents an app installation that the event is visible to.
     parse: Optional[str] = None,  # none, full
     reply_broadcast: Optional[bool] = None,
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Updates a message in a channel.
-    https://api.slack.com/methods/chat.update
+    https://docs.slack.dev/reference/methods/chat.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10415,6 +10496,7 @@ Each authorization represents an app installation that the event is visible to.
             &#34;parse&#34;: parse,
             &#34;reply_broadcast&#34;: reply_broadcast,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     if isinstance(file_ids, (list, tuple)):
@@ -10423,12 +10505,12 @@ Each authorization represents an app installation that the event is visible to.
         kwargs.update({&#34;file_ids&#34;: file_ids})
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.update&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.update&#34;, kwargs)
     # NOTE: intentionally using json over params for API methods using blocks/attachments
     return self.api_call(&#34;chat.update&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Updates a message in a channel.
-<a href="https://api.slack.com/methods/chat.update">https://api.slack.com/methods/chat.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.update">https://docs.slack.dev/reference/methods/chat.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_acceptSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_acceptSharedInvite</span></span>(<span>self,<br>*,<br>channel_name: str,<br>channel_id: str | None = None,<br>invite_id: str | None = None,<br>free_trial_accepted: bool | None = None,<br>is_private: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10450,7 +10532,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Accepts an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.acceptSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
     &#34;&#34;&#34;
     if channel_id is None and invite_id is None:
         raise e.SlackRequestError(&#34;Either channel_id or invite_id must be provided.&#34;)
@@ -10467,7 +10549,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.acceptSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Accepts an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.acceptSharedInvite">https://api.slack.com/methods/conversations.acceptSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite">https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_approveSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_approveSharedInvite</span></span>(<span>self, *, invite_id: str, target_team: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10485,13 +10567,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Approves an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.approveSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
     return self.api_call(&#34;conversations.approveSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approves an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.approveSharedInvite">https://api.slack.com/methods/conversations.approveSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.approveSharedInvite">https://docs.slack.dev/reference/methods/conversations.approveSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_archive"><code class="name flex">
 <span>def <span class="ident">conversations_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10508,13 +10590,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Archives a conversation.
-    https://api.slack.com/methods/conversations.archive
+    https://docs.slack.dev/reference/methods/conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.archive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archives a conversation.
-<a href="https://api.slack.com/methods/conversations.archive">https://api.slack.com/methods/conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.archive">https://docs.slack.dev/reference/methods/conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_canvases_create"><code class="name flex">
 <span>def <span class="ident">conversations_canvases_create</span></span>(<span>self, *, channel_id: str, document_content: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10532,13 +10614,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a Channel Canvas for a channel
-    https://api.slack.com/methods/conversations.canvases.create
+    https://docs.slack.dev/reference/methods/conversations.canvases.create
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;document_content&#34;: document_content})
     return self.api_call(&#34;conversations.canvases.create&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Channel Canvas for a channel
-<a href="https://api.slack.com/methods/conversations.canvases.create">https://api.slack.com/methods/conversations.canvases.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.canvases.create">https://docs.slack.dev/reference/methods/conversations.canvases.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_close"><code class="name flex">
 <span>def <span class="ident">conversations_close</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10555,13 +10637,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Closes a direct message or multi-person direct message.
-    https://api.slack.com/methods/conversations.close
+    https://docs.slack.dev/reference/methods/conversations.close
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.close&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Closes a direct message or multi-person direct message.
-<a href="https://api.slack.com/methods/conversations.close">https://api.slack.com/methods/conversations.close</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.close">https://docs.slack.dev/reference/methods/conversations.close</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_create"><code class="name flex">
 <span>def <span class="ident">conversations_create</span></span>(<span>self,<br>*,<br>name: str,<br>is_private: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10580,13 +10662,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Initiates a public or private channel-based conversation
-    https://api.slack.com/methods/conversations.create
+    https://docs.slack.dev/reference/methods/conversations.create
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;is_private&#34;: is_private, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;conversations.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Initiates a public or private channel-based conversation
-<a href="https://api.slack.com/methods/conversations.create">https://api.slack.com/methods/conversations.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.create">https://docs.slack.dev/reference/methods/conversations.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_declineSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_declineSharedInvite</span></span>(<span>self, *, invite_id: str, target_team: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10604,13 +10686,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Declines a Slack Connect channel invite.
-    https://api.slack.com/methods/conversations.declineSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
     return self.api_call(&#34;conversations.declineSharedInvite&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Declines a Slack Connect channel invite.
-<a href="https://api.slack.com/methods/conversations.declineSharedInvite">https://api.slack.com/methods/conversations.declineSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.declineSharedInvite">https://docs.slack.dev/reference/methods/conversations.declineSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_externalInvitePermissions_set"><code class="name flex">
 <span>def <span class="ident">conversations_externalInvitePermissions_set</span></span>(<span>self, *, action: str, channel: str, target_team: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10624,7 +10706,7 @@ Each authorization represents an app installation that the event is visible to.
     self, *, action: str, channel: str, target_team: str, **kwargs
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-    https://api.slack.com/methods/conversations.externalInvitePermissions.set
+    https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10636,7 +10718,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.externalInvitePermissions.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-<a href="https://api.slack.com/methods/conversations.externalInvitePermissions.set">https://api.slack.com/methods/conversations.externalInvitePermissions.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set">https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_history"><code class="name flex">
 <span>def <span class="ident">conversations_history</span></span>(<span>self,<br>*,<br>channel: str,<br>cursor: str | None = None,<br>inclusive: bool | None = None,<br>include_all_metadata: bool | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10659,7 +10741,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Fetches a conversation&#39;s history of messages and events.
-    https://api.slack.com/methods/conversations.history
+    https://docs.slack.dev/reference/methods/conversations.history
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10675,7 +10757,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.history&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetches a conversation's history of messages and events.
-<a href="https://api.slack.com/methods/conversations.history">https://api.slack.com/methods/conversations.history</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.history">https://docs.slack.dev/reference/methods/conversations.history</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_info"><code class="name flex">
 <span>def <span class="ident">conversations_info</span></span>(<span>self,<br>*,<br>channel: str,<br>include_locale: bool | None = None,<br>include_num_members: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10694,7 +10776,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve information about a conversation.
-    https://api.slack.com/methods/conversations.info
+    https://docs.slack.dev/reference/methods/conversations.info
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10706,7 +10788,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a conversation.
-<a href="https://api.slack.com/methods/conversations.info">https://api.slack.com/methods/conversations.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.info">https://docs.slack.dev/reference/methods/conversations.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_invite"><code class="name flex">
 <span>def <span class="ident">conversations_invite</span></span>(<span>self,<br>*,<br>channel: str,<br>users: str | Sequence[str],<br>force: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10725,7 +10807,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Invites users to a channel.
-    https://api.slack.com/methods/conversations.invite
+    https://docs.slack.dev/reference/methods/conversations.invite
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10740,7 +10822,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invites users to a channel.
-<a href="https://api.slack.com/methods/conversations.invite">https://api.slack.com/methods/conversations.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.invite">https://docs.slack.dev/reference/methods/conversations.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_inviteShared"><code class="name flex">
 <span>def <span class="ident">conversations_inviteShared</span></span>(<span>self,<br>*,<br>channel: str,<br>emails: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10759,7 +10841,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sends an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.inviteShared
+    https://docs.slack.dev/reference/methods/conversations.inviteShared
     &#34;&#34;&#34;
     if emails is None and user_ids is None:
         raise e.SlackRequestError(&#34;Either emails or user ids must be provided.&#34;)
@@ -10775,7 +10857,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.inviteShared&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.inviteShared">https://api.slack.com/methods/conversations.inviteShared</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.inviteShared">https://docs.slack.dev/reference/methods/conversations.inviteShared</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_join"><code class="name flex">
 <span>def <span class="ident">conversations_join</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10792,13 +10874,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Joins an existing conversation.
-    https://api.slack.com/methods/conversations.join
+    https://docs.slack.dev/reference/methods/conversations.join
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.join&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Joins an existing conversation.
-<a href="https://api.slack.com/methods/conversations.join">https://api.slack.com/methods/conversations.join</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.join">https://docs.slack.dev/reference/methods/conversations.join</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_kick"><code class="name flex">
 <span>def <span class="ident">conversations_kick</span></span>(<span>self, *, channel: str, user: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10816,13 +10898,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a user from a conversation.
-    https://api.slack.com/methods/conversations.kick
+    https://docs.slack.dev/reference/methods/conversations.kick
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;user&#34;: user})
     return self.api_call(&#34;conversations.kick&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a user from a conversation.
-<a href="https://api.slack.com/methods/conversations.kick">https://api.slack.com/methods/conversations.kick</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.kick">https://docs.slack.dev/reference/methods/conversations.kick</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_leave"><code class="name flex">
 <span>def <span class="ident">conversations_leave</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10839,13 +10921,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Leaves a conversation.
-    https://api.slack.com/methods/conversations.leave
+    https://docs.slack.dev/reference/methods/conversations.leave
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.leave&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Leaves a conversation.
-<a href="https://api.slack.com/methods/conversations.leave">https://api.slack.com/methods/conversations.leave</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.leave">https://docs.slack.dev/reference/methods/conversations.leave</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_list"><code class="name flex">
 <span>def <span class="ident">conversations_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>exclude_archived: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>types: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10866,7 +10948,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all channels in a Slack team.
-    https://api.slack.com/methods/conversations.list
+    https://docs.slack.dev/reference/methods/conversations.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10883,7 +10965,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all channels in a Slack team.
-<a href="https://api.slack.com/methods/conversations.list">https://api.slack.com/methods/conversations.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.list">https://docs.slack.dev/reference/methods/conversations.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_listConnectInvites"><code class="name flex">
 <span>def <span class="ident">conversations_listConnectInvites</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10903,14 +10985,14 @@ Each authorization represents an app installation that the event is visible to.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List shared channel invites that have been generated
     or received but have not yet been approved by all parties.
-    https://api.slack.com/methods/conversations.listConnectInvites
+    https://docs.slack.dev/reference/methods/conversations.listConnectInvites
     &#34;&#34;&#34;
     kwargs.update({&#34;count&#34;: count, &#34;cursor&#34;: cursor, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;conversations.listConnectInvites&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List shared channel invites that have been generated
 or received but have not yet been approved by all parties.
-<a href="https://api.slack.com/methods/conversations.listConnectInvites">https://api.slack.com/methods/conversations.listConnectInvites</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.listConnectInvites">https://docs.slack.dev/reference/methods/conversations.listConnectInvites</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_mark"><code class="name flex">
 <span>def <span class="ident">conversations_mark</span></span>(<span>self, *, channel: str, ts: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10928,13 +11010,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the read cursor in a channel.
-    https://api.slack.com/methods/conversations.mark
+    https://docs.slack.dev/reference/methods/conversations.mark
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts})
     return self.api_call(&#34;conversations.mark&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the read cursor in a channel.
-<a href="https://api.slack.com/methods/conversations.mark">https://api.slack.com/methods/conversations.mark</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.mark">https://docs.slack.dev/reference/methods/conversations.mark</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_members"><code class="name flex">
 <span>def <span class="ident">conversations_members</span></span>(<span>self, *, channel: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10953,13 +11035,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve members of a conversation.
-    https://api.slack.com/methods/conversations.members
+    https://docs.slack.dev/reference/methods/conversations.members
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;conversations.members&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve members of a conversation.
-<a href="https://api.slack.com/methods/conversations.members">https://api.slack.com/methods/conversations.members</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.members">https://docs.slack.dev/reference/methods/conversations.members</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_open"><code class="name flex">
 <span>def <span class="ident">conversations_open</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>return_im: bool | None = None,<br>users: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -10978,7 +11060,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Opens or resumes a direct message or multi-person direct message.
-    https://api.slack.com/methods/conversations.open
+    https://docs.slack.dev/reference/methods/conversations.open
     &#34;&#34;&#34;
     if channel is None and users is None:
         raise e.SlackRequestError(&#34;Either channel or users must be provided.&#34;)
@@ -10990,7 +11072,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.open&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Opens or resumes a direct message or multi-person direct message.
-<a href="https://api.slack.com/methods/conversations.open">https://api.slack.com/methods/conversations.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.open">https://docs.slack.dev/reference/methods/conversations.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_rename"><code class="name flex">
 <span>def <span class="ident">conversations_rename</span></span>(<span>self, *, channel: str, name: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11008,13 +11090,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Renames a conversation.
-    https://api.slack.com/methods/conversations.rename
+    https://docs.slack.dev/reference/methods/conversations.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name})
     return self.api_call(&#34;conversations.rename&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Renames a conversation.
-<a href="https://api.slack.com/methods/conversations.rename">https://api.slack.com/methods/conversations.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.rename">https://docs.slack.dev/reference/methods/conversations.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_replies"><code class="name flex">
 <span>def <span class="ident">conversations_replies</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>cursor: str | None = None,<br>inclusive: bool | None = None,<br>include_all_metadata: bool | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11038,7 +11120,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a thread of messages posted to a conversation
-    https://api.slack.com/methods/conversations.replies
+    https://docs.slack.dev/reference/methods/conversations.replies
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11055,7 +11137,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.replies&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a thread of messages posted to a conversation
-<a href="https://api.slack.com/methods/conversations.replies">https://api.slack.com/methods/conversations.replies</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.replies">https://docs.slack.dev/reference/methods/conversations.replies</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_requestSharedInvite_approve"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_approve</span></span>(<span>self,<br>*,<br>invite_id: str,<br>channel_id: str | None = None,<br>is_external_limited: str | None = None,<br>message: Dict[str, Any] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11075,7 +11157,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-    https://api.slack.com/methods/conversations.requestSharedInvite.approve
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11089,7 +11171,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.requestSharedInvite.approve&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.approve">https://api.slack.com/methods/conversations.requestSharedInvite.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_requestSharedInvite_deny"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_deny</span></span>(<span>self, *, invite_id: str, message: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11107,13 +11189,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deny a request to invite an external user to a channel.
-    https://api.slack.com/methods/conversations.requestSharedInvite.deny
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;message&#34;: message})
     return self.api_call(&#34;conversations.requestSharedInvite.deny&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deny a request to invite an external user to a channel.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.deny">https://api.slack.com/methods/conversations.requestSharedInvite.deny</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_requestSharedInvite_list"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>include_approved: bool | None = None,<br>include_denied: bool | None = None,<br>include_expired: bool | None = None,<br>invite_ids: str | Sequence[str] | None = None,<br>limit: int | None = None,<br>user_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11136,7 +11218,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists requests to add external users to channels with ability to filter.
-    https://api.slack.com/methods/conversations.requestSharedInvite.list
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11156,7 +11238,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.requestSharedInvite.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists requests to add external users to channels with ability to filter.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.list">https://api.slack.com/methods/conversations.requestSharedInvite.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_setPurpose"><code class="name flex">
 <span>def <span class="ident">conversations_setPurpose</span></span>(<span>self, *, channel: str, purpose: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11174,13 +11256,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the purpose for a conversation.
-    https://api.slack.com/methods/conversations.setPurpose
+    https://docs.slack.dev/reference/methods/conversations.setPurpose
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;purpose&#34;: purpose})
     return self.api_call(&#34;conversations.setPurpose&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the purpose for a conversation.
-<a href="https://api.slack.com/methods/conversations.setPurpose">https://api.slack.com/methods/conversations.setPurpose</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.setPurpose">https://docs.slack.dev/reference/methods/conversations.setPurpose</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_setTopic"><code class="name flex">
 <span>def <span class="ident">conversations_setTopic</span></span>(<span>self, *, channel: str, topic: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11198,13 +11280,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Sets the topic for a conversation.
-    https://api.slack.com/methods/conversations.setTopic
+    https://docs.slack.dev/reference/methods/conversations.setTopic
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;topic&#34;: topic})
     return self.api_call(&#34;conversations.setTopic&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the topic for a conversation.
-<a href="https://api.slack.com/methods/conversations.setTopic">https://api.slack.com/methods/conversations.setTopic</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.setTopic">https://docs.slack.dev/reference/methods/conversations.setTopic</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.conversations_unarchive"><code class="name flex">
 <span>def <span class="ident">conversations_unarchive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11221,13 +11303,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Reverses conversation archival.
-    https://api.slack.com/methods/conversations.unarchive
+    https://docs.slack.dev/reference/methods/conversations.unarchive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.unarchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Reverses conversation archival.
-<a href="https://api.slack.com/methods/conversations.unarchive">https://api.slack.com/methods/conversations.unarchive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.unarchive">https://docs.slack.dev/reference/methods/conversations.unarchive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.dialog_open"><code class="name flex">
 <span>def <span class="ident">dialog_open</span></span>(<span>self, *, dialog: Dict[str, Any], trigger_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11245,7 +11327,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Open a dialog with a user.
-    https://api.slack.com/methods/dialog.open
+    https://docs.slack.dev/reference/methods/dialog.open
     &#34;&#34;&#34;
     kwargs.update({&#34;dialog&#34;: dialog, &#34;trigger_id&#34;: trigger_id})
     kwargs = _remove_none_values(kwargs)
@@ -11253,7 +11335,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;dialog.open&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Open a dialog with a user.
-<a href="https://api.slack.com/methods/dialog.open">https://api.slack.com/methods/dialog.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dialog.open">https://docs.slack.dev/reference/methods/dialog.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.dnd_endDnd"><code class="name flex">
 <span>def <span class="ident">dnd_endDnd</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11268,12 +11350,12 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ends the current user&#39;s Do Not Disturb session immediately.
-    https://api.slack.com/methods/dnd.endDnd
+    https://docs.slack.dev/reference/methods/dnd.endDnd
     &#34;&#34;&#34;
     return self.api_call(&#34;dnd.endDnd&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends the current user's Do Not Disturb session immediately.
-<a href="https://api.slack.com/methods/dnd.endDnd">https://api.slack.com/methods/dnd.endDnd</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.endDnd">https://docs.slack.dev/reference/methods/dnd.endDnd</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.dnd_endSnooze"><code class="name flex">
 <span>def <span class="ident">dnd_endSnooze</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11288,12 +11370,12 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Ends the current user&#39;s snooze mode immediately.
-    https://api.slack.com/methods/dnd.endSnooze
+    https://docs.slack.dev/reference/methods/dnd.endSnooze
     &#34;&#34;&#34;
     return self.api_call(&#34;dnd.endSnooze&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends the current user's snooze mode immediately.
-<a href="https://api.slack.com/methods/dnd.endSnooze">https://api.slack.com/methods/dnd.endSnooze</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.endSnooze">https://docs.slack.dev/reference/methods/dnd.endSnooze</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.dnd_info"><code class="name flex">
 <span>def <span class="ident">dnd_info</span></span>(<span>self, *, team_id: str | None = None, user: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11311,13 +11393,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieves a user&#39;s current Do Not Disturb status.
-    https://api.slack.com/methods/dnd.info
+    https://docs.slack.dev/reference/methods/dnd.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
     return self.api_call(&#34;dnd.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves a user's current Do Not Disturb status.
-<a href="https://api.slack.com/methods/dnd.info">https://api.slack.com/methods/dnd.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.info">https://docs.slack.dev/reference/methods/dnd.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.dnd_setSnooze"><code class="name flex">
 <span>def <span class="ident">dnd_setSnooze</span></span>(<span>self, *, num_minutes: str | int, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11334,13 +11416,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Turns on Do Not Disturb mode for the current user, or changes its duration.
-    https://api.slack.com/methods/dnd.setSnooze
+    https://docs.slack.dev/reference/methods/dnd.setSnooze
     &#34;&#34;&#34;
     kwargs.update({&#34;num_minutes&#34;: num_minutes})
     return self.api_call(&#34;dnd.setSnooze&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Turns on Do Not Disturb mode for the current user, or changes its duration.
-<a href="https://api.slack.com/methods/dnd.setSnooze">https://api.slack.com/methods/dnd.setSnooze</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.setSnooze">https://docs.slack.dev/reference/methods/dnd.setSnooze</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.dnd_teamInfo"><code class="name flex">
 <span>def <span class="ident">dnd_teamInfo</span></span>(<span>self, users: str | Sequence[str], team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11357,7 +11439,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieves the Do Not Disturb status for users on a team.
-    https://api.slack.com/methods/dnd.teamInfo
+    https://docs.slack.dev/reference/methods/dnd.teamInfo
     &#34;&#34;&#34;
     if isinstance(users, (list, tuple)):
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -11367,7 +11449,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;dnd.teamInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves the Do Not Disturb status for users on a team.
-<a href="https://api.slack.com/methods/dnd.teamInfo">https://api.slack.com/methods/dnd.teamInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.teamInfo">https://docs.slack.dev/reference/methods/dnd.teamInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.emoji_list"><code class="name flex">
 <span>def <span class="ident">emoji_list</span></span>(<span>self, include_categories: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11383,13 +11465,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists custom emoji for a team.
-    https://api.slack.com/methods/emoji.list
+    https://docs.slack.dev/reference/methods/emoji.list
     &#34;&#34;&#34;
     kwargs.update({&#34;include_categories&#34;: include_categories})
     return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists custom emoji for a team.
-<a href="https://api.slack.com/methods/emoji.list">https://api.slack.com/methods/emoji.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/emoji.list">https://docs.slack.dev/reference/methods/emoji.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_comments_delete"><code class="name flex">
 <span>def <span class="ident">files_comments_delete</span></span>(<span>self, *, file: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11407,13 +11489,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes an existing comment on a file.
-    https://api.slack.com/methods/files.comments.delete
+    https://docs.slack.dev/reference/methods/files.comments.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file, &#34;id&#34;: id})
     return self.api_call(&#34;files.comments.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes an existing comment on a file.
-<a href="https://api.slack.com/methods/files.comments.delete">https://api.slack.com/methods/files.comments.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.comments.delete">https://docs.slack.dev/reference/methods/files.comments.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_completeUploadExternal"><code class="name flex">
 <span>def <span class="ident">files_completeUploadExternal</span></span>(<span>self,<br>*,<br>files: List[Dict[str, str]],<br>channel_id: str | None = None,<br>channels: List[str] | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11434,7 +11516,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Finishes an upload started with files.getUploadURLExternal.
-    https://api.slack.com/methods/files.completeUploadExternal
+    https://docs.slack.dev/reference/methods/files.completeUploadExternal
     &#34;&#34;&#34;
     _files = [{k: v for k, v in f.items() if v is not None} for f in files]
     kwargs.update(
@@ -11450,7 +11532,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.completeUploadExternal&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Finishes an upload started with files.getUploadURLExternal.
-<a href="https://api.slack.com/methods/files.completeUploadExternal">https://api.slack.com/methods/files.completeUploadExternal</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.completeUploadExternal">https://docs.slack.dev/reference/methods/files.completeUploadExternal</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_delete"><code class="name flex">
 <span>def <span class="ident">files_delete</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11467,13 +11549,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a file.
-    https://api.slack.com/methods/files.delete
+    https://docs.slack.dev/reference/methods/files.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a file.
-<a href="https://api.slack.com/methods/files.delete">https://api.slack.com/methods/files.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.delete">https://docs.slack.dev/reference/methods/files.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_getUploadURLExternal"><code class="name flex">
 <span>def <span class="ident">files_getUploadURLExternal</span></span>(<span>self,<br>*,<br>filename: str,<br>length: int,<br>alt_txt: str | None = None,<br>snippet_type: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11493,7 +11575,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets a URL for an edge external upload.
-    https://api.slack.com/methods/files.getUploadURLExternal
+    https://docs.slack.dev/reference/methods/files.getUploadURLExternal
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11506,7 +11588,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.getUploadURLExternal&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets a URL for an edge external upload.
-<a href="https://api.slack.com/methods/files.getUploadURLExternal">https://api.slack.com/methods/files.getUploadURLExternal</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.getUploadURLExternal">https://docs.slack.dev/reference/methods/files.getUploadURLExternal</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_info"><code class="name flex">
 <span>def <span class="ident">files_info</span></span>(<span>self,<br>*,<br>file: str,<br>count: int | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11527,7 +11609,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a team file.
-    https://api.slack.com/methods/files.info
+    https://docs.slack.dev/reference/methods/files.info
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11541,7 +11623,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a team file.
-<a href="https://api.slack.com/methods/files.info">https://api.slack.com/methods/files.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.info">https://docs.slack.dev/reference/methods/files.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_list"><code class="name flex">
 <span>def <span class="ident">files_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>count: int | None = None,<br>page: int | None = None,<br>show_files_hidden_by_limit: bool | None = None,<br>team_id: str | None = None,<br>ts_from: str | None = None,<br>ts_to: str | None = None,<br>types: str | Sequence[str] | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11566,7 +11648,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists &amp; filters team files.
-    https://api.slack.com/methods/files.list
+    https://docs.slack.dev/reference/methods/files.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11587,7 +11669,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists &amp; filters team files.
-<a href="https://api.slack.com/methods/files.list">https://api.slack.com/methods/files.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.list">https://docs.slack.dev/reference/methods/files.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_remote_add"><code class="name flex">
 <span>def <span class="ident">files_remote_add</span></span>(<span>self,<br>*,<br>external_id: str,<br>external_url: str,<br>title: str,<br>filetype: str | None = None,<br>indexable_file_contents: str | bytes | io.IOBase | None = None,<br>preview_image: str | bytes | io.IOBase | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11609,7 +11691,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds a file from a remote service.
-    https://api.slack.com/methods/files.remote.add
+    https://docs.slack.dev/reference/methods/files.remote.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11636,7 +11718,7 @@ or received but have not yet been approved by all parties.
     )</code></pre>
 </details>
 <div class="desc"><p>Adds a file from a remote service.
-<a href="https://api.slack.com/methods/files.remote.add">https://api.slack.com/methods/files.remote.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.add">https://docs.slack.dev/reference/methods/files.remote.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_remote_info"><code class="name flex">
 <span>def <span class="ident">files_remote_info</span></span>(<span>self, *, external_id: str | None = None, file: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11654,13 +11736,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-    https://api.slack.com/methods/files.remote.info
+    https://docs.slack.dev/reference/methods/files.remote.info
     &#34;&#34;&#34;
     kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
     return self.api_call(&#34;files.remote.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a remote file added to Slack.
-<a href="https://api.slack.com/methods/files.remote.info">https://api.slack.com/methods/files.remote.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.info">https://docs.slack.dev/reference/methods/files.remote.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_remote_list"><code class="name flex">
 <span>def <span class="ident">files_remote_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>ts_from: str | None = None,<br>ts_to: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11681,7 +11763,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-    https://api.slack.com/methods/files.remote.list
+    https://docs.slack.dev/reference/methods/files.remote.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11695,7 +11777,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.remote.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a remote file added to Slack.
-<a href="https://api.slack.com/methods/files.remote.list">https://api.slack.com/methods/files.remote.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.list">https://docs.slack.dev/reference/methods/files.remote.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_remote_remove"><code class="name flex">
 <span>def <span class="ident">files_remote_remove</span></span>(<span>self, *, external_id: str | None = None, file: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11713,13 +11795,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Remove a remote file.
-    https://api.slack.com/methods/files.remote.remove
+    https://docs.slack.dev/reference/methods/files.remote.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
     return self.api_call(&#34;files.remote.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a remote file.
-<a href="https://api.slack.com/methods/files.remote.remove">https://api.slack.com/methods/files.remote.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.remove">https://docs.slack.dev/reference/methods/files.remote.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_remote_share"><code class="name flex">
 <span>def <span class="ident">files_remote_share</span></span>(<span>self,<br>*,<br>channels: str | Sequence[str],<br>external_id: str | None = None,<br>file: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11738,7 +11820,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Share a remote file into a channel.
-    https://api.slack.com/methods/files.remote.share
+    https://docs.slack.dev/reference/methods/files.remote.share
     &#34;&#34;&#34;
     if external_id is None and file is None:
         raise e.SlackRequestError(&#34;Either external_id or file must be provided.&#34;)
@@ -11750,7 +11832,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.remote.share&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Share a remote file into a channel.
-<a href="https://api.slack.com/methods/files.remote.share">https://api.slack.com/methods/files.remote.share</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.share">https://docs.slack.dev/reference/methods/files.remote.share</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_remote_update"><code class="name flex">
 <span>def <span class="ident">files_remote_update</span></span>(<span>self,<br>*,<br>external_id: str | None = None,<br>external_url: str | None = None,<br>file: str | None = None,<br>title: str | None = None,<br>filetype: str | None = None,<br>indexable_file_contents: str | None = None,<br>preview_image: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11773,7 +11855,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Updates an existing remote file.
-    https://api.slack.com/methods/files.remote.update
+    https://docs.slack.dev/reference/methods/files.remote.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11801,7 +11883,7 @@ or received but have not yet been approved by all parties.
     )</code></pre>
 </details>
 <div class="desc"><p>Updates an existing remote file.
-<a href="https://api.slack.com/methods/files.remote.update">https://api.slack.com/methods/files.remote.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.update">https://docs.slack.dev/reference/methods/files.remote.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_revokePublicURL"><code class="name flex">
 <span>def <span class="ident">files_revokePublicURL</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11818,13 +11900,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Revokes public/external sharing access for a file
-    https://api.slack.com/methods/files.revokePublicURL
+    https://docs.slack.dev/reference/methods/files.revokePublicURL
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.revokePublicURL&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes public/external sharing access for a file
-<a href="https://api.slack.com/methods/files.revokePublicURL">https://api.slack.com/methods/files.revokePublicURL</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.revokePublicURL">https://docs.slack.dev/reference/methods/files.revokePublicURL</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_sharedPublicURL"><code class="name flex">
 <span>def <span class="ident">files_sharedPublicURL</span></span>(<span>self, *, file: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11841,13 +11923,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Enables a file for public/external sharing.
-    https://api.slack.com/methods/files.sharedPublicURL
+    https://docs.slack.dev/reference/methods/files.sharedPublicURL
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.sharedPublicURL&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enables a file for public/external sharing.
-<a href="https://api.slack.com/methods/files.sharedPublicURL">https://api.slack.com/methods/files.sharedPublicURL</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.sharedPublicURL">https://docs.slack.dev/reference/methods/files.sharedPublicURL</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_upload"><code class="name flex">
 <span>def <span class="ident">files_upload</span></span>(<span>self,<br>*,<br>file: str | bytes | io.IOBase | None = None,<br>content: str | bytes | None = None,<br>filename: str | None = None,<br>filetype: str | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>title: str | None = None,<br>channels: str | Sequence[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11871,7 +11953,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Uploads or creates a file.
-    https://api.slack.com/methods/files.upload
+    https://docs.slack.dev/reference/methods/files.upload
     &#34;&#34;&#34;
     _print_files_upload_v2_suggestion()
 
@@ -11904,7 +11986,7 @@ or received but have not yet been approved by all parties.
         return self.api_call(&#34;files.upload&#34;, data=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Uploads or creates a file.
-<a href="https://api.slack.com/methods/files.upload">https://api.slack.com/methods/files.upload</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.upload">https://docs.slack.dev/reference/methods/files.upload</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_upload_v2"><code class="name flex">
 <span>def <span class="ident">files_upload_v2</span></span>(<span>self,<br>*,<br>filename: str | None = None,<br>file: str | bytes | io.IOBase | os.PathLike | None = None,<br>content: str | bytes | None = None,<br>title: str | None = None,<br>alt_txt: str | None = None,<br>snippet_type: str | None = None,<br>file_uploads: List[Dict[str, Any]] | None = None,<br>channel: str | None = None,<br>channels: List[str] | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>request_file_info: bool = True,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -11935,12 +12017,12 @@ or received but have not yet been approved by all parties.
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;This wrapper method provides an easy way to upload files using the following endpoints:
 
-    - step1: https://api.slack.com/methods/files.getUploadURLExternal
+    - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
     - step2: &#34;https://files.slack.com/upload/v1/...&#34; URLs returned from files.getUploadURLExternal API
 
-    - step3: https://api.slack.com/methods/files.completeUploadExternal
-        and https://api.slack.com/methods/files.info
+    - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+        and https://docs.slack.dev/reference/methods/files.info
 
     &#34;&#34;&#34;
     if file is None and content is None and file_uploads is None:
@@ -12019,14 +12101,14 @@ or received but have not yet been approved by all parties.
 <div class="desc"><p>This wrapper method provides an easy way to upload files using the following endpoints:</p>
 <ul>
 <li>
-<p>step1: <a href="https://api.slack.com/methods/files.getUploadURLExternal">https://api.slack.com/methods/files.getUploadURLExternal</a></p>
+<p>step1: <a href="https://docs.slack.dev/reference/methods/files.getUploadURLExternal">https://docs.slack.dev/reference/methods/files.getUploadURLExternal</a></p>
 </li>
 <li>
 <p>step2: "https://files.slack.com/upload/v1/&hellip;" URLs returned from files.getUploadURLExternal API</p>
 </li>
 <li>
-<p>step3: <a href="https://api.slack.com/methods/files.completeUploadExternal">https://api.slack.com/methods/files.completeUploadExternal</a>
-and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/methods/files.info</a></p>
+<p>step3: <a href="https://docs.slack.dev/reference/methods/files.completeUploadExternal">https://docs.slack.dev/reference/methods/files.completeUploadExternal</a>
+and <a href="https://docs.slack.dev/reference/methods/files.info">https://docs.slack.dev/reference/methods/files.info</a></p>
 </li>
 </ul></div>
 </dd>
@@ -12046,13 +12128,13 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Signal the failure to execute a function
-    https://api.slack.com/methods/functions.completeError
+    https://docs.slack.dev/reference/methods/functions.completeError
     &#34;&#34;&#34;
     kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;error&#34;: error})
     return self.api_call(&#34;functions.completeError&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Signal the failure to execute a function
-<a href="https://api.slack.com/methods/functions.completeError">https://api.slack.com/methods/functions.completeError</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/functions.completeError">https://docs.slack.dev/reference/methods/functions.completeError</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.functions_completeSuccess"><code class="name flex">
 <span>def <span class="ident">functions_completeSuccess</span></span>(<span>self, *, function_execution_id: str, outputs: Dict[str, Any], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12070,13 +12152,13 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Signal the successful completion of a function
-    https://api.slack.com/methods/functions.completeSuccess
+    https://docs.slack.dev/reference/methods/functions.completeSuccess
     &#34;&#34;&#34;
     kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;outputs&#34;: json.dumps(outputs)})
     return self.api_call(&#34;functions.completeSuccess&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Signal the successful completion of a function
-<a href="https://api.slack.com/methods/functions.completeSuccess">https://api.slack.com/methods/functions.completeSuccess</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/functions.completeSuccess">https://docs.slack.dev/reference/methods/functions.completeSuccess</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.groups_archive"><code class="name flex">
 <span>def <span class="ident">groups_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12552,7 +12634,7 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;For Enterprise Grid workspaces, map local user IDs to global user IDs
-    https://api.slack.com/methods/migration.exchange
+    https://docs.slack.dev/reference/methods/migration.exchange
     &#34;&#34;&#34;
     if isinstance(users, (list, tuple)):
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -12562,7 +12644,7 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     return self.api_call(&#34;migration.exchange&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>For Enterprise Grid workspaces, map local user IDs to global user IDs
-<a href="https://api.slack.com/methods/migration.exchange">https://api.slack.com/methods/migration.exchange</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/migration.exchange">https://docs.slack.dev/reference/methods/migration.exchange</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.mpim_close"><code class="name flex">
 <span>def <span class="ident">mpim_close</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12709,7 +12791,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-    https://api.slack.com/methods/oauth.access
+    https://docs.slack.dev/reference/methods/oauth.access
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12721,7 +12803,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.
-<a href="https://api.slack.com/methods/oauth.access">https://api.slack.com/methods/oauth.access</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.access">https://docs.slack.dev/reference/methods/oauth.access</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.oauth_v2_access"><code class="name flex">
 <span>def <span class="ident">oauth_v2_access</span></span>(<span>self,<br>*,<br>client_id: str,<br>client_secret: str,<br>code: str | None = None,<br>redirect_uri: str | None = None,<br>grant_type: str | None = None,<br>refresh_token: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12747,7 +12829,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-    https://api.slack.com/methods/oauth.v2.access
+    https://docs.slack.dev/reference/methods/oauth.v2.access
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12764,7 +12846,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.
-<a href="https://api.slack.com/methods/oauth.v2.access">https://api.slack.com/methods/oauth.v2.access</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.v2.access">https://docs.slack.dev/reference/methods/oauth.v2.access</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.oauth_v2_exchange"><code class="name flex">
 <span>def <span class="ident">oauth_v2_exchange</span></span>(<span>self, *, token: str, client_id: str, client_secret: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12783,13 +12865,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
-    https://api.slack.com/methods/oauth.v2.exchange
+    https://docs.slack.dev/reference/methods/oauth.v2.exchange
     &#34;&#34;&#34;
     kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token})
     return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Exchanges a legacy access token for a new expiring access token and refresh token
-<a href="https://api.slack.com/methods/oauth.v2.exchange">https://api.slack.com/methods/oauth.v2.exchange</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.v2.exchange">https://docs.slack.dev/reference/methods/oauth.v2.exchange</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.openid_connect_token"><code class="name flex">
 <span>def <span class="ident">openid_connect_token</span></span>(<span>self,<br>client_id: str,<br>client_secret: str,<br>code: str | None = None,<br>redirect_uri: str | None = None,<br>grant_type: str | None = None,<br>refresh_token: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12810,7 +12892,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-    https://api.slack.com/methods/openid.connect.token
+    https://docs.slack.dev/reference/methods/openid.connect.token
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12827,7 +12909,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-<a href="https://api.slack.com/methods/openid.connect.token">https://api.slack.com/methods/openid.connect.token</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/openid.connect.token">https://docs.slack.dev/reference/methods/openid.connect.token</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.openid_connect_userInfo"><code class="name flex">
 <span>def <span class="ident">openid_connect_userInfo</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12842,12 +12924,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get the identity of a user who has authorized Sign in with Slack.
-    https://api.slack.com/methods/openid.connect.userInfo
+    https://docs.slack.dev/reference/methods/openid.connect.userInfo
     &#34;&#34;&#34;
     return self.api_call(&#34;openid.connect.userInfo&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get the identity of a user who has authorized Sign in with Slack.
-<a href="https://api.slack.com/methods/openid.connect.userInfo">https://api.slack.com/methods/openid.connect.userInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/openid.connect.userInfo">https://docs.slack.dev/reference/methods/openid.connect.userInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.pins_add"><code class="name flex">
 <span>def <span class="ident">pins_add</span></span>(<span>self, *, channel: str, timestamp: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12865,13 +12947,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Pins an item to a channel.
-    https://api.slack.com/methods/pins.add
+    https://docs.slack.dev/reference/methods/pins.add
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;pins.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Pins an item to a channel.
-<a href="https://api.slack.com/methods/pins.add">https://api.slack.com/methods/pins.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.add">https://docs.slack.dev/reference/methods/pins.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.pins_list"><code class="name flex">
 <span>def <span class="ident">pins_list</span></span>(<span>self, *, channel: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12888,13 +12970,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists items pinned to a channel.
-    https://api.slack.com/methods/pins.list
+    https://docs.slack.dev/reference/methods/pins.list
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;pins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists items pinned to a channel.
-<a href="https://api.slack.com/methods/pins.list">https://api.slack.com/methods/pins.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.list">https://docs.slack.dev/reference/methods/pins.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.pins_remove"><code class="name flex">
 <span>def <span class="ident">pins_remove</span></span>(<span>self, *, channel: str, timestamp: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12912,13 +12994,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Un-pins an item from a channel.
-    https://api.slack.com/methods/pins.remove
+    https://docs.slack.dev/reference/methods/pins.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;pins.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Un-pins an item from a channel.
-<a href="https://api.slack.com/methods/pins.remove">https://api.slack.com/methods/pins.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.remove">https://docs.slack.dev/reference/methods/pins.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.reactions_add"><code class="name flex">
 <span>def <span class="ident">reactions_add</span></span>(<span>self, *, channel: str, name: str, timestamp: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12937,13 +13019,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds a reaction to an item.
-    https://api.slack.com/methods/reactions.add
+    https://docs.slack.dev/reference/methods/reactions.add
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;reactions.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds a reaction to an item.
-<a href="https://api.slack.com/methods/reactions.add">https://api.slack.com/methods/reactions.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.add">https://docs.slack.dev/reference/methods/reactions.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.reactions_get"><code class="name flex">
 <span>def <span class="ident">reactions_get</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>full: bool | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -12964,7 +13046,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets reactions for an item.
-    https://api.slack.com/methods/reactions.get
+    https://docs.slack.dev/reference/methods/reactions.get
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12978,7 +13060,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets reactions for an item.
-<a href="https://api.slack.com/methods/reactions.get">https://api.slack.com/methods/reactions.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.get">https://docs.slack.dev/reference/methods/reactions.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.reactions_list"><code class="name flex">
 <span>def <span class="ident">reactions_list</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>full: bool | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>team_id: str | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13001,7 +13083,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists reactions made by a user.
-    https://api.slack.com/methods/reactions.list
+    https://docs.slack.dev/reference/methods/reactions.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13017,7 +13099,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists reactions made by a user.
-<a href="https://api.slack.com/methods/reactions.list">https://api.slack.com/methods/reactions.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.list">https://docs.slack.dev/reference/methods/reactions.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.reactions_remove"><code class="name flex">
 <span>def <span class="ident">reactions_remove</span></span>(<span>self,<br>*,<br>name: str,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13038,7 +13120,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a reaction from an item.
-    https://api.slack.com/methods/reactions.remove
+    https://docs.slack.dev/reference/methods/reactions.remove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13052,7 +13134,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a reaction from an item.
-<a href="https://api.slack.com/methods/reactions.remove">https://api.slack.com/methods/reactions.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.remove">https://docs.slack.dev/reference/methods/reactions.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.reminders_add"><code class="name flex">
 <span>def <span class="ident">reminders_add</span></span>(<span>self,<br>*,<br>text: str,<br>time: str,<br>team_id: str | None = None,<br>user: str | None = None,<br>recurrence: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13073,7 +13155,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Creates a reminder.
-    https://api.slack.com/methods/reminders.add
+    https://docs.slack.dev/reference/methods/reminders.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13087,7 +13169,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reminders.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Creates a reminder.
-<a href="https://api.slack.com/methods/reminders.add">https://api.slack.com/methods/reminders.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.add">https://docs.slack.dev/reference/methods/reminders.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.reminders_complete"><code class="name flex">
 <span>def <span class="ident">reminders_complete</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13105,13 +13187,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Marks a reminder as complete.
-    https://api.slack.com/methods/reminders.complete
+    https://docs.slack.dev/reference/methods/reminders.complete
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.complete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Marks a reminder as complete.
-<a href="https://api.slack.com/methods/reminders.complete">https://api.slack.com/methods/reminders.complete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.complete">https://docs.slack.dev/reference/methods/reminders.complete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.reminders_delete"><code class="name flex">
 <span>def <span class="ident">reminders_delete</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13129,13 +13211,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Deletes a reminder.
-    https://api.slack.com/methods/reminders.delete
+    https://docs.slack.dev/reference/methods/reminders.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a reminder.
-<a href="https://api.slack.com/methods/reminders.delete">https://api.slack.com/methods/reminders.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.delete">https://docs.slack.dev/reference/methods/reminders.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.reminders_info"><code class="name flex">
 <span>def <span class="ident">reminders_info</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13153,13 +13235,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a reminder.
-    https://api.slack.com/methods/reminders.info
+    https://docs.slack.dev/reference/methods/reminders.info
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a reminder.
-<a href="https://api.slack.com/methods/reminders.info">https://api.slack.com/methods/reminders.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.info">https://docs.slack.dev/reference/methods/reminders.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.reminders_list"><code class="name flex">
 <span>def <span class="ident">reminders_list</span></span>(<span>self, *, team_id: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13176,13 +13258,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all reminders created by or for a given user.
-    https://api.slack.com/methods/reminders.list
+    https://docs.slack.dev/reference/methods/reminders.list
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all reminders created by or for a given user.
-<a href="https://api.slack.com/methods/reminders.list">https://api.slack.com/methods/reminders.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.list">https://docs.slack.dev/reference/methods/reminders.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.rtm_connect"><code class="name flex">
 <span>def <span class="ident">rtm_connect</span></span>(<span>self,<br>*,<br>batch_presence_aware: bool | None = None,<br>presence_sub: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13200,13 +13282,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Starts a Real Time Messaging session.
-    https://api.slack.com/methods/rtm.connect
+    https://docs.slack.dev/reference/methods/rtm.connect
     &#34;&#34;&#34;
     kwargs.update({&#34;batch_presence_aware&#34;: batch_presence_aware, &#34;presence_sub&#34;: presence_sub})
     return self.api_call(&#34;rtm.connect&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Starts a Real Time Messaging session.
-<a href="https://api.slack.com/methods/rtm.connect">https://api.slack.com/methods/rtm.connect</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/rtm.connect">https://docs.slack.dev/reference/methods/rtm.connect</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.rtm_start"><code class="name flex">
 <span>def <span class="ident">rtm_start</span></span>(<span>self,<br>*,<br>batch_presence_aware: bool | None = None,<br>include_locale: bool | None = None,<br>mpim_aware: bool | None = None,<br>no_latest: bool | None = None,<br>no_unreads: bool | None = None,<br>presence_sub: bool | None = None,<br>simple_latest: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13229,7 +13311,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Starts a Real Time Messaging session.
-    https://api.slack.com/methods/rtm.start
+    https://docs.slack.dev/reference/methods/rtm.start
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13245,7 +13327,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;rtm.start&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Starts a Real Time Messaging session.
-<a href="https://api.slack.com/methods/rtm.start">https://api.slack.com/methods/rtm.start</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/rtm.start">https://docs.slack.dev/reference/methods/rtm.start</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.search_all"><code class="name flex">
 <span>def <span class="ident">search_all</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13268,7 +13350,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Searches for messages and files matching a query.
-    https://api.slack.com/methods/search.all
+    https://docs.slack.dev/reference/methods/search.all
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13284,7 +13366,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.all&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for messages and files matching a query.
-<a href="https://api.slack.com/methods/search.all">https://api.slack.com/methods/search.all</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.all">https://docs.slack.dev/reference/methods/search.all</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.search_files"><code class="name flex">
 <span>def <span class="ident">search_files</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13307,7 +13389,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Searches for files matching a query.
-    https://api.slack.com/methods/search.files
+    https://docs.slack.dev/reference/methods/search.files
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13323,7 +13405,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.files&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for files matching a query.
-<a href="https://api.slack.com/methods/search.files">https://api.slack.com/methods/search.files</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.files">https://docs.slack.dev/reference/methods/search.files</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.search_messages"><code class="name flex">
 <span>def <span class="ident">search_messages</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>cursor: str | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13347,7 +13429,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Searches for messages matching a query.
-    https://api.slack.com/methods/search.messages
+    https://docs.slack.dev/reference/methods/search.messages
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13364,7 +13446,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.messages&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for messages matching a query.
-<a href="https://api.slack.com/methods/search.messages">https://api.slack.com/methods/search.messages</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.messages">https://docs.slack.dev/reference/methods/search.messages</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.stars_add"><code class="name flex">
 <span>def <span class="ident">stars_add</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13384,7 +13466,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Adds a star to an item.
-    https://api.slack.com/methods/stars.add
+    https://docs.slack.dev/reference/methods/stars.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13397,7 +13479,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds a star to an item.
-<a href="https://api.slack.com/methods/stars.add">https://api.slack.com/methods/stars.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.add">https://docs.slack.dev/reference/methods/stars.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.stars_list"><code class="name flex">
 <span>def <span class="ident">stars_list</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13418,7 +13500,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists stars for a user.
-    https://api.slack.com/methods/stars.list
+    https://docs.slack.dev/reference/methods/stars.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13432,7 +13514,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists stars for a user.
-<a href="https://api.slack.com/methods/stars.list">https://api.slack.com/methods/stars.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.list">https://docs.slack.dev/reference/methods/stars.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.stars_remove"><code class="name flex">
 <span>def <span class="ident">stars_remove</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13452,7 +13534,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Removes a star from an item.
-    https://api.slack.com/methods/stars.remove
+    https://docs.slack.dev/reference/methods/stars.remove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13465,7 +13547,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a star from an item.
-<a href="https://api.slack.com/methods/stars.remove">https://api.slack.com/methods/stars.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.remove">https://docs.slack.dev/reference/methods/stars.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.team_accessLogs"><code class="name flex">
 <span>def <span class="ident">team_accessLogs</span></span>(<span>self,<br>*,<br>before: str | int | None = None,<br>count: str | int | None = None,<br>page: str | int | None = None,<br>team_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13487,7 +13569,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets the access logs for the current team.
-    https://api.slack.com/methods/team.accessLogs
+    https://docs.slack.dev/reference/methods/team.accessLogs
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13502,7 +13584,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.accessLogs&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets the access logs for the current team.
-<a href="https://api.slack.com/methods/team.accessLogs">https://api.slack.com/methods/team.accessLogs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.accessLogs">https://docs.slack.dev/reference/methods/team.accessLogs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.team_billableInfo"><code class="name flex">
 <span>def <span class="ident">team_billableInfo</span></span>(<span>self, *, team_id: str | None = None, user: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13520,13 +13602,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets billable users information for the current team.
-    https://api.slack.com/methods/team.billableInfo
+    https://docs.slack.dev/reference/methods/team.billableInfo
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
     return self.api_call(&#34;team.billableInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets billable users information for the current team.
-<a href="https://api.slack.com/methods/team.billableInfo">https://api.slack.com/methods/team.billableInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.billableInfo">https://docs.slack.dev/reference/methods/team.billableInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.team_billing_info"><code class="name flex">
 <span>def <span class="ident">team_billing_info</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13541,12 +13623,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Reads a workspace&#39;s billing plan information.
-    https://api.slack.com/methods/team.billing.info
+    https://docs.slack.dev/reference/methods/team.billing.info
     &#34;&#34;&#34;
     return self.api_call(&#34;team.billing.info&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Reads a workspace's billing plan information.
-<a href="https://api.slack.com/methods/team.billing.info">https://api.slack.com/methods/team.billing.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.billing.info">https://docs.slack.dev/reference/methods/team.billing.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.team_externalTeams_disconnect"><code class="name flex">
 <span>def <span class="ident">team_externalTeams_disconnect</span></span>(<span>self, *, target_team: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13563,7 +13645,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Disconnects an external organization.
-    https://api.slack.com/methods/team.externalTeams.disconnect
+    https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13573,7 +13655,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.externalTeams.disconnect&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disconnects an external organization.
-<a href="https://api.slack.com/methods/team.externalTeams.disconnect">https://api.slack.com/methods/team.externalTeams.disconnect</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.externalTeams.disconnect">https://docs.slack.dev/reference/methods/team.externalTeams.disconnect</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.team_externalTeams_list"><code class="name flex">
 <span>def <span class="ident">team_externalTeams_list</span></span>(<span>self,<br>*,<br>connection_status_filter: str | None = None,<br>slack_connect_pref_filter: Sequence[str] | None = None,<br>sort_direction: str | None = None,<br>sort_field: str | None = None,<br>workspace_filter: Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13596,7 +13678,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
-    https://api.slack.com/methods/team.externalTeams.list
+    https://docs.slack.dev/reference/methods/team.externalTeams.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13620,7 +13702,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns a list of all the external teams connected and details about the connection.
-<a href="https://api.slack.com/methods/team.externalTeams.list">https://api.slack.com/methods/team.externalTeams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.externalTeams.list">https://docs.slack.dev/reference/methods/team.externalTeams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.team_info"><code class="name flex">
 <span>def <span class="ident">team_info</span></span>(<span>self, *, team: str | None = None, domain: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13638,13 +13720,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about the current team.
-    https://api.slack.com/methods/team.info
+    https://docs.slack.dev/reference/methods/team.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team&#34;: team, &#34;domain&#34;: domain})
     return self.api_call(&#34;team.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about the current team.
-<a href="https://api.slack.com/methods/team.info">https://api.slack.com/methods/team.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.info">https://docs.slack.dev/reference/methods/team.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.team_integrationLogs"><code class="name flex">
 <span>def <span class="ident">team_integrationLogs</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>change_type: str | None = None,<br>count: str | int | None = None,<br>page: str | int | None = None,<br>service_id: str | None = None,<br>team_id: str | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13667,7 +13749,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets the integration logs for the current team.
-    https://api.slack.com/methods/team.integrationLogs
+    https://docs.slack.dev/reference/methods/team.integrationLogs
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13683,7 +13765,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.integrationLogs&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets the integration logs for the current team.
-<a href="https://api.slack.com/methods/team.integrationLogs">https://api.slack.com/methods/team.integrationLogs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.integrationLogs">https://docs.slack.dev/reference/methods/team.integrationLogs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.team_preferences_list"><code class="name flex">
 <span>def <span class="ident">team_preferences_list</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13698,12 +13780,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a list of a workspace&#39;s team preferences.
-    https://api.slack.com/methods/team.preferences.list
+    https://docs.slack.dev/reference/methods/team.preferences.list
     &#34;&#34;&#34;
     return self.api_call(&#34;team.preferences.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a list of a workspace's team preferences.
-<a href="https://api.slack.com/methods/team.preferences.list">https://api.slack.com/methods/team.preferences.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.preferences.list">https://docs.slack.dev/reference/methods/team.preferences.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.team_profile_get"><code class="name flex">
 <span>def <span class="ident">team_profile_get</span></span>(<span>self, *, visibility: str | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13720,13 +13802,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieve a team&#39;s profile.
-    https://api.slack.com/methods/team.profile.get
+    https://docs.slack.dev/reference/methods/team.profile.get
     &#34;&#34;&#34;
     kwargs.update({&#34;visibility&#34;: visibility})
     return self.api_call(&#34;team.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a team's profile.
-<a href="https://api.slack.com/methods/team.profile.get">https://api.slack.com/methods/team.profile.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.profile.get">https://docs.slack.dev/reference/methods/team.profile.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.tooling_tokens_rotate"><code class="name flex">
 <span>def <span class="ident">tooling_tokens_rotate</span></span>(<span>self, *, refresh_token: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13743,13 +13825,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Exchanges a refresh token for a new app configuration token
-    https://api.slack.com/methods/tooling.tokens.rotate
+    https://docs.slack.dev/reference/methods/tooling.tokens.rotate
     &#34;&#34;&#34;
     kwargs.update({&#34;refresh_token&#34;: refresh_token})
     return self.api_call(&#34;tooling.tokens.rotate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Exchanges a refresh token for a new app configuration token
-<a href="https://api.slack.com/methods/tooling.tokens.rotate">https://api.slack.com/methods/tooling.tokens.rotate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/tooling.tokens.rotate">https://docs.slack.dev/reference/methods/tooling.tokens.rotate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.usergroups_create"><code class="name flex">
 <span>def <span class="ident">usergroups_create</span></span>(<span>self,<br>*,<br>name: str,<br>channels: str | Sequence[str] | None = None,<br>description: str | None = None,<br>handle: str | None = None,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13771,7 +13853,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Create a User Group
-    https://api.slack.com/methods/usergroups.create
+    https://docs.slack.dev/reference/methods/usergroups.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13789,7 +13871,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a User Group
-<a href="https://api.slack.com/methods/usergroups.create">https://api.slack.com/methods/usergroups.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.create">https://docs.slack.dev/reference/methods/usergroups.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.usergroups_disable"><code class="name flex">
 <span>def <span class="ident">usergroups_disable</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13808,13 +13890,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Disable an existing User Group
-    https://api.slack.com/methods/usergroups.disable
+    https://docs.slack.dev/reference/methods/usergroups.disable
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;usergroups.disable&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disable an existing User Group
-<a href="https://api.slack.com/methods/usergroups.disable">https://api.slack.com/methods/usergroups.disable</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.disable">https://docs.slack.dev/reference/methods/usergroups.disable</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.usergroups_enable"><code class="name flex">
 <span>def <span class="ident">usergroups_enable</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13833,13 +13915,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Enable a User Group
-    https://api.slack.com/methods/usergroups.enable
+    https://docs.slack.dev/reference/methods/usergroups.enable
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;usergroups.enable&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enable a User Group
-<a href="https://api.slack.com/methods/usergroups.enable">https://api.slack.com/methods/usergroups.enable</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.enable">https://docs.slack.dev/reference/methods/usergroups.enable</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.usergroups_list"><code class="name flex">
 <span>def <span class="ident">usergroups_list</span></span>(<span>self,<br>*,<br>include_count: bool | None = None,<br>include_disabled: bool | None = None,<br>include_users: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13859,7 +13941,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all User Groups for a team
-    https://api.slack.com/methods/usergroups.list
+    https://docs.slack.dev/reference/methods/usergroups.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13872,7 +13954,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all User Groups for a team
-<a href="https://api.slack.com/methods/usergroups.list">https://api.slack.com/methods/usergroups.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.list">https://docs.slack.dev/reference/methods/usergroups.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.usergroups_update"><code class="name flex">
 <span>def <span class="ident">usergroups_update</span></span>(<span>self,<br>*,<br>usergroup: str,<br>channels: str | Sequence[str] | None = None,<br>description: str | None = None,<br>handle: str | None = None,<br>include_count: bool | None = None,<br>name: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13895,7 +13977,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update an existing User Group
-    https://api.slack.com/methods/usergroups.update
+    https://docs.slack.dev/reference/methods/usergroups.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13914,7 +13996,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing User Group
-<a href="https://api.slack.com/methods/usergroups.update">https://api.slack.com/methods/usergroups.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.update">https://docs.slack.dev/reference/methods/usergroups.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.usergroups_users_list"><code class="name flex">
 <span>def <span class="ident">usergroups_users_list</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_disabled: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13933,7 +14015,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List all users in a User Group
-    https://api.slack.com/methods/usergroups.users.list
+    https://docs.slack.dev/reference/methods/usergroups.users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13945,7 +14027,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.users.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all users in a User Group
-<a href="https://api.slack.com/methods/usergroups.users.list">https://api.slack.com/methods/usergroups.users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.users.list">https://docs.slack.dev/reference/methods/usergroups.users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.usergroups_users_update"><code class="name flex">
 <span>def <span class="ident">usergroups_users_update</span></span>(<span>self,<br>*,<br>usergroup: str,<br>users: str | Sequence[str],<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13965,7 +14047,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update the list of users for a User Group
-    https://api.slack.com/methods/usergroups.users.update
+    https://docs.slack.dev/reference/methods/usergroups.users.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13981,7 +14063,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update the list of users for a User Group
-<a href="https://api.slack.com/methods/usergroups.users.update">https://api.slack.com/methods/usergroups.users.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.users.update">https://docs.slack.dev/reference/methods/usergroups.users.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_conversations"><code class="name flex">
 <span>def <span class="ident">users_conversations</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>exclude_archived: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>types: str | Sequence[str] | None = None,<br>user: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14003,7 +14085,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;List conversations the calling user may access.
-    https://api.slack.com/methods/users.conversations
+    https://docs.slack.dev/reference/methods/users.conversations
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -14021,7 +14103,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.conversations&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List conversations the calling user may access.
-<a href="https://api.slack.com/methods/users.conversations">https://api.slack.com/methods/users.conversations</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.conversations">https://docs.slack.dev/reference/methods/users.conversations</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_deletePhoto"><code class="name flex">
 <span>def <span class="ident">users_deletePhoto</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14036,12 +14118,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Delete the user profile photo
-    https://api.slack.com/methods/users.deletePhoto
+    https://docs.slack.dev/reference/methods/users.deletePhoto
     &#34;&#34;&#34;
     return self.api_call(&#34;users.deletePhoto&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete the user profile photo
-<a href="https://api.slack.com/methods/users.deletePhoto">https://api.slack.com/methods/users.deletePhoto</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.deletePhoto">https://docs.slack.dev/reference/methods/users.deletePhoto</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_discoverableContacts_lookup"><code class="name flex">
 <span>def <span class="ident">users_discoverableContacts_lookup</span></span>(<span>self, email: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14057,13 +14139,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lookup an email address to see if someone is on Slack
-    https://api.slack.com/methods/users.discoverableContacts.lookup
+    https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
     &#34;&#34;&#34;
     kwargs.update({&#34;email&#34;: email})
     return self.api_call(&#34;users.discoverableContacts.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lookup an email address to see if someone is on Slack
-<a href="https://api.slack.com/methods/users.discoverableContacts.lookup">https://api.slack.com/methods/users.discoverableContacts.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup">https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_getPresence"><code class="name flex">
 <span>def <span class="ident">users_getPresence</span></span>(<span>self, *, user: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14080,13 +14162,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets user presence information.
-    https://api.slack.com/methods/users.getPresence
+    https://docs.slack.dev/reference/methods/users.getPresence
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user})
     return self.api_call(&#34;users.getPresence&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets user presence information.
-<a href="https://api.slack.com/methods/users.getPresence">https://api.slack.com/methods/users.getPresence</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.getPresence">https://docs.slack.dev/reference/methods/users.getPresence</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_identity"><code class="name flex">
 <span>def <span class="ident">users_identity</span></span>(<span>self, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14101,12 +14183,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Get a user&#39;s identity.
-    https://api.slack.com/methods/users.identity
+    https://docs.slack.dev/reference/methods/users.identity
     &#34;&#34;&#34;
     return self.api_call(&#34;users.identity&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a user's identity.
-<a href="https://api.slack.com/methods/users.identity">https://api.slack.com/methods/users.identity</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.identity">https://docs.slack.dev/reference/methods/users.identity</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_info"><code class="name flex">
 <span>def <span class="ident">users_info</span></span>(<span>self, *, user: str, include_locale: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14124,13 +14206,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Gets information about a user.
-    https://api.slack.com/methods/users.info
+    https://docs.slack.dev/reference/methods/users.info
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user, &#34;include_locale&#34;: include_locale})
     return self.api_call(&#34;users.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a user.
-<a href="https://api.slack.com/methods/users.info">https://api.slack.com/methods/users.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.info">https://docs.slack.dev/reference/methods/users.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_list"><code class="name flex">
 <span>def <span class="ident">users_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>include_locale: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14150,7 +14232,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Lists all users in a Slack team.
-    https://api.slack.com/methods/users.list
+    https://docs.slack.dev/reference/methods/users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -14163,7 +14245,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all users in a Slack team.
-<a href="https://api.slack.com/methods/users.list">https://api.slack.com/methods/users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.list">https://docs.slack.dev/reference/methods/users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_lookupByEmail"><code class="name flex">
 <span>def <span class="ident">users_lookupByEmail</span></span>(<span>self, *, email: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14180,13 +14262,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Find a user with an email address.
-    https://api.slack.com/methods/users.lookupByEmail
+    https://docs.slack.dev/reference/methods/users.lookupByEmail
     &#34;&#34;&#34;
     kwargs.update({&#34;email&#34;: email})
     return self.api_call(&#34;users.lookupByEmail&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Find a user with an email address.
-<a href="https://api.slack.com/methods/users.lookupByEmail">https://api.slack.com/methods/users.lookupByEmail</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.lookupByEmail">https://docs.slack.dev/reference/methods/users.lookupByEmail</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_profile_get"><code class="name flex">
 <span>def <span class="ident">users_profile_get</span></span>(<span>self, *, user: str | None = None, include_labels: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14204,13 +14286,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Retrieves a user&#39;s profile information.
-    https://api.slack.com/methods/users.profile.get
+    https://docs.slack.dev/reference/methods/users.profile.get
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user, &#34;include_labels&#34;: include_labels})
     return self.api_call(&#34;users.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves a user's profile information.
-<a href="https://api.slack.com/methods/users.profile.get">https://api.slack.com/methods/users.profile.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.profile.get">https://docs.slack.dev/reference/methods/users.profile.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_profile_set"><code class="name flex">
 <span>def <span class="ident">users_profile_set</span></span>(<span>self,<br>*,<br>name: str | None = None,<br>value: str | None = None,<br>user: str | None = None,<br>profile: Dict | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14230,7 +14312,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the profile information for a user.
-    https://api.slack.com/methods/users.profile.set
+    https://docs.slack.dev/reference/methods/users.profile.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -14245,7 +14327,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.profile.set&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the profile information for a user.
-<a href="https://api.slack.com/methods/users.profile.set">https://api.slack.com/methods/users.profile.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.profile.set">https://docs.slack.dev/reference/methods/users.profile.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_setPhoto"><code class="name flex">
 <span>def <span class="ident">users_setPhoto</span></span>(<span>self,<br>*,<br>image: str | io.IOBase,<br>crop_w: str | int | None = None,<br>crop_x: str | int | None = None,<br>crop_y: str | int | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14265,13 +14347,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Set the user profile photo
-    https://api.slack.com/methods/users.setPhoto
+    https://docs.slack.dev/reference/methods/users.setPhoto
     &#34;&#34;&#34;
     kwargs.update({&#34;crop_w&#34;: crop_w, &#34;crop_x&#34;: crop_x, &#34;crop_y&#34;: crop_y})
     return self.api_call(&#34;users.setPhoto&#34;, files={&#34;image&#34;: image}, data=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the user profile photo
-<a href="https://api.slack.com/methods/users.setPhoto">https://api.slack.com/methods/users.setPhoto</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.setPhoto">https://docs.slack.dev/reference/methods/users.setPhoto</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.users_setPresence"><code class="name flex">
 <span>def <span class="ident">users_setPresence</span></span>(<span>self, *, presence: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14288,13 +14370,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Manually sets user presence.
-    https://api.slack.com/methods/users.setPresence
+    https://docs.slack.dev/reference/methods/users.setPresence
     &#34;&#34;&#34;
     kwargs.update({&#34;presence&#34;: presence})
     return self.api_call(&#34;users.setPresence&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Manually sets user presence.
-<a href="https://api.slack.com/methods/users.setPresence">https://api.slack.com/methods/users.setPresence</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.setPresence">https://docs.slack.dev/reference/methods/users.setPresence</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.views_open"><code class="name flex">
 <span>def <span class="ident">views_open</span></span>(<span>self,<br>*,<br>trigger_id: str | None = None,<br>interactivity_pointer: str | None = None,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14313,8 +14395,8 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Open a view for a user.
-    https://api.slack.com/methods/views.open
-    See https://api.slack.com/surfaces/modals for details.
+    https://docs.slack.dev/reference/methods/views.open
+    See https://docs.slack.dev/surfaces/modals/ for details.
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
     if isinstance(view, View):
@@ -14326,8 +14408,8 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;views.open&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Open a view for a user.
-<a href="https://api.slack.com/methods/views.open">https://api.slack.com/methods/views.open</a>
-See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a> for details.</p></div>
+<a href="https://docs.slack.dev/reference/methods/views.open">https://docs.slack.dev/reference/methods/views.open</a>
+See <a href="https://docs.slack.dev/surfaces/modals/">https://docs.slack.dev/surfaces/modals/</a> for details.</p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.views_publish"><code class="name flex">
 <span>def <span class="ident">views_publish</span></span>(<span>self,<br>*,<br>user_id: str,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>hash: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14347,8 +14429,8 @@ See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfac
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Publish a static view for a User.
     Create or update the view that comprises an
-    app&#39;s Home tab (https://api.slack.com/surfaces/tabs)
-    https://api.slack.com/methods/views.publish
+    app&#39;s Home tab (https://docs.slack.dev/surfaces/app-home/)
+    https://docs.slack.dev/reference/methods/views.publish
     &#34;&#34;&#34;
     kwargs.update({&#34;user_id&#34;: user_id, &#34;hash&#34;: hash})
     if isinstance(view, View):
@@ -14361,8 +14443,8 @@ See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfac
 </details>
 <div class="desc"><p>Publish a static view for a User.
 Create or update the view that comprises an
-app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.com/surfaces/tabs</a>)
-<a href="https://api.slack.com/methods/views.publish">https://api.slack.com/methods/views.publish</a></p></div>
+app's Home tab (<a href="https://docs.slack.dev/surfaces/app-home/">https://docs.slack.dev/surfaces/app-home/</a>)
+<a href="https://docs.slack.dev/reference/methods/views.publish">https://docs.slack.dev/reference/methods/views.publish</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.views_push"><code class="name flex">
 <span>def <span class="ident">views_push</span></span>(<span>self,<br>*,<br>trigger_id: str | None = None,<br>interactivity_pointer: str | None = None,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14384,9 +14466,9 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
     Push a new view onto the existing view stack by passing a view
     payload and a valid trigger_id generated from an interaction
     within the existing modal.
-    Read the modals documentation (https://api.slack.com/surfaces/modals)
+    Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
     to learn more about the lifecycle and intricacies of views.
-    https://api.slack.com/methods/views.push
+    https://docs.slack.dev/reference/methods/views.push
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
     if isinstance(view, View):
@@ -14401,9 +14483,9 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
 Push a new view onto the existing view stack by passing a view
 payload and a valid trigger_id generated from an interaction
 within the existing modal.
-Read the modals documentation (<a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a>)
+Read the modals documentation (<a href="https://docs.slack.dev/surfaces/modals/">https://docs.slack.dev/surfaces/modals/</a>)
 to learn more about the lifecycle and intricacies of views.
-<a href="https://api.slack.com/methods/views.push">https://api.slack.com/methods/views.push</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/views.push">https://docs.slack.dev/reference/methods/views.push</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.views_update"><code class="name flex">
 <span>def <span class="ident">views_update</span></span>(<span>self,<br>*,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>external_id: str | None = None,<br>view_id: str | None = None,<br>hash: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14425,9 +14507,9 @@ to learn more about the lifecycle and intricacies of views.
     &#34;&#34;&#34;Update an existing view.
     Update a view by passing a new view definition along with the
     view_id returned in views.open or the external_id.
-    See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+    See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
     to learn more about updating views and avoiding race conditions with the hash argument.
-    https://api.slack.com/methods/views.update
+    https://docs.slack.dev/reference/methods/views.update
     &#34;&#34;&#34;
     if isinstance(view, View):
         kwargs.update({&#34;view&#34;: view.to_dict()})
@@ -14447,9 +14529,119 @@ to learn more about the lifecycle and intricacies of views.
 <div class="desc"><p>Update an existing view.
 Update a view by passing a new view definition along with the
 view_id returned in views.open or the external_id.
-See the modals documentation (<a href="https://api.slack.com/surfaces/modals#updating_views">https://api.slack.com/surfaces/modals#updating_views</a>)
+See the modals documentation (<a href="https://docs.slack.dev/surfaces/modals/#updating_views">https://docs.slack.dev/surfaces/modals/#updating_views</a>)
 to learn more about updating views and avoiding race conditions with the hash argument.
-<a href="https://api.slack.com/methods/views.update">https://api.slack.com/methods/views.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/views.update">https://docs.slack.dev/reference/methods/views.update</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.workflows_featured_add"><code class="name flex">
+<span>def <span class="ident">workflows_featured_add</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_add(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Add featured workflows to a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.add
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.add&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Add featured workflows to a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.add">https://docs.slack.dev/reference/methods/workflows.featured.add</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.workflows_featured_list"><code class="name flex">
+<span>def <span class="ident">workflows_featured_list</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_list(
+    self,
+    *,
+    channel_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;List the featured workflows for specified channels.
+    https://docs.slack.dev/reference/methods/workflows.featured.list
+    &#34;&#34;&#34;
+    if isinstance(channel_ids, (list, tuple)):
+        kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
+    else:
+        kwargs.update({&#34;channel_ids&#34;: channel_ids})
+    return self.api_call(&#34;workflows.featured.list&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>List the featured workflows for specified channels.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.list">https://docs.slack.dev/reference/methods/workflows.featured.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.workflows_featured_remove"><code class="name flex">
+<span>def <span class="ident">workflows_featured_remove</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_remove(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Remove featured workflows from a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.remove
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.remove&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Remove featured workflows from a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.remove">https://docs.slack.dev/reference/methods/workflows.featured.remove</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.workflows_featured_set"><code class="name flex">
+<span>def <span class="ident">workflows_featured_set</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_set(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Set featured workflows for a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.set
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.set&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Set featured workflows for a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.set">https://docs.slack.dev/reference/methods/workflows.featured.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.workflows_stepCompleted"><code class="name flex">
 <span>def <span class="ident">workflows_stepCompleted</span></span>(<span>self, *, workflow_step_execute_id: str, outputs: dict | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14467,7 +14659,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Indicate a successful outcome of a workflow step&#39;s execution.
-    https://api.slack.com/methods/workflows.stepCompleted
+    https://docs.slack.dev/reference/methods/workflows.stepCompleted
     &#34;&#34;&#34;
     kwargs.update({&#34;workflow_step_execute_id&#34;: workflow_step_execute_id})
     if outputs is not None:
@@ -14477,7 +14669,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.stepCompleted&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Indicate a successful outcome of a workflow step's execution.
-<a href="https://api.slack.com/methods/workflows.stepCompleted">https://api.slack.com/methods/workflows.stepCompleted</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.stepCompleted">https://docs.slack.dev/reference/methods/workflows.stepCompleted</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.workflows_stepFailed"><code class="name flex">
 <span>def <span class="ident">workflows_stepFailed</span></span>(<span>self, *, workflow_step_execute_id: str, error: Dict[str, str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14495,7 +14687,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Indicate an unsuccessful outcome of a workflow step&#39;s execution.
-    https://api.slack.com/methods/workflows.stepFailed
+    https://docs.slack.dev/reference/methods/workflows.stepFailed
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -14508,7 +14700,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.stepFailed&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Indicate an unsuccessful outcome of a workflow step's execution.
-<a href="https://api.slack.com/methods/workflows.stepFailed">https://api.slack.com/methods/workflows.stepFailed</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.stepFailed">https://docs.slack.dev/reference/methods/workflows.stepFailed</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.workflows_updateStep"><code class="name flex">
 <span>def <span class="ident">workflows_updateStep</span></span>(<span>self,<br>*,<br>workflow_step_edit_id: str,<br>inputs: Dict[str, Any] | None = None,<br>outputs: List[Dict[str, str]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -14527,7 +14719,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; SlackResponse:
     &#34;&#34;&#34;Update the configuration for a workflow extension step.
-    https://api.slack.com/methods/workflows.updateStep
+    https://docs.slack.dev/reference/methods/workflows.updateStep
     &#34;&#34;&#34;
     kwargs.update({&#34;workflow_step_edit_id&#34;: workflow_step_edit_id})
     if inputs is not None:
@@ -14539,7 +14731,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.updateStep&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update the configuration for a workflow extension step.
-<a href="https://api.slack.com/methods/workflows.updateStep">https://api.slack.com/methods/workflows.updateStep</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.updateStep">https://docs.slack.dev/reference/methods/workflows.updateStep</a></p></div>
 </dd>
 </dl>
 <h3>Inherited members</h3>
@@ -14897,6 +15089,10 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.WebClient.views_publish" href="#slack_sdk.web.WebClient.views_publish">views_publish</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.views_push" href="#slack_sdk.web.WebClient.views_push">views_push</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.views_update" href="#slack_sdk.web.WebClient.views_update">views_update</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.workflows_featured_add" href="#slack_sdk.web.WebClient.workflows_featured_add">workflows_featured_add</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.workflows_featured_list" href="#slack_sdk.web.WebClient.workflows_featured_list">workflows_featured_list</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.workflows_featured_remove" href="#slack_sdk.web.WebClient.workflows_featured_remove">workflows_featured_remove</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.workflows_featured_set" href="#slack_sdk.web.WebClient.workflows_featured_set">workflows_featured_set</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.workflows_stepCompleted" href="#slack_sdk.web.WebClient.workflows_stepCompleted">workflows_stepCompleted</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.workflows_stepFailed" href="#slack_sdk.web.WebClient.workflows_stepFailed">workflows_stepFailed</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.workflows_updateStep" href="#slack_sdk.web.WebClient.workflows_updateStep">workflows_updateStep</a></code></li>

--- a/docs/reference/web/internal_utils.html
+++ b/docs/reference/web/internal_utils.html
@@ -95,7 +95,7 @@ This method converts only the bool values in top-level of a given dict.</p>
 
     Returns:
         The user agent string.
-        e.g. &#39;Python/3.6.7 slackclient/2.0.0 Darwin/17.7.0&#39;
+        e.g. &#39;Python/3.7.17 slackclient/2.0.0 Darwin/17.7.0&#39;
     &#34;&#34;&#34;
     # __name__ returns all classes, we only want the client
     client = &#34;{0}/{1}&#34;.format(&#34;slackclient&#34;, version.__version__)
@@ -110,7 +110,7 @@ This method converts only the bool values in top-level of a given dict.</p>
 Python version and OS version.</p>
 <h2 id="returns">Returns</h2>
 <p>The user agent string.
-e.g. 'Python/3.6.7 slackclient/2.0.0 Darwin/17.7.0'</p></div>
+e.g. 'Python/3.7.17 slackclient/2.0.0 Darwin/17.7.0'</p></div>
 </dd>
 </dl>
 </section>

--- a/docs/reference/web/legacy_base_client.html
+++ b/docs/reference/web/legacy_base_client.html
@@ -580,7 +580,7 @@ el.replaceWith(d);
         On each HTTP request that Slack sends, we add an X-Slack-Signature HTTP
         header. The signature is created by combining the signing secret with the
         body of the request we&#39;re sending using a standard HMAC-SHA256 keyed hash.
-        https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview
+        https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview
         Args:
             signing_secret: Your application&#39;s signing secret, available in the
                 Slack API dashboard
@@ -633,7 +633,7 @@ def validate_slack_signature(*, signing_secret: str, data: str, timestamp: str, 
     On each HTTP request that Slack sends, we add an X-Slack-Signature HTTP
     header. The signature is created by combining the signing secret with the
     body of the request we&#39;re sending using a standard HMAC-SHA256 keyed hash.
-    https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview
+    https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview
     Args:
         signing_secret: Your application&#39;s signing secret, available in the
             Slack API dashboard
@@ -661,7 +661,7 @@ signing secret.
 On each HTTP request that Slack sends, we add an X-Slack-Signature HTTP
 header. The signature is created by combining the signing secret with the
 body of the request we're sending using a standard HMAC-SHA256 keyed hash.
-<a href="https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview">https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview</a></p>
+<a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview">https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>signing_secret</code></strong></dt>

--- a/docs/reference/web/legacy_client.html
+++ b/docs/reference/web/legacy_client.html
@@ -58,7 +58,7 @@ el.replaceWith(d);
 <pre><code class="python">class LegacyWebClient(LegacyBaseClient):
     &#34;&#34;&#34;A WebClient allows apps to communicate with the Slack Platform&#39;s Web API.
 
-    https://api.slack.com/methods
+    https://docs.slack.dev/reference/methods
 
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
@@ -129,7 +129,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieve analytics data for a given date, presented as a compressed JSON file
-        https://api.slack.com/methods/admin.analytics.getFile
+        https://docs.slack.dev/reference/methods/admin.analytics.getFile
         &#34;&#34;&#34;
         kwargs.update({&#34;type&#34;: type})
         if date is not None:
@@ -151,7 +151,7 @@ el.replaceWith(d);
         Either app_id or request_id is required.
         These IDs can be obtained either directly via the app_requested event,
         or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.approve
+        https://docs.slack.dev/reference/methods/admin.apps.approve
         &#34;&#34;&#34;
         if app_id:
             kwargs.update({&#34;app_id&#34;: app_id})
@@ -178,7 +178,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List approved apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.approved.list
+        https://docs.slack.dev/reference/methods/admin.apps.approved.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -199,7 +199,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Clear an app resolution
-        https://api.slack.com/methods/admin.apps.clearResolution
+        https://docs.slack.dev/reference/methods/admin.apps.clearResolution
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -219,7 +219,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.cancel
+        https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -239,7 +239,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.list
+        https://docs.slack.dev/reference/methods/admin.apps.requests.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -263,7 +263,7 @@ el.replaceWith(d);
         Exactly one of the team_id or enterprise_id arguments is required, not both.
         Either app_id or request_id is required. These IDs can be obtained either directly
         via the app_requested event, or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.restrict
+        https://docs.slack.dev/reference/methods/admin.apps.restrict
         &#34;&#34;&#34;
         if app_id:
             kwargs.update({&#34;app_id&#34;: app_id})
@@ -290,7 +290,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List restricted apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.restricted.list
+        https://docs.slack.dev/reference/methods/admin.apps.restricted.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -312,7 +312,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Uninstall an app from one or many workspaces, or an entire enterprise organization.
         With an org-level token, enterprise_id or team_ids is required.
-        https://api.slack.com/methods/admin.apps.uninstall
+        https://docs.slack.dev/reference/methods/admin.apps.uninstall
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         if enterprise_id is not None:
@@ -343,7 +343,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Get logs for a specified team/org
-        https://api.slack.com/methods/admin.apps.activities.list
+        https://docs.slack.dev/reference/methods/admin.apps.activities.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -371,7 +371,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Look up the app config for connectors by their IDs
-        https://api.slack.com/methods/admin.apps.config.lookup
+        https://docs.slack.dev/reference/methods/admin.apps.config.lookup
         &#34;&#34;&#34;
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -388,7 +388,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set the app config for a connector
-        https://api.slack.com/methods/admin.apps.config.set
+        https://docs.slack.dev/reference/methods/admin.apps.config.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -410,7 +410,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.
-        https://api.slack.com/methods/admin.auth.policy.getEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
         &#34;&#34;&#34;
         kwargs.update({&#34;policy_name&#34;: policy_name})
         if cursor is not None:
@@ -430,7 +430,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Assign entities to a particular authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.assignEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
         &#34;&#34;&#34;
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -449,7 +449,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Remove specified entities from a specified authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.removeEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
         &#34;&#34;&#34;
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -468,7 +468,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Create a Salesforce channel for the corresponding object provided.
-        https://api.slack.com/methods/admin.conversations.createForObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
         &#34;&#34;&#34;
         kwargs.update(
             {&#34;object_id&#34;: object_id, &#34;salesforce_org_id&#34;: salesforce_org_id, &#34;invite_object_team&#34;: invite_object_team}
@@ -484,7 +484,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Link a Salesforce record to a channel.
-        https://api.slack.com/methods/admin.conversations.linkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -503,7 +503,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Unlink a Salesforce record from a channel.
-        https://api.slack.com/methods/admin.conversations.unlinkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -522,7 +522,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Create an Information Barrier
-        https://api.slack.com/methods/admin.barriers.create
+        https://docs.slack.dev/reference/methods/admin.barriers.create
         &#34;&#34;&#34;
         kwargs.update({&#34;primary_usergroup_id&#34;: primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -542,7 +542,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Delete an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.delete
+        https://docs.slack.dev/reference/methods/admin.barriers.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;barrier_id&#34;: barrier_id})
         return self.api_call(&#34;admin.barriers.delete&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -557,7 +557,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Update an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.update
+        https://docs.slack.dev/reference/methods/admin.barriers.update
         &#34;&#34;&#34;
         kwargs.update({&#34;barrier_id&#34;: barrier_id, &#34;primary_usergroup_id&#34;: primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -578,7 +578,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Get all Information Barriers for your organization
-        https://api.slack.com/methods/admin.barriers.list&#34;&#34;&#34;
+        https://docs.slack.dev/reference/methods/admin.barriers.list&#34;&#34;&#34;
         kwargs.update(
             {
                 &#34;cursor&#34;: cursor,
@@ -598,7 +598,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Create a public or private channel-based conversation.
-        https://api.slack.com/methods/admin.conversations.create
+        https://docs.slack.dev/reference/methods/admin.conversations.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -618,7 +618,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Delete a public or private channel.
-        https://api.slack.com/methods/admin.conversations.delete
+        https://docs.slack.dev/reference/methods/admin.conversations.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.delete&#34;, params=kwargs)
@@ -631,7 +631,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Invite a user to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.invite
+        https://docs.slack.dev/reference/methods/admin.conversations.invite
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(user_ids, (list, tuple)):
@@ -648,7 +648,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Archive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.archive&#34;, params=kwargs)
@@ -660,7 +660,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Unarchive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.unarchive&#34;, params=kwargs)
@@ -673,7 +673,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Rename a public or private channel.
-        https://api.slack.com/methods/admin.conversations.rename
+        https://docs.slack.dev/reference/methods/admin.conversations.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;name&#34;: name})
         return self.api_call(&#34;admin.conversations.rename&#34;, params=kwargs)
@@ -691,7 +691,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.
-        https://api.slack.com/methods/admin.conversations.search
+        https://docs.slack.dev/reference/methods/admin.conversations.search
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -722,7 +722,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Convert a public channel to a private channel.
-        https://api.slack.com/methods/admin.conversations.convertToPrivate
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.convertToPrivate&#34;, params=kwargs)
@@ -734,7 +734,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Convert a privte channel to a public channel.
-        https://api.slack.com/methods/admin.conversations.convertToPublic
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.convertToPublic&#34;, params=kwargs)
@@ -747,7 +747,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set the posting permissions for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(prefs, dict):
@@ -763,7 +763,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Get conversation preferences for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.getConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.getConversationPrefs&#34;, params=kwargs)
@@ -776,7 +776,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Disconnect a connected channel from one or more workspaces.
-        https://api.slack.com/methods/admin.conversations.disconnectShared
+        https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         if isinstance(leaving_team_ids, (list, tuple)):
@@ -796,7 +796,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Returns channels on the given team using the filters.
-        https://api.slack.com/methods/admin.conversations.lookup
+        https://docs.slack.dev/reference/methods/admin.conversations.lookup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -824,7 +824,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;List all disconnected channels—i.e.,
         channels that were once connected to other workspaces and then disconnected—and
         the corresponding original channel IDs for key revocation with EKM.
-        https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+        https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -851,7 +851,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add an allowlist of IDP groups for accessing a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -874,7 +874,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all IDP Groups linked to a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -897,7 +897,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Remove a linked IDP group linked from a private channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -922,7 +922,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.setTeams
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -946,7 +946,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a channel.
-        https://api.slack.com/methods/admin.conversations.getTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.getTeams
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -964,7 +964,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Get a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.getCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.getCustomRetention&#34;, params=kwargs)
@@ -976,7 +976,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Remove a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.removeCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;admin.conversations.removeCustomRetention&#34;, params=kwargs)
@@ -989,7 +989,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set a channel&#39;s retention policy
-        https://api.slack.com/methods/admin.conversations.setCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;duration_days&#34;: duration_days})
         return self.api_call(&#34;admin.conversations.setCustomRetention&#34;, params=kwargs)
@@ -1001,7 +1001,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Archive public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkArchive
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
         return self.api_call(&#34;admin.conversations.bulkArchive&#34;, params=kwargs)
@@ -1026,7 +1026,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Move public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkMove
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1044,7 +1044,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add an emoji.
-        https://api.slack.com/methods/admin.emoji.add
+        https://docs.slack.dev/reference/methods/admin.emoji.add
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;url&#34;: url})
         return self.api_call(&#34;admin.emoji.add&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1057,7 +1057,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add an emoji alias.
-        https://api.slack.com/methods/admin.emoji.addAlias
+        https://docs.slack.dev/reference/methods/admin.emoji.addAlias
         &#34;&#34;&#34;
         kwargs.update({&#34;alias_for&#34;: alias_for, &#34;name&#34;: name})
         return self.api_call(&#34;admin.emoji.addAlias&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1070,7 +1070,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List emoji for an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.list
+        https://docs.slack.dev/reference/methods/admin.emoji.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1082,7 +1082,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Remove an emoji across an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.remove
+        https://docs.slack.dev/reference/methods/admin.emoji.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name})
         return self.api_call(&#34;admin.emoji.remove&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1095,7 +1095,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Rename an emoji.
-        https://api.slack.com/methods/admin.emoji.rename
+        https://docs.slack.dev/reference/methods/admin.emoji.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;new_name&#34;: new_name})
         return self.api_call(&#34;admin.emoji.rename&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1110,7 +1110,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Look up functions by a set of apps
-        https://api.slack.com/methods/admin.functions.list
+        https://docs.slack.dev/reference/methods/admin.functions.list
         &#34;&#34;&#34;
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -1133,7 +1133,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lookup the visibility of multiple Slack functions
         and include the users if it is limited to particular named entities.
-        https://api.slack.com/methods/admin.functions.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
         &#34;&#34;&#34;
         if isinstance(function_ids, (list, tuple)):
             kwargs.update({&#34;function_ids&#34;: &#34;,&#34;.join(function_ids)})
@@ -1151,7 +1151,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set the visibility of a Slack function
         and define the users or workspaces if it is set to named_entities
-        https://api.slack.com/methods/admin.functions.permissions.set
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1175,7 +1175,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Adds members to the specified role with the specified scopes
-        https://api.slack.com/methods/admin.roles.addAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.addAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;role_id&#34;: role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1200,7 +1200,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists assignments for all roles across entities.
             Options to scope results by any combination of roles or entities
-        https://api.slack.com/methods/admin.roles.listAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.listAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;sort_dir&#34;: sort_dir})
         if isinstance(entity_ids, (list, tuple)):
@@ -1222,7 +1222,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Removes a set of users from a role for the given scopes and entities
-        https://api.slack.com/methods/admin.roles.removeAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
         &#34;&#34;&#34;
         kwargs.update({&#34;role_id&#34;: role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1244,7 +1244,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Wipes all valid sessions on all devices for a given user.
-        https://api.slack.com/methods/admin.users.session.reset
+        https://docs.slack.dev/reference/methods/admin.users.session.reset
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1264,7 +1264,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-        https://api.slack.com/methods/admin.users.session.resetBulk
+        https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1286,7 +1286,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Invalidate a single session for a user by session_id.
-        https://api.slack.com/methods/admin.users.session.invalidate
+        https://docs.slack.dev/reference/methods/admin.users.session.invalidate
         &#34;&#34;&#34;
         kwargs.update({&#34;session_id&#34;: session_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.users.session.invalidate&#34;, params=kwargs)
@@ -1301,7 +1301,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists all active user sessions for an organization
-        https://api.slack.com/methods/admin.users.session.list
+        https://docs.slack.dev/reference/methods/admin.users.session.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1321,7 +1321,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set the default channels of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1338,7 +1338,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Get user-specific session settings—the session duration
         and what happens when the client closes—given a list of users.
-        https://api.slack.com/methods/admin.users.session.getSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.getSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1356,7 +1356,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Configure the user-level session settings—the session duration
         and what happens when the client closes—for one or more users.
-        https://api.slack.com/methods/admin.users.session.setSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.setSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1378,7 +1378,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Clear user-specific session settings—the session duration
         and what happens when the client closes—for a list of users.
-        https://api.slack.com/methods/admin.users.session.clearSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
         &#34;&#34;&#34;
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -1395,7 +1395,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Ask Slackbot to send you an export listing all workspace members using unsupported software,
         presented as a zipped CSV file.
-        https://api.slack.com/methods/admin.users.unsupportedVersions.export
+        https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1413,7 +1413,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Approve a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.approve
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.inviteRequests.approve&#34;, params=kwargs)
@@ -1427,7 +1427,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all approved workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.approved.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1447,7 +1447,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all denied workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.denied.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1466,7 +1466,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Deny a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.deny
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.inviteRequests.deny&#34;, params=kwargs)
@@ -1487,7 +1487,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.inviteRequests.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1508,7 +1508,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Create an Enterprise team.
-        https://api.slack.com/methods/admin.teams.create
+        https://docs.slack.dev/reference/methods/admin.teams.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1528,7 +1528,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all teams on an Enterprise organization.
-        https://api.slack.com/methods/admin.teams.list
+        https://docs.slack.dev/reference/methods/admin.teams.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)
@@ -1542,7 +1542,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.teams.owners.list
+        https://docs.slack.dev/reference/methods/admin.teams.owners.list
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;admin.teams.owners.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1554,7 +1554,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Fetch information about settings in a workspace
-        https://api.slack.com/methods/admin.teams.settings.info
+        https://docs.slack.dev/reference/methods/admin.teams.settings.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         return self.api_call(&#34;admin.teams.settings.info&#34;, params=kwargs)
@@ -1567,7 +1567,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set the description of a given workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDescription
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;description&#34;: description})
         return self.api_call(&#34;admin.teams.settings.setDescription&#34;, params=kwargs)
@@ -1580,7 +1580,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;discoverability&#34;: discoverability})
         return self.api_call(&#34;admin.teams.settings.setDiscoverability&#34;, params=kwargs)
@@ -1593,7 +1593,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setIcon
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;image_url&#34;: image_url})
         return self.api_call(&#34;admin.teams.settings.setIcon&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -1606,7 +1606,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setName
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setName
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;name&#34;: name})
         return self.api_call(&#34;admin.teams.settings.setName&#34;, params=kwargs)
@@ -1620,7 +1620,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.addChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;usergroup_id&#34;: usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1638,7 +1638,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Associate one or more default workspaces with an organization-wide IDP group.
-        https://api.slack.com/methods/admin.usergroups.addTeams
+        https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup_id&#34;: usergroup_id, &#34;auto_provision&#34;: auto_provision})
         if isinstance(team_ids, (list, tuple)):
@@ -1656,7 +1656,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.listChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1675,7 +1675,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.removeChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup_id&#34;: usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1695,7 +1695,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add an Enterprise user to a workspace.
-        https://api.slack.com/methods/admin.users.assign
+        https://docs.slack.dev/reference/methods/admin.users.assign
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1727,7 +1727,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Invite a user to a workspace.
-        https://api.slack.com/methods/admin.users.invite
+        https://docs.slack.dev/reference/methods/admin.users.invite
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1751,7 +1751,7 @@ el.replaceWith(d);
     def admin_users_list(
         self,
         *,
-        team_id: str,
+        team_id: Optional[str] = None,
         include_deactivated_user_workspaces: Optional[bool] = None,
         is_active: Optional[bool] = None,
         cursor: Optional[str] = None,
@@ -1759,7 +1759,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List users on a workspace
-        https://api.slack.com/methods/admin.users.list
+        https://docs.slack.dev/reference/methods/admin.users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -1780,7 +1780,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Remove a user from a workspace.
-        https://api.slack.com/methods/admin.users.remove
+        https://docs.slack.dev/reference/methods/admin.users.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.remove&#34;, params=kwargs)
@@ -1793,7 +1793,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set an existing guest, regular user, or owner to be an admin user.
-        https://api.slack.com/methods/admin.users.setAdmin
+        https://docs.slack.dev/reference/methods/admin.users.setAdmin
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setAdmin&#34;, params=kwargs)
@@ -1807,7 +1807,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set an expiration for a guest user.
-        https://api.slack.com/methods/admin.users.setExpiration
+        https://docs.slack.dev/reference/methods/admin.users.setExpiration
         &#34;&#34;&#34;
         kwargs.update({&#34;expiration_ts&#34;: expiration_ts, &#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setExpiration&#34;, params=kwargs)
@@ -1820,7 +1820,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set an existing guest, regular user, or admin user to be a workspace owner.
-        https://api.slack.com/methods/admin.users.setOwner
+        https://docs.slack.dev/reference/methods/admin.users.setOwner
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setOwner&#34;, params=kwargs)
@@ -1833,7 +1833,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set an existing guest user, admin user, or owner to be a regular user.
-        https://api.slack.com/methods/admin.users.setRegular
+        https://docs.slack.dev/reference/methods/admin.users.setRegular
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
         return self.api_call(&#34;admin.users.setRegular&#34;, params=kwargs)
@@ -1854,7 +1854,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Search workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.search
+        https://docs.slack.dev/reference/methods/admin.workflows.search
         &#34;&#34;&#34;
         if collaborator_ids is not None:
             if isinstance(collaborator_ids, (list, tuple)):
@@ -1884,7 +1884,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Look up the permissions for a set of workflows
-        https://api.slack.com/methods/admin.workflows.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
         &#34;&#34;&#34;
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -1905,7 +1905,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add collaborators to workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.add
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
         &#34;&#34;&#34;
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -1925,7 +1925,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Remove collaborators from workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.remove
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
         &#34;&#34;&#34;
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -1944,7 +1944,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Unpublish workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.unpublish
+        https://docs.slack.dev/reference/methods/admin.workflows.unpublish
         &#34;&#34;&#34;
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -1959,7 +1959,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Checks API calling code.
-        https://api.slack.com/methods/api.test
+        https://docs.slack.dev/reference/methods/api.test
         &#34;&#34;&#34;
         kwargs.update({&#34;error&#34;: error})
         return self.api_call(&#34;api.test&#34;, params=kwargs)
@@ -1972,7 +1972,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Generate a temporary Socket Mode WebSocket URL that your app can connect to
         in order to receive events and interactive payloads
-        https://api.slack.com/methods/apps.connections.open
+        https://docs.slack.dev/reference/methods/apps.connections.open
         &#34;&#34;&#34;
         kwargs.update({&#34;token&#34;: app_token})
         return self.api_call(&#34;apps.connections.open&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -1987,7 +1987,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Get a list of authorizations for the given event context.
         Each authorization represents an app installation that the event is visible to.
-        https://api.slack.com/methods/apps.event.authorizations.list
+        https://docs.slack.dev/reference/methods/apps.event.authorizations.list
         &#34;&#34;&#34;
         kwargs.update({&#34;event_context&#34;: event_context, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;apps.event.authorizations.list&#34;, params=kwargs)
@@ -2000,7 +2000,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Uninstalls your app from a workspace.
-        https://api.slack.com/methods/apps.uninstall
+        https://docs.slack.dev/reference/methods/apps.uninstall
         &#34;&#34;&#34;
         kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret})
         return self.api_call(&#34;apps.uninstall&#34;, params=kwargs)
@@ -2012,7 +2012,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Create an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.create
+        https://docs.slack.dev/reference/methods/apps.manifest.create
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2027,7 +2027,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Permanently deletes an app created through app manifests
-        https://api.slack.com/methods/apps.manifest.delete
+        https://docs.slack.dev/reference/methods/apps.manifest.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         return self.api_call(&#34;apps.manifest.delete&#34;, params=kwargs)
@@ -2039,7 +2039,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Export an app manifest from an existing app
-        https://api.slack.com/methods/apps.manifest.export
+        https://docs.slack.dev/reference/methods/apps.manifest.export
         &#34;&#34;&#34;
         kwargs.update({&#34;app_id&#34;: app_id})
         return self.api_call(&#34;apps.manifest.export&#34;, params=kwargs)
@@ -2052,7 +2052,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Update an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.update
+        https://docs.slack.dev/reference/methods/apps.manifest.update
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2069,7 +2069,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Validate an app manifest
-        https://api.slack.com/methods/apps.manifest.validate
+        https://docs.slack.dev/reference/methods/apps.manifest.validate
         &#34;&#34;&#34;
         if isinstance(manifest, str):
             kwargs.update({&#34;manifest&#34;: manifest})
@@ -2085,7 +2085,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Exchanges a refresh token for a new app configuration token
-        https://api.slack.com/methods/tooling.tokens.rotate
+        https://docs.slack.dev/reference/methods/tooling.tokens.rotate
         &#34;&#34;&#34;
         kwargs.update({&#34;refresh_token&#34;: refresh_token})
         return self.api_call(&#34;tooling.tokens.rotate&#34;, params=kwargs)
@@ -2099,7 +2099,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setStatus
+        https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status})
         return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)
@@ -2113,7 +2113,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setTitle
+        https://docs.slack.dev/reference/methods/assistant.threads.setTitle
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;title&#34;: title})
         return self.api_call(&#34;assistant.threads.setTitle&#34;, params=kwargs)
@@ -2128,7 +2128,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+        https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
         if title is not None:
@@ -2142,7 +2142,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Revokes a token.
-        https://api.slack.com/methods/auth.revoke
+        https://docs.slack.dev/reference/methods/auth.revoke
         &#34;&#34;&#34;
         kwargs.update({&#34;test&#34;: test})
         return self.api_call(&#34;auth.revoke&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2152,7 +2152,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Checks authentication &amp; identity.
-        https://api.slack.com/methods/auth.test
+        https://docs.slack.dev/reference/methods/auth.test
         &#34;&#34;&#34;
         return self.api_call(&#34;auth.test&#34;, params=kwargs)
 
@@ -2164,7 +2164,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List the workspaces a token can access.
-        https://api.slack.com/methods/auth.teams.list
+        https://docs.slack.dev/reference/methods/auth.teams.list
         &#34;&#34;&#34;
         kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;include_icon&#34;: include_icon})
         return self.api_call(&#34;auth.teams.list&#34;, params=kwargs)
@@ -2182,7 +2182,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Add bookmark to a channel.
-        https://api.slack.com/methods/bookmarks.add
+        https://docs.slack.dev/reference/methods/bookmarks.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2208,7 +2208,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Edit bookmark.
-        https://api.slack.com/methods/bookmarks.edit
+        https://docs.slack.dev/reference/methods/bookmarks.edit
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2228,7 +2228,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List bookmark for the channel.
-        https://api.slack.com/methods/bookmarks.list
+        https://docs.slack.dev/reference/methods/bookmarks.list
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;bookmarks.list&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2241,7 +2241,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Remove bookmark from the channel.
-        https://api.slack.com/methods/bookmarks.remove
+        https://docs.slack.dev/reference/methods/bookmarks.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;bookmark_id&#34;: bookmark_id, &#34;channel_id&#34;: channel_id})
         return self.api_call(&#34;bookmarks.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2254,7 +2254,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets information about a bot user.
-        https://api.slack.com/methods/bots.info
+        https://docs.slack.dev/reference/methods/bots.info
         &#34;&#34;&#34;
         kwargs.update({&#34;bot&#34;: bot, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;bots.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2273,7 +2273,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Registers a new Call.
-        https://api.slack.com/methods/calls.add
+        https://docs.slack.dev/reference/methods/calls.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2300,7 +2300,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Ends a Call.
-        https://api.slack.com/methods/calls.end
+        https://docs.slack.dev/reference/methods/calls.end
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id, &#34;duration&#34;: duration})
         return self.api_call(&#34;calls.end&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2312,7 +2312,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Returns information about a Call.
-        https://api.slack.com/methods/calls.info
+        https://docs.slack.dev/reference/methods/calls.info
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         return self.api_call(&#34;calls.info&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2325,7 +2325,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Registers new participants added to a Call.
-        https://api.slack.com/methods/calls.participants.add
+        https://docs.slack.dev/reference/methods/calls.participants.add
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         _update_call_participants(kwargs, users)
@@ -2339,7 +2339,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Registers participants removed from a Call.
-        https://api.slack.com/methods/calls.participants.remove
+        https://docs.slack.dev/reference/methods/calls.participants.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;id&#34;: id})
         _update_call_participants(kwargs, users)
@@ -2355,7 +2355,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Updates information about a Call.
-        https://api.slack.com/methods/calls.update
+        https://docs.slack.dev/reference/methods/calls.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2375,7 +2375,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Create Canvas for a user
-        https://api.slack.com/methods/canvases.create
+        https://docs.slack.dev/reference/methods/canvases.create
         &#34;&#34;&#34;
         kwargs.update({&#34;title&#34;: title, &#34;document_content&#34;: document_content})
         return self.api_call(&#34;canvases.create&#34;, json=kwargs)
@@ -2388,7 +2388,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Update an existing canvas
-        https://api.slack.com/methods/canvases.edit
+        https://docs.slack.dev/reference/methods/canvases.edit
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;changes&#34;: changes})
         return self.api_call(&#34;canvases.edit&#34;, json=kwargs)
@@ -2400,7 +2400,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Deletes a canvas
-        https://api.slack.com/methods/canvases.delete
+        https://docs.slack.dev/reference/methods/canvases.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id})
         return self.api_call(&#34;canvases.delete&#34;, params=kwargs)
@@ -2415,7 +2415,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sets the access level to a canvas for specified entities
-        https://api.slack.com/methods/canvases.access.set
+        https://docs.slack.dev/reference/methods/canvases.access.set
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;access_level&#34;: access_level})
         if channel_ids is not None:
@@ -2440,7 +2440,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Create a Channel Canvas for a channel
-        https://api.slack.com/methods/canvases.access.delete
+        https://docs.slack.dev/reference/methods/canvases.access.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id})
         if channel_ids is not None:
@@ -2463,7 +2463,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Find sections matching the provided criteria
-        https://api.slack.com/methods/canvases.sections.lookup
+        https://docs.slack.dev/reference/methods/canvases.sections.lookup
         &#34;&#34;&#34;
         kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;criteria&#34;: json.dumps(criteria)})
         return self.api_call(&#34;canvases.sections.lookup&#34;, params=kwargs)
@@ -2471,7 +2471,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: channels.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def channels_archive(
@@ -2650,7 +2650,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Deletes a message.
-        https://api.slack.com/methods/chat.delete
+        https://docs.slack.dev/reference/methods/chat.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts, &#34;as_user&#34;: as_user})
         return self.api_call(&#34;chat.delete&#34;, params=kwargs)
@@ -2664,7 +2664,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Deletes a scheduled message.
-        https://api.slack.com/methods/chat.deleteScheduledMessage
+        https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2683,7 +2683,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieve a permalink URL for a specific extant message
-        https://api.slack.com/methods/chat.getPermalink
+        https://docs.slack.dev/reference/methods/chat.getPermalink
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;message_ts&#34;: message_ts})
         return self.api_call(&#34;chat.getPermalink&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -2696,7 +2696,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Share a me message into a channel.
-        https://api.slack.com/methods/chat.meMessage
+        https://docs.slack.dev/reference/methods/chat.meMessage
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;text&#34;: text})
         return self.api_call(&#34;chat.meMessage&#34;, params=kwargs)
@@ -2716,10 +2716,11 @@ el.replaceWith(d);
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sends an ephemeral message to a user in a channel.
-        https://api.slack.com/methods/chat.postEphemeral
+        https://docs.slack.dev/reference/methods/chat.postEphemeral
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2735,11 +2736,12 @@ el.replaceWith(d);
                 &#34;link_names&#34;: link_names,
                 &#34;username&#34;: username,
                 &#34;parse&#34;: parse,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.postEphemeral&#34;, json=kwargs)
 
@@ -2763,10 +2765,11 @@ el.replaceWith(d);
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sends a message to a channel.
-        https://api.slack.com/methods/chat.postMessage
+        https://docs.slack.dev/reference/methods/chat.postMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2787,11 +2790,12 @@ el.replaceWith(d);
                 &#34;username&#34;: username,
                 &#34;parse&#34;: parse,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postMessage&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.postMessage&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.postMessage&#34;, json=kwargs)
 
@@ -2800,7 +2804,7 @@ el.replaceWith(d);
         *,
         channel: str,
         post_at: Union[str, int],
-        text: str,
+        text: Optional[str] = None,
         as_user: Optional[bool] = None,
         attachments: Optional[Union[str, Sequence[Union[Dict, Attachment]]]] = None,
         blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
@@ -2811,10 +2815,11 @@ el.replaceWith(d);
         unfurl_media: Optional[bool] = None,
         link_names: Optional[bool] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Schedules a message.
-        https://api.slack.com/methods/chat.scheduleMessage
+        https://docs.slack.dev/reference/methods/chat.scheduleMessage
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2831,11 +2836,12 @@ el.replaceWith(d);
                 &#34;unfurl_media&#34;: unfurl_media,
                 &#34;link_names&#34;: link_names,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
         # NOTE: intentionally using json over params for the API methods using blocks/attachments
         return self.api_call(&#34;chat.scheduleMessage&#34;, json=kwargs)
 
@@ -2854,7 +2860,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Provide custom unfurl behavior for user-posted URLs.
-        https://api.slack.com/methods/chat.unfurl
+        https://docs.slack.dev/reference/methods/chat.unfurl
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2888,10 +2894,11 @@ el.replaceWith(d);
         parse: Optional[str] = None,  # none, full
         reply_broadcast: Optional[bool] = None,
         metadata: Optional[Union[Dict, Metadata]] = None,
+        markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Updates a message in a channel.
-        https://api.slack.com/methods/chat.update
+        https://docs.slack.dev/reference/methods/chat.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2905,6 +2912,7 @@ el.replaceWith(d);
                 &#34;parse&#34;: parse,
                 &#34;reply_broadcast&#34;: reply_broadcast,
                 &#34;metadata&#34;: metadata,
+                &#34;markdown_text&#34;: markdown_text,
             }
         )
         if isinstance(file_ids, (list, tuple)):
@@ -2913,7 +2921,7 @@ el.replaceWith(d);
             kwargs.update({&#34;file_ids&#34;: file_ids})
         _parse_web_class_objects(kwargs)
         kwargs = _remove_none_values(kwargs)
-        _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.update&#34;, kwargs)
+        _warn_if_message_text_content_is_missing(&#34;chat.update&#34;, kwargs)
         # NOTE: intentionally using json over params for API methods using blocks/attachments
         return self.api_call(&#34;chat.update&#34;, json=kwargs)
 
@@ -2929,7 +2937,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists all scheduled messages.
-        https://api.slack.com/methods/chat.scheduledMessages.list
+        https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -2955,7 +2963,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Accepts an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.acceptSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
         &#34;&#34;&#34;
         if channel_id is None and invite_id is None:
             raise e.SlackRequestError(&#34;Either channel_id or invite_id must be provided.&#34;)
@@ -2979,7 +2987,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Approves an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.approveSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
         return self.api_call(&#34;conversations.approveSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -2991,7 +2999,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Archives a conversation.
-        https://api.slack.com/methods/conversations.archive
+        https://docs.slack.dev/reference/methods/conversations.archive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.archive&#34;, params=kwargs)
@@ -3003,7 +3011,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Closes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.close
+        https://docs.slack.dev/reference/methods/conversations.close
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.close&#34;, params=kwargs)
@@ -3017,7 +3025,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Initiates a public or private channel-based conversation
-        https://api.slack.com/methods/conversations.create
+        https://docs.slack.dev/reference/methods/conversations.create
         &#34;&#34;&#34;
         kwargs.update({&#34;name&#34;: name, &#34;is_private&#34;: is_private, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;conversations.create&#34;, params=kwargs)
@@ -3030,7 +3038,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Declines a Slack Connect channel invite.
-        https://api.slack.com/methods/conversations.declineSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
         return self.api_call(&#34;conversations.declineSharedInvite&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3039,7 +3047,7 @@ el.replaceWith(d);
         self, *, action: str, channel: str, target_team: str, **kwargs
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-        https://api.slack.com/methods/conversations.externalInvitePermissions.set
+        https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3063,7 +3071,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Fetches a conversation&#39;s history of messages and events.
-        https://api.slack.com/methods/conversations.history
+        https://docs.slack.dev/reference/methods/conversations.history
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3087,7 +3095,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieve information about a conversation.
-        https://api.slack.com/methods/conversations.info
+        https://docs.slack.dev/reference/methods/conversations.info
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3107,7 +3115,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Invites users to a channel.
-        https://api.slack.com/methods/conversations.invite
+        https://docs.slack.dev/reference/methods/conversations.invite
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3130,7 +3138,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sends an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.inviteShared
+        https://docs.slack.dev/reference/methods/conversations.inviteShared
         &#34;&#34;&#34;
         if emails is None and user_ids is None:
             raise e.SlackRequestError(&#34;Either emails or user ids must be provided.&#34;)
@@ -3152,7 +3160,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Joins an existing conversation.
-        https://api.slack.com/methods/conversations.join
+        https://docs.slack.dev/reference/methods/conversations.join
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.join&#34;, params=kwargs)
@@ -3165,7 +3173,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Removes a user from a conversation.
-        https://api.slack.com/methods/conversations.kick
+        https://docs.slack.dev/reference/methods/conversations.kick
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;user&#34;: user})
         return self.api_call(&#34;conversations.kick&#34;, params=kwargs)
@@ -3177,7 +3185,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Leaves a conversation.
-        https://api.slack.com/methods/conversations.leave
+        https://docs.slack.dev/reference/methods/conversations.leave
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.leave&#34;, params=kwargs)
@@ -3193,7 +3201,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists all channels in a Slack team.
-        https://api.slack.com/methods/conversations.list
+        https://docs.slack.dev/reference/methods/conversations.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3219,7 +3227,7 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List shared channel invites that have been generated
         or received but have not yet been approved by all parties.
-        https://api.slack.com/methods/conversations.listConnectInvites
+        https://docs.slack.dev/reference/methods/conversations.listConnectInvites
         &#34;&#34;&#34;
         kwargs.update({&#34;count&#34;: count, &#34;cursor&#34;: cursor, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;conversations.listConnectInvites&#34;, params=kwargs)
@@ -3232,7 +3240,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sets the read cursor in a channel.
-        https://api.slack.com/methods/conversations.mark
+        https://docs.slack.dev/reference/methods/conversations.mark
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts})
         return self.api_call(&#34;conversations.mark&#34;, params=kwargs)
@@ -3246,7 +3254,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieve members of a conversation.
-        https://api.slack.com/methods/conversations.members
+        https://docs.slack.dev/reference/methods/conversations.members
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
         return self.api_call(&#34;conversations.members&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3260,7 +3268,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Opens or resumes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.open
+        https://docs.slack.dev/reference/methods/conversations.open
         &#34;&#34;&#34;
         if channel is None and users is None:
             raise e.SlackRequestError(&#34;Either channel or users must be provided.&#34;)
@@ -3279,7 +3287,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Renames a conversation.
-        https://api.slack.com/methods/conversations.rename
+        https://docs.slack.dev/reference/methods/conversations.rename
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name})
         return self.api_call(&#34;conversations.rename&#34;, params=kwargs)
@@ -3298,7 +3306,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieve a thread of messages posted to a conversation
-        https://api.slack.com/methods/conversations.replies
+        https://docs.slack.dev/reference/methods/conversations.replies
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3324,7 +3332,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-        https://api.slack.com/methods/conversations.requestSharedInvite.approve
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3345,7 +3353,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Deny a request to invite an external user to a channel.
-        https://api.slack.com/methods/conversations.requestSharedInvite.deny
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
         &#34;&#34;&#34;
         kwargs.update({&#34;invite_id&#34;: invite_id, &#34;message&#34;: message})
         return self.api_call(&#34;conversations.requestSharedInvite.deny&#34;, params=kwargs)
@@ -3363,7 +3371,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists requests to add external users to channels with ability to filter.
-        https://api.slack.com/methods/conversations.requestSharedInvite.list
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3390,7 +3398,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sets the purpose for a conversation.
-        https://api.slack.com/methods/conversations.setPurpose
+        https://docs.slack.dev/reference/methods/conversations.setPurpose
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;purpose&#34;: purpose})
         return self.api_call(&#34;conversations.setPurpose&#34;, params=kwargs)
@@ -3403,7 +3411,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Sets the topic for a conversation.
-        https://api.slack.com/methods/conversations.setTopic
+        https://docs.slack.dev/reference/methods/conversations.setTopic
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;topic&#34;: topic})
         return self.api_call(&#34;conversations.setTopic&#34;, params=kwargs)
@@ -3415,7 +3423,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Reverses conversation archival.
-        https://api.slack.com/methods/conversations.unarchive
+        https://docs.slack.dev/reference/methods/conversations.unarchive
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;conversations.unarchive&#34;, params=kwargs)
@@ -3428,7 +3436,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Create a Channel Canvas for a channel
-        https://api.slack.com/methods/conversations.canvases.create
+        https://docs.slack.dev/reference/methods/conversations.canvases.create
         &#34;&#34;&#34;
         kwargs.update({&#34;channel_id&#34;: channel_id, &#34;document_content&#34;: document_content})
         return self.api_call(&#34;conversations.canvases.create&#34;, json=kwargs)
@@ -3441,7 +3449,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Open a dialog with a user.
-        https://api.slack.com/methods/dialog.open
+        https://docs.slack.dev/reference/methods/dialog.open
         &#34;&#34;&#34;
         kwargs.update({&#34;dialog&#34;: dialog, &#34;trigger_id&#34;: trigger_id})
         kwargs = _remove_none_values(kwargs)
@@ -3453,7 +3461,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Ends the current user&#39;s Do Not Disturb session immediately.
-        https://api.slack.com/methods/dnd.endDnd
+        https://docs.slack.dev/reference/methods/dnd.endDnd
         &#34;&#34;&#34;
         return self.api_call(&#34;dnd.endDnd&#34;, params=kwargs)
 
@@ -3462,7 +3470,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Ends the current user&#39;s snooze mode immediately.
-        https://api.slack.com/methods/dnd.endSnooze
+        https://docs.slack.dev/reference/methods/dnd.endSnooze
         &#34;&#34;&#34;
         return self.api_call(&#34;dnd.endSnooze&#34;, params=kwargs)
 
@@ -3474,7 +3482,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieves a user&#39;s current Do Not Disturb status.
-        https://api.slack.com/methods/dnd.info
+        https://docs.slack.dev/reference/methods/dnd.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
         return self.api_call(&#34;dnd.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3486,7 +3494,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Turns on Do Not Disturb mode for the current user, or changes its duration.
-        https://api.slack.com/methods/dnd.setSnooze
+        https://docs.slack.dev/reference/methods/dnd.setSnooze
         &#34;&#34;&#34;
         kwargs.update({&#34;num_minutes&#34;: num_minutes})
         return self.api_call(&#34;dnd.setSnooze&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3498,7 +3506,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieves the Do Not Disturb status for users on a team.
-        https://api.slack.com/methods/dnd.teamInfo
+        https://docs.slack.dev/reference/methods/dnd.teamInfo
         &#34;&#34;&#34;
         if isinstance(users, (list, tuple)):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -3513,7 +3521,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists custom emoji for a team.
-        https://api.slack.com/methods/emoji.list
+        https://docs.slack.dev/reference/methods/emoji.list
         &#34;&#34;&#34;
         kwargs.update({&#34;include_categories&#34;: include_categories})
         return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3526,7 +3534,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Deletes an existing comment on a file.
-        https://api.slack.com/methods/files.comments.delete
+        https://docs.slack.dev/reference/methods/files.comments.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file, &#34;id&#34;: id})
         return self.api_call(&#34;files.comments.delete&#34;, params=kwargs)
@@ -3538,7 +3546,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Deletes a file.
-        https://api.slack.com/methods/files.delete
+        https://docs.slack.dev/reference/methods/files.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.delete&#34;, params=kwargs)
@@ -3554,7 +3562,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets information about a team file.
-        https://api.slack.com/methods/files.info
+        https://docs.slack.dev/reference/methods/files.info
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3582,7 +3590,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists &amp; filters team files.
-        https://api.slack.com/methods/files.list
+        https://docs.slack.dev/reference/methods/files.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3610,7 +3618,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.info
+        https://docs.slack.dev/reference/methods/files.remote.info
         &#34;&#34;&#34;
         kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
         return self.api_call(&#34;files.remote.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -3626,7 +3634,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.list
+        https://docs.slack.dev/reference/methods/files.remote.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3651,7 +3659,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Adds a file from a remote service.
-        https://api.slack.com/methods/files.remote.add
+        https://docs.slack.dev/reference/methods/files.remote.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3690,7 +3698,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Updates an existing remote file.
-        https://api.slack.com/methods/files.remote.update
+        https://docs.slack.dev/reference/methods/files.remote.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3725,7 +3733,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Remove a remote file.
-        https://api.slack.com/methods/files.remote.remove
+        https://docs.slack.dev/reference/methods/files.remote.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
         return self.api_call(&#34;files.remote.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)
@@ -3739,7 +3747,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Share a remote file into a channel.
-        https://api.slack.com/methods/files.remote.share
+        https://docs.slack.dev/reference/methods/files.remote.share
         &#34;&#34;&#34;
         if external_id is None and file is None:
             raise e.SlackRequestError(&#34;Either external_id or file must be provided.&#34;)
@@ -3757,7 +3765,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Revokes public/external sharing access for a file
-        https://api.slack.com/methods/files.revokePublicURL
+        https://docs.slack.dev/reference/methods/files.revokePublicURL
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.revokePublicURL&#34;, params=kwargs)
@@ -3769,7 +3777,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Enables a file for public/external sharing.
-        https://api.slack.com/methods/files.sharedPublicURL
+        https://docs.slack.dev/reference/methods/files.sharedPublicURL
         &#34;&#34;&#34;
         kwargs.update({&#34;file&#34;: file})
         return self.api_call(&#34;files.sharedPublicURL&#34;, params=kwargs)
@@ -3788,7 +3796,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Uploads or creates a file.
-        https://api.slack.com/methods/files.upload
+        https://docs.slack.dev/reference/methods/files.upload
         &#34;&#34;&#34;
         _print_files_upload_v2_suggestion()
 
@@ -3841,12 +3849,12 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;This wrapper method provides an easy way to upload files using the following endpoints:
 
-        - step1: https://api.slack.com/methods/files.getUploadURLExternal
+        - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
         - step2: &#34;https://files.slack.com/upload/v1/...&#34; URLs returned from files.getUploadURLExternal API
 
-        - step3: https://api.slack.com/methods/files.completeUploadExternal
-            and https://api.slack.com/methods/files.info
+        - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+            and https://docs.slack.dev/reference/methods/files.info
 
         &#34;&#34;&#34;
         if file is None and content is None and file_uploads is None:
@@ -3932,7 +3940,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets a URL for an edge external upload.
-        https://api.slack.com/methods/files.getUploadURLExternal
+        https://docs.slack.dev/reference/methods/files.getUploadURLExternal
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -3955,7 +3963,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Finishes an upload started with files.getUploadURLExternal.
-        https://api.slack.com/methods/files.completeUploadExternal
+        https://docs.slack.dev/reference/methods/files.completeUploadExternal
         &#34;&#34;&#34;
         _files = [{k: v for k, v in f.items() if v is not None} for f in files]
         kwargs.update(
@@ -3978,7 +3986,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Signal the successful completion of a function
-        https://api.slack.com/methods/functions.completeSuccess
+        https://docs.slack.dev/reference/methods/functions.completeSuccess
         &#34;&#34;&#34;
         kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;outputs&#34;: json.dumps(outputs)})
         return self.api_call(&#34;functions.completeSuccess&#34;, params=kwargs)
@@ -3991,7 +3999,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Signal the failure to execute a function
-        https://api.slack.com/methods/functions.completeError
+        https://docs.slack.dev/reference/methods/functions.completeError
         &#34;&#34;&#34;
         kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;error&#34;: error})
         return self.api_call(&#34;functions.completeError&#34;, params=kwargs)
@@ -3999,7 +4007,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def groups_archive(
@@ -4180,7 +4188,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: im.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def im_close(
@@ -4256,7 +4264,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;For Enterprise Grid workspaces, map local user IDs to global user IDs
-        https://api.slack.com/methods/migration.exchange
+        https://docs.slack.dev/reference/methods/migration.exchange
         &#34;&#34;&#34;
         if isinstance(users, (list, tuple)):
             kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -4268,7 +4276,7 @@ el.replaceWith(d);
     # --------------------------
     # Deprecated: mpim.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def mpim_close(
@@ -4355,7 +4363,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.v2.access
+        https://docs.slack.dev/reference/methods/oauth.v2.access
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4381,7 +4389,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.access
+        https://docs.slack.dev/reference/methods/oauth.access
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4401,7 +4409,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
-        https://api.slack.com/methods/oauth.v2.exchange
+        https://docs.slack.dev/reference/methods/oauth.v2.exchange
         &#34;&#34;&#34;
         kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token})
         return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)
@@ -4417,7 +4425,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.token
+        https://docs.slack.dev/reference/methods/openid.connect.token
         &#34;&#34;&#34;
         if redirect_uri is not None:
             kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -4438,7 +4446,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Get the identity of a user who has authorized Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.userInfo
+        https://docs.slack.dev/reference/methods/openid.connect.userInfo
         &#34;&#34;&#34;
         return self.api_call(&#34;openid.connect.userInfo&#34;, params=kwargs)
 
@@ -4450,7 +4458,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Pins an item to a channel.
-        https://api.slack.com/methods/pins.add
+        https://docs.slack.dev/reference/methods/pins.add
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;pins.add&#34;, params=kwargs)
@@ -4462,7 +4470,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists items pinned to a channel.
-        https://api.slack.com/methods/pins.list
+        https://docs.slack.dev/reference/methods/pins.list
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel})
         return self.api_call(&#34;pins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4475,7 +4483,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Un-pins an item from a channel.
-        https://api.slack.com/methods/pins.remove
+        https://docs.slack.dev/reference/methods/pins.remove
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;pins.remove&#34;, params=kwargs)
@@ -4489,7 +4497,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Adds a reaction to an item.
-        https://api.slack.com/methods/reactions.add
+        https://docs.slack.dev/reference/methods/reactions.add
         &#34;&#34;&#34;
         kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name, &#34;timestamp&#34;: timestamp})
         return self.api_call(&#34;reactions.add&#34;, params=kwargs)
@@ -4505,7 +4513,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets reactions for an item.
-        https://api.slack.com/methods/reactions.get
+        https://docs.slack.dev/reference/methods/reactions.get
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4531,7 +4539,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists reactions made by a user.
-        https://api.slack.com/methods/reactions.list
+        https://docs.slack.dev/reference/methods/reactions.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4557,7 +4565,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Removes a reaction from an item.
-        https://api.slack.com/methods/reactions.remove
+        https://docs.slack.dev/reference/methods/reactions.remove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4581,7 +4589,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Creates a reminder.
-        https://api.slack.com/methods/reminders.add
+        https://docs.slack.dev/reference/methods/reminders.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4602,7 +4610,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Marks a reminder as complete.
-        https://api.slack.com/methods/reminders.complete
+        https://docs.slack.dev/reference/methods/reminders.complete
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.complete&#34;, params=kwargs)
@@ -4615,7 +4623,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Deletes a reminder.
-        https://api.slack.com/methods/reminders.delete
+        https://docs.slack.dev/reference/methods/reminders.delete
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.delete&#34;, params=kwargs)
@@ -4628,7 +4636,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets information about a reminder.
-        https://api.slack.com/methods/reminders.info
+        https://docs.slack.dev/reference/methods/reminders.info
         &#34;&#34;&#34;
         kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4640,7 +4648,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists all reminders created by or for a given user.
-        https://api.slack.com/methods/reminders.list
+        https://docs.slack.dev/reference/methods/reminders.list
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id})
         return self.api_call(&#34;reminders.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4653,7 +4661,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.connect
+        https://docs.slack.dev/reference/methods/rtm.connect
         &#34;&#34;&#34;
         kwargs.update({&#34;batch_presence_aware&#34;: batch_presence_aware, &#34;presence_sub&#34;: presence_sub})
         return self.api_call(&#34;rtm.connect&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4671,7 +4679,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.start
+        https://docs.slack.dev/reference/methods/rtm.start
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4699,7 +4707,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Searches for messages and files matching a query.
-        https://api.slack.com/methods/search.all
+        https://docs.slack.dev/reference/methods/search.all
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4727,7 +4735,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Searches for files matching a query.
-        https://api.slack.com/methods/search.files
+        https://docs.slack.dev/reference/methods/search.files
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4756,7 +4764,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Searches for messages matching a query.
-        https://api.slack.com/methods/search.messages
+        https://docs.slack.dev/reference/methods/search.messages
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4782,7 +4790,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Adds a star to an item.
-        https://api.slack.com/methods/stars.add
+        https://docs.slack.dev/reference/methods/stars.add
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4805,7 +4813,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists stars for a user.
-        https://api.slack.com/methods/stars.list
+        https://docs.slack.dev/reference/methods/stars.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4828,7 +4836,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Removes a star from an item.
-        https://api.slack.com/methods/stars.remove
+        https://docs.slack.dev/reference/methods/stars.remove
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4852,7 +4860,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets the access logs for the current team.
-        https://api.slack.com/methods/team.accessLogs
+        https://docs.slack.dev/reference/methods/team.accessLogs
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4874,7 +4882,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets billable users information for the current team.
-        https://api.slack.com/methods/team.billableInfo
+        https://docs.slack.dev/reference/methods/team.billableInfo
         &#34;&#34;&#34;
         kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
         return self.api_call(&#34;team.billableInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4884,7 +4892,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Reads a workspace&#39;s billing plan information.
-        https://api.slack.com/methods/team.billing.info
+        https://docs.slack.dev/reference/methods/team.billing.info
         &#34;&#34;&#34;
         return self.api_call(&#34;team.billing.info&#34;, params=kwargs)
 
@@ -4895,7 +4903,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Disconnects an external organization.
-        https://api.slack.com/methods/team.externalTeams.disconnect
+        https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4917,7 +4925,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
-        https://api.slack.com/methods/team.externalTeams.list
+        https://docs.slack.dev/reference/methods/team.externalTeams.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4948,7 +4956,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets information about the current team.
-        https://api.slack.com/methods/team.info
+        https://docs.slack.dev/reference/methods/team.info
         &#34;&#34;&#34;
         kwargs.update({&#34;team&#34;: team, &#34;domain&#34;: domain})
         return self.api_call(&#34;team.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4966,7 +4974,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets the integration logs for the current team.
-        https://api.slack.com/methods/team.integrationLogs
+        https://docs.slack.dev/reference/methods/team.integrationLogs
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -4988,7 +4996,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieve a team&#39;s profile.
-        https://api.slack.com/methods/team.profile.get
+        https://docs.slack.dev/reference/methods/team.profile.get
         &#34;&#34;&#34;
         kwargs.update({&#34;visibility&#34;: visibility})
         return self.api_call(&#34;team.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -4998,7 +5006,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieve a list of a workspace&#39;s team preferences.
-        https://api.slack.com/methods/team.preferences.list
+        https://docs.slack.dev/reference/methods/team.preferences.list
         &#34;&#34;&#34;
         return self.api_call(&#34;team.preferences.list&#34;, params=kwargs)
 
@@ -5014,7 +5022,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Create a User Group
-        https://api.slack.com/methods/usergroups.create
+        https://docs.slack.dev/reference/methods/usergroups.create
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5040,7 +5048,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Disable an existing User Group
-        https://api.slack.com/methods/usergroups.disable
+        https://docs.slack.dev/reference/methods/usergroups.disable
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;usergroups.disable&#34;, params=kwargs)
@@ -5054,7 +5062,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Enable a User Group
-        https://api.slack.com/methods/usergroups.enable
+        https://docs.slack.dev/reference/methods/usergroups.enable
         &#34;&#34;&#34;
         kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
         return self.api_call(&#34;usergroups.enable&#34;, params=kwargs)
@@ -5069,7 +5077,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all User Groups for a team
-        https://api.slack.com/methods/usergroups.list
+        https://docs.slack.dev/reference/methods/usergroups.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5094,7 +5102,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Update an existing User Group
-        https://api.slack.com/methods/usergroups.update
+        https://docs.slack.dev/reference/methods/usergroups.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5121,7 +5129,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List all users in a User Group
-        https://api.slack.com/methods/usergroups.users.list
+        https://docs.slack.dev/reference/methods/usergroups.users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5142,7 +5150,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Update the list of users for a User Group
-        https://api.slack.com/methods/usergroups.users.update
+        https://docs.slack.dev/reference/methods/usergroups.users.update
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5169,7 +5177,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;List conversations the calling user may access.
-        https://api.slack.com/methods/users.conversations
+        https://docs.slack.dev/reference/methods/users.conversations
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5191,7 +5199,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Delete the user profile photo
-        https://api.slack.com/methods/users.deletePhoto
+        https://docs.slack.dev/reference/methods/users.deletePhoto
         &#34;&#34;&#34;
         return self.api_call(&#34;users.deletePhoto&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
@@ -5202,7 +5210,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets user presence information.
-        https://api.slack.com/methods/users.getPresence
+        https://docs.slack.dev/reference/methods/users.getPresence
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user})
         return self.api_call(&#34;users.getPresence&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5212,7 +5220,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Get a user&#39;s identity.
-        https://api.slack.com/methods/users.identity
+        https://docs.slack.dev/reference/methods/users.identity
         &#34;&#34;&#34;
         return self.api_call(&#34;users.identity&#34;, http_verb=&#34;GET&#34;, params=kwargs)
 
@@ -5224,7 +5232,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Gets information about a user.
-        https://api.slack.com/methods/users.info
+        https://docs.slack.dev/reference/methods/users.info
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user, &#34;include_locale&#34;: include_locale})
         return self.api_call(&#34;users.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5239,7 +5247,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lists all users in a Slack team.
-        https://api.slack.com/methods/users.list
+        https://docs.slack.dev/reference/methods/users.list
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5258,7 +5266,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Find a user with an email address.
-        https://api.slack.com/methods/users.lookupByEmail
+        https://docs.slack.dev/reference/methods/users.lookupByEmail
         &#34;&#34;&#34;
         kwargs.update({&#34;email&#34;: email})
         return self.api_call(&#34;users.lookupByEmail&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5273,7 +5281,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set the user profile photo
-        https://api.slack.com/methods/users.setPhoto
+        https://docs.slack.dev/reference/methods/users.setPhoto
         &#34;&#34;&#34;
         kwargs.update({&#34;crop_w&#34;: crop_w, &#34;crop_x&#34;: crop_x, &#34;crop_y&#34;: crop_y})
         return self.api_call(&#34;users.setPhoto&#34;, files={&#34;image&#34;: image}, data=kwargs)
@@ -5285,7 +5293,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Manually sets user presence.
-        https://api.slack.com/methods/users.setPresence
+        https://docs.slack.dev/reference/methods/users.setPresence
         &#34;&#34;&#34;
         kwargs.update({&#34;presence&#34;: presence})
         return self.api_call(&#34;users.setPresence&#34;, params=kwargs)
@@ -5296,7 +5304,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Lookup an email address to see if someone is on Slack
-        https://api.slack.com/methods/users.discoverableContacts.lookup
+        https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
         &#34;&#34;&#34;
         kwargs.update({&#34;email&#34;: email})
         return self.api_call(&#34;users.discoverableContacts.lookup&#34;, params=kwargs)
@@ -5309,7 +5317,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Retrieves a user&#39;s profile information.
-        https://api.slack.com/methods/users.profile.get
+        https://docs.slack.dev/reference/methods/users.profile.get
         &#34;&#34;&#34;
         kwargs.update({&#34;user&#34;: user, &#34;include_labels&#34;: include_labels})
         return self.api_call(&#34;users.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)
@@ -5324,7 +5332,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Set the profile information for a user.
-        https://api.slack.com/methods/users.profile.set
+        https://docs.slack.dev/reference/methods/users.profile.set
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5347,8 +5355,8 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Open a view for a user.
-        https://api.slack.com/methods/views.open
-        See https://api.slack.com/surfaces/modals for details.
+        https://docs.slack.dev/reference/methods/views.open
+        See https://docs.slack.dev/surfaces/modals/ for details.
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
         if isinstance(view, View):
@@ -5371,9 +5379,9 @@ el.replaceWith(d);
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/surfaces/modals)
+        Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
         to learn more about the lifecycle and intricacies of views.
-        https://api.slack.com/methods/views.push
+        https://docs.slack.dev/reference/methods/views.push
         &#34;&#34;&#34;
         kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
         if isinstance(view, View):
@@ -5396,9 +5404,9 @@ el.replaceWith(d);
         &#34;&#34;&#34;Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+        See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
-        https://api.slack.com/methods/views.update
+        https://docs.slack.dev/reference/methods/views.update
         &#34;&#34;&#34;
         if isinstance(view, View):
             kwargs.update({&#34;view&#34;: view.to_dict()})
@@ -5425,8 +5433,8 @@ el.replaceWith(d);
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Publish a static view for a User.
         Create or update the view that comprises an
-        app&#39;s Home tab (https://api.slack.com/surfaces/tabs)
-        https://api.slack.com/methods/views.publish
+        app&#39;s Home tab (https://docs.slack.dev/surfaces/app-home/)
+        https://docs.slack.dev/reference/methods/views.publish
         &#34;&#34;&#34;
         kwargs.update({&#34;user_id&#34;: user_id, &#34;hash&#34;: hash})
         if isinstance(view, View):
@@ -5437,6 +5445,72 @@ el.replaceWith(d);
         # NOTE: Intentionally using json for the &#34;view&#34; parameter
         return self.api_call(&#34;views.publish&#34;, json=kwargs)
 
+    def workflows_featured_add(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Add featured workflows to a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.add
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.add&#34;, params=kwargs)
+
+    def workflows_featured_list(
+        self,
+        *,
+        channel_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;List the featured workflows for specified channels.
+        https://docs.slack.dev/reference/methods/workflows.featured.list
+        &#34;&#34;&#34;
+        if isinstance(channel_ids, (list, tuple)):
+            kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
+        else:
+            kwargs.update({&#34;channel_ids&#34;: channel_ids})
+        return self.api_call(&#34;workflows.featured.list&#34;, params=kwargs)
+
+    def workflows_featured_remove(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Remove featured workflows from a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.remove
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.remove&#34;, params=kwargs)
+
+    def workflows_featured_set(
+        self,
+        *,
+        channel_id: str,
+        trigger_ids: Union[str, Sequence[str]],
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Set featured workflows for a channel.
+        https://docs.slack.dev/reference/methods/workflows.featured.set
+        &#34;&#34;&#34;
+        kwargs.update({&#34;channel_id&#34;: channel_id})
+        if isinstance(trigger_ids, (list, tuple)):
+            kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+        else:
+            kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+        return self.api_call(&#34;workflows.featured.set&#34;, params=kwargs)
+
     def workflows_stepCompleted(
         self,
         *,
@@ -5445,7 +5519,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Indicate a successful outcome of a workflow step&#39;s execution.
-        https://api.slack.com/methods/workflows.stepCompleted
+        https://docs.slack.dev/reference/methods/workflows.stepCompleted
         &#34;&#34;&#34;
         kwargs.update({&#34;workflow_step_execute_id&#34;: workflow_step_execute_id})
         if outputs is not None:
@@ -5462,7 +5536,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Indicate an unsuccessful outcome of a workflow step&#39;s execution.
-        https://api.slack.com/methods/workflows.stepFailed
+        https://docs.slack.dev/reference/methods/workflows.stepFailed
         &#34;&#34;&#34;
         kwargs.update(
             {
@@ -5483,7 +5557,7 @@ el.replaceWith(d);
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
         &#34;&#34;&#34;Update the configuration for a workflow extension step.
-        https://api.slack.com/methods/workflows.updateStep
+        https://docs.slack.dev/reference/methods/workflows.updateStep
         &#34;&#34;&#34;
         kwargs.update({&#34;workflow_step_edit_id&#34;: workflow_step_edit_id})
         if inputs is not None:
@@ -5495,7 +5569,7 @@ el.replaceWith(d);
         return self.api_call(&#34;workflows.updateStep&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>A WebClient allows apps to communicate with the Slack Platform's Web API.</p>
-<p><a href="https://api.slack.com/methods">https://api.slack.com/methods</a></p>
+<p><a href="https://docs.slack.dev/reference/methods">https://docs.slack.dev/reference/methods</a></p>
 <p>The Slack Web API is an interface for querying information from
 and enacting change in a Slack workspace.</p>
 <p>This client handles constructing and sending HTTP requests to Slack
@@ -5575,7 +5649,7 @@ removed at anytime.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieve analytics data for a given date, presented as a compressed JSON file
-    https://api.slack.com/methods/admin.analytics.getFile
+    https://docs.slack.dev/reference/methods/admin.analytics.getFile
     &#34;&#34;&#34;
     kwargs.update({&#34;type&#34;: type})
     if date is not None:
@@ -5585,7 +5659,7 @@ removed at anytime.</p></div>
     return self.api_call(&#34;admin.analytics.getFile&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve analytics data for a given date, presented as a compressed JSON file
-<a href="https://api.slack.com/methods/admin.analytics.getFile">https://api.slack.com/methods/admin.analytics.getFile</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.analytics.getFile">https://docs.slack.dev/reference/methods/admin.analytics.getFile</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_activities_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_activities_list</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>component_id: str | None = None,<br>component_type: str | None = None,<br>log_event_type: str | None = None,<br>max_date_created: int | None = None,<br>min_date_created: int | None = None,<br>min_log_level: str | None = None,<br>sort_direction: str | None = None,<br>source: str | None = None,<br>team_id: str | None = None,<br>trace_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5614,7 +5688,7 @@ removed at anytime.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Get logs for a specified team/org
-    https://api.slack.com/methods/admin.apps.activities.list
+    https://docs.slack.dev/reference/methods/admin.apps.activities.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5636,7 +5710,7 @@ removed at anytime.</p></div>
     return self.api_call(&#34;admin.apps.activities.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get logs for a specified team/org
-<a href="https://api.slack.com/methods/admin.apps.activities.list">https://api.slack.com/methods/admin.apps.activities.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.activities.list">https://docs.slack.dev/reference/methods/admin.apps.activities.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_approve"><code class="name flex">
 <span>def <span class="ident">admin_apps_approve</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>request_id: str | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5659,7 +5733,7 @@ removed at anytime.</p></div>
     Either app_id or request_id is required.
     These IDs can be obtained either directly via the app_requested event,
     or by the admin.apps.requests.list method.
-    https://api.slack.com/methods/admin.apps.approve
+    https://docs.slack.dev/reference/methods/admin.apps.approve
     &#34;&#34;&#34;
     if app_id:
         kwargs.update({&#34;app_id&#34;: app_id})
@@ -5680,7 +5754,7 @@ removed at anytime.</p></div>
 Either app_id or request_id is required.
 These IDs can be obtained either directly via the app_requested event,
 or by the admin.apps.requests.list method.
-<a href="https://api.slack.com/methods/admin.apps.approve">https://api.slack.com/methods/admin.apps.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.approve">https://docs.slack.dev/reference/methods/admin.apps.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_approved_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_approved_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5700,7 +5774,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List approved apps for an org or workspace.
-    https://api.slack.com/methods/admin.apps.approved.list
+    https://docs.slack.dev/reference/methods/admin.apps.approved.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5713,7 +5787,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.approved.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List approved apps for an org or workspace.
-<a href="https://api.slack.com/methods/admin.apps.approved.list">https://api.slack.com/methods/admin.apps.approved.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.approved.list">https://docs.slack.dev/reference/methods/admin.apps.approved.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_clearResolution"><code class="name flex">
 <span>def <span class="ident">admin_apps_clearResolution</span></span>(<span>self,<br>*,<br>app_id: str,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5732,7 +5806,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Clear an app resolution
-    https://api.slack.com/methods/admin.apps.clearResolution
+    https://docs.slack.dev/reference/methods/admin.apps.clearResolution
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5744,7 +5818,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.clearResolution&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Clear an app resolution
-<a href="https://api.slack.com/methods/admin.apps.clearResolution">https://api.slack.com/methods/admin.apps.clearResolution</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.clearResolution">https://docs.slack.dev/reference/methods/admin.apps.clearResolution</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_config_lookup"><code class="name flex">
 <span>def <span class="ident">admin_apps_config_lookup</span></span>(<span>self, *, app_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5761,7 +5835,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Look up the app config for connectors by their IDs
-    https://api.slack.com/methods/admin.apps.config.lookup
+    https://docs.slack.dev/reference/methods/admin.apps.config.lookup
     &#34;&#34;&#34;
     if isinstance(app_ids, (list, tuple)):
         kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -5770,7 +5844,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.config.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up the app config for connectors by their IDs
-<a href="https://api.slack.com/methods/admin.apps.config.lookup">https://api.slack.com/methods/admin.apps.config.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.config.lookup">https://docs.slack.dev/reference/methods/admin.apps.config.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_config_set"><code class="name flex">
 <span>def <span class="ident">admin_apps_config_set</span></span>(<span>self,<br>*,<br>app_id: str,<br>domain_restrictions: Dict[str, Any] | None = None,<br>workflow_auth_strategy: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5789,7 +5863,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set the app config for a connector
-    https://api.slack.com/methods/admin.apps.config.set
+    https://docs.slack.dev/reference/methods/admin.apps.config.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5802,7 +5876,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.config.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the app config for a connector
-<a href="https://api.slack.com/methods/admin.apps.config.set">https://api.slack.com/methods/admin.apps.config.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.config.set">https://docs.slack.dev/reference/methods/admin.apps.config.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_requests_cancel"><code class="name flex">
 <span>def <span class="ident">admin_apps_requests_cancel</span></span>(<span>self,<br>*,<br>request_id: str,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5821,7 +5895,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List app requests for a team/workspace.
-    https://api.slack.com/methods/admin.apps.requests.cancel
+    https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5833,7 +5907,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.requests.cancel&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List app requests for a team/workspace.
-<a href="https://api.slack.com/methods/admin.apps.requests.cancel">https://api.slack.com/methods/admin.apps.requests.cancel</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.requests.cancel">https://docs.slack.dev/reference/methods/admin.apps.requests.cancel</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_requests_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_requests_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5852,7 +5926,7 @@ or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List app requests for a team/workspace.
-    https://api.slack.com/methods/admin.apps.requests.list
+    https://docs.slack.dev/reference/methods/admin.apps.requests.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5864,7 +5938,7 @@ or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.requests.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List app requests for a team/workspace.
-<a href="https://api.slack.com/methods/admin.apps.requests.list">https://api.slack.com/methods/admin.apps.requests.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.requests.list">https://docs.slack.dev/reference/methods/admin.apps.requests.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_restrict"><code class="name flex">
 <span>def <span class="ident">admin_apps_restrict</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>request_id: str | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5887,7 +5961,7 @@ or by the admin.apps.requests.list method.
     Exactly one of the team_id or enterprise_id arguments is required, not both.
     Either app_id or request_id is required. These IDs can be obtained either directly
     via the app_requested event, or by the admin.apps.requests.list method.
-    https://api.slack.com/methods/admin.apps.restrict
+    https://docs.slack.dev/reference/methods/admin.apps.restrict
     &#34;&#34;&#34;
     if app_id:
         kwargs.update({&#34;app_id&#34;: app_id})
@@ -5908,7 +5982,7 @@ or by the admin.apps.requests.list method.
 Exactly one of the team_id or enterprise_id arguments is required, not both.
 Either app_id or request_id is required. These IDs can be obtained either directly
 via the app_requested event, or by the admin.apps.requests.list method.
-<a href="https://api.slack.com/methods/admin.apps.restrict">https://api.slack.com/methods/admin.apps.restrict</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.restrict">https://docs.slack.dev/reference/methods/admin.apps.restrict</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_restricted_list"><code class="name flex">
 <span>def <span class="ident">admin_apps_restricted_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>enterprise_id: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5928,7 +6002,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List restricted apps for an org or workspace.
-    https://api.slack.com/methods/admin.apps.restricted.list
+    https://docs.slack.dev/reference/methods/admin.apps.restricted.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -5941,7 +6015,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
     return self.api_call(&#34;admin.apps.restricted.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List restricted apps for an org or workspace.
-<a href="https://api.slack.com/methods/admin.apps.restricted.list">https://api.slack.com/methods/admin.apps.restricted.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.restricted.list">https://docs.slack.dev/reference/methods/admin.apps.restricted.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_apps_uninstall"><code class="name flex">
 <span>def <span class="ident">admin_apps_uninstall</span></span>(<span>self,<br>*,<br>app_id: str,<br>enterprise_id: str | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5961,7 +6035,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Uninstall an app from one or many workspaces, or an entire enterprise organization.
     With an org-level token, enterprise_id or team_ids is required.
-    https://api.slack.com/methods/admin.apps.uninstall
+    https://docs.slack.dev/reference/methods/admin.apps.uninstall
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     if enterprise_id is not None:
@@ -5975,7 +6049,7 @@ via the app_requested event, or by the admin.apps.requests.list method.
 </details>
 <div class="desc"><p>Uninstall an app from one or many workspaces, or an entire enterprise organization.
 With an org-level token, enterprise_id or team_ids is required.
-<a href="https://api.slack.com/methods/admin.apps.uninstall">https://api.slack.com/methods/admin.apps.uninstall</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.apps.uninstall">https://docs.slack.dev/reference/methods/admin.apps.uninstall</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_assignEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_assignEntities</span></span>(<span>self,<br>*,<br>entity_ids: str | Sequence[str],<br>policy_name: str,<br>entity_type: str,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -5994,7 +6068,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Assign entities to a particular authentication policy.
-    https://api.slack.com/methods/admin.auth.policy.assignEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
     &#34;&#34;&#34;
     if isinstance(entity_ids, (list, tuple)):
         kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -6005,7 +6079,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.assignEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Assign entities to a particular authentication policy.
-<a href="https://api.slack.com/methods/admin.auth.policy.assignEntities">https://api.slack.com/methods/admin.auth.policy.assignEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_getEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_getEntities</span></span>(<span>self,<br>*,<br>policy_name: str,<br>cursor: str | None = None,<br>entity_type: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6025,7 +6099,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Fetch all the entities assigned to a particular authentication policy by name.
-    https://api.slack.com/methods/admin.auth.policy.getEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
     &#34;&#34;&#34;
     kwargs.update({&#34;policy_name&#34;: policy_name})
     if cursor is not None:
@@ -6037,7 +6111,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.getEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetch all the entities assigned to a particular authentication policy by name.
-<a href="https://api.slack.com/methods/admin.auth.policy.getEntities">https://api.slack.com/methods/admin.auth.policy.getEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_auth_policy_removeEntities"><code class="name flex">
 <span>def <span class="ident">admin_auth_policy_removeEntities</span></span>(<span>self,<br>*,<br>entity_ids: str | Sequence[str],<br>policy_name: str,<br>entity_type: str,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6056,7 +6130,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Remove specified entities from a specified authentication policy.
-    https://api.slack.com/methods/admin.auth.policy.removeEntities
+    https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
     &#34;&#34;&#34;
     if isinstance(entity_ids, (list, tuple)):
         kwargs.update({&#34;entity_ids&#34;: &#34;,&#34;.join(entity_ids)})
@@ -6067,7 +6141,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.auth.policy.removeEntities&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove specified entities from a specified authentication policy.
-<a href="https://api.slack.com/methods/admin.auth.policy.removeEntities">https://api.slack.com/methods/admin.auth.policy.removeEntities</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities">https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_create"><code class="name flex">
 <span>def <span class="ident">admin_barriers_create</span></span>(<span>self,<br>*,<br>barriered_from_usergroup_ids: str | Sequence[str],<br>primary_usergroup_id: str,<br>restricted_subjects: str | Sequence[str],<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6086,7 +6160,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Create an Information Barrier
-    https://api.slack.com/methods/admin.barriers.create
+    https://docs.slack.dev/reference/methods/admin.barriers.create
     &#34;&#34;&#34;
     kwargs.update({&#34;primary_usergroup_id&#34;: primary_usergroup_id})
     if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -6100,7 +6174,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.create&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.create">https://api.slack.com/methods/admin.barriers.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.create">https://docs.slack.dev/reference/methods/admin.barriers.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_delete"><code class="name flex">
 <span>def <span class="ident">admin_barriers_delete</span></span>(<span>self, *, barrier_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6117,13 +6191,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Delete an existing Information Barrier
-    https://api.slack.com/methods/admin.barriers.delete
+    https://docs.slack.dev/reference/methods/admin.barriers.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;barrier_id&#34;: barrier_id})
     return self.api_call(&#34;admin.barriers.delete&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete an existing Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.delete">https://api.slack.com/methods/admin.barriers.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.delete">https://docs.slack.dev/reference/methods/admin.barriers.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_list"><code class="name flex">
 <span>def <span class="ident">admin_barriers_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6141,7 +6215,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Get all Information Barriers for your organization
-    https://api.slack.com/methods/admin.barriers.list&#34;&#34;&#34;
+    https://docs.slack.dev/reference/methods/admin.barriers.list&#34;&#34;&#34;
     kwargs.update(
         {
             &#34;cursor&#34;: cursor,
@@ -6151,7 +6225,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get all Information Barriers for your organization
-<a href="https://api.slack.com/methods/admin.barriers.list">https://api.slack.com/methods/admin.barriers.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.list">https://docs.slack.dev/reference/methods/admin.barriers.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_barriers_update"><code class="name flex">
 <span>def <span class="ident">admin_barriers_update</span></span>(<span>self,<br>*,<br>barrier_id: str,<br>barriered_from_usergroup_ids: str | Sequence[str],<br>primary_usergroup_id: str,<br>restricted_subjects: str | Sequence[str],<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6171,7 +6245,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Update an existing Information Barrier
-    https://api.slack.com/methods/admin.barriers.update
+    https://docs.slack.dev/reference/methods/admin.barriers.update
     &#34;&#34;&#34;
     kwargs.update({&#34;barrier_id&#34;: barrier_id, &#34;primary_usergroup_id&#34;: primary_usergroup_id})
     if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -6185,7 +6259,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.barriers.update&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing Information Barrier
-<a href="https://api.slack.com/methods/admin.barriers.update">https://api.slack.com/methods/admin.barriers.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.barriers.update">https://docs.slack.dev/reference/methods/admin.barriers.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_archive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_archive</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6202,13 +6276,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Archive a public or private channel.
-    https://api.slack.com/methods/admin.conversations.archive
+    https://docs.slack.dev/reference/methods/admin.conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.archive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archive a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.archive">https://api.slack.com/methods/admin.conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.archive">https://docs.slack.dev/reference/methods/admin.conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_bulkArchive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_bulkArchive</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6225,13 +6299,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Archive public or private channels in bulk.
-    https://api.slack.com/methods/admin.conversations.bulkArchive
+    https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
     return self.api_call(&#34;admin.conversations.bulkArchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archive public or private channels in bulk.
-<a href="https://api.slack.com/methods/admin.conversations.bulkArchive">https://api.slack.com/methods/admin.conversations.bulkArchive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive">https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_bulkDelete"><code class="name flex">
 <span>def <span class="ident">admin_conversations_bulkDelete</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6272,7 +6346,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Move public or private channels in bulk.
-    https://api.slack.com/methods/admin.conversations.bulkMove
+    https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6283,7 +6357,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.bulkMove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Move public or private channels in bulk.
-<a href="https://api.slack.com/methods/admin.conversations.bulkMove">https://api.slack.com/methods/admin.conversations.bulkMove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.bulkMove">https://docs.slack.dev/reference/methods/admin.conversations.bulkMove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_convertToPrivate"><code class="name flex">
 <span>def <span class="ident">admin_conversations_convertToPrivate</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6300,13 +6374,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Convert a public channel to a private channel.
-    https://api.slack.com/methods/admin.conversations.convertToPrivate
+    https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.convertToPrivate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Convert a public channel to a private channel.
-<a href="https://api.slack.com/methods/admin.conversations.convertToPrivate">https://api.slack.com/methods/admin.conversations.convertToPrivate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate">https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_convertToPublic"><code class="name flex">
 <span>def <span class="ident">admin_conversations_convertToPublic</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6323,13 +6397,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Convert a privte channel to a public channel.
-    https://api.slack.com/methods/admin.conversations.convertToPublic
+    https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.convertToPublic&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Convert a privte channel to a public channel.
-<a href="https://api.slack.com/methods/admin.conversations.convertToPublic">https://api.slack.com/methods/admin.conversations.convertToPublic</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic">https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_create"><code class="name flex">
 <span>def <span class="ident">admin_conversations_create</span></span>(<span>self,<br>*,<br>is_private: bool,<br>name: str,<br>description: str | None = None,<br>org_wide: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6350,7 +6424,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Create a public or private channel-based conversation.
-    https://api.slack.com/methods/admin.conversations.create
+    https://docs.slack.dev/reference/methods/admin.conversations.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6364,7 +6438,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a public or private channel-based conversation.
-<a href="https://api.slack.com/methods/admin.conversations.create">https://api.slack.com/methods/admin.conversations.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.create">https://docs.slack.dev/reference/methods/admin.conversations.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_createForObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_createForObjects</span></span>(<span>self,<br>*,<br>object_id: str,<br>salesforce_org_id: str,<br>invite_object_team: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6383,7 +6457,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Create a Salesforce channel for the corresponding object provided.
-    https://api.slack.com/methods/admin.conversations.createForObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
     &#34;&#34;&#34;
     kwargs.update(
         {&#34;object_id&#34;: object_id, &#34;salesforce_org_id&#34;: salesforce_org_id, &#34;invite_object_team&#34;: invite_object_team}
@@ -6391,7 +6465,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.createForObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Salesforce channel for the corresponding object provided.
-<a href="https://api.slack.com/methods/admin.conversations.createForObjects">https://api.slack.com/methods/admin.conversations.createForObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.createForObjects">https://docs.slack.dev/reference/methods/admin.conversations.createForObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_delete"><code class="name flex">
 <span>def <span class="ident">admin_conversations_delete</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6408,13 +6482,13 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Delete a public or private channel.
-    https://api.slack.com/methods/admin.conversations.delete
+    https://docs.slack.dev/reference/methods/admin.conversations.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.delete">https://api.slack.com/methods/admin.conversations.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.delete">https://docs.slack.dev/reference/methods/admin.conversations.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_disconnectShared"><code class="name flex">
 <span>def <span class="ident">admin_conversations_disconnectShared</span></span>(<span>self,<br>*,<br>channel_id: str,<br>leaving_team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6432,7 +6506,7 @@ With an org-level token, enterprise_id or team_ids is required.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Disconnect a connected channel from one or more workspaces.
-    https://api.slack.com/methods/admin.conversations.disconnectShared
+    https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(leaving_team_ids, (list, tuple)):
@@ -6442,7 +6516,7 @@ With an org-level token, enterprise_id or team_ids is required.
     return self.api_call(&#34;admin.conversations.disconnectShared&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disconnect a connected channel from one or more workspaces.
-<a href="https://api.slack.com/methods/admin.conversations.disconnectShared">https://api.slack.com/methods/admin.conversations.disconnectShared</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared">https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_ekm_listOriginalConnectedChannelInfo"><code class="name flex">
 <span>def <span class="ident">admin_conversations_ekm_listOriginalConnectedChannelInfo</span></span>(<span>self,<br>*,<br>channel_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6464,7 +6538,7 @@ With an org-level token, enterprise_id or team_ids is required.
     &#34;&#34;&#34;List all disconnected channels—i.e.,
     channels that were once connected to other workspaces and then disconnected—and
     the corresponding original channel IDs for key revocation with EKM.
-    https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+    https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6485,7 +6559,7 @@ With an org-level token, enterprise_id or team_ids is required.
 <div class="desc"><p>List all disconnected channels—i.e.,
 channels that were once connected to other workspaces and then disconnected—and
 the corresponding original channel IDs for key revocation with EKM.
-<a href="https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo">https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo">https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_getConversationPrefs"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getConversationPrefs</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6502,13 +6576,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Get conversation preferences for a public or private channel.
-    https://api.slack.com/methods/admin.conversations.getConversationPrefs
+    https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.getConversationPrefs&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get conversation preferences for a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.getConversationPrefs">https://api.slack.com/methods/admin.conversations.getConversationPrefs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs">https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_getCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getCustomRetention</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6525,13 +6599,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Get a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.getCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.getCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.getCustomRetention">https://api.slack.com/methods/admin.conversations.getCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_getTeams"><code class="name flex">
 <span>def <span class="ident">admin_conversations_getTeams</span></span>(<span>self,<br>*,<br>channel_id: str,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6550,7 +6624,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a channel.
-    https://api.slack.com/methods/admin.conversations.getTeams
+    https://docs.slack.dev/reference/methods/admin.conversations.getTeams
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6562,7 +6636,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.getTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the workspaces in an Enterprise grid org that connect to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.getTeams">https://api.slack.com/methods/admin.conversations.getTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.getTeams">https://docs.slack.dev/reference/methods/admin.conversations.getTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_invite"><code class="name flex">
 <span>def <span class="ident">admin_conversations_invite</span></span>(<span>self, *, channel_id: str, user_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6580,7 +6654,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Invite a user to a public or private channel.
-    https://api.slack.com/methods/admin.conversations.invite
+    https://docs.slack.dev/reference/methods/admin.conversations.invite
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(user_ids, (list, tuple)):
@@ -6591,7 +6665,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invite a user to a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.invite">https://api.slack.com/methods/admin.conversations.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.invite">https://docs.slack.dev/reference/methods/admin.conversations.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_linkObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_linkObjects</span></span>(<span>self, *, channel: str, record_id: str, salesforce_org_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6610,7 +6684,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Link a Salesforce record to a channel.
-    https://api.slack.com/methods/admin.conversations.linkObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6622,7 +6696,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.linkObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Link a Salesforce record to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.linkObjects">https://api.slack.com/methods/admin.conversations.linkObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.linkObjects">https://docs.slack.dev/reference/methods/admin.conversations.linkObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_lookup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_lookup</span></span>(<span>self,<br>*,<br>last_message_activity_before: int,<br>team_ids: str | Sequence[str],<br>cursor: str | None = None,<br>limit: int | None = None,<br>max_member_count: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6643,7 +6717,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Returns channels on the given team using the filters.
-    https://api.slack.com/methods/admin.conversations.lookup
+    https://docs.slack.dev/reference/methods/admin.conversations.lookup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6660,7 +6734,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns channels on the given team using the filters.
-<a href="https://api.slack.com/methods/admin.conversations.lookup">https://api.slack.com/methods/admin.conversations.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.lookup">https://docs.slack.dev/reference/methods/admin.conversations.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_removeCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_removeCustomRetention</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6677,13 +6751,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Remove a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.removeCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.removeCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.removeCustomRetention">https://api.slack.com/methods/admin.conversations.removeCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_rename"><code class="name flex">
 <span>def <span class="ident">admin_conversations_rename</span></span>(<span>self, *, channel_id: str, name: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6701,13 +6775,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Rename a public or private channel.
-    https://api.slack.com/methods/admin.conversations.rename
+    https://docs.slack.dev/reference/methods/admin.conversations.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;name&#34;: name})
     return self.api_call(&#34;admin.conversations.rename&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Rename a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.rename">https://api.slack.com/methods/admin.conversations.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.rename">https://docs.slack.dev/reference/methods/admin.conversations.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_restrictAccess_addGroup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_addGroup</span></span>(<span>self, *, channel_id: str, group_id: str, team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6726,7 +6800,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Add an allowlist of IDP groups for accessing a channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6742,7 +6816,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>Add an allowlist of IDP groups for accessing a channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup">https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_restrictAccess_listGroups"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_listGroups</span></span>(<span>self, *, channel_id: str, team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6760,7 +6834,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all IDP Groups linked to a channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6775,7 +6849,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>List all IDP Groups linked to a channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups">https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_restrictAccess_removeGroup"><code class="name flex">
 <span>def <span class="ident">admin_conversations_restrictAccess_removeGroup</span></span>(<span>self, *, channel_id: str, group_id: str, team_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6794,7 +6868,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Remove a linked IDP group linked from a private channel.
-    https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+    https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6810,7 +6884,7 @@ the corresponding original channel IDs for key revocation with EKM.
     )</code></pre>
 </details>
 <div class="desc"><p>Remove a linked IDP group linked from a private channel.
-<a href="https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup">https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup">https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_search"><code class="name flex">
 <span>def <span class="ident">admin_conversations_search</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>query: str | None = None,<br>search_channel_types: str | Sequence[str] | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6833,7 +6907,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Search for public or private channels in an Enterprise organization.
-    https://api.slack.com/methods/admin.conversations.search
+    https://docs.slack.dev/reference/methods/admin.conversations.search
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6858,7 +6932,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.search&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Search for public or private channels in an Enterprise organization.
-<a href="https://api.slack.com/methods/admin.conversations.search">https://api.slack.com/methods/admin.conversations.search</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.search">https://docs.slack.dev/reference/methods/admin.conversations.search</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_setConversationPrefs"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setConversationPrefs</span></span>(<span>self, *, channel_id: str, prefs: str | Dict[str, str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6876,7 +6950,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set the posting permissions for a public or private channel.
-    https://api.slack.com/methods/admin.conversations.setConversationPrefs
+    https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     if isinstance(prefs, dict):
@@ -6886,7 +6960,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.setConversationPrefs&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the posting permissions for a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.setConversationPrefs">https://api.slack.com/methods/admin.conversations.setConversationPrefs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs">https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_setCustomRetention"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setCustomRetention</span></span>(<span>self, *, channel_id: str, duration_days: int, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6904,13 +6978,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set a channel&#39;s retention policy
-    https://api.slack.com/methods/admin.conversations.setCustomRetention
+    https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;duration_days&#34;: duration_days})
     return self.api_call(&#34;admin.conversations.setCustomRetention&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set a channel's retention policy
-<a href="https://api.slack.com/methods/admin.conversations.setCustomRetention">https://api.slack.com/methods/admin.conversations.setCustomRetention</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention">https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_setTeams"><code class="name flex">
 <span>def <span class="ident">admin_conversations_setTeams</span></span>(<span>self,<br>*,<br>channel_id: str,<br>org_channel: bool | None = None,<br>target_team_ids: str | Sequence[str] | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6930,7 +7004,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-    https://api.slack.com/methods/admin.conversations.setTeams
+    https://docs.slack.dev/reference/methods/admin.conversations.setTeams
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6946,7 +7020,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.setTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.setTeams">https://api.slack.com/methods/admin.conversations.setTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.setTeams">https://docs.slack.dev/reference/methods/admin.conversations.setTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_unarchive"><code class="name flex">
 <span>def <span class="ident">admin_conversations_unarchive</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6963,13 +7037,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Unarchive a public or private channel.
-    https://api.slack.com/methods/admin.conversations.archive
+    https://docs.slack.dev/reference/methods/admin.conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;admin.conversations.unarchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unarchive a public or private channel.
-<a href="https://api.slack.com/methods/admin.conversations.archive">https://api.slack.com/methods/admin.conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.archive">https://docs.slack.dev/reference/methods/admin.conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_conversations_unlinkObjects"><code class="name flex">
 <span>def <span class="ident">admin_conversations_unlinkObjects</span></span>(<span>self, *, channel: str, new_name: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -6987,7 +7061,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Unlink a Salesforce record from a channel.
-    https://api.slack.com/methods/admin.conversations.unlinkObjects
+    https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -6998,7 +7072,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.conversations.unlinkObjects&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unlink a Salesforce record from a channel.
-<a href="https://api.slack.com/methods/admin.conversations.unlinkObjects">https://api.slack.com/methods/admin.conversations.unlinkObjects</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects">https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_emoji_add"><code class="name flex">
 <span>def <span class="ident">admin_emoji_add</span></span>(<span>self, *, name: str, url: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7016,13 +7090,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Add an emoji.
-    https://api.slack.com/methods/admin.emoji.add
+    https://docs.slack.dev/reference/methods/admin.emoji.add
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;url&#34;: url})
     return self.api_call(&#34;admin.emoji.add&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an emoji.
-<a href="https://api.slack.com/methods/admin.emoji.add">https://api.slack.com/methods/admin.emoji.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.add">https://docs.slack.dev/reference/methods/admin.emoji.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_emoji_addAlias"><code class="name flex">
 <span>def <span class="ident">admin_emoji_addAlias</span></span>(<span>self, *, alias_for: str, name: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7040,13 +7114,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Add an emoji alias.
-    https://api.slack.com/methods/admin.emoji.addAlias
+    https://docs.slack.dev/reference/methods/admin.emoji.addAlias
     &#34;&#34;&#34;
     kwargs.update({&#34;alias_for&#34;: alias_for, &#34;name&#34;: name})
     return self.api_call(&#34;admin.emoji.addAlias&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an emoji alias.
-<a href="https://api.slack.com/methods/admin.emoji.addAlias">https://api.slack.com/methods/admin.emoji.addAlias</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.addAlias">https://docs.slack.dev/reference/methods/admin.emoji.addAlias</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_emoji_list"><code class="name flex">
 <span>def <span class="ident">admin_emoji_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7064,13 +7138,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List emoji for an Enterprise Grid organization.
-    https://api.slack.com/methods/admin.emoji.list
+    https://docs.slack.dev/reference/methods/admin.emoji.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List emoji for an Enterprise Grid organization.
-<a href="https://api.slack.com/methods/admin.emoji.list">https://api.slack.com/methods/admin.emoji.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.list">https://docs.slack.dev/reference/methods/admin.emoji.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_emoji_remove"><code class="name flex">
 <span>def <span class="ident">admin_emoji_remove</span></span>(<span>self, *, name: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7087,13 +7161,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Remove an emoji across an Enterprise Grid organization.
-    https://api.slack.com/methods/admin.emoji.remove
+    https://docs.slack.dev/reference/methods/admin.emoji.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name})
     return self.api_call(&#34;admin.emoji.remove&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove an emoji across an Enterprise Grid organization.
-<a href="https://api.slack.com/methods/admin.emoji.remove">https://api.slack.com/methods/admin.emoji.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.remove">https://docs.slack.dev/reference/methods/admin.emoji.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_emoji_rename"><code class="name flex">
 <span>def <span class="ident">admin_emoji_rename</span></span>(<span>self, *, name: str, new_name: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7111,13 +7185,13 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Rename an emoji.
-    https://api.slack.com/methods/admin.emoji.rename
+    https://docs.slack.dev/reference/methods/admin.emoji.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;new_name&#34;: new_name})
     return self.api_call(&#34;admin.emoji.rename&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Rename an emoji.
-<a href="https://api.slack.com/methods/admin.emoji.rename">https://api.slack.com/methods/admin.emoji.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.emoji.rename">https://docs.slack.dev/reference/methods/admin.emoji.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_functions_list"><code class="name flex">
 <span>def <span class="ident">admin_functions_list</span></span>(<span>self,<br>*,<br>app_ids: str | Sequence[str],<br>team_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7137,7 +7211,7 @@ the corresponding original channel IDs for key revocation with EKM.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Look up functions by a set of apps
-    https://api.slack.com/methods/admin.functions.list
+    https://docs.slack.dev/reference/methods/admin.functions.list
     &#34;&#34;&#34;
     if isinstance(app_ids, (list, tuple)):
         kwargs.update({&#34;app_ids&#34;: &#34;,&#34;.join(app_ids)})
@@ -7153,7 +7227,7 @@ the corresponding original channel IDs for key revocation with EKM.
     return self.api_call(&#34;admin.functions.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up functions by a set of apps
-<a href="https://api.slack.com/methods/admin.functions.list">https://api.slack.com/methods/admin.functions.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.list">https://docs.slack.dev/reference/methods/admin.functions.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_functions_permissions_lookup"><code class="name flex">
 <span>def <span class="ident">admin_functions_permissions_lookup</span></span>(<span>self, *, function_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7171,7 +7245,7 @@ the corresponding original channel IDs for key revocation with EKM.
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lookup the visibility of multiple Slack functions
     and include the users if it is limited to particular named entities.
-    https://api.slack.com/methods/admin.functions.permissions.lookup
+    https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
     &#34;&#34;&#34;
     if isinstance(function_ids, (list, tuple)):
         kwargs.update({&#34;function_ids&#34;: &#34;,&#34;.join(function_ids)})
@@ -7181,7 +7255,7 @@ the corresponding original channel IDs for key revocation with EKM.
 </details>
 <div class="desc"><p>Lookup the visibility of multiple Slack functions
 and include the users if it is limited to particular named entities.
-<a href="https://api.slack.com/methods/admin.functions.permissions.lookup">https://api.slack.com/methods/admin.functions.permissions.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup">https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_functions_permissions_set"><code class="name flex">
 <span>def <span class="ident">admin_functions_permissions_set</span></span>(<span>self,<br>*,<br>function_id: str,<br>visibility: str,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7201,7 +7275,7 @@ and include the users if it is limited to particular named entities.
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set the visibility of a Slack function
     and define the users or workspaces if it is set to named_entities
-    https://api.slack.com/methods/admin.functions.permissions.set
+    https://docs.slack.dev/reference/methods/admin.functions.permissions.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7218,7 +7292,7 @@ and include the users if it is limited to particular named entities.
 </details>
 <div class="desc"><p>Set the visibility of a Slack function
 and define the users or workspaces if it is set to named_entities
-<a href="https://api.slack.com/methods/admin.functions.permissions.set">https://api.slack.com/methods/admin.functions.permissions.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.functions.permissions.set">https://docs.slack.dev/reference/methods/admin.functions.permissions.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_inviteRequests_approve"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_approve</span></span>(<span>self, *, invite_request_id: str, team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7236,13 +7310,13 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Approve a workspace invite request.
-    https://api.slack.com/methods/admin.inviteRequests.approve
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.inviteRequests.approve&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approve a workspace invite request.
-<a href="https://api.slack.com/methods/admin.inviteRequests.approve">https://api.slack.com/methods/admin.inviteRequests.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.approve">https://docs.slack.dev/reference/methods/admin.inviteRequests.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_inviteRequests_approved_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_approved_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7261,7 +7335,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all approved workspace invite requests.
-    https://api.slack.com/methods/admin.inviteRequests.approved.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7273,7 +7347,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.inviteRequests.approved.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all approved workspace invite requests.
-<a href="https://api.slack.com/methods/admin.inviteRequests.approved.list">https://api.slack.com/methods/admin.inviteRequests.approved.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_inviteRequests_denied_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_denied_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7292,7 +7366,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all denied workspace invite requests.
-    https://api.slack.com/methods/admin.inviteRequests.denied.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7304,7 +7378,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.inviteRequests.denied.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all denied workspace invite requests.
-<a href="https://api.slack.com/methods/admin.inviteRequests.denied.list">https://api.slack.com/methods/admin.inviteRequests.denied.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_inviteRequests_deny"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_deny</span></span>(<span>self, *, invite_request_id: str, team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7322,13 +7396,13 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Deny a workspace invite request.
-    https://api.slack.com/methods/admin.inviteRequests.deny
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_request_id&#34;: invite_request_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.inviteRequests.deny&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deny a workspace invite request.
-<a href="https://api.slack.com/methods/admin.inviteRequests.deny">https://api.slack.com/methods/admin.inviteRequests.deny</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.deny">https://docs.slack.dev/reference/methods/admin.inviteRequests.deny</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_inviteRequests_list"><code class="name flex">
 <span>def <span class="ident">admin_inviteRequests_list</span></span>(<span>self, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7364,7 +7438,7 @@ and define the users or workspaces if it is set to named_entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Adds members to the specified role with the specified scopes
-    https://api.slack.com/methods/admin.roles.addAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.addAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;role_id&#34;: role_id})
     if isinstance(entity_ids, (list, tuple)):
@@ -7378,7 +7452,7 @@ and define the users or workspaces if it is set to named_entities
     return self.api_call(&#34;admin.roles.addAssignments&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds members to the specified role with the specified scopes
-<a href="https://api.slack.com/methods/admin.roles.addAssignments">https://api.slack.com/methods/admin.roles.addAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.addAssignments">https://docs.slack.dev/reference/methods/admin.roles.addAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_roles_listAssignments"><code class="name flex">
 <span>def <span class="ident">admin_roles_listAssignments</span></span>(<span>self,<br>*,<br>role_ids: str | Sequence[str] | None = None,<br>entity_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: str | int | None = None,<br>sort_dir: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7400,7 +7474,7 @@ and define the users or workspaces if it is set to named_entities
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists assignments for all roles across entities.
         Options to scope results by any combination of roles or entities
-    https://api.slack.com/methods/admin.roles.listAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.listAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;sort_dir&#34;: sort_dir})
     if isinstance(entity_ids, (list, tuple)):
@@ -7415,7 +7489,7 @@ and define the users or workspaces if it is set to named_entities
 </details>
 <div class="desc"><p>Lists assignments for all roles across entities.
 Options to scope results by any combination of roles or entities
-<a href="https://api.slack.com/methods/admin.roles.listAssignments">https://api.slack.com/methods/admin.roles.listAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.listAssignments">https://docs.slack.dev/reference/methods/admin.roles.listAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_roles_removeAssignments"><code class="name flex">
 <span>def <span class="ident">admin_roles_removeAssignments</span></span>(<span>self,<br>*,<br>role_id: str,<br>entity_ids: str | Sequence[str],<br>user_ids: str | Sequence[str],<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7434,7 +7508,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Removes a set of users from a role for the given scopes and entities
-    https://api.slack.com/methods/admin.roles.removeAssignments
+    https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
     &#34;&#34;&#34;
     kwargs.update({&#34;role_id&#34;: role_id})
     if isinstance(entity_ids, (list, tuple)):
@@ -7448,7 +7522,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.roles.removeAssignments&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a set of users from a role for the given scopes and entities
-<a href="https://api.slack.com/methods/admin.roles.removeAssignments">https://api.slack.com/methods/admin.roles.removeAssignments</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.roles.removeAssignments">https://docs.slack.dev/reference/methods/admin.roles.removeAssignments</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_admins_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_admins_list</span></span>(<span>self, *, team_id: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7467,7 +7541,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all of the admins on a given workspace.
-    https://api.slack.com/methods/admin.inviteRequests.list
+    https://docs.slack.dev/reference/methods/admin.inviteRequests.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7479,7 +7553,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.admins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all of the admins on a given workspace.
-<a href="https://api.slack.com/methods/admin.inviteRequests.list">https://api.slack.com/methods/admin.inviteRequests.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.inviteRequests.list">https://docs.slack.dev/reference/methods/admin.inviteRequests.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_create"><code class="name flex">
 <span>def <span class="ident">admin_teams_create</span></span>(<span>self,<br>*,<br>team_domain: str,<br>team_name: str,<br>team_description: str | None = None,<br>team_discoverability: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7499,7 +7573,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Create an Enterprise team.
-    https://api.slack.com/methods/admin.teams.create
+    https://docs.slack.dev/reference/methods/admin.teams.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7512,7 +7586,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an Enterprise team.
-<a href="https://api.slack.com/methods/admin.teams.create">https://api.slack.com/methods/admin.teams.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.create">https://docs.slack.dev/reference/methods/admin.teams.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_list</span></span>(<span>self, *, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7530,13 +7604,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all teams on an Enterprise organization.
-    https://api.slack.com/methods/admin.teams.list
+    https://docs.slack.dev/reference/methods/admin.teams.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all teams on an Enterprise organization.
-<a href="https://api.slack.com/methods/admin.teams.list">https://api.slack.com/methods/admin.teams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.list">https://docs.slack.dev/reference/methods/admin.teams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_owners_list"><code class="name flex">
 <span>def <span class="ident">admin_teams_owners_list</span></span>(<span>self, *, team_id: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7555,13 +7629,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all of the admins on a given workspace.
-    https://api.slack.com/methods/admin.teams.owners.list
+    https://docs.slack.dev/reference/methods/admin.teams.owners.list
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;admin.teams.owners.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all of the admins on a given workspace.
-<a href="https://api.slack.com/methods/admin.teams.owners.list">https://api.slack.com/methods/admin.teams.owners.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.owners.list">https://docs.slack.dev/reference/methods/admin.teams.owners.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_settings_info"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_info</span></span>(<span>self, *, team_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7578,13 +7652,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Fetch information about settings in a workspace
-    https://api.slack.com/methods/admin.teams.settings.info
+    https://docs.slack.dev/reference/methods/admin.teams.settings.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.teams.settings.info&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetch information about settings in a workspace
-<a href="https://api.slack.com/methods/admin.teams.settings.info">https://api.slack.com/methods/admin.teams.settings.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.info">https://docs.slack.dev/reference/methods/admin.teams.settings.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_settings_setDefaultChannels"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDefaultChannels</span></span>(<span>self, *, team_id: str, channel_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7602,7 +7676,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set the default channels of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7612,7 +7686,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.teams.settings.setDefaultChannels&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the default channels of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDefaultChannels">https://api.slack.com/methods/admin.teams.settings.setDefaultChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels">https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_settings_setDescription"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDescription</span></span>(<span>self, *, team_id: str, description: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7630,13 +7704,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set the description of a given workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDescription
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;description&#34;: description})
     return self.api_call(&#34;admin.teams.settings.setDescription&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the description of a given workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDescription">https://api.slack.com/methods/admin.teams.settings.setDescription</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription">https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_settings_setDiscoverability"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setDiscoverability</span></span>(<span>self, *, team_id: str, discoverability: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7654,13 +7728,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;discoverability&#34;: discoverability})
     return self.api_call(&#34;admin.teams.settings.setDiscoverability&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setDiscoverability">https://api.slack.com/methods/admin.teams.settings.setDiscoverability</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability">https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_settings_setIcon"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setIcon</span></span>(<span>self, *, team_id: str, image_url: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7678,13 +7752,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setIcon
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;image_url&#34;: image_url})
     return self.api_call(&#34;admin.teams.settings.setIcon&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setIcon">https://api.slack.com/methods/admin.teams.settings.setIcon</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon">https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_teams_settings_setName"><code class="name flex">
 <span>def <span class="ident">admin_teams_settings_setName</span></span>(<span>self, *, team_id: str, name: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7702,13 +7776,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sets the icon of a workspace.
-    https://api.slack.com/methods/admin.teams.settings.setName
+    https://docs.slack.dev/reference/methods/admin.teams.settings.setName
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;name&#34;: name})
     return self.api_call(&#34;admin.teams.settings.setName&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the icon of a workspace.
-<a href="https://api.slack.com/methods/admin.teams.settings.setName">https://api.slack.com/methods/admin.teams.settings.setName</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.teams.settings.setName">https://docs.slack.dev/reference/methods/admin.teams.settings.setName</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_usergroups_addChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_addChannels</span></span>(<span>self,<br>*,<br>channel_ids: str | Sequence[str],<br>usergroup_id: str,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7727,7 +7801,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.addChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;usergroup_id&#34;: usergroup_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7737,7 +7811,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.addChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.addChannels">https://api.slack.com/methods/admin.usergroups.addChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.addChannels">https://docs.slack.dev/reference/methods/admin.usergroups.addChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_usergroups_addTeams"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_addTeams</span></span>(<span>self,<br>*,<br>usergroup_id: str,<br>team_ids: str | Sequence[str],<br>auto_provision: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7756,7 +7830,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Associate one or more default workspaces with an organization-wide IDP group.
-    https://api.slack.com/methods/admin.usergroups.addTeams
+    https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup_id&#34;: usergroup_id, &#34;auto_provision&#34;: auto_provision})
     if isinstance(team_ids, (list, tuple)):
@@ -7766,7 +7840,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.addTeams&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Associate one or more default workspaces with an organization-wide IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.addTeams">https://api.slack.com/methods/admin.usergroups.addTeams</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.addTeams">https://docs.slack.dev/reference/methods/admin.usergroups.addTeams</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_usergroups_listChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_listChannels</span></span>(<span>self,<br>*,<br>usergroup_id: str,<br>include_num_members: bool | None = None,<br>team_id: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7785,7 +7859,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.listChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7797,7 +7871,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.listChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.listChannels">https://api.slack.com/methods/admin.usergroups.listChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.listChannels">https://docs.slack.dev/reference/methods/admin.usergroups.listChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_usergroups_removeChannels"><code class="name flex">
 <span>def <span class="ident">admin_usergroups_removeChannels</span></span>(<span>self, *, usergroup_id: str, channel_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7815,7 +7889,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Add one or more default channels to an IDP group.
-    https://api.slack.com/methods/admin.usergroups.removeChannels
+    https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup_id&#34;: usergroup_id})
     if isinstance(channel_ids, (list, tuple)):
@@ -7825,7 +7899,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.usergroups.removeChannels&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add one or more default channels to an IDP group.
-<a href="https://api.slack.com/methods/admin.usergroups.removeChannels">https://api.slack.com/methods/admin.usergroups.removeChannels</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels">https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_assign"><code class="name flex">
 <span>def <span class="ident">admin_users_assign</span></span>(<span>self,<br>*,<br>team_id: str,<br>user_id: str,<br>channel_ids: str | Sequence[str] | None = None,<br>is_restricted: bool | None = None,<br>is_ultra_restricted: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7846,7 +7920,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Add an Enterprise user to a workspace.
-    https://api.slack.com/methods/admin.users.assign
+    https://docs.slack.dev/reference/methods/admin.users.assign
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7863,7 +7937,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.assign&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add an Enterprise user to a workspace.
-<a href="https://api.slack.com/methods/admin.users.assign">https://api.slack.com/methods/admin.users.assign</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.assign">https://docs.slack.dev/reference/methods/admin.users.assign</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_invite"><code class="name flex">
 <span>def <span class="ident">admin_users_invite</span></span>(<span>self,<br>*,<br>team_id: str,<br>email: str,<br>channel_ids: str | Sequence[str],<br>custom_message: str | None = None,<br>email_password_policy_enabled: bool | None = None,<br>guest_expiration_ts: str | float | None = None,<br>is_restricted: bool | None = None,<br>is_ultra_restricted: bool | None = None,<br>real_name: str | None = None,<br>resend: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7889,7 +7963,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Invite a user to a workspace.
-    https://api.slack.com/methods/admin.users.invite
+    https://docs.slack.dev/reference/methods/admin.users.invite
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7911,10 +7985,10 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invite a user to a workspace.
-<a href="https://api.slack.com/methods/admin.users.invite">https://api.slack.com/methods/admin.users.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.invite">https://docs.slack.dev/reference/methods/admin.users.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_list"><code class="name flex">
-<span>def <span class="ident">admin_users_list</span></span>(<span>self,<br>*,<br>team_id: str,<br>include_deactivated_user_workspaces: bool | None = None,<br>is_active: bool | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+<span>def <span class="ident">admin_users_list</span></span>(<span>self,<br>*,<br>team_id: str | None = None,<br>include_deactivated_user_workspaces: bool | None = None,<br>is_active: bool | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -7924,7 +7998,7 @@ Options to scope results by any combination of roles or entities
 <pre><code class="python">def admin_users_list(
     self,
     *,
-    team_id: str,
+    team_id: Optional[str] = None,
     include_deactivated_user_workspaces: Optional[bool] = None,
     is_active: Optional[bool] = None,
     cursor: Optional[str] = None,
@@ -7932,7 +8006,7 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List users on a workspace
-    https://api.slack.com/methods/admin.users.list
+    https://docs.slack.dev/reference/methods/admin.users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -7946,7 +8020,7 @@ Options to scope results by any combination of roles or entities
     return self.api_call(&#34;admin.users.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List users on a workspace
-<a href="https://api.slack.com/methods/admin.users.list">https://api.slack.com/methods/admin.users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.list">https://docs.slack.dev/reference/methods/admin.users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_remove"><code class="name flex">
 <span>def <span class="ident">admin_users_remove</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7964,13 +8038,13 @@ Options to scope results by any combination of roles or entities
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Remove a user from a workspace.
-    https://api.slack.com/methods/admin.users.remove
+    https://docs.slack.dev/reference/methods/admin.users.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a user from a workspace.
-<a href="https://api.slack.com/methods/admin.users.remove">https://api.slack.com/methods/admin.users.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.remove">https://docs.slack.dev/reference/methods/admin.users.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_session_clearSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_clearSettings</span></span>(<span>self, *, user_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -7988,7 +8062,7 @@ Options to scope results by any combination of roles or entities
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Clear user-specific session settings—the session duration
     and what happens when the client closes—for a list of users.
-    https://api.slack.com/methods/admin.users.session.clearSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -7998,7 +8072,7 @@ Options to scope results by any combination of roles or entities
 </details>
 <div class="desc"><p>Clear user-specific session settings—the session duration
 and what happens when the client closes—for a list of users.
-<a href="https://api.slack.com/methods/admin.users.session.clearSettings">https://api.slack.com/methods/admin.users.session.clearSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.clearSettings">https://docs.slack.dev/reference/methods/admin.users.session.clearSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_session_getSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_getSettings</span></span>(<span>self, *, user_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8016,7 +8090,7 @@ and what happens when the client closes—for a list of users.
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Get user-specific session settings—the session duration
     and what happens when the client closes—given a list of users.
-    https://api.slack.com/methods/admin.users.session.getSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.getSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8026,7 +8100,7 @@ and what happens when the client closes—for a list of users.
 </details>
 <div class="desc"><p>Get user-specific session settings—the session duration
 and what happens when the client closes—given a list of users.
-<a href="https://api.slack.com/methods/admin.users.session.getSettings">https://api.slack.com/methods/admin.users.session.getSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.getSettings">https://docs.slack.dev/reference/methods/admin.users.session.getSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_session_invalidate"><code class="name flex">
 <span>def <span class="ident">admin_users_session_invalidate</span></span>(<span>self, *, session_id: str, team_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8044,13 +8118,13 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Invalidate a single session for a user by session_id.
-    https://api.slack.com/methods/admin.users.session.invalidate
+    https://docs.slack.dev/reference/methods/admin.users.session.invalidate
     &#34;&#34;&#34;
     kwargs.update({&#34;session_id&#34;: session_id, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;admin.users.session.invalidate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invalidate a single session for a user by session_id.
-<a href="https://api.slack.com/methods/admin.users.session.invalidate">https://api.slack.com/methods/admin.users.session.invalidate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.invalidate">https://docs.slack.dev/reference/methods/admin.users.session.invalidate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_session_list"><code class="name flex">
 <span>def <span class="ident">admin_users_session_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>user_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8070,7 +8144,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists all active user sessions for an organization
-    https://api.slack.com/methods/admin.users.session.list
+    https://docs.slack.dev/reference/methods/admin.users.session.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8083,7 +8157,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all active user sessions for an organization
-<a href="https://api.slack.com/methods/admin.users.session.list">https://api.slack.com/methods/admin.users.session.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.list">https://docs.slack.dev/reference/methods/admin.users.session.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_session_reset"><code class="name flex">
 <span>def <span class="ident">admin_users_session_reset</span></span>(<span>self,<br>*,<br>user_id: str,<br>mobile_only: bool | None = None,<br>web_only: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8102,7 +8176,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Wipes all valid sessions on all devices for a given user.
-    https://api.slack.com/methods/admin.users.session.reset
+    https://docs.slack.dev/reference/methods/admin.users.session.reset
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8114,7 +8188,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.reset&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Wipes all valid sessions on all devices for a given user.
-<a href="https://api.slack.com/methods/admin.users.session.reset">https://api.slack.com/methods/admin.users.session.reset</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.reset">https://docs.slack.dev/reference/methods/admin.users.session.reset</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_session_resetBulk"><code class="name flex">
 <span>def <span class="ident">admin_users_session_resetBulk</span></span>(<span>self,<br>*,<br>user_ids: str | Sequence[str],<br>mobile_only: bool | None = None,<br>web_only: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8133,7 +8207,7 @@ and what happens when the client closes—given a list of users.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-    https://api.slack.com/methods/admin.users.session.resetBulk
+    https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8148,7 +8222,7 @@ and what happens when the client closes—given a list of users.
     return self.api_call(&#34;admin.users.session.resetBulk&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-<a href="https://api.slack.com/methods/admin.users.session.resetBulk">https://api.slack.com/methods/admin.users.session.resetBulk</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.resetBulk">https://docs.slack.dev/reference/methods/admin.users.session.resetBulk</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_session_setSettings"><code class="name flex">
 <span>def <span class="ident">admin_users_session_setSettings</span></span>(<span>self,<br>*,<br>user_ids: str | Sequence[str],<br>desktop_app_browser_quit: bool | None = None,<br>duration: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8168,7 +8242,7 @@ and what happens when the client closes—given a list of users.
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Configure the user-level session settings—the session duration
     and what happens when the client closes—for one or more users.
-    https://api.slack.com/methods/admin.users.session.setSettings
+    https://docs.slack.dev/reference/methods/admin.users.session.setSettings
     &#34;&#34;&#34;
     if isinstance(user_ids, (list, tuple)):
         kwargs.update({&#34;user_ids&#34;: &#34;,&#34;.join(user_ids)})
@@ -8184,7 +8258,7 @@ and what happens when the client closes—given a list of users.
 </details>
 <div class="desc"><p>Configure the user-level session settings—the session duration
 and what happens when the client closes—for one or more users.
-<a href="https://api.slack.com/methods/admin.users.session.setSettings">https://api.slack.com/methods/admin.users.session.setSettings</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.session.setSettings">https://docs.slack.dev/reference/methods/admin.users.session.setSettings</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_setAdmin"><code class="name flex">
 <span>def <span class="ident">admin_users_setAdmin</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8202,13 +8276,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set an existing guest, regular user, or owner to be an admin user.
-    https://api.slack.com/methods/admin.users.setAdmin
+    https://docs.slack.dev/reference/methods/admin.users.setAdmin
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setAdmin&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest, regular user, or owner to be an admin user.
-<a href="https://api.slack.com/methods/admin.users.setAdmin">https://api.slack.com/methods/admin.users.setAdmin</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setAdmin">https://docs.slack.dev/reference/methods/admin.users.setAdmin</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_setExpiration"><code class="name flex">
 <span>def <span class="ident">admin_users_setExpiration</span></span>(<span>self, *, expiration_ts: int, user_id: str, team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8227,13 +8301,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set an expiration for a guest user.
-    https://api.slack.com/methods/admin.users.setExpiration
+    https://docs.slack.dev/reference/methods/admin.users.setExpiration
     &#34;&#34;&#34;
     kwargs.update({&#34;expiration_ts&#34;: expiration_ts, &#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setExpiration&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an expiration for a guest user.
-<a href="https://api.slack.com/methods/admin.users.setExpiration">https://api.slack.com/methods/admin.users.setExpiration</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setExpiration">https://docs.slack.dev/reference/methods/admin.users.setExpiration</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_setOwner"><code class="name flex">
 <span>def <span class="ident">admin_users_setOwner</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8251,13 +8325,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set an existing guest, regular user, or admin user to be a workspace owner.
-    https://api.slack.com/methods/admin.users.setOwner
+    https://docs.slack.dev/reference/methods/admin.users.setOwner
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setOwner&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest, regular user, or admin user to be a workspace owner.
-<a href="https://api.slack.com/methods/admin.users.setOwner">https://api.slack.com/methods/admin.users.setOwner</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setOwner">https://docs.slack.dev/reference/methods/admin.users.setOwner</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_setRegular"><code class="name flex">
 <span>def <span class="ident">admin_users_setRegular</span></span>(<span>self, *, team_id: str, user_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8275,13 +8349,13 @@ and what happens when the client closes—for one or more users.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set an existing guest user, admin user, or owner to be a regular user.
-    https://api.slack.com/methods/admin.users.setRegular
+    https://docs.slack.dev/reference/methods/admin.users.setRegular
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user_id&#34;: user_id})
     return self.api_call(&#34;admin.users.setRegular&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set an existing guest user, admin user, or owner to be a regular user.
-<a href="https://api.slack.com/methods/admin.users.setRegular">https://api.slack.com/methods/admin.users.setRegular</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.setRegular">https://docs.slack.dev/reference/methods/admin.users.setRegular</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_users_unsupportedVersions_export"><code class="name flex">
 <span>def <span class="ident">admin_users_unsupportedVersions_export</span></span>(<span>self,<br>*,<br>date_end_of_support: str | int | None = None,<br>date_sessions_started: str | int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8300,7 +8374,7 @@ and what happens when the client closes—for one or more users.
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Ask Slackbot to send you an export listing all workspace members using unsupported software,
     presented as a zipped CSV file.
-    https://api.slack.com/methods/admin.users.unsupportedVersions.export
+    https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8312,7 +8386,7 @@ and what happens when the client closes—for one or more users.
 </details>
 <div class="desc"><p>Ask Slackbot to send you an export listing all workspace members using unsupported software,
 presented as a zipped CSV file.
-<a href="https://api.slack.com/methods/admin.users.unsupportedVersions.export">https://api.slack.com/methods/admin.users.unsupportedVersions.export</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export">https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_workflows_collaborators_add"><code class="name flex">
 <span>def <span class="ident">admin_workflows_collaborators_add</span></span>(<span>self,<br>*,<br>collaborator_ids: str | Sequence[str],<br>workflow_ids: str | Sequence[str],<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8330,7 +8404,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Add collaborators to workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.collaborators.add
+    https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
     &#34;&#34;&#34;
     if isinstance(collaborator_ids, (list, tuple)):
         kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -8343,7 +8417,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.collaborators.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add collaborators to workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.collaborators.add">https://api.slack.com/methods/admin.workflows.collaborators.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add">https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_workflows_collaborators_remove"><code class="name flex">
 <span>def <span class="ident">admin_workflows_collaborators_remove</span></span>(<span>self,<br>*,<br>collaborator_ids: str | Sequence[str],<br>workflow_ids: str | Sequence[str],<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8361,7 +8435,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Remove collaborators from workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.collaborators.remove
+    https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
     &#34;&#34;&#34;
     if isinstance(collaborator_ids, (list, tuple)):
         kwargs.update({&#34;collaborator_ids&#34;: &#34;,&#34;.join(collaborator_ids)})
@@ -8374,7 +8448,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.collaborators.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove collaborators from workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.collaborators.remove">https://api.slack.com/methods/admin.workflows.collaborators.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove">https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_workflows_permissions_lookup"><code class="name flex">
 <span>def <span class="ident">admin_workflows_permissions_lookup</span></span>(<span>self,<br>*,<br>workflow_ids: str | Sequence[str],<br>max_workflow_triggers: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8392,7 +8466,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Look up the permissions for a set of workflows
-    https://api.slack.com/methods/admin.workflows.permissions.lookup
+    https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
     &#34;&#34;&#34;
     if isinstance(workflow_ids, (list, tuple)):
         kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -8406,7 +8480,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.permissions.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Look up the permissions for a set of workflows
-<a href="https://api.slack.com/methods/admin.workflows.permissions.lookup">https://api.slack.com/methods/admin.workflows.permissions.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup">https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_workflows_search"><code class="name flex">
 <span>def <span class="ident">admin_workflows_search</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>collaborator_ids: str | Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>no_collaborators: bool | None = None,<br>num_trigger_ids: int | None = None,<br>query: str | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>source: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8432,7 +8506,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Search workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.search
+    https://docs.slack.dev/reference/methods/admin.workflows.search
     &#34;&#34;&#34;
     if collaborator_ids is not None:
         if isinstance(collaborator_ids, (list, tuple)):
@@ -8455,7 +8529,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.search&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Search workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.search">https://api.slack.com/methods/admin.workflows.search</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.search">https://docs.slack.dev/reference/methods/admin.workflows.search</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.admin_workflows_unpublish"><code class="name flex">
 <span>def <span class="ident">admin_workflows_unpublish</span></span>(<span>self, *, workflow_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8472,7 +8546,7 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Unpublish workflows within the team or enterprise
-    https://api.slack.com/methods/admin.workflows.unpublish
+    https://docs.slack.dev/reference/methods/admin.workflows.unpublish
     &#34;&#34;&#34;
     if isinstance(workflow_ids, (list, tuple)):
         kwargs.update({&#34;workflow_ids&#34;: &#34;,&#34;.join(workflow_ids)})
@@ -8481,7 +8555,7 @@ presented as a zipped CSV file.
     return self.api_call(&#34;admin.workflows.unpublish&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Unpublish workflows within the team or enterprise
-<a href="https://api.slack.com/methods/admin.workflows.unpublish">https://api.slack.com/methods/admin.workflows.unpublish</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/admin.workflows.unpublish">https://docs.slack.dev/reference/methods/admin.workflows.unpublish</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.api_test"><code class="name flex">
 <span>def <span class="ident">api_test</span></span>(<span>self, *, error: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8498,13 +8572,13 @@ presented as a zipped CSV file.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Checks API calling code.
-    https://api.slack.com/methods/api.test
+    https://docs.slack.dev/reference/methods/api.test
     &#34;&#34;&#34;
     kwargs.update({&#34;error&#34;: error})
     return self.api_call(&#34;api.test&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Checks API calling code.
-<a href="https://api.slack.com/methods/api.test">https://api.slack.com/methods/api.test</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/api.test">https://docs.slack.dev/reference/methods/api.test</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.apps_connections_open"><code class="name flex">
 <span>def <span class="ident">apps_connections_open</span></span>(<span>self, *, app_token: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8522,14 +8596,14 @@ presented as a zipped CSV file.
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Generate a temporary Socket Mode WebSocket URL that your app can connect to
     in order to receive events and interactive payloads
-    https://api.slack.com/methods/apps.connections.open
+    https://docs.slack.dev/reference/methods/apps.connections.open
     &#34;&#34;&#34;
     kwargs.update({&#34;token&#34;: app_token})
     return self.api_call(&#34;apps.connections.open&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Generate a temporary Socket Mode WebSocket URL that your app can connect to
 in order to receive events and interactive payloads
-<a href="https://api.slack.com/methods/apps.connections.open">https://api.slack.com/methods/apps.connections.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.connections.open">https://docs.slack.dev/reference/methods/apps.connections.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.apps_event_authorizations_list"><code class="name flex">
 <span>def <span class="ident">apps_event_authorizations_list</span></span>(<span>self,<br>*,<br>event_context: str,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8549,14 +8623,14 @@ in order to receive events and interactive payloads
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Get a list of authorizations for the given event context.
     Each authorization represents an app installation that the event is visible to.
-    https://api.slack.com/methods/apps.event.authorizations.list
+    https://docs.slack.dev/reference/methods/apps.event.authorizations.list
     &#34;&#34;&#34;
     kwargs.update({&#34;event_context&#34;: event_context, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;apps.event.authorizations.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a list of authorizations for the given event context.
 Each authorization represents an app installation that the event is visible to.
-<a href="https://api.slack.com/methods/apps.event.authorizations.list">https://api.slack.com/methods/apps.event.authorizations.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.event.authorizations.list">https://docs.slack.dev/reference/methods/apps.event.authorizations.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.apps_manifest_create"><code class="name flex">
 <span>def <span class="ident">apps_manifest_create</span></span>(<span>self, *, manifest: str | Dict[str, Any], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8573,7 +8647,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Create an app from an app manifest
-    https://api.slack.com/methods/apps.manifest.create
+    https://docs.slack.dev/reference/methods/apps.manifest.create
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8582,7 +8656,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create an app from an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.create">https://api.slack.com/methods/apps.manifest.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.create">https://docs.slack.dev/reference/methods/apps.manifest.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.apps_manifest_delete"><code class="name flex">
 <span>def <span class="ident">apps_manifest_delete</span></span>(<span>self, *, app_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8599,13 +8673,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Permanently deletes an app created through app manifests
-    https://api.slack.com/methods/apps.manifest.delete
+    https://docs.slack.dev/reference/methods/apps.manifest.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     return self.api_call(&#34;apps.manifest.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Permanently deletes an app created through app manifests
-<a href="https://api.slack.com/methods/apps.manifest.delete">https://api.slack.com/methods/apps.manifest.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.delete">https://docs.slack.dev/reference/methods/apps.manifest.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.apps_manifest_export"><code class="name flex">
 <span>def <span class="ident">apps_manifest_export</span></span>(<span>self, *, app_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8622,13 +8696,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Export an app manifest from an existing app
-    https://api.slack.com/methods/apps.manifest.export
+    https://docs.slack.dev/reference/methods/apps.manifest.export
     &#34;&#34;&#34;
     kwargs.update({&#34;app_id&#34;: app_id})
     return self.api_call(&#34;apps.manifest.export&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Export an app manifest from an existing app
-<a href="https://api.slack.com/methods/apps.manifest.export">https://api.slack.com/methods/apps.manifest.export</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.export">https://docs.slack.dev/reference/methods/apps.manifest.export</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.apps_manifest_update"><code class="name flex">
 <span>def <span class="ident">apps_manifest_update</span></span>(<span>self, *, app_id: str, manifest: str | Dict[str, Any], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8646,7 +8720,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Update an app from an app manifest
-    https://api.slack.com/methods/apps.manifest.update
+    https://docs.slack.dev/reference/methods/apps.manifest.update
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8656,7 +8730,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an app from an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.update">https://api.slack.com/methods/apps.manifest.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.update">https://docs.slack.dev/reference/methods/apps.manifest.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.apps_manifest_validate"><code class="name flex">
 <span>def <span class="ident">apps_manifest_validate</span></span>(<span>self, *, manifest: str | Dict[str, Any], app_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8674,7 +8748,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Validate an app manifest
-    https://api.slack.com/methods/apps.manifest.validate
+    https://docs.slack.dev/reference/methods/apps.manifest.validate
     &#34;&#34;&#34;
     if isinstance(manifest, str):
         kwargs.update({&#34;manifest&#34;: manifest})
@@ -8684,7 +8758,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;apps.manifest.validate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Validate an app manifest
-<a href="https://api.slack.com/methods/apps.manifest.validate">https://api.slack.com/methods/apps.manifest.validate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.manifest.validate">https://docs.slack.dev/reference/methods/apps.manifest.validate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.apps_uninstall"><code class="name flex">
 <span>def <span class="ident">apps_uninstall</span></span>(<span>self, *, client_id: str, client_secret: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8702,13 +8776,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Uninstalls your app from a workspace.
-    https://api.slack.com/methods/apps.uninstall
+    https://docs.slack.dev/reference/methods/apps.uninstall
     &#34;&#34;&#34;
     kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret})
     return self.api_call(&#34;apps.uninstall&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Uninstalls your app from a workspace.
-<a href="https://api.slack.com/methods/apps.uninstall">https://api.slack.com/methods/apps.uninstall</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/apps.uninstall">https://docs.slack.dev/reference/methods/apps.uninstall</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.assistant_threads_setStatus"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setStatus</span></span>(<span>self, *, channel_id: str, thread_ts: str, status: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8727,13 +8801,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setStatus
+    https://docs.slack.dev/reference/methods/assistant.threads.setStatus
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;status&#34;: status})
     return self.api_call(&#34;assistant.threads.setStatus&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setStatus">https://api.slack.com/methods/assistant.threads.setStatus</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setStatus">https://docs.slack.dev/reference/methods/assistant.threads.setStatus</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.assistant_threads_setSuggestedPrompts"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8753,7 +8827,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+    https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
     if title is not None:
@@ -8761,7 +8835,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setSuggestedPrompts">https://api.slack.com/methods/assistant.threads.setSuggestedPrompts</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts">https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.assistant_threads_setTitle"><code class="name flex">
 <span>def <span class="ident">assistant_threads_setTitle</span></span>(<span>self, *, channel_id: str, thread_ts: str, title: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8780,13 +8854,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/assistant.threads.setTitle
+    https://docs.slack.dev/reference/methods/assistant.threads.setTitle
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;title&#34;: title})
     return self.api_call(&#34;assistant.threads.setTitle&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/assistant.threads.setTitle">https://api.slack.com/methods/assistant.threads.setTitle</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/assistant.threads.setTitle">https://docs.slack.dev/reference/methods/assistant.threads.setTitle</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.auth_revoke"><code class="name flex">
 <span>def <span class="ident">auth_revoke</span></span>(<span>self, *, test: bool | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8803,13 +8877,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Revokes a token.
-    https://api.slack.com/methods/auth.revoke
+    https://docs.slack.dev/reference/methods/auth.revoke
     &#34;&#34;&#34;
     kwargs.update({&#34;test&#34;: test})
     return self.api_call(&#34;auth.revoke&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes a token.
-<a href="https://api.slack.com/methods/auth.revoke">https://api.slack.com/methods/auth.revoke</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.revoke">https://docs.slack.dev/reference/methods/auth.revoke</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.auth_teams_list"><code class="name flex">
 <span>def <span class="ident">auth_teams_list</span></span>(<span>self,<br>cursor: str | None = None,<br>limit: int | None = None,<br>include_icon: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8827,13 +8901,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List the workspaces a token can access.
-    https://api.slack.com/methods/auth.teams.list
+    https://docs.slack.dev/reference/methods/auth.teams.list
     &#34;&#34;&#34;
     kwargs.update({&#34;cursor&#34;: cursor, &#34;limit&#34;: limit, &#34;include_icon&#34;: include_icon})
     return self.api_call(&#34;auth.teams.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List the workspaces a token can access.
-<a href="https://api.slack.com/methods/auth.teams.list">https://api.slack.com/methods/auth.teams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.teams.list">https://docs.slack.dev/reference/methods/auth.teams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.auth_test"><code class="name flex">
 <span>def <span class="ident">auth_test</span></span>(<span>self, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8848,12 +8922,12 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Checks authentication &amp; identity.
-    https://api.slack.com/methods/auth.test
+    https://docs.slack.dev/reference/methods/auth.test
     &#34;&#34;&#34;
     return self.api_call(&#34;auth.test&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Checks authentication &amp; identity.
-<a href="https://api.slack.com/methods/auth.test">https://api.slack.com/methods/auth.test</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/auth.test">https://docs.slack.dev/reference/methods/auth.test</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.bookmarks_add"><code class="name flex">
 <span>def <span class="ident">bookmarks_add</span></span>(<span>self,<br>*,<br>channel_id: str,<br>title: str,<br>type: str,<br>emoji: str | None = None,<br>entity_id: str | None = None,<br>link: str | None = None,<br>parent_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8876,7 +8950,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Add bookmark to a channel.
-    https://api.slack.com/methods/bookmarks.add
+    https://docs.slack.dev/reference/methods/bookmarks.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8892,7 +8966,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;bookmarks.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Add bookmark to a channel.
-<a href="https://api.slack.com/methods/bookmarks.add">https://api.slack.com/methods/bookmarks.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.add">https://docs.slack.dev/reference/methods/bookmarks.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.bookmarks_edit"><code class="name flex">
 <span>def <span class="ident">bookmarks_edit</span></span>(<span>self,<br>*,<br>bookmark_id: str,<br>channel_id: str,<br>emoji: str | None = None,<br>link: str | None = None,<br>title: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8913,7 +8987,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Edit bookmark.
-    https://api.slack.com/methods/bookmarks.edit
+    https://docs.slack.dev/reference/methods/bookmarks.edit
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -8927,7 +9001,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;bookmarks.edit&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Edit bookmark.
-<a href="https://api.slack.com/methods/bookmarks.edit">https://api.slack.com/methods/bookmarks.edit</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.edit">https://docs.slack.dev/reference/methods/bookmarks.edit</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.bookmarks_list"><code class="name flex">
 <span>def <span class="ident">bookmarks_list</span></span>(<span>self, *, channel_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8944,13 +9018,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List bookmark for the channel.
-    https://api.slack.com/methods/bookmarks.list
+    https://docs.slack.dev/reference/methods/bookmarks.list
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;bookmarks.list&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List bookmark for the channel.
-<a href="https://api.slack.com/methods/bookmarks.list">https://api.slack.com/methods/bookmarks.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.list">https://docs.slack.dev/reference/methods/bookmarks.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.bookmarks_remove"><code class="name flex">
 <span>def <span class="ident">bookmarks_remove</span></span>(<span>self, *, bookmark_id: str, channel_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8968,13 +9042,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Remove bookmark from the channel.
-    https://api.slack.com/methods/bookmarks.remove
+    https://docs.slack.dev/reference/methods/bookmarks.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;bookmark_id&#34;: bookmark_id, &#34;channel_id&#34;: channel_id})
     return self.api_call(&#34;bookmarks.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove bookmark from the channel.
-<a href="https://api.slack.com/methods/bookmarks.remove">https://api.slack.com/methods/bookmarks.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bookmarks.remove">https://docs.slack.dev/reference/methods/bookmarks.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.bots_info"><code class="name flex">
 <span>def <span class="ident">bots_info</span></span>(<span>self, *, bot: str | None = None, team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -8992,13 +9066,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets information about a bot user.
-    https://api.slack.com/methods/bots.info
+    https://docs.slack.dev/reference/methods/bots.info
     &#34;&#34;&#34;
     kwargs.update({&#34;bot&#34;: bot, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;bots.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a bot user.
-<a href="https://api.slack.com/methods/bots.info">https://api.slack.com/methods/bots.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/bots.info">https://docs.slack.dev/reference/methods/bots.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.calls_add"><code class="name flex">
 <span>def <span class="ident">calls_add</span></span>(<span>self,<br>*,<br>external_unique_id: str,<br>join_url: str,<br>created_by: str | None = None,<br>date_start: int | None = None,<br>desktop_app_join_url: str | None = None,<br>external_display_id: str | None = None,<br>title: str | None = None,<br>users: str | Sequence[Dict[str, str]] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9022,7 +9096,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Registers a new Call.
-    https://api.slack.com/methods/calls.add
+    https://docs.slack.dev/reference/methods/calls.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9042,7 +9116,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;calls.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers a new Call.
-<a href="https://api.slack.com/methods/calls.add">https://api.slack.com/methods/calls.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.add">https://docs.slack.dev/reference/methods/calls.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.calls_end"><code class="name flex">
 <span>def <span class="ident">calls_end</span></span>(<span>self, *, id: str, duration: int | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9060,13 +9134,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Ends a Call.
-    https://api.slack.com/methods/calls.end
+    https://docs.slack.dev/reference/methods/calls.end
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id, &#34;duration&#34;: duration})
     return self.api_call(&#34;calls.end&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends a Call.
-<a href="https://api.slack.com/methods/calls.end">https://api.slack.com/methods/calls.end</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.end">https://docs.slack.dev/reference/methods/calls.end</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.calls_info"><code class="name flex">
 <span>def <span class="ident">calls_info</span></span>(<span>self, *, id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9083,13 +9157,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Returns information about a Call.
-    https://api.slack.com/methods/calls.info
+    https://docs.slack.dev/reference/methods/calls.info
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     return self.api_call(&#34;calls.info&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns information about a Call.
-<a href="https://api.slack.com/methods/calls.info">https://api.slack.com/methods/calls.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.info">https://docs.slack.dev/reference/methods/calls.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.calls_participants_add"><code class="name flex">
 <span>def <span class="ident">calls_participants_add</span></span>(<span>self, *, id: str, users: str | Sequence[Dict[str, str]], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9107,14 +9181,14 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Registers new participants added to a Call.
-    https://api.slack.com/methods/calls.participants.add
+    https://docs.slack.dev/reference/methods/calls.participants.add
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     _update_call_participants(kwargs, users)
     return self.api_call(&#34;calls.participants.add&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers new participants added to a Call.
-<a href="https://api.slack.com/methods/calls.participants.add">https://api.slack.com/methods/calls.participants.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.participants.add">https://docs.slack.dev/reference/methods/calls.participants.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.calls_participants_remove"><code class="name flex">
 <span>def <span class="ident">calls_participants_remove</span></span>(<span>self, *, id: str, users: str | Sequence[Dict[str, str]], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9132,14 +9206,14 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Registers participants removed from a Call.
-    https://api.slack.com/methods/calls.participants.remove
+    https://docs.slack.dev/reference/methods/calls.participants.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;id&#34;: id})
     _update_call_participants(kwargs, users)
     return self.api_call(&#34;calls.participants.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Registers participants removed from a Call.
-<a href="https://api.slack.com/methods/calls.participants.remove">https://api.slack.com/methods/calls.participants.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.participants.remove">https://docs.slack.dev/reference/methods/calls.participants.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.calls_update"><code class="name flex">
 <span>def <span class="ident">calls_update</span></span>(<span>self,<br>*,<br>id: str,<br>desktop_app_join_url: str | None = None,<br>join_url: str | None = None,<br>title: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9159,7 +9233,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Updates information about a Call.
-    https://api.slack.com/methods/calls.update
+    https://docs.slack.dev/reference/methods/calls.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9172,7 +9246,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;calls.update&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Updates information about a Call.
-<a href="https://api.slack.com/methods/calls.update">https://api.slack.com/methods/calls.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/calls.update">https://docs.slack.dev/reference/methods/calls.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.canvases_access_delete"><code class="name flex">
 <span>def <span class="ident">canvases_access_delete</span></span>(<span>self,<br>*,<br>canvas_id: str,<br>channel_ids: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9191,7 +9265,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Create a Channel Canvas for a channel
-    https://api.slack.com/methods/canvases.access.delete
+    https://docs.slack.dev/reference/methods/canvases.access.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id})
     if channel_ids is not None:
@@ -9207,7 +9281,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;canvases.access.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Channel Canvas for a channel
-<a href="https://api.slack.com/methods/canvases.access.delete">https://api.slack.com/methods/canvases.access.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.access.delete">https://docs.slack.dev/reference/methods/canvases.access.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.canvases_access_set"><code class="name flex">
 <span>def <span class="ident">canvases_access_set</span></span>(<span>self,<br>*,<br>canvas_id: str,<br>access_level: str,<br>channel_ids: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9227,7 +9301,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sets the access level to a canvas for specified entities
-    https://api.slack.com/methods/canvases.access.set
+    https://docs.slack.dev/reference/methods/canvases.access.set
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;access_level&#34;: access_level})
     if channel_ids is not None:
@@ -9244,7 +9318,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;canvases.access.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the access level to a canvas for specified entities
-<a href="https://api.slack.com/methods/canvases.access.set">https://api.slack.com/methods/canvases.access.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.access.set">https://docs.slack.dev/reference/methods/canvases.access.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.canvases_create"><code class="name flex">
 <span>def <span class="ident">canvases_create</span></span>(<span>self, *, title: str | None = None, document_content: Dict[str, str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9262,13 +9336,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Create Canvas for a user
-    https://api.slack.com/methods/canvases.create
+    https://docs.slack.dev/reference/methods/canvases.create
     &#34;&#34;&#34;
     kwargs.update({&#34;title&#34;: title, &#34;document_content&#34;: document_content})
     return self.api_call(&#34;canvases.create&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create Canvas for a user
-<a href="https://api.slack.com/methods/canvases.create">https://api.slack.com/methods/canvases.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.create">https://docs.slack.dev/reference/methods/canvases.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.canvases_delete"><code class="name flex">
 <span>def <span class="ident">canvases_delete</span></span>(<span>self, *, canvas_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9285,13 +9359,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Deletes a canvas
-    https://api.slack.com/methods/canvases.delete
+    https://docs.slack.dev/reference/methods/canvases.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id})
     return self.api_call(&#34;canvases.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a canvas
-<a href="https://api.slack.com/methods/canvases.delete">https://api.slack.com/methods/canvases.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.delete">https://docs.slack.dev/reference/methods/canvases.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.canvases_edit"><code class="name flex">
 <span>def <span class="ident">canvases_edit</span></span>(<span>self, *, canvas_id: str, changes: Sequence[Dict[str, Any]], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9309,13 +9383,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Update an existing canvas
-    https://api.slack.com/methods/canvases.edit
+    https://docs.slack.dev/reference/methods/canvases.edit
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;changes&#34;: changes})
     return self.api_call(&#34;canvases.edit&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing canvas
-<a href="https://api.slack.com/methods/canvases.edit">https://api.slack.com/methods/canvases.edit</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.edit">https://docs.slack.dev/reference/methods/canvases.edit</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.canvases_sections_lookup"><code class="name flex">
 <span>def <span class="ident">canvases_sections_lookup</span></span>(<span>self, *, canvas_id: str, criteria: Dict[str, Any], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9333,13 +9407,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Find sections matching the provided criteria
-    https://api.slack.com/methods/canvases.sections.lookup
+    https://docs.slack.dev/reference/methods/canvases.sections.lookup
     &#34;&#34;&#34;
     kwargs.update({&#34;canvas_id&#34;: canvas_id, &#34;criteria&#34;: json.dumps(criteria)})
     return self.api_call(&#34;canvases.sections.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Find sections matching the provided criteria
-<a href="https://api.slack.com/methods/canvases.sections.lookup">https://api.slack.com/methods/canvases.sections.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/canvases.sections.lookup">https://docs.slack.dev/reference/methods/canvases.sections.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.channels_archive"><code class="name flex">
 <span>def <span class="ident">channels_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9673,13 +9747,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Deletes a message.
-    https://api.slack.com/methods/chat.delete
+    https://docs.slack.dev/reference/methods/chat.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts, &#34;as_user&#34;: as_user})
     return self.api_call(&#34;chat.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a message.
-<a href="https://api.slack.com/methods/chat.delete">https://api.slack.com/methods/chat.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.delete">https://docs.slack.dev/reference/methods/chat.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_deleteScheduledMessage"><code class="name flex">
 <span>def <span class="ident">chat_deleteScheduledMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>scheduled_message_id: str,<br>as_user: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9698,7 +9772,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Deletes a scheduled message.
-    https://api.slack.com/methods/chat.deleteScheduledMessage
+    https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9710,7 +9784,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.deleteScheduledMessage&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a scheduled message.
-<a href="https://api.slack.com/methods/chat.deleteScheduledMessage">https://api.slack.com/methods/chat.deleteScheduledMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage">https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_getPermalink"><code class="name flex">
 <span>def <span class="ident">chat_getPermalink</span></span>(<span>self, *, channel: str, message_ts: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9728,13 +9802,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieve a permalink URL for a specific extant message
-    https://api.slack.com/methods/chat.getPermalink
+    https://docs.slack.dev/reference/methods/chat.getPermalink
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;message_ts&#34;: message_ts})
     return self.api_call(&#34;chat.getPermalink&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a permalink URL for a specific extant message
-<a href="https://api.slack.com/methods/chat.getPermalink">https://api.slack.com/methods/chat.getPermalink</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.getPermalink">https://docs.slack.dev/reference/methods/chat.getPermalink</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_meMessage"><code class="name flex">
 <span>def <span class="ident">chat_meMessage</span></span>(<span>self, *, channel: str, text: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9752,16 +9826,16 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Share a me message into a channel.
-    https://api.slack.com/methods/chat.meMessage
+    https://docs.slack.dev/reference/methods/chat.meMessage
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;text&#34;: text})
     return self.api_call(&#34;chat.meMessage&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Share a me message into a channel.
-<a href="https://api.slack.com/methods/chat.meMessage">https://api.slack.com/methods/chat.meMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.meMessage">https://docs.slack.dev/reference/methods/chat.meMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_postEphemeral"><code class="name flex">
-<span>def <span class="ident">chat_postEphemeral</span></span>(<span>self,<br>*,<br>channel: str,<br>user: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+<span>def <span class="ident">chat_postEphemeral</span></span>(<span>self,<br>*,<br>channel: str,<br>user: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9783,10 +9857,11 @@ Each authorization represents an app installation that the event is visible to.
     link_names: Optional[bool] = None,
     username: Optional[str] = None,
     parse: Optional[str] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sends an ephemeral message to a user in a channel.
-    https://api.slack.com/methods/chat.postEphemeral
+    https://docs.slack.dev/reference/methods/chat.postEphemeral
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9802,19 +9877,20 @@ Each authorization represents an app installation that the event is visible to.
             &#34;link_names&#34;: link_names,
             &#34;username&#34;: username,
             &#34;parse&#34;: parse,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.postEphemeral&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.postEphemeral&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends an ephemeral message to a user in a channel.
-<a href="https://api.slack.com/methods/chat.postEphemeral">https://api.slack.com/methods/chat.postEphemeral</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.postEphemeral">https://docs.slack.dev/reference/methods/chat.postEphemeral</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_postMessage"><code class="name flex">
-<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9841,10 +9917,11 @@ Each authorization represents an app installation that the event is visible to.
     username: Optional[str] = None,
     parse: Optional[str] = None,  # none, full
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sends a message to a channel.
-    https://api.slack.com/methods/chat.postMessage
+    https://docs.slack.dev/reference/methods/chat.postMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9865,19 +9942,20 @@ Each authorization represents an app installation that the event is visible to.
             &#34;username&#34;: username,
             &#34;parse&#34;: parse,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.postMessage&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.postMessage&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.postMessage&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends a message to a channel.
-<a href="https://api.slack.com/methods/chat.postMessage">https://api.slack.com/methods/chat.postMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.postMessage">https://docs.slack.dev/reference/methods/chat.postMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_scheduleMessage"><code class="name flex">
-<span>def <span class="ident">chat_scheduleMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>post_at: str | int,<br>text: str,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>link_names: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+<span>def <span class="ident">chat_scheduleMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>post_at: str | int,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>link_names: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9889,7 +9967,7 @@ Each authorization represents an app installation that the event is visible to.
     *,
     channel: str,
     post_at: Union[str, int],
-    text: str,
+    text: Optional[str] = None,
     as_user: Optional[bool] = None,
     attachments: Optional[Union[str, Sequence[Union[Dict, Attachment]]]] = None,
     blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
@@ -9900,10 +9978,11 @@ Each authorization represents an app installation that the event is visible to.
     unfurl_media: Optional[bool] = None,
     link_names: Optional[bool] = None,
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Schedules a message.
-    https://api.slack.com/methods/chat.scheduleMessage
+    https://docs.slack.dev/reference/methods/chat.scheduleMessage
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9920,16 +9999,17 @@ Each authorization represents an app installation that the event is visible to.
             &#34;unfurl_media&#34;: unfurl_media,
             &#34;link_names&#34;: link_names,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.scheduleMessage&#34;, kwargs)
     # NOTE: intentionally using json over params for the API methods using blocks/attachments
     return self.api_call(&#34;chat.scheduleMessage&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Schedules a message.
-<a href="https://api.slack.com/methods/chat.scheduleMessage">https://api.slack.com/methods/chat.scheduleMessage</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.scheduleMessage">https://docs.slack.dev/reference/methods/chat.scheduleMessage</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_scheduledMessages_list"><code class="name flex">
 <span>def <span class="ident">chat_scheduledMessages_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>cursor: str | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9951,7 +10031,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists all scheduled messages.
-    https://api.slack.com/methods/chat.scheduledMessages.list
+    https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -9966,7 +10046,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.scheduledMessages.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all scheduled messages.
-<a href="https://api.slack.com/methods/chat.scheduledMessages.list">https://api.slack.com/methods/chat.scheduledMessages.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.scheduledMessages.list">https://docs.slack.dev/reference/methods/chat.scheduledMessages.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_unfurl"><code class="name flex">
 <span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -9991,7 +10071,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Provide custom unfurl behavior for user-posted URLs.
-    https://api.slack.com/methods/chat.unfurl
+    https://docs.slack.dev/reference/methods/chat.unfurl
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10012,10 +10092,10 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;chat.unfurl&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Provide custom unfurl behavior for user-posted URLs.
-<a href="https://api.slack.com/methods/chat.unfurl">https://api.slack.com/methods/chat.unfurl</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.unfurl">https://docs.slack.dev/reference/methods/chat.unfurl</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_update"><code class="name flex">
-<span>def <span class="ident">chat_update</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>text: str | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>as_user: bool | None = None,<br>file_ids: str | Sequence[str] | None = None,<br>link_names: bool | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+<span>def <span class="ident">chat_update</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>text: str | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>as_user: bool | None = None,<br>file_ids: str | Sequence[str] | None = None,<br>link_names: bool | None = None,<br>parse: str | None = None,<br>reply_broadcast: bool | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10036,10 +10116,11 @@ Each authorization represents an app installation that the event is visible to.
     parse: Optional[str] = None,  # none, full
     reply_broadcast: Optional[bool] = None,
     metadata: Optional[Union[Dict, Metadata]] = None,
+    markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Updates a message in a channel.
-    https://api.slack.com/methods/chat.update
+    https://docs.slack.dev/reference/methods/chat.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10053,6 +10134,7 @@ Each authorization represents an app installation that the event is visible to.
             &#34;parse&#34;: parse,
             &#34;reply_broadcast&#34;: reply_broadcast,
             &#34;metadata&#34;: metadata,
+            &#34;markdown_text&#34;: markdown_text,
         }
     )
     if isinstance(file_ids, (list, tuple)):
@@ -10061,12 +10143,12 @@ Each authorization represents an app installation that the event is visible to.
         kwargs.update({&#34;file_ids&#34;: file_ids})
     _parse_web_class_objects(kwargs)
     kwargs = _remove_none_values(kwargs)
-    _warn_if_text_or_attachment_fallback_is_missing(&#34;chat.update&#34;, kwargs)
+    _warn_if_message_text_content_is_missing(&#34;chat.update&#34;, kwargs)
     # NOTE: intentionally using json over params for API methods using blocks/attachments
     return self.api_call(&#34;chat.update&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Updates a message in a channel.
-<a href="https://api.slack.com/methods/chat.update">https://api.slack.com/methods/chat.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/chat.update">https://docs.slack.dev/reference/methods/chat.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_acceptSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_acceptSharedInvite</span></span>(<span>self,<br>*,<br>channel_name: str,<br>channel_id: str | None = None,<br>invite_id: str | None = None,<br>free_trial_accepted: bool | None = None,<br>is_private: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10088,7 +10170,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Accepts an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.acceptSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
     &#34;&#34;&#34;
     if channel_id is None and invite_id is None:
         raise e.SlackRequestError(&#34;Either channel_id or invite_id must be provided.&#34;)
@@ -10105,7 +10187,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.acceptSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Accepts an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.acceptSharedInvite">https://api.slack.com/methods/conversations.acceptSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite">https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_approveSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_approveSharedInvite</span></span>(<span>self, *, invite_id: str, target_team: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10123,13 +10205,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Approves an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.approveSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
     return self.api_call(&#34;conversations.approveSharedInvite&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approves an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.approveSharedInvite">https://api.slack.com/methods/conversations.approveSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.approveSharedInvite">https://docs.slack.dev/reference/methods/conversations.approveSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_archive"><code class="name flex">
 <span>def <span class="ident">conversations_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10146,13 +10228,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Archives a conversation.
-    https://api.slack.com/methods/conversations.archive
+    https://docs.slack.dev/reference/methods/conversations.archive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.archive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Archives a conversation.
-<a href="https://api.slack.com/methods/conversations.archive">https://api.slack.com/methods/conversations.archive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.archive">https://docs.slack.dev/reference/methods/conversations.archive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_canvases_create"><code class="name flex">
 <span>def <span class="ident">conversations_canvases_create</span></span>(<span>self, *, channel_id: str, document_content: Dict[str, str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10170,13 +10252,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Create a Channel Canvas for a channel
-    https://api.slack.com/methods/conversations.canvases.create
+    https://docs.slack.dev/reference/methods/conversations.canvases.create
     &#34;&#34;&#34;
     kwargs.update({&#34;channel_id&#34;: channel_id, &#34;document_content&#34;: document_content})
     return self.api_call(&#34;conversations.canvases.create&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a Channel Canvas for a channel
-<a href="https://api.slack.com/methods/conversations.canvases.create">https://api.slack.com/methods/conversations.canvases.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.canvases.create">https://docs.slack.dev/reference/methods/conversations.canvases.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_close"><code class="name flex">
 <span>def <span class="ident">conversations_close</span></span>(<span>self, *, channel: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10193,13 +10275,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Closes a direct message or multi-person direct message.
-    https://api.slack.com/methods/conversations.close
+    https://docs.slack.dev/reference/methods/conversations.close
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.close&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Closes a direct message or multi-person direct message.
-<a href="https://api.slack.com/methods/conversations.close">https://api.slack.com/methods/conversations.close</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.close">https://docs.slack.dev/reference/methods/conversations.close</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_create"><code class="name flex">
 <span>def <span class="ident">conversations_create</span></span>(<span>self,<br>*,<br>name: str,<br>is_private: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10218,13 +10300,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Initiates a public or private channel-based conversation
-    https://api.slack.com/methods/conversations.create
+    https://docs.slack.dev/reference/methods/conversations.create
     &#34;&#34;&#34;
     kwargs.update({&#34;name&#34;: name, &#34;is_private&#34;: is_private, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;conversations.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Initiates a public or private channel-based conversation
-<a href="https://api.slack.com/methods/conversations.create">https://api.slack.com/methods/conversations.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.create">https://docs.slack.dev/reference/methods/conversations.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_declineSharedInvite"><code class="name flex">
 <span>def <span class="ident">conversations_declineSharedInvite</span></span>(<span>self, *, invite_id: str, target_team: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10242,13 +10324,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Declines a Slack Connect channel invite.
-    https://api.slack.com/methods/conversations.declineSharedInvite
+    https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;target_team&#34;: target_team})
     return self.api_call(&#34;conversations.declineSharedInvite&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Declines a Slack Connect channel invite.
-<a href="https://api.slack.com/methods/conversations.declineSharedInvite">https://api.slack.com/methods/conversations.declineSharedInvite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.declineSharedInvite">https://docs.slack.dev/reference/methods/conversations.declineSharedInvite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_externalInvitePermissions_set"><code class="name flex">
 <span>def <span class="ident">conversations_externalInvitePermissions_set</span></span>(<span>self, *, action: str, channel: str, target_team: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10262,7 +10344,7 @@ Each authorization represents an app installation that the event is visible to.
     self, *, action: str, channel: str, target_team: str, **kwargs
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-    https://api.slack.com/methods/conversations.externalInvitePermissions.set
+    https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10274,7 +10356,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.externalInvitePermissions.set&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-<a href="https://api.slack.com/methods/conversations.externalInvitePermissions.set">https://api.slack.com/methods/conversations.externalInvitePermissions.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set">https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_history"><code class="name flex">
 <span>def <span class="ident">conversations_history</span></span>(<span>self,<br>*,<br>channel: str,<br>cursor: str | None = None,<br>inclusive: bool | None = None,<br>include_all_metadata: bool | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10297,7 +10379,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Fetches a conversation&#39;s history of messages and events.
-    https://api.slack.com/methods/conversations.history
+    https://docs.slack.dev/reference/methods/conversations.history
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10313,7 +10395,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.history&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Fetches a conversation's history of messages and events.
-<a href="https://api.slack.com/methods/conversations.history">https://api.slack.com/methods/conversations.history</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.history">https://docs.slack.dev/reference/methods/conversations.history</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_info"><code class="name flex">
 <span>def <span class="ident">conversations_info</span></span>(<span>self,<br>*,<br>channel: str,<br>include_locale: bool | None = None,<br>include_num_members: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10332,7 +10414,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieve information about a conversation.
-    https://api.slack.com/methods/conversations.info
+    https://docs.slack.dev/reference/methods/conversations.info
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10344,7 +10426,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a conversation.
-<a href="https://api.slack.com/methods/conversations.info">https://api.slack.com/methods/conversations.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.info">https://docs.slack.dev/reference/methods/conversations.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_invite"><code class="name flex">
 <span>def <span class="ident">conversations_invite</span></span>(<span>self,<br>*,<br>channel: str,<br>users: str | Sequence[str],<br>force: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10363,7 +10445,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Invites users to a channel.
-    https://api.slack.com/methods/conversations.invite
+    https://docs.slack.dev/reference/methods/conversations.invite
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10378,7 +10460,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.invite&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Invites users to a channel.
-<a href="https://api.slack.com/methods/conversations.invite">https://api.slack.com/methods/conversations.invite</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.invite">https://docs.slack.dev/reference/methods/conversations.invite</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_inviteShared"><code class="name flex">
 <span>def <span class="ident">conversations_inviteShared</span></span>(<span>self,<br>*,<br>channel: str,<br>emails: str | Sequence[str] | None = None,<br>user_ids: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10397,7 +10479,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sends an invitation to a Slack Connect channel.
-    https://api.slack.com/methods/conversations.inviteShared
+    https://docs.slack.dev/reference/methods/conversations.inviteShared
     &#34;&#34;&#34;
     if emails is None and user_ids is None:
         raise e.SlackRequestError(&#34;Either emails or user ids must be provided.&#34;)
@@ -10413,7 +10495,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.inviteShared&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sends an invitation to a Slack Connect channel.
-<a href="https://api.slack.com/methods/conversations.inviteShared">https://api.slack.com/methods/conversations.inviteShared</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.inviteShared">https://docs.slack.dev/reference/methods/conversations.inviteShared</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_join"><code class="name flex">
 <span>def <span class="ident">conversations_join</span></span>(<span>self, *, channel: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10430,13 +10512,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Joins an existing conversation.
-    https://api.slack.com/methods/conversations.join
+    https://docs.slack.dev/reference/methods/conversations.join
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.join&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Joins an existing conversation.
-<a href="https://api.slack.com/methods/conversations.join">https://api.slack.com/methods/conversations.join</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.join">https://docs.slack.dev/reference/methods/conversations.join</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_kick"><code class="name flex">
 <span>def <span class="ident">conversations_kick</span></span>(<span>self, *, channel: str, user: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10454,13 +10536,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Removes a user from a conversation.
-    https://api.slack.com/methods/conversations.kick
+    https://docs.slack.dev/reference/methods/conversations.kick
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;user&#34;: user})
     return self.api_call(&#34;conversations.kick&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a user from a conversation.
-<a href="https://api.slack.com/methods/conversations.kick">https://api.slack.com/methods/conversations.kick</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.kick">https://docs.slack.dev/reference/methods/conversations.kick</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_leave"><code class="name flex">
 <span>def <span class="ident">conversations_leave</span></span>(<span>self, *, channel: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10477,13 +10559,13 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Leaves a conversation.
-    https://api.slack.com/methods/conversations.leave
+    https://docs.slack.dev/reference/methods/conversations.leave
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.leave&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Leaves a conversation.
-<a href="https://api.slack.com/methods/conversations.leave">https://api.slack.com/methods/conversations.leave</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.leave">https://docs.slack.dev/reference/methods/conversations.leave</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_list"><code class="name flex">
 <span>def <span class="ident">conversations_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>exclude_archived: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>types: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10504,7 +10586,7 @@ Each authorization represents an app installation that the event is visible to.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists all channels in a Slack team.
-    https://api.slack.com/methods/conversations.list
+    https://docs.slack.dev/reference/methods/conversations.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10521,7 +10603,7 @@ Each authorization represents an app installation that the event is visible to.
     return self.api_call(&#34;conversations.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all channels in a Slack team.
-<a href="https://api.slack.com/methods/conversations.list">https://api.slack.com/methods/conversations.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.list">https://docs.slack.dev/reference/methods/conversations.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_listConnectInvites"><code class="name flex">
 <span>def <span class="ident">conversations_listConnectInvites</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10541,14 +10623,14 @@ Each authorization represents an app installation that the event is visible to.
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List shared channel invites that have been generated
     or received but have not yet been approved by all parties.
-    https://api.slack.com/methods/conversations.listConnectInvites
+    https://docs.slack.dev/reference/methods/conversations.listConnectInvites
     &#34;&#34;&#34;
     kwargs.update({&#34;count&#34;: count, &#34;cursor&#34;: cursor, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;conversations.listConnectInvites&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List shared channel invites that have been generated
 or received but have not yet been approved by all parties.
-<a href="https://api.slack.com/methods/conversations.listConnectInvites">https://api.slack.com/methods/conversations.listConnectInvites</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.listConnectInvites">https://docs.slack.dev/reference/methods/conversations.listConnectInvites</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_mark"><code class="name flex">
 <span>def <span class="ident">conversations_mark</span></span>(<span>self, *, channel: str, ts: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10566,13 +10648,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sets the read cursor in a channel.
-    https://api.slack.com/methods/conversations.mark
+    https://docs.slack.dev/reference/methods/conversations.mark
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;ts&#34;: ts})
     return self.api_call(&#34;conversations.mark&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the read cursor in a channel.
-<a href="https://api.slack.com/methods/conversations.mark">https://api.slack.com/methods/conversations.mark</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.mark">https://docs.slack.dev/reference/methods/conversations.mark</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_members"><code class="name flex">
 <span>def <span class="ident">conversations_members</span></span>(<span>self, *, channel: str, cursor: str | None = None, limit: int | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10591,13 +10673,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieve members of a conversation.
-    https://api.slack.com/methods/conversations.members
+    https://docs.slack.dev/reference/methods/conversations.members
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;cursor&#34;: cursor, &#34;limit&#34;: limit})
     return self.api_call(&#34;conversations.members&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve members of a conversation.
-<a href="https://api.slack.com/methods/conversations.members">https://api.slack.com/methods/conversations.members</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.members">https://docs.slack.dev/reference/methods/conversations.members</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_open"><code class="name flex">
 <span>def <span class="ident">conversations_open</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>return_im: bool | None = None,<br>users: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10616,7 +10698,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Opens or resumes a direct message or multi-person direct message.
-    https://api.slack.com/methods/conversations.open
+    https://docs.slack.dev/reference/methods/conversations.open
     &#34;&#34;&#34;
     if channel is None and users is None:
         raise e.SlackRequestError(&#34;Either channel or users must be provided.&#34;)
@@ -10628,7 +10710,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.open&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Opens or resumes a direct message or multi-person direct message.
-<a href="https://api.slack.com/methods/conversations.open">https://api.slack.com/methods/conversations.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.open">https://docs.slack.dev/reference/methods/conversations.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_rename"><code class="name flex">
 <span>def <span class="ident">conversations_rename</span></span>(<span>self, *, channel: str, name: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10646,13 +10728,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Renames a conversation.
-    https://api.slack.com/methods/conversations.rename
+    https://docs.slack.dev/reference/methods/conversations.rename
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name})
     return self.api_call(&#34;conversations.rename&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Renames a conversation.
-<a href="https://api.slack.com/methods/conversations.rename">https://api.slack.com/methods/conversations.rename</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.rename">https://docs.slack.dev/reference/methods/conversations.rename</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_replies"><code class="name flex">
 <span>def <span class="ident">conversations_replies</span></span>(<span>self,<br>*,<br>channel: str,<br>ts: str,<br>cursor: str | None = None,<br>inclusive: bool | None = None,<br>include_all_metadata: bool | None = None,<br>latest: str | None = None,<br>limit: int | None = None,<br>oldest: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10676,7 +10758,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieve a thread of messages posted to a conversation
-    https://api.slack.com/methods/conversations.replies
+    https://docs.slack.dev/reference/methods/conversations.replies
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10693,7 +10775,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.replies&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a thread of messages posted to a conversation
-<a href="https://api.slack.com/methods/conversations.replies">https://api.slack.com/methods/conversations.replies</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.replies">https://docs.slack.dev/reference/methods/conversations.replies</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_requestSharedInvite_approve"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_approve</span></span>(<span>self,<br>*,<br>invite_id: str,<br>channel_id: str | None = None,<br>is_external_limited: str | None = None,<br>message: Dict[str, Any] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10713,7 +10795,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-    https://api.slack.com/methods/conversations.requestSharedInvite.approve
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10727,7 +10809,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.requestSharedInvite.approve&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.approve">https://api.slack.com/methods/conversations.requestSharedInvite.approve</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_requestSharedInvite_deny"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_deny</span></span>(<span>self, *, invite_id: str, message: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10745,13 +10827,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Deny a request to invite an external user to a channel.
-    https://api.slack.com/methods/conversations.requestSharedInvite.deny
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
     &#34;&#34;&#34;
     kwargs.update({&#34;invite_id&#34;: invite_id, &#34;message&#34;: message})
     return self.api_call(&#34;conversations.requestSharedInvite.deny&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deny a request to invite an external user to a channel.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.deny">https://api.slack.com/methods/conversations.requestSharedInvite.deny</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_requestSharedInvite_list"><code class="name flex">
 <span>def <span class="ident">conversations_requestSharedInvite_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>include_approved: bool | None = None,<br>include_denied: bool | None = None,<br>include_expired: bool | None = None,<br>invite_ids: str | Sequence[str] | None = None,<br>limit: int | None = None,<br>user_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10774,7 +10856,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists requests to add external users to channels with ability to filter.
-    https://api.slack.com/methods/conversations.requestSharedInvite.list
+    https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -10794,7 +10876,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;conversations.requestSharedInvite.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists requests to add external users to channels with ability to filter.
-<a href="https://api.slack.com/methods/conversations.requestSharedInvite.list">https://api.slack.com/methods/conversations.requestSharedInvite.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list">https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_setPurpose"><code class="name flex">
 <span>def <span class="ident">conversations_setPurpose</span></span>(<span>self, *, channel: str, purpose: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10812,13 +10894,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sets the purpose for a conversation.
-    https://api.slack.com/methods/conversations.setPurpose
+    https://docs.slack.dev/reference/methods/conversations.setPurpose
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;purpose&#34;: purpose})
     return self.api_call(&#34;conversations.setPurpose&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the purpose for a conversation.
-<a href="https://api.slack.com/methods/conversations.setPurpose">https://api.slack.com/methods/conversations.setPurpose</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.setPurpose">https://docs.slack.dev/reference/methods/conversations.setPurpose</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_setTopic"><code class="name flex">
 <span>def <span class="ident">conversations_setTopic</span></span>(<span>self, *, channel: str, topic: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10836,13 +10918,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Sets the topic for a conversation.
-    https://api.slack.com/methods/conversations.setTopic
+    https://docs.slack.dev/reference/methods/conversations.setTopic
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;topic&#34;: topic})
     return self.api_call(&#34;conversations.setTopic&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Sets the topic for a conversation.
-<a href="https://api.slack.com/methods/conversations.setTopic">https://api.slack.com/methods/conversations.setTopic</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.setTopic">https://docs.slack.dev/reference/methods/conversations.setTopic</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.conversations_unarchive"><code class="name flex">
 <span>def <span class="ident">conversations_unarchive</span></span>(<span>self, *, channel: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10859,13 +10941,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Reverses conversation archival.
-    https://api.slack.com/methods/conversations.unarchive
+    https://docs.slack.dev/reference/methods/conversations.unarchive
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;conversations.unarchive&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Reverses conversation archival.
-<a href="https://api.slack.com/methods/conversations.unarchive">https://api.slack.com/methods/conversations.unarchive</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/conversations.unarchive">https://docs.slack.dev/reference/methods/conversations.unarchive</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.dialog_open"><code class="name flex">
 <span>def <span class="ident">dialog_open</span></span>(<span>self, *, dialog: Dict[str, Any], trigger_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10883,7 +10965,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Open a dialog with a user.
-    https://api.slack.com/methods/dialog.open
+    https://docs.slack.dev/reference/methods/dialog.open
     &#34;&#34;&#34;
     kwargs.update({&#34;dialog&#34;: dialog, &#34;trigger_id&#34;: trigger_id})
     kwargs = _remove_none_values(kwargs)
@@ -10891,7 +10973,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;dialog.open&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Open a dialog with a user.
-<a href="https://api.slack.com/methods/dialog.open">https://api.slack.com/methods/dialog.open</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dialog.open">https://docs.slack.dev/reference/methods/dialog.open</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.dnd_endDnd"><code class="name flex">
 <span>def <span class="ident">dnd_endDnd</span></span>(<span>self, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10906,12 +10988,12 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Ends the current user&#39;s Do Not Disturb session immediately.
-    https://api.slack.com/methods/dnd.endDnd
+    https://docs.slack.dev/reference/methods/dnd.endDnd
     &#34;&#34;&#34;
     return self.api_call(&#34;dnd.endDnd&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends the current user's Do Not Disturb session immediately.
-<a href="https://api.slack.com/methods/dnd.endDnd">https://api.slack.com/methods/dnd.endDnd</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.endDnd">https://docs.slack.dev/reference/methods/dnd.endDnd</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.dnd_endSnooze"><code class="name flex">
 <span>def <span class="ident">dnd_endSnooze</span></span>(<span>self, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10926,12 +11008,12 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Ends the current user&#39;s snooze mode immediately.
-    https://api.slack.com/methods/dnd.endSnooze
+    https://docs.slack.dev/reference/methods/dnd.endSnooze
     &#34;&#34;&#34;
     return self.api_call(&#34;dnd.endSnooze&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Ends the current user's snooze mode immediately.
-<a href="https://api.slack.com/methods/dnd.endSnooze">https://api.slack.com/methods/dnd.endSnooze</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.endSnooze">https://docs.slack.dev/reference/methods/dnd.endSnooze</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.dnd_info"><code class="name flex">
 <span>def <span class="ident">dnd_info</span></span>(<span>self, *, team_id: str | None = None, user: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10949,13 +11031,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieves a user&#39;s current Do Not Disturb status.
-    https://api.slack.com/methods/dnd.info
+    https://docs.slack.dev/reference/methods/dnd.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
     return self.api_call(&#34;dnd.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves a user's current Do Not Disturb status.
-<a href="https://api.slack.com/methods/dnd.info">https://api.slack.com/methods/dnd.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.info">https://docs.slack.dev/reference/methods/dnd.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.dnd_setSnooze"><code class="name flex">
 <span>def <span class="ident">dnd_setSnooze</span></span>(<span>self, *, num_minutes: str | int, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10972,13 +11054,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Turns on Do Not Disturb mode for the current user, or changes its duration.
-    https://api.slack.com/methods/dnd.setSnooze
+    https://docs.slack.dev/reference/methods/dnd.setSnooze
     &#34;&#34;&#34;
     kwargs.update({&#34;num_minutes&#34;: num_minutes})
     return self.api_call(&#34;dnd.setSnooze&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Turns on Do Not Disturb mode for the current user, or changes its duration.
-<a href="https://api.slack.com/methods/dnd.setSnooze">https://api.slack.com/methods/dnd.setSnooze</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.setSnooze">https://docs.slack.dev/reference/methods/dnd.setSnooze</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.dnd_teamInfo"><code class="name flex">
 <span>def <span class="ident">dnd_teamInfo</span></span>(<span>self, users: str | Sequence[str], team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -10995,7 +11077,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieves the Do Not Disturb status for users on a team.
-    https://api.slack.com/methods/dnd.teamInfo
+    https://docs.slack.dev/reference/methods/dnd.teamInfo
     &#34;&#34;&#34;
     if isinstance(users, (list, tuple)):
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -11005,7 +11087,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;dnd.teamInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves the Do Not Disturb status for users on a team.
-<a href="https://api.slack.com/methods/dnd.teamInfo">https://api.slack.com/methods/dnd.teamInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/dnd.teamInfo">https://docs.slack.dev/reference/methods/dnd.teamInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.emoji_list"><code class="name flex">
 <span>def <span class="ident">emoji_list</span></span>(<span>self, include_categories: bool | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11021,13 +11103,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists custom emoji for a team.
-    https://api.slack.com/methods/emoji.list
+    https://docs.slack.dev/reference/methods/emoji.list
     &#34;&#34;&#34;
     kwargs.update({&#34;include_categories&#34;: include_categories})
     return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists custom emoji for a team.
-<a href="https://api.slack.com/methods/emoji.list">https://api.slack.com/methods/emoji.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/emoji.list">https://docs.slack.dev/reference/methods/emoji.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_comments_delete"><code class="name flex">
 <span>def <span class="ident">files_comments_delete</span></span>(<span>self, *, file: str, id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11045,13 +11127,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Deletes an existing comment on a file.
-    https://api.slack.com/methods/files.comments.delete
+    https://docs.slack.dev/reference/methods/files.comments.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file, &#34;id&#34;: id})
     return self.api_call(&#34;files.comments.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes an existing comment on a file.
-<a href="https://api.slack.com/methods/files.comments.delete">https://api.slack.com/methods/files.comments.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.comments.delete">https://docs.slack.dev/reference/methods/files.comments.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_completeUploadExternal"><code class="name flex">
 <span>def <span class="ident">files_completeUploadExternal</span></span>(<span>self,<br>*,<br>files: List[Dict[str, str]],<br>channel_id: str | None = None,<br>channels: List[str] | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11072,7 +11154,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Finishes an upload started with files.getUploadURLExternal.
-    https://api.slack.com/methods/files.completeUploadExternal
+    https://docs.slack.dev/reference/methods/files.completeUploadExternal
     &#34;&#34;&#34;
     _files = [{k: v for k, v in f.items() if v is not None} for f in files]
     kwargs.update(
@@ -11088,7 +11170,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.completeUploadExternal&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Finishes an upload started with files.getUploadURLExternal.
-<a href="https://api.slack.com/methods/files.completeUploadExternal">https://api.slack.com/methods/files.completeUploadExternal</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.completeUploadExternal">https://docs.slack.dev/reference/methods/files.completeUploadExternal</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_delete"><code class="name flex">
 <span>def <span class="ident">files_delete</span></span>(<span>self, *, file: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11105,13 +11187,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Deletes a file.
-    https://api.slack.com/methods/files.delete
+    https://docs.slack.dev/reference/methods/files.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a file.
-<a href="https://api.slack.com/methods/files.delete">https://api.slack.com/methods/files.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.delete">https://docs.slack.dev/reference/methods/files.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_getUploadURLExternal"><code class="name flex">
 <span>def <span class="ident">files_getUploadURLExternal</span></span>(<span>self,<br>*,<br>filename: str,<br>length: int,<br>alt_txt: str | None = None,<br>snippet_type: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11131,7 +11213,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets a URL for an edge external upload.
-    https://api.slack.com/methods/files.getUploadURLExternal
+    https://docs.slack.dev/reference/methods/files.getUploadURLExternal
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11144,7 +11226,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.getUploadURLExternal&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets a URL for an edge external upload.
-<a href="https://api.slack.com/methods/files.getUploadURLExternal">https://api.slack.com/methods/files.getUploadURLExternal</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.getUploadURLExternal">https://docs.slack.dev/reference/methods/files.getUploadURLExternal</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_info"><code class="name flex">
 <span>def <span class="ident">files_info</span></span>(<span>self,<br>*,<br>file: str,<br>count: int | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11165,7 +11247,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets information about a team file.
-    https://api.slack.com/methods/files.info
+    https://docs.slack.dev/reference/methods/files.info
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11179,7 +11261,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a team file.
-<a href="https://api.slack.com/methods/files.info">https://api.slack.com/methods/files.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.info">https://docs.slack.dev/reference/methods/files.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_list"><code class="name flex">
 <span>def <span class="ident">files_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>count: int | None = None,<br>page: int | None = None,<br>show_files_hidden_by_limit: bool | None = None,<br>team_id: str | None = None,<br>ts_from: str | None = None,<br>ts_to: str | None = None,<br>types: str | Sequence[str] | None = None,<br>user: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11204,7 +11286,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists &amp; filters team files.
-    https://api.slack.com/methods/files.list
+    https://docs.slack.dev/reference/methods/files.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11225,7 +11307,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists &amp; filters team files.
-<a href="https://api.slack.com/methods/files.list">https://api.slack.com/methods/files.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.list">https://docs.slack.dev/reference/methods/files.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_remote_add"><code class="name flex">
 <span>def <span class="ident">files_remote_add</span></span>(<span>self,<br>*,<br>external_id: str,<br>external_url: str,<br>title: str,<br>filetype: str | None = None,<br>indexable_file_contents: str | bytes | io.IOBase | None = None,<br>preview_image: str | bytes | io.IOBase | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11247,7 +11329,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Adds a file from a remote service.
-    https://api.slack.com/methods/files.remote.add
+    https://docs.slack.dev/reference/methods/files.remote.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11274,7 +11356,7 @@ or received but have not yet been approved by all parties.
     )</code></pre>
 </details>
 <div class="desc"><p>Adds a file from a remote service.
-<a href="https://api.slack.com/methods/files.remote.add">https://api.slack.com/methods/files.remote.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.add">https://docs.slack.dev/reference/methods/files.remote.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_remote_info"><code class="name flex">
 <span>def <span class="ident">files_remote_info</span></span>(<span>self, *, external_id: str | None = None, file: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11292,13 +11374,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-    https://api.slack.com/methods/files.remote.info
+    https://docs.slack.dev/reference/methods/files.remote.info
     &#34;&#34;&#34;
     kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
     return self.api_call(&#34;files.remote.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a remote file added to Slack.
-<a href="https://api.slack.com/methods/files.remote.info">https://api.slack.com/methods/files.remote.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.info">https://docs.slack.dev/reference/methods/files.remote.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_remote_list"><code class="name flex">
 <span>def <span class="ident">files_remote_list</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>ts_from: str | None = None,<br>ts_to: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11319,7 +11401,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieve information about a remote file added to Slack.
-    https://api.slack.com/methods/files.remote.list
+    https://docs.slack.dev/reference/methods/files.remote.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11333,7 +11415,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.remote.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve information about a remote file added to Slack.
-<a href="https://api.slack.com/methods/files.remote.list">https://api.slack.com/methods/files.remote.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.list">https://docs.slack.dev/reference/methods/files.remote.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_remote_remove"><code class="name flex">
 <span>def <span class="ident">files_remote_remove</span></span>(<span>self, *, external_id: str | None = None, file: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11351,13 +11433,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Remove a remote file.
-    https://api.slack.com/methods/files.remote.remove
+    https://docs.slack.dev/reference/methods/files.remote.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;external_id&#34;: external_id, &#34;file&#34;: file})
     return self.api_call(&#34;files.remote.remove&#34;, http_verb=&#34;POST&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Remove a remote file.
-<a href="https://api.slack.com/methods/files.remote.remove">https://api.slack.com/methods/files.remote.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.remove">https://docs.slack.dev/reference/methods/files.remote.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_remote_share"><code class="name flex">
 <span>def <span class="ident">files_remote_share</span></span>(<span>self,<br>*,<br>channels: str | Sequence[str],<br>external_id: str | None = None,<br>file: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11376,7 +11458,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Share a remote file into a channel.
-    https://api.slack.com/methods/files.remote.share
+    https://docs.slack.dev/reference/methods/files.remote.share
     &#34;&#34;&#34;
     if external_id is None and file is None:
         raise e.SlackRequestError(&#34;Either external_id or file must be provided.&#34;)
@@ -11388,7 +11470,7 @@ or received but have not yet been approved by all parties.
     return self.api_call(&#34;files.remote.share&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Share a remote file into a channel.
-<a href="https://api.slack.com/methods/files.remote.share">https://api.slack.com/methods/files.remote.share</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.share">https://docs.slack.dev/reference/methods/files.remote.share</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_remote_update"><code class="name flex">
 <span>def <span class="ident">files_remote_update</span></span>(<span>self,<br>*,<br>external_id: str | None = None,<br>external_url: str | None = None,<br>file: str | None = None,<br>title: str | None = None,<br>filetype: str | None = None,<br>indexable_file_contents: str | None = None,<br>preview_image: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11411,7 +11493,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Updates an existing remote file.
-    https://api.slack.com/methods/files.remote.update
+    https://docs.slack.dev/reference/methods/files.remote.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -11439,7 +11521,7 @@ or received but have not yet been approved by all parties.
     )</code></pre>
 </details>
 <div class="desc"><p>Updates an existing remote file.
-<a href="https://api.slack.com/methods/files.remote.update">https://api.slack.com/methods/files.remote.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.remote.update">https://docs.slack.dev/reference/methods/files.remote.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_revokePublicURL"><code class="name flex">
 <span>def <span class="ident">files_revokePublicURL</span></span>(<span>self, *, file: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11456,13 +11538,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Revokes public/external sharing access for a file
-    https://api.slack.com/methods/files.revokePublicURL
+    https://docs.slack.dev/reference/methods/files.revokePublicURL
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.revokePublicURL&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Revokes public/external sharing access for a file
-<a href="https://api.slack.com/methods/files.revokePublicURL">https://api.slack.com/methods/files.revokePublicURL</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.revokePublicURL">https://docs.slack.dev/reference/methods/files.revokePublicURL</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_sharedPublicURL"><code class="name flex">
 <span>def <span class="ident">files_sharedPublicURL</span></span>(<span>self, *, file: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11479,13 +11561,13 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Enables a file for public/external sharing.
-    https://api.slack.com/methods/files.sharedPublicURL
+    https://docs.slack.dev/reference/methods/files.sharedPublicURL
     &#34;&#34;&#34;
     kwargs.update({&#34;file&#34;: file})
     return self.api_call(&#34;files.sharedPublicURL&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enables a file for public/external sharing.
-<a href="https://api.slack.com/methods/files.sharedPublicURL">https://api.slack.com/methods/files.sharedPublicURL</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.sharedPublicURL">https://docs.slack.dev/reference/methods/files.sharedPublicURL</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_upload"><code class="name flex">
 <span>def <span class="ident">files_upload</span></span>(<span>self,<br>*,<br>file: str | bytes | io.IOBase | None = None,<br>content: str | bytes | None = None,<br>filename: str | None = None,<br>filetype: str | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>title: str | None = None,<br>channels: str | Sequence[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11509,7 +11591,7 @@ or received but have not yet been approved by all parties.
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Uploads or creates a file.
-    https://api.slack.com/methods/files.upload
+    https://docs.slack.dev/reference/methods/files.upload
     &#34;&#34;&#34;
     _print_files_upload_v2_suggestion()
 
@@ -11542,7 +11624,7 @@ or received but have not yet been approved by all parties.
         return self.api_call(&#34;files.upload&#34;, data=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Uploads or creates a file.
-<a href="https://api.slack.com/methods/files.upload">https://api.slack.com/methods/files.upload</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/files.upload">https://docs.slack.dev/reference/methods/files.upload</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_upload_v2"><code class="name flex">
 <span>def <span class="ident">files_upload_v2</span></span>(<span>self,<br>*,<br>filename: str | None = None,<br>file: str | bytes | io.IOBase | os.PathLike | None = None,<br>content: str | bytes | None = None,<br>title: str | None = None,<br>alt_txt: str | None = None,<br>snippet_type: str | None = None,<br>file_uploads: List[Dict[str, Any]] | None = None,<br>channel: str | None = None,<br>channels: List[str] | None = None,<br>initial_comment: str | None = None,<br>thread_ts: str | None = None,<br>request_file_info: bool = True,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11573,12 +11655,12 @@ or received but have not yet been approved by all parties.
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;This wrapper method provides an easy way to upload files using the following endpoints:
 
-    - step1: https://api.slack.com/methods/files.getUploadURLExternal
+    - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
     - step2: &#34;https://files.slack.com/upload/v1/...&#34; URLs returned from files.getUploadURLExternal API
 
-    - step3: https://api.slack.com/methods/files.completeUploadExternal
-        and https://api.slack.com/methods/files.info
+    - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+        and https://docs.slack.dev/reference/methods/files.info
 
     &#34;&#34;&#34;
     if file is None and content is None and file_uploads is None:
@@ -11657,14 +11739,14 @@ or received but have not yet been approved by all parties.
 <div class="desc"><p>This wrapper method provides an easy way to upload files using the following endpoints:</p>
 <ul>
 <li>
-<p>step1: <a href="https://api.slack.com/methods/files.getUploadURLExternal">https://api.slack.com/methods/files.getUploadURLExternal</a></p>
+<p>step1: <a href="https://docs.slack.dev/reference/methods/files.getUploadURLExternal">https://docs.slack.dev/reference/methods/files.getUploadURLExternal</a></p>
 </li>
 <li>
 <p>step2: "https://files.slack.com/upload/v1/&hellip;" URLs returned from files.getUploadURLExternal API</p>
 </li>
 <li>
-<p>step3: <a href="https://api.slack.com/methods/files.completeUploadExternal">https://api.slack.com/methods/files.completeUploadExternal</a>
-and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/methods/files.info</a></p>
+<p>step3: <a href="https://docs.slack.dev/reference/methods/files.completeUploadExternal">https://docs.slack.dev/reference/methods/files.completeUploadExternal</a>
+and <a href="https://docs.slack.dev/reference/methods/files.info">https://docs.slack.dev/reference/methods/files.info</a></p>
 </li>
 </ul></div>
 </dd>
@@ -11684,13 +11766,13 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Signal the failure to execute a function
-    https://api.slack.com/methods/functions.completeError
+    https://docs.slack.dev/reference/methods/functions.completeError
     &#34;&#34;&#34;
     kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;error&#34;: error})
     return self.api_call(&#34;functions.completeError&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Signal the failure to execute a function
-<a href="https://api.slack.com/methods/functions.completeError">https://api.slack.com/methods/functions.completeError</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/functions.completeError">https://docs.slack.dev/reference/methods/functions.completeError</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.functions_completeSuccess"><code class="name flex">
 <span>def <span class="ident">functions_completeSuccess</span></span>(<span>self, *, function_execution_id: str, outputs: Dict[str, Any], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -11708,13 +11790,13 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Signal the successful completion of a function
-    https://api.slack.com/methods/functions.completeSuccess
+    https://docs.slack.dev/reference/methods/functions.completeSuccess
     &#34;&#34;&#34;
     kwargs.update({&#34;function_execution_id&#34;: function_execution_id, &#34;outputs&#34;: json.dumps(outputs)})
     return self.api_call(&#34;functions.completeSuccess&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Signal the successful completion of a function
-<a href="https://api.slack.com/methods/functions.completeSuccess">https://api.slack.com/methods/functions.completeSuccess</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/functions.completeSuccess">https://docs.slack.dev/reference/methods/functions.completeSuccess</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.groups_archive"><code class="name flex">
 <span>def <span class="ident">groups_archive</span></span>(<span>self, *, channel: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12190,7 +12272,7 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;For Enterprise Grid workspaces, map local user IDs to global user IDs
-    https://api.slack.com/methods/migration.exchange
+    https://docs.slack.dev/reference/methods/migration.exchange
     &#34;&#34;&#34;
     if isinstance(users, (list, tuple)):
         kwargs.update({&#34;users&#34;: &#34;,&#34;.join(users)})
@@ -12200,7 +12282,7 @@ and <a href="https://api.slack.com/methods/files.info">https://api.slack.com/met
     return self.api_call(&#34;migration.exchange&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>For Enterprise Grid workspaces, map local user IDs to global user IDs
-<a href="https://api.slack.com/methods/migration.exchange">https://api.slack.com/methods/migration.exchange</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/migration.exchange">https://docs.slack.dev/reference/methods/migration.exchange</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.mpim_close"><code class="name flex">
 <span>def <span class="ident">mpim_close</span></span>(<span>self, *, channel: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12347,7 +12429,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-    https://api.slack.com/methods/oauth.access
+    https://docs.slack.dev/reference/methods/oauth.access
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12359,7 +12441,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.
-<a href="https://api.slack.com/methods/oauth.access">https://api.slack.com/methods/oauth.access</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.access">https://docs.slack.dev/reference/methods/oauth.access</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.oauth_v2_access"><code class="name flex">
 <span>def <span class="ident">oauth_v2_access</span></span>(<span>self,<br>*,<br>client_id: str,<br>client_secret: str,<br>code: str | None = None,<br>redirect_uri: str | None = None,<br>grant_type: str | None = None,<br>refresh_token: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12385,7 +12467,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token.
-    https://api.slack.com/methods/oauth.v2.access
+    https://docs.slack.dev/reference/methods/oauth.v2.access
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12402,7 +12484,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token.
-<a href="https://api.slack.com/methods/oauth.v2.access">https://api.slack.com/methods/oauth.v2.access</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.v2.access">https://docs.slack.dev/reference/methods/oauth.v2.access</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.oauth_v2_exchange"><code class="name flex">
 <span>def <span class="ident">oauth_v2_exchange</span></span>(<span>self, *, token: str, client_id: str, client_secret: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12421,13 +12503,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Exchanges a legacy access token for a new expiring access token and refresh token
-    https://api.slack.com/methods/oauth.v2.exchange
+    https://docs.slack.dev/reference/methods/oauth.v2.exchange
     &#34;&#34;&#34;
     kwargs.update({&#34;client_id&#34;: client_id, &#34;client_secret&#34;: client_secret, &#34;token&#34;: token})
     return self.api_call(&#34;oauth.v2.exchange&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Exchanges a legacy access token for a new expiring access token and refresh token
-<a href="https://api.slack.com/methods/oauth.v2.exchange">https://api.slack.com/methods/oauth.v2.exchange</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/oauth.v2.exchange">https://docs.slack.dev/reference/methods/oauth.v2.exchange</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.openid_connect_token"><code class="name flex">
 <span>def <span class="ident">openid_connect_token</span></span>(<span>self,<br>client_id: str,<br>client_secret: str,<br>code: str | None = None,<br>redirect_uri: str | None = None,<br>grant_type: str | None = None,<br>refresh_token: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12448,7 +12530,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-    https://api.slack.com/methods/openid.connect.token
+    https://docs.slack.dev/reference/methods/openid.connect.token
     &#34;&#34;&#34;
     if redirect_uri is not None:
         kwargs.update({&#34;redirect_uri&#34;: redirect_uri})
@@ -12465,7 +12547,7 @@ multiparty direct message.</p></div>
     )</code></pre>
 </details>
 <div class="desc"><p>Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-<a href="https://api.slack.com/methods/openid.connect.token">https://api.slack.com/methods/openid.connect.token</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/openid.connect.token">https://docs.slack.dev/reference/methods/openid.connect.token</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.openid_connect_userInfo"><code class="name flex">
 <span>def <span class="ident">openid_connect_userInfo</span></span>(<span>self, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12480,12 +12562,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Get the identity of a user who has authorized Sign in with Slack.
-    https://api.slack.com/methods/openid.connect.userInfo
+    https://docs.slack.dev/reference/methods/openid.connect.userInfo
     &#34;&#34;&#34;
     return self.api_call(&#34;openid.connect.userInfo&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get the identity of a user who has authorized Sign in with Slack.
-<a href="https://api.slack.com/methods/openid.connect.userInfo">https://api.slack.com/methods/openid.connect.userInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/openid.connect.userInfo">https://docs.slack.dev/reference/methods/openid.connect.userInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.pins_add"><code class="name flex">
 <span>def <span class="ident">pins_add</span></span>(<span>self, *, channel: str, timestamp: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12503,13 +12585,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Pins an item to a channel.
-    https://api.slack.com/methods/pins.add
+    https://docs.slack.dev/reference/methods/pins.add
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;pins.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Pins an item to a channel.
-<a href="https://api.slack.com/methods/pins.add">https://api.slack.com/methods/pins.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.add">https://docs.slack.dev/reference/methods/pins.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.pins_list"><code class="name flex">
 <span>def <span class="ident">pins_list</span></span>(<span>self, *, channel: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12526,13 +12608,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists items pinned to a channel.
-    https://api.slack.com/methods/pins.list
+    https://docs.slack.dev/reference/methods/pins.list
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel})
     return self.api_call(&#34;pins.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists items pinned to a channel.
-<a href="https://api.slack.com/methods/pins.list">https://api.slack.com/methods/pins.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.list">https://docs.slack.dev/reference/methods/pins.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.pins_remove"><code class="name flex">
 <span>def <span class="ident">pins_remove</span></span>(<span>self, *, channel: str, timestamp: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12550,13 +12632,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Un-pins an item from a channel.
-    https://api.slack.com/methods/pins.remove
+    https://docs.slack.dev/reference/methods/pins.remove
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;pins.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Un-pins an item from a channel.
-<a href="https://api.slack.com/methods/pins.remove">https://api.slack.com/methods/pins.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/pins.remove">https://docs.slack.dev/reference/methods/pins.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.reactions_add"><code class="name flex">
 <span>def <span class="ident">reactions_add</span></span>(<span>self, *, channel: str, name: str, timestamp: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12575,13 +12657,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Adds a reaction to an item.
-    https://api.slack.com/methods/reactions.add
+    https://docs.slack.dev/reference/methods/reactions.add
     &#34;&#34;&#34;
     kwargs.update({&#34;channel&#34;: channel, &#34;name&#34;: name, &#34;timestamp&#34;: timestamp})
     return self.api_call(&#34;reactions.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds a reaction to an item.
-<a href="https://api.slack.com/methods/reactions.add">https://api.slack.com/methods/reactions.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.add">https://docs.slack.dev/reference/methods/reactions.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.reactions_get"><code class="name flex">
 <span>def <span class="ident">reactions_get</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>full: bool | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12602,7 +12684,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets reactions for an item.
-    https://api.slack.com/methods/reactions.get
+    https://docs.slack.dev/reference/methods/reactions.get
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12616,7 +12698,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets reactions for an item.
-<a href="https://api.slack.com/methods/reactions.get">https://api.slack.com/methods/reactions.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.get">https://docs.slack.dev/reference/methods/reactions.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.reactions_list"><code class="name flex">
 <span>def <span class="ident">reactions_list</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>full: bool | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>team_id: str | None = None,<br>user: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12639,7 +12721,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists reactions made by a user.
-    https://api.slack.com/methods/reactions.list
+    https://docs.slack.dev/reference/methods/reactions.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12655,7 +12737,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists reactions made by a user.
-<a href="https://api.slack.com/methods/reactions.list">https://api.slack.com/methods/reactions.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.list">https://docs.slack.dev/reference/methods/reactions.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.reactions_remove"><code class="name flex">
 <span>def <span class="ident">reactions_remove</span></span>(<span>self,<br>*,<br>name: str,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12676,7 +12758,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Removes a reaction from an item.
-    https://api.slack.com/methods/reactions.remove
+    https://docs.slack.dev/reference/methods/reactions.remove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12690,7 +12772,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reactions.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a reaction from an item.
-<a href="https://api.slack.com/methods/reactions.remove">https://api.slack.com/methods/reactions.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reactions.remove">https://docs.slack.dev/reference/methods/reactions.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.reminders_add"><code class="name flex">
 <span>def <span class="ident">reminders_add</span></span>(<span>self,<br>*,<br>text: str,<br>time: str,<br>team_id: str | None = None,<br>user: str | None = None,<br>recurrence: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12711,7 +12793,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Creates a reminder.
-    https://api.slack.com/methods/reminders.add
+    https://docs.slack.dev/reference/methods/reminders.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12725,7 +12807,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;reminders.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Creates a reminder.
-<a href="https://api.slack.com/methods/reminders.add">https://api.slack.com/methods/reminders.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.add">https://docs.slack.dev/reference/methods/reminders.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.reminders_complete"><code class="name flex">
 <span>def <span class="ident">reminders_complete</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12743,13 +12825,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Marks a reminder as complete.
-    https://api.slack.com/methods/reminders.complete
+    https://docs.slack.dev/reference/methods/reminders.complete
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.complete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Marks a reminder as complete.
-<a href="https://api.slack.com/methods/reminders.complete">https://api.slack.com/methods/reminders.complete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.complete">https://docs.slack.dev/reference/methods/reminders.complete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.reminders_delete"><code class="name flex">
 <span>def <span class="ident">reminders_delete</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12767,13 +12849,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Deletes a reminder.
-    https://api.slack.com/methods/reminders.delete
+    https://docs.slack.dev/reference/methods/reminders.delete
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.delete&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Deletes a reminder.
-<a href="https://api.slack.com/methods/reminders.delete">https://api.slack.com/methods/reminders.delete</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.delete">https://docs.slack.dev/reference/methods/reminders.delete</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.reminders_info"><code class="name flex">
 <span>def <span class="ident">reminders_info</span></span>(<span>self, *, reminder: str, team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12791,13 +12873,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets information about a reminder.
-    https://api.slack.com/methods/reminders.info
+    https://docs.slack.dev/reference/methods/reminders.info
     &#34;&#34;&#34;
     kwargs.update({&#34;reminder&#34;: reminder, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a reminder.
-<a href="https://api.slack.com/methods/reminders.info">https://api.slack.com/methods/reminders.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.info">https://docs.slack.dev/reference/methods/reminders.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.reminders_list"><code class="name flex">
 <span>def <span class="ident">reminders_list</span></span>(<span>self, *, team_id: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12814,13 +12896,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists all reminders created by or for a given user.
-    https://api.slack.com/methods/reminders.list
+    https://docs.slack.dev/reference/methods/reminders.list
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id})
     return self.api_call(&#34;reminders.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all reminders created by or for a given user.
-<a href="https://api.slack.com/methods/reminders.list">https://api.slack.com/methods/reminders.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/reminders.list">https://docs.slack.dev/reference/methods/reminders.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.rtm_connect"><code class="name flex">
 <span>def <span class="ident">rtm_connect</span></span>(<span>self,<br>*,<br>batch_presence_aware: bool | None = None,<br>presence_sub: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12838,13 +12920,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Starts a Real Time Messaging session.
-    https://api.slack.com/methods/rtm.connect
+    https://docs.slack.dev/reference/methods/rtm.connect
     &#34;&#34;&#34;
     kwargs.update({&#34;batch_presence_aware&#34;: batch_presence_aware, &#34;presence_sub&#34;: presence_sub})
     return self.api_call(&#34;rtm.connect&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Starts a Real Time Messaging session.
-<a href="https://api.slack.com/methods/rtm.connect">https://api.slack.com/methods/rtm.connect</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/rtm.connect">https://docs.slack.dev/reference/methods/rtm.connect</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.rtm_start"><code class="name flex">
 <span>def <span class="ident">rtm_start</span></span>(<span>self,<br>*,<br>batch_presence_aware: bool | None = None,<br>include_locale: bool | None = None,<br>mpim_aware: bool | None = None,<br>no_latest: bool | None = None,<br>no_unreads: bool | None = None,<br>presence_sub: bool | None = None,<br>simple_latest: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12867,7 +12949,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Starts a Real Time Messaging session.
-    https://api.slack.com/methods/rtm.start
+    https://docs.slack.dev/reference/methods/rtm.start
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12883,7 +12965,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;rtm.start&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Starts a Real Time Messaging session.
-<a href="https://api.slack.com/methods/rtm.start">https://api.slack.com/methods/rtm.start</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/rtm.start">https://docs.slack.dev/reference/methods/rtm.start</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.search_all"><code class="name flex">
 <span>def <span class="ident">search_all</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12906,7 +12988,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Searches for messages and files matching a query.
-    https://api.slack.com/methods/search.all
+    https://docs.slack.dev/reference/methods/search.all
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12922,7 +13004,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.all&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for messages and files matching a query.
-<a href="https://api.slack.com/methods/search.all">https://api.slack.com/methods/search.all</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.all">https://docs.slack.dev/reference/methods/search.all</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.search_files"><code class="name flex">
 <span>def <span class="ident">search_files</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12945,7 +13027,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Searches for files matching a query.
-    https://api.slack.com/methods/search.files
+    https://docs.slack.dev/reference/methods/search.files
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -12961,7 +13043,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.files&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for files matching a query.
-<a href="https://api.slack.com/methods/search.files">https://api.slack.com/methods/search.files</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.files">https://docs.slack.dev/reference/methods/search.files</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.search_messages"><code class="name flex">
 <span>def <span class="ident">search_messages</span></span>(<span>self,<br>*,<br>query: str,<br>count: int | None = None,<br>cursor: str | None = None,<br>highlight: bool | None = None,<br>page: int | None = None,<br>sort: str | None = None,<br>sort_dir: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -12985,7 +13067,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Searches for messages matching a query.
-    https://api.slack.com/methods/search.messages
+    https://docs.slack.dev/reference/methods/search.messages
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13002,7 +13084,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;search.messages&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Searches for messages matching a query.
-<a href="https://api.slack.com/methods/search.messages">https://api.slack.com/methods/search.messages</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/search.messages">https://docs.slack.dev/reference/methods/search.messages</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.stars_add"><code class="name flex">
 <span>def <span class="ident">stars_add</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13022,7 +13104,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Adds a star to an item.
-    https://api.slack.com/methods/stars.add
+    https://docs.slack.dev/reference/methods/stars.add
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13035,7 +13117,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.add&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Adds a star to an item.
-<a href="https://api.slack.com/methods/stars.add">https://api.slack.com/methods/stars.add</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.add">https://docs.slack.dev/reference/methods/stars.add</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.stars_list"><code class="name flex">
 <span>def <span class="ident">stars_list</span></span>(<span>self,<br>*,<br>count: int | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>page: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13056,7 +13138,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists stars for a user.
-    https://api.slack.com/methods/stars.list
+    https://docs.slack.dev/reference/methods/stars.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13070,7 +13152,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists stars for a user.
-<a href="https://api.slack.com/methods/stars.list">https://api.slack.com/methods/stars.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.list">https://docs.slack.dev/reference/methods/stars.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.stars_remove"><code class="name flex">
 <span>def <span class="ident">stars_remove</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13090,7 +13172,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Removes a star from an item.
-    https://api.slack.com/methods/stars.remove
+    https://docs.slack.dev/reference/methods/stars.remove
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13103,7 +13185,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;stars.remove&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Removes a star from an item.
-<a href="https://api.slack.com/methods/stars.remove">https://api.slack.com/methods/stars.remove</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/stars.remove">https://docs.slack.dev/reference/methods/stars.remove</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_accessLogs"><code class="name flex">
 <span>def <span class="ident">team_accessLogs</span></span>(<span>self,<br>*,<br>before: str | int | None = None,<br>count: str | int | None = None,<br>page: str | int | None = None,<br>team_id: str | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13125,7 +13207,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets the access logs for the current team.
-    https://api.slack.com/methods/team.accessLogs
+    https://docs.slack.dev/reference/methods/team.accessLogs
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13140,7 +13222,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.accessLogs&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets the access logs for the current team.
-<a href="https://api.slack.com/methods/team.accessLogs">https://api.slack.com/methods/team.accessLogs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.accessLogs">https://docs.slack.dev/reference/methods/team.accessLogs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_billableInfo"><code class="name flex">
 <span>def <span class="ident">team_billableInfo</span></span>(<span>self, *, team_id: str | None = None, user: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13158,13 +13240,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets billable users information for the current team.
-    https://api.slack.com/methods/team.billableInfo
+    https://docs.slack.dev/reference/methods/team.billableInfo
     &#34;&#34;&#34;
     kwargs.update({&#34;team_id&#34;: team_id, &#34;user&#34;: user})
     return self.api_call(&#34;team.billableInfo&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets billable users information for the current team.
-<a href="https://api.slack.com/methods/team.billableInfo">https://api.slack.com/methods/team.billableInfo</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.billableInfo">https://docs.slack.dev/reference/methods/team.billableInfo</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_billing_info"><code class="name flex">
 <span>def <span class="ident">team_billing_info</span></span>(<span>self, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13179,12 +13261,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Reads a workspace&#39;s billing plan information.
-    https://api.slack.com/methods/team.billing.info
+    https://docs.slack.dev/reference/methods/team.billing.info
     &#34;&#34;&#34;
     return self.api_call(&#34;team.billing.info&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Reads a workspace's billing plan information.
-<a href="https://api.slack.com/methods/team.billing.info">https://api.slack.com/methods/team.billing.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.billing.info">https://docs.slack.dev/reference/methods/team.billing.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_externalTeams_disconnect"><code class="name flex">
 <span>def <span class="ident">team_externalTeams_disconnect</span></span>(<span>self, *, target_team: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13201,7 +13283,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Disconnects an external organization.
-    https://api.slack.com/methods/team.externalTeams.disconnect
+    https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13211,7 +13293,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.externalTeams.disconnect&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disconnects an external organization.
-<a href="https://api.slack.com/methods/team.externalTeams.disconnect">https://api.slack.com/methods/team.externalTeams.disconnect</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.externalTeams.disconnect">https://docs.slack.dev/reference/methods/team.externalTeams.disconnect</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_externalTeams_list"><code class="name flex">
 <span>def <span class="ident">team_externalTeams_list</span></span>(<span>self,<br>*,<br>connection_status_filter: str | None = None,<br>slack_connect_pref_filter: Sequence[str] | None = None,<br>sort_direction: str | None = None,<br>sort_field: str | None = None,<br>workspace_filter: Sequence[str] | None = None,<br>cursor: str | None = None,<br>limit: int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13234,7 +13316,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Returns a list of all the external teams connected and details about the connection.
-    https://api.slack.com/methods/team.externalTeams.list
+    https://docs.slack.dev/reference/methods/team.externalTeams.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13258,7 +13340,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.externalTeams.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Returns a list of all the external teams connected and details about the connection.
-<a href="https://api.slack.com/methods/team.externalTeams.list">https://api.slack.com/methods/team.externalTeams.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.externalTeams.list">https://docs.slack.dev/reference/methods/team.externalTeams.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_info"><code class="name flex">
 <span>def <span class="ident">team_info</span></span>(<span>self, *, team: str | None = None, domain: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13276,13 +13358,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets information about the current team.
-    https://api.slack.com/methods/team.info
+    https://docs.slack.dev/reference/methods/team.info
     &#34;&#34;&#34;
     kwargs.update({&#34;team&#34;: team, &#34;domain&#34;: domain})
     return self.api_call(&#34;team.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about the current team.
-<a href="https://api.slack.com/methods/team.info">https://api.slack.com/methods/team.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.info">https://docs.slack.dev/reference/methods/team.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_integrationLogs"><code class="name flex">
 <span>def <span class="ident">team_integrationLogs</span></span>(<span>self,<br>*,<br>app_id: str | None = None,<br>change_type: str | None = None,<br>count: str | int | None = None,<br>page: str | int | None = None,<br>service_id: str | None = None,<br>team_id: str | None = None,<br>user: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13305,7 +13387,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets the integration logs for the current team.
-    https://api.slack.com/methods/team.integrationLogs
+    https://docs.slack.dev/reference/methods/team.integrationLogs
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13321,7 +13403,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;team.integrationLogs&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets the integration logs for the current team.
-<a href="https://api.slack.com/methods/team.integrationLogs">https://api.slack.com/methods/team.integrationLogs</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.integrationLogs">https://docs.slack.dev/reference/methods/team.integrationLogs</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_preferences_list"><code class="name flex">
 <span>def <span class="ident">team_preferences_list</span></span>(<span>self, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13336,12 +13418,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieve a list of a workspace&#39;s team preferences.
-    https://api.slack.com/methods/team.preferences.list
+    https://docs.slack.dev/reference/methods/team.preferences.list
     &#34;&#34;&#34;
     return self.api_call(&#34;team.preferences.list&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a list of a workspace's team preferences.
-<a href="https://api.slack.com/methods/team.preferences.list">https://api.slack.com/methods/team.preferences.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.preferences.list">https://docs.slack.dev/reference/methods/team.preferences.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.team_profile_get"><code class="name flex">
 <span>def <span class="ident">team_profile_get</span></span>(<span>self, *, visibility: str | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13358,13 +13440,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieve a team&#39;s profile.
-    https://api.slack.com/methods/team.profile.get
+    https://docs.slack.dev/reference/methods/team.profile.get
     &#34;&#34;&#34;
     kwargs.update({&#34;visibility&#34;: visibility})
     return self.api_call(&#34;team.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieve a team's profile.
-<a href="https://api.slack.com/methods/team.profile.get">https://api.slack.com/methods/team.profile.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/team.profile.get">https://docs.slack.dev/reference/methods/team.profile.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.tooling_tokens_rotate"><code class="name flex">
 <span>def <span class="ident">tooling_tokens_rotate</span></span>(<span>self, *, refresh_token: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13381,13 +13463,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Exchanges a refresh token for a new app configuration token
-    https://api.slack.com/methods/tooling.tokens.rotate
+    https://docs.slack.dev/reference/methods/tooling.tokens.rotate
     &#34;&#34;&#34;
     kwargs.update({&#34;refresh_token&#34;: refresh_token})
     return self.api_call(&#34;tooling.tokens.rotate&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Exchanges a refresh token for a new app configuration token
-<a href="https://api.slack.com/methods/tooling.tokens.rotate">https://api.slack.com/methods/tooling.tokens.rotate</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/tooling.tokens.rotate">https://docs.slack.dev/reference/methods/tooling.tokens.rotate</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.usergroups_create"><code class="name flex">
 <span>def <span class="ident">usergroups_create</span></span>(<span>self,<br>*,<br>name: str,<br>channels: str | Sequence[str] | None = None,<br>description: str | None = None,<br>handle: str | None = None,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13409,7 +13491,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Create a User Group
-    https://api.slack.com/methods/usergroups.create
+    https://docs.slack.dev/reference/methods/usergroups.create
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13427,7 +13509,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.create&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Create a User Group
-<a href="https://api.slack.com/methods/usergroups.create">https://api.slack.com/methods/usergroups.create</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.create">https://docs.slack.dev/reference/methods/usergroups.create</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.usergroups_disable"><code class="name flex">
 <span>def <span class="ident">usergroups_disable</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13446,13 +13528,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Disable an existing User Group
-    https://api.slack.com/methods/usergroups.disable
+    https://docs.slack.dev/reference/methods/usergroups.disable
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;usergroups.disable&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Disable an existing User Group
-<a href="https://api.slack.com/methods/usergroups.disable">https://api.slack.com/methods/usergroups.disable</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.disable">https://docs.slack.dev/reference/methods/usergroups.disable</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.usergroups_enable"><code class="name flex">
 <span>def <span class="ident">usergroups_enable</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13471,13 +13553,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Enable a User Group
-    https://api.slack.com/methods/usergroups.enable
+    https://docs.slack.dev/reference/methods/usergroups.enable
     &#34;&#34;&#34;
     kwargs.update({&#34;usergroup&#34;: usergroup, &#34;include_count&#34;: include_count, &#34;team_id&#34;: team_id})
     return self.api_call(&#34;usergroups.enable&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Enable a User Group
-<a href="https://api.slack.com/methods/usergroups.enable">https://api.slack.com/methods/usergroups.enable</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.enable">https://docs.slack.dev/reference/methods/usergroups.enable</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.usergroups_list"><code class="name flex">
 <span>def <span class="ident">usergroups_list</span></span>(<span>self,<br>*,<br>include_count: bool | None = None,<br>include_disabled: bool | None = None,<br>include_users: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13497,7 +13579,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all User Groups for a team
-    https://api.slack.com/methods/usergroups.list
+    https://docs.slack.dev/reference/methods/usergroups.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13510,7 +13592,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all User Groups for a team
-<a href="https://api.slack.com/methods/usergroups.list">https://api.slack.com/methods/usergroups.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.list">https://docs.slack.dev/reference/methods/usergroups.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.usergroups_update"><code class="name flex">
 <span>def <span class="ident">usergroups_update</span></span>(<span>self,<br>*,<br>usergroup: str,<br>channels: str | Sequence[str] | None = None,<br>description: str | None = None,<br>handle: str | None = None,<br>include_count: bool | None = None,<br>name: str | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13533,7 +13615,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Update an existing User Group
-    https://api.slack.com/methods/usergroups.update
+    https://docs.slack.dev/reference/methods/usergroups.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13552,7 +13634,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update an existing User Group
-<a href="https://api.slack.com/methods/usergroups.update">https://api.slack.com/methods/usergroups.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.update">https://docs.slack.dev/reference/methods/usergroups.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.usergroups_users_list"><code class="name flex">
 <span>def <span class="ident">usergroups_users_list</span></span>(<span>self,<br>*,<br>usergroup: str,<br>include_disabled: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13571,7 +13653,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List all users in a User Group
-    https://api.slack.com/methods/usergroups.users.list
+    https://docs.slack.dev/reference/methods/usergroups.users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13583,7 +13665,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.users.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List all users in a User Group
-<a href="https://api.slack.com/methods/usergroups.users.list">https://api.slack.com/methods/usergroups.users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.users.list">https://docs.slack.dev/reference/methods/usergroups.users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.usergroups_users_update"><code class="name flex">
 <span>def <span class="ident">usergroups_users_update</span></span>(<span>self,<br>*,<br>usergroup: str,<br>users: str | Sequence[str],<br>include_count: bool | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13603,7 +13685,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Update the list of users for a User Group
-    https://api.slack.com/methods/usergroups.users.update
+    https://docs.slack.dev/reference/methods/usergroups.users.update
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13619,7 +13701,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;usergroups.users.update&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update the list of users for a User Group
-<a href="https://api.slack.com/methods/usergroups.users.update">https://api.slack.com/methods/usergroups.users.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/usergroups.users.update">https://docs.slack.dev/reference/methods/usergroups.users.update</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_conversations"><code class="name flex">
 <span>def <span class="ident">users_conversations</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>exclude_archived: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>types: str | Sequence[str] | None = None,<br>user: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13641,7 +13723,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;List conversations the calling user may access.
-    https://api.slack.com/methods/users.conversations
+    https://docs.slack.dev/reference/methods/users.conversations
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13659,7 +13741,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.conversations&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>List conversations the calling user may access.
-<a href="https://api.slack.com/methods/users.conversations">https://api.slack.com/methods/users.conversations</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.conversations">https://docs.slack.dev/reference/methods/users.conversations</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_deletePhoto"><code class="name flex">
 <span>def <span class="ident">users_deletePhoto</span></span>(<span>self, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13674,12 +13756,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Delete the user profile photo
-    https://api.slack.com/methods/users.deletePhoto
+    https://docs.slack.dev/reference/methods/users.deletePhoto
     &#34;&#34;&#34;
     return self.api_call(&#34;users.deletePhoto&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Delete the user profile photo
-<a href="https://api.slack.com/methods/users.deletePhoto">https://api.slack.com/methods/users.deletePhoto</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.deletePhoto">https://docs.slack.dev/reference/methods/users.deletePhoto</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_discoverableContacts_lookup"><code class="name flex">
 <span>def <span class="ident">users_discoverableContacts_lookup</span></span>(<span>self, email: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13695,13 +13777,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lookup an email address to see if someone is on Slack
-    https://api.slack.com/methods/users.discoverableContacts.lookup
+    https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
     &#34;&#34;&#34;
     kwargs.update({&#34;email&#34;: email})
     return self.api_call(&#34;users.discoverableContacts.lookup&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lookup an email address to see if someone is on Slack
-<a href="https://api.slack.com/methods/users.discoverableContacts.lookup">https://api.slack.com/methods/users.discoverableContacts.lookup</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup">https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_getPresence"><code class="name flex">
 <span>def <span class="ident">users_getPresence</span></span>(<span>self, *, user: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13718,13 +13800,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets user presence information.
-    https://api.slack.com/methods/users.getPresence
+    https://docs.slack.dev/reference/methods/users.getPresence
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user})
     return self.api_call(&#34;users.getPresence&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets user presence information.
-<a href="https://api.slack.com/methods/users.getPresence">https://api.slack.com/methods/users.getPresence</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.getPresence">https://docs.slack.dev/reference/methods/users.getPresence</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_identity"><code class="name flex">
 <span>def <span class="ident">users_identity</span></span>(<span>self, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13739,12 +13821,12 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Get a user&#39;s identity.
-    https://api.slack.com/methods/users.identity
+    https://docs.slack.dev/reference/methods/users.identity
     &#34;&#34;&#34;
     return self.api_call(&#34;users.identity&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Get a user's identity.
-<a href="https://api.slack.com/methods/users.identity">https://api.slack.com/methods/users.identity</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.identity">https://docs.slack.dev/reference/methods/users.identity</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_info"><code class="name flex">
 <span>def <span class="ident">users_info</span></span>(<span>self, *, user: str, include_locale: bool | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13762,13 +13844,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Gets information about a user.
-    https://api.slack.com/methods/users.info
+    https://docs.slack.dev/reference/methods/users.info
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user, &#34;include_locale&#34;: include_locale})
     return self.api_call(&#34;users.info&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Gets information about a user.
-<a href="https://api.slack.com/methods/users.info">https://api.slack.com/methods/users.info</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.info">https://docs.slack.dev/reference/methods/users.info</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_list"><code class="name flex">
 <span>def <span class="ident">users_list</span></span>(<span>self,<br>*,<br>cursor: str | None = None,<br>include_locale: bool | None = None,<br>limit: int | None = None,<br>team_id: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13788,7 +13870,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Lists all users in a Slack team.
-    https://api.slack.com/methods/users.list
+    https://docs.slack.dev/reference/methods/users.list
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13801,7 +13883,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Lists all users in a Slack team.
-<a href="https://api.slack.com/methods/users.list">https://api.slack.com/methods/users.list</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.list">https://docs.slack.dev/reference/methods/users.list</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_lookupByEmail"><code class="name flex">
 <span>def <span class="ident">users_lookupByEmail</span></span>(<span>self, *, email: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13818,13 +13900,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Find a user with an email address.
-    https://api.slack.com/methods/users.lookupByEmail
+    https://docs.slack.dev/reference/methods/users.lookupByEmail
     &#34;&#34;&#34;
     kwargs.update({&#34;email&#34;: email})
     return self.api_call(&#34;users.lookupByEmail&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Find a user with an email address.
-<a href="https://api.slack.com/methods/users.lookupByEmail">https://api.slack.com/methods/users.lookupByEmail</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.lookupByEmail">https://docs.slack.dev/reference/methods/users.lookupByEmail</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_profile_get"><code class="name flex">
 <span>def <span class="ident">users_profile_get</span></span>(<span>self, *, user: str | None = None, include_labels: bool | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13842,13 +13924,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Retrieves a user&#39;s profile information.
-    https://api.slack.com/methods/users.profile.get
+    https://docs.slack.dev/reference/methods/users.profile.get
     &#34;&#34;&#34;
     kwargs.update({&#34;user&#34;: user, &#34;include_labels&#34;: include_labels})
     return self.api_call(&#34;users.profile.get&#34;, http_verb=&#34;GET&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Retrieves a user's profile information.
-<a href="https://api.slack.com/methods/users.profile.get">https://api.slack.com/methods/users.profile.get</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.profile.get">https://docs.slack.dev/reference/methods/users.profile.get</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_profile_set"><code class="name flex">
 <span>def <span class="ident">users_profile_set</span></span>(<span>self,<br>*,<br>name: str | None = None,<br>value: str | None = None,<br>user: str | None = None,<br>profile: Dict | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13868,7 +13950,7 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set the profile information for a user.
-    https://api.slack.com/methods/users.profile.set
+    https://docs.slack.dev/reference/methods/users.profile.set
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -13883,7 +13965,7 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;users.profile.set&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the profile information for a user.
-<a href="https://api.slack.com/methods/users.profile.set">https://api.slack.com/methods/users.profile.set</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.profile.set">https://docs.slack.dev/reference/methods/users.profile.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_setPhoto"><code class="name flex">
 <span>def <span class="ident">users_setPhoto</span></span>(<span>self,<br>*,<br>image: str | io.IOBase,<br>crop_w: str | int | None = None,<br>crop_x: str | int | None = None,<br>crop_y: str | int | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13903,13 +13985,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Set the user profile photo
-    https://api.slack.com/methods/users.setPhoto
+    https://docs.slack.dev/reference/methods/users.setPhoto
     &#34;&#34;&#34;
     kwargs.update({&#34;crop_w&#34;: crop_w, &#34;crop_x&#34;: crop_x, &#34;crop_y&#34;: crop_y})
     return self.api_call(&#34;users.setPhoto&#34;, files={&#34;image&#34;: image}, data=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Set the user profile photo
-<a href="https://api.slack.com/methods/users.setPhoto">https://api.slack.com/methods/users.setPhoto</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.setPhoto">https://docs.slack.dev/reference/methods/users.setPhoto</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.users_setPresence"><code class="name flex">
 <span>def <span class="ident">users_setPresence</span></span>(<span>self, *, presence: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13926,13 +14008,13 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Manually sets user presence.
-    https://api.slack.com/methods/users.setPresence
+    https://docs.slack.dev/reference/methods/users.setPresence
     &#34;&#34;&#34;
     kwargs.update({&#34;presence&#34;: presence})
     return self.api_call(&#34;users.setPresence&#34;, params=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Manually sets user presence.
-<a href="https://api.slack.com/methods/users.setPresence">https://api.slack.com/methods/users.setPresence</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/users.setPresence">https://docs.slack.dev/reference/methods/users.setPresence</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.views_open"><code class="name flex">
 <span>def <span class="ident">views_open</span></span>(<span>self,<br>*,<br>trigger_id: str | None = None,<br>interactivity_pointer: str | None = None,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13951,8 +14033,8 @@ multiparty direct message.</p></div>
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Open a view for a user.
-    https://api.slack.com/methods/views.open
-    See https://api.slack.com/surfaces/modals for details.
+    https://docs.slack.dev/reference/methods/views.open
+    See https://docs.slack.dev/surfaces/modals/ for details.
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
     if isinstance(view, View):
@@ -13964,8 +14046,8 @@ multiparty direct message.</p></div>
     return self.api_call(&#34;views.open&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Open a view for a user.
-<a href="https://api.slack.com/methods/views.open">https://api.slack.com/methods/views.open</a>
-See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a> for details.</p></div>
+<a href="https://docs.slack.dev/reference/methods/views.open">https://docs.slack.dev/reference/methods/views.open</a>
+See <a href="https://docs.slack.dev/surfaces/modals/">https://docs.slack.dev/surfaces/modals/</a> for details.</p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.views_publish"><code class="name flex">
 <span>def <span class="ident">views_publish</span></span>(<span>self,<br>*,<br>user_id: str,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>hash: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13985,8 +14067,8 @@ See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfac
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Publish a static view for a User.
     Create or update the view that comprises an
-    app&#39;s Home tab (https://api.slack.com/surfaces/tabs)
-    https://api.slack.com/methods/views.publish
+    app&#39;s Home tab (https://docs.slack.dev/surfaces/app-home/)
+    https://docs.slack.dev/reference/methods/views.publish
     &#34;&#34;&#34;
     kwargs.update({&#34;user_id&#34;: user_id, &#34;hash&#34;: hash})
     if isinstance(view, View):
@@ -13999,8 +14081,8 @@ See <a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfac
 </details>
 <div class="desc"><p>Publish a static view for a User.
 Create or update the view that comprises an
-app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.com/surfaces/tabs</a>)
-<a href="https://api.slack.com/methods/views.publish">https://api.slack.com/methods/views.publish</a></p></div>
+app's Home tab (<a href="https://docs.slack.dev/surfaces/app-home/">https://docs.slack.dev/surfaces/app-home/</a>)
+<a href="https://docs.slack.dev/reference/methods/views.publish">https://docs.slack.dev/reference/methods/views.publish</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.views_push"><code class="name flex">
 <span>def <span class="ident">views_push</span></span>(<span>self,<br>*,<br>trigger_id: str | None = None,<br>interactivity_pointer: str | None = None,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -14022,9 +14104,9 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
     Push a new view onto the existing view stack by passing a view
     payload and a valid trigger_id generated from an interaction
     within the existing modal.
-    Read the modals documentation (https://api.slack.com/surfaces/modals)
+    Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
     to learn more about the lifecycle and intricacies of views.
-    https://api.slack.com/methods/views.push
+    https://docs.slack.dev/reference/methods/views.push
     &#34;&#34;&#34;
     kwargs.update({&#34;trigger_id&#34;: trigger_id, &#34;interactivity_pointer&#34;: interactivity_pointer})
     if isinstance(view, View):
@@ -14039,9 +14121,9 @@ app's Home tab (<a href="https://api.slack.com/surfaces/tabs">https://api.slack.
 Push a new view onto the existing view stack by passing a view
 payload and a valid trigger_id generated from an interaction
 within the existing modal.
-Read the modals documentation (<a href="https://api.slack.com/surfaces/modals">https://api.slack.com/surfaces/modals</a>)
+Read the modals documentation (<a href="https://docs.slack.dev/surfaces/modals/">https://docs.slack.dev/surfaces/modals/</a>)
 to learn more about the lifecycle and intricacies of views.
-<a href="https://api.slack.com/methods/views.push">https://api.slack.com/methods/views.push</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/views.push">https://docs.slack.dev/reference/methods/views.push</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.views_update"><code class="name flex">
 <span>def <span class="ident">views_update</span></span>(<span>self,<br>*,<br>view: dict | <a title="slack_sdk.models.views.View" href="../models/views/index.html#slack_sdk.models.views.View">View</a>,<br>external_id: str | None = None,<br>view_id: str | None = None,<br>hash: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -14063,9 +14145,9 @@ to learn more about the lifecycle and intricacies of views.
     &#34;&#34;&#34;Update an existing view.
     Update a view by passing a new view definition along with the
     view_id returned in views.open or the external_id.
-    See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+    See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
     to learn more about updating views and avoiding race conditions with the hash argument.
-    https://api.slack.com/methods/views.update
+    https://docs.slack.dev/reference/methods/views.update
     &#34;&#34;&#34;
     if isinstance(view, View):
         kwargs.update({&#34;view&#34;: view.to_dict()})
@@ -14085,9 +14167,119 @@ to learn more about the lifecycle and intricacies of views.
 <div class="desc"><p>Update an existing view.
 Update a view by passing a new view definition along with the
 view_id returned in views.open or the external_id.
-See the modals documentation (<a href="https://api.slack.com/surfaces/modals#updating_views">https://api.slack.com/surfaces/modals#updating_views</a>)
+See the modals documentation (<a href="https://docs.slack.dev/surfaces/modals/#updating_views">https://docs.slack.dev/surfaces/modals/#updating_views</a>)
 to learn more about updating views and avoiding race conditions with the hash argument.
-<a href="https://api.slack.com/methods/views.update">https://api.slack.com/methods/views.update</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/views.update">https://docs.slack.dev/reference/methods/views.update</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_add"><code class="name flex">
+<span>def <span class="ident">workflows_featured_add</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_add(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Add featured workflows to a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.add
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.add&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Add featured workflows to a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.add">https://docs.slack.dev/reference/methods/workflows.featured.add</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_list"><code class="name flex">
+<span>def <span class="ident">workflows_featured_list</span></span>(<span>self, *, channel_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_list(
+    self,
+    *,
+    channel_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;List the featured workflows for specified channels.
+    https://docs.slack.dev/reference/methods/workflows.featured.list
+    &#34;&#34;&#34;
+    if isinstance(channel_ids, (list, tuple)):
+        kwargs.update({&#34;channel_ids&#34;: &#34;,&#34;.join(channel_ids)})
+    else:
+        kwargs.update({&#34;channel_ids&#34;: channel_ids})
+    return self.api_call(&#34;workflows.featured.list&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>List the featured workflows for specified channels.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.list">https://docs.slack.dev/reference/methods/workflows.featured.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_remove"><code class="name flex">
+<span>def <span class="ident">workflows_featured_remove</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_remove(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Remove featured workflows from a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.remove
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.remove&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Remove featured workflows from a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.remove">https://docs.slack.dev/reference/methods/workflows.featured.remove</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_set"><code class="name flex">
+<span>def <span class="ident">workflows_featured_set</span></span>(<span>self, *, channel_id: str, trigger_ids: str | Sequence[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def workflows_featured_set(
+    self,
+    *,
+    channel_id: str,
+    trigger_ids: Union[str, Sequence[str]],
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Set featured workflows for a channel.
+    https://docs.slack.dev/reference/methods/workflows.featured.set
+    &#34;&#34;&#34;
+    kwargs.update({&#34;channel_id&#34;: channel_id})
+    if isinstance(trigger_ids, (list, tuple)):
+        kwargs.update({&#34;trigger_ids&#34;: &#34;,&#34;.join(trigger_ids)})
+    else:
+        kwargs.update({&#34;trigger_ids&#34;: trigger_ids})
+    return self.api_call(&#34;workflows.featured.set&#34;, params=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Set featured workflows for a channel.
+<a href="https://docs.slack.dev/reference/methods/workflows.featured.set">https://docs.slack.dev/reference/methods/workflows.featured.set</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.workflows_stepCompleted"><code class="name flex">
 <span>def <span class="ident">workflows_stepCompleted</span></span>(<span>self, *, workflow_step_execute_id: str, outputs: dict | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -14105,7 +14297,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Indicate a successful outcome of a workflow step&#39;s execution.
-    https://api.slack.com/methods/workflows.stepCompleted
+    https://docs.slack.dev/reference/methods/workflows.stepCompleted
     &#34;&#34;&#34;
     kwargs.update({&#34;workflow_step_execute_id&#34;: workflow_step_execute_id})
     if outputs is not None:
@@ -14115,7 +14307,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.stepCompleted&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Indicate a successful outcome of a workflow step's execution.
-<a href="https://api.slack.com/methods/workflows.stepCompleted">https://api.slack.com/methods/workflows.stepCompleted</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.stepCompleted">https://docs.slack.dev/reference/methods/workflows.stepCompleted</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.workflows_stepFailed"><code class="name flex">
 <span>def <span class="ident">workflows_stepFailed</span></span>(<span>self, *, workflow_step_execute_id: str, error: Dict[str, str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -14133,7 +14325,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Indicate an unsuccessful outcome of a workflow step&#39;s execution.
-    https://api.slack.com/methods/workflows.stepFailed
+    https://docs.slack.dev/reference/methods/workflows.stepFailed
     &#34;&#34;&#34;
     kwargs.update(
         {
@@ -14146,7 +14338,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.stepFailed&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Indicate an unsuccessful outcome of a workflow step's execution.
-<a href="https://api.slack.com/methods/workflows.stepFailed">https://api.slack.com/methods/workflows.stepFailed</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.stepFailed">https://docs.slack.dev/reference/methods/workflows.stepFailed</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.workflows_updateStep"><code class="name flex">
 <span>def <span class="ident">workflows_updateStep</span></span>(<span>self,<br>*,<br>workflow_step_edit_id: str,<br>inputs: Dict[str, Any] | None = None,<br>outputs: List[Dict[str, str]] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -14165,7 +14357,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
     &#34;&#34;&#34;Update the configuration for a workflow extension step.
-    https://api.slack.com/methods/workflows.updateStep
+    https://docs.slack.dev/reference/methods/workflows.updateStep
     &#34;&#34;&#34;
     kwargs.update({&#34;workflow_step_edit_id&#34;: workflow_step_edit_id})
     if inputs is not None:
@@ -14177,7 +14369,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
     return self.api_call(&#34;workflows.updateStep&#34;, json=kwargs)</code></pre>
 </details>
 <div class="desc"><p>Update the configuration for a workflow extension step.
-<a href="https://api.slack.com/methods/workflows.updateStep">https://api.slack.com/methods/workflows.updateStep</a></p></div>
+<a href="https://docs.slack.dev/reference/methods/workflows.updateStep">https://docs.slack.dev/reference/methods/workflows.updateStep</a></p></div>
 </dd>
 </dl>
 <h3>Inherited members</h3>
@@ -14510,6 +14702,10 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.views_publish" href="#slack_sdk.web.legacy_client.LegacyWebClient.views_publish">views_publish</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.views_push" href="#slack_sdk.web.legacy_client.LegacyWebClient.views_push">views_push</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.views_update" href="#slack_sdk.web.legacy_client.LegacyWebClient.views_update">views_update</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_add" href="#slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_add">workflows_featured_add</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_list" href="#slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_list">workflows_featured_list</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_remove" href="#slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_remove">workflows_featured_remove</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_set" href="#slack_sdk.web.legacy_client.LegacyWebClient.workflows_featured_set">workflows_featured_set</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.workflows_stepCompleted" href="#slack_sdk.web.legacy_client.LegacyWebClient.workflows_stepCompleted">workflows_stepCompleted</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.workflows_stepFailed" href="#slack_sdk.web.legacy_client.LegacyWebClient.workflows_stepFailed">workflows_stepFailed</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.workflows_updateStep" href="#slack_sdk.web.legacy_client.LegacyWebClient.workflows_updateStep">workflows_updateStep</a></code></li>

--- a/docs/reference/webhook/async_client.html
+++ b/docs/reference/webhook/async_client.html
@@ -84,7 +84,7 @@ el.replaceWith(d);
     ):
         &#34;&#34;&#34;API client for Incoming Webhooks and `response_url`
 
-        https://api.slack.com/messaging/webhooks
+        https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/
 
         Args:
             url: Complete URL to send data (e.g., `https://hooks.slack.com/XXX`)
@@ -302,7 +302,7 @@ el.replaceWith(d);
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for Incoming Webhooks and <code>response_url</code></p>
-<p><a href="https://api.slack.com/messaging/webhooks">https://api.slack.com/messaging/webhooks</a></p>
+<p><a href="https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/">https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>url</code></strong></dt>

--- a/docs/reference/webhook/client.html
+++ b/docs/reference/webhook/client.html
@@ -78,7 +78,7 @@ el.replaceWith(d);
     ):
         &#34;&#34;&#34;API client for Incoming Webhooks and `response_url`
 
-        https://api.slack.com/messaging/webhooks
+        https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/
 
         Args:
             url: Complete URL to send data (e.g., `https://hooks.slack.com/XXX`)
@@ -297,19 +297,19 @@ el.replaceWith(d);
             http_resp = opener.open(req, timeout=self.timeout)
         else:
             http_resp = urlopen(req, context=self.ssl, timeout=self.timeout)
-        charset: str = http_resp.headers.get_content_charset() or &#34;utf-8&#34;  # type: ignore[union-attr]
-        response_body: str = http_resp.read().decode(charset)  # type: ignore[union-attr]
+        charset: str = http_resp.headers.get_content_charset() or &#34;utf-8&#34;
+        response_body: str = http_resp.read().decode(charset)
         resp = WebhookResponse(
             url=url,
-            status_code=http_resp.status,  # type: ignore[union-attr]
+            status_code=http_resp.status,
             body=response_body,
-            headers=http_resp.headers,  # type: ignore[arg-type, union-attr]
+            headers=http_resp.headers,  # type: ignore[arg-type]
         )
         _debug_log_response(self.logger, resp)
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for Incoming Webhooks and <code>response_url</code></p>
-<p><a href="https://api.slack.com/messaging/webhooks">https://api.slack.com/messaging/webhooks</a></p>
+<p><a href="https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/">https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>url</code></strong></dt>

--- a/docs/reference/webhook/index.html
+++ b/docs/reference/webhook/index.html
@@ -100,7 +100,7 @@ and message responses using response_url in payloads.</p>
     ):
         &#34;&#34;&#34;API client for Incoming Webhooks and `response_url`
 
-        https://api.slack.com/messaging/webhooks
+        https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/
 
         Args:
             url: Complete URL to send data (e.g., `https://hooks.slack.com/XXX`)
@@ -319,19 +319,19 @@ and message responses using response_url in payloads.</p>
             http_resp = opener.open(req, timeout=self.timeout)
         else:
             http_resp = urlopen(req, context=self.ssl, timeout=self.timeout)
-        charset: str = http_resp.headers.get_content_charset() or &#34;utf-8&#34;  # type: ignore[union-attr]
-        response_body: str = http_resp.read().decode(charset)  # type: ignore[union-attr]
+        charset: str = http_resp.headers.get_content_charset() or &#34;utf-8&#34;
+        response_body: str = http_resp.read().decode(charset)
         resp = WebhookResponse(
             url=url,
-            status_code=http_resp.status,  # type: ignore[union-attr]
+            status_code=http_resp.status,
             body=response_body,
-            headers=http_resp.headers,  # type: ignore[arg-type, union-attr]
+            headers=http_resp.headers,  # type: ignore[arg-type]
         )
         _debug_log_response(self.logger, resp)
         return resp</code></pre>
 </details>
 <div class="desc"><p>API client for Incoming Webhooks and <code>response_url</code></p>
-<p><a href="https://api.slack.com/messaging/webhooks">https://api.slack.com/messaging/webhooks</a></p>
+<p><a href="https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/">https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/</a></p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>url</code></strong></dt>

--- a/integration_tests/web/test_conversations_connect.py
+++ b/integration_tests/web/test_conversations_connect.py
@@ -22,7 +22,7 @@ class TestWebClient(unittest.TestCase):
     one for the inviting workspace(list and send invites) another for the recipient
     workspace (accept and approve) sent invites. Before being able to run this test suite,
     we also need to have manually created a slack connect shared channel and added
-    these two bots as members first. See: https://api.slack.com/apis/connect
+    these two bots as members first. See: https://docs.slack.dev/apis/slack-connect/
 
     In addition to conversations.connect:* scopes, your sender bot token should have channels:manage scopes.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 
 
 [project.urls]
-Documentation = "https://slack.dev/python-slack-sdk/"
+Documentation = "https://docs.slack.dev/tools/python-slack-sdk/"
 
 [tool.setuptools.packages.find]
 include = ["slack*", "slack_sdk*"]

--- a/slack/deprecation.py
+++ b/slack/deprecation.py
@@ -9,6 +9,6 @@ def show_message(old: str, new: str) -> None:
 
     message = (
         f"{old} package is deprecated. Please use {new} package instead. "
-        "For more info, go to https://slack.dev/python-slack-sdk/v3-migration/"
+        "For more info, go to https://docs.slack.dev/tools/python-slack-sdk/v3-migration/"
     )
     warnings.warn(message)

--- a/slack/signature/verifier.py
+++ b/slack/signature/verifier.py
@@ -17,7 +17,7 @@ class SignatureVerifier:
         Slack signs its requests using a secret that's unique to your app.
         With the help of signing secrets, your app can more confidently verify
         whether requests from us are authentic.
-        https://api.slack.com/authentication/verifying-requests-from-slack
+        https://docs.slack.dev/authentication/verifying-requests-from-slack/
         """
         self.signing_secret = signing_secret
         self.clock = clock

--- a/slack/web/base_client.py
+++ b/slack/web/base_client.py
@@ -472,7 +472,7 @@ class BaseClient:
         header. The signature is created by combining the signing secret with the
         body of the request we're sending using a standard HMAC-SHA256 keyed hash.
 
-        https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview
+        https://docs.slack.dev/authentication/verifying-requests-from-slack/
 
         Args:
             signing_secret: Your application's signing secret, available in the

--- a/slack/web/deprecation.py
+++ b/slack/web/deprecation.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 
-# https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+# https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
 deprecated_method_prefixes_2020_01 = [
     "channels.",
     "groups.",
@@ -25,6 +25,6 @@ def show_2020_01_deprecation(method_name: str):
         message = (
             f"{method_name} is deprecated. Please use the Conversations API instead. "
             "For more info, go to "
-            "https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api"
+            "https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/"
         )
         warnings.warn(message)

--- a/slack_sdk/__init__.py
+++ b/slack_sdk/__init__.py
@@ -1,5 +1,5 @@
 """
-* The SDK website: https://slack.dev/python-slack-sdk/
+* The SDK website: https://docs.slack.dev/tools/python-slack-sdk
 * PyPI package: https://pypi.org/project/slack-sdk/
 
 Here is the list of key modules in this SDK:

--- a/slack_sdk/audit_logs/__init__.py
+++ b/slack_sdk/audit_logs/__init__.py
@@ -1,6 +1,6 @@
 """Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.
 
-Refer to https://slack.dev/python-slack-sdk/audit-logs/ for details.
+Refer to https://docs.slack.dev/tools/python-slack-sdk/audit-logs for details.
 """
 from .v1.client import AuditLogsClient
 from .v1.response import AuditLogsResponse

--- a/slack_sdk/audit_logs/v1/__init__.py
+++ b/slack_sdk/audit_logs/v1/__init__.py
@@ -1,4 +1,4 @@
 """Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.
 
-Refer to https://slack.dev/python-slack-sdk/audit-logs/ for details.
+Refer to https://docs.slack.dev/tools/python-slack-sdk/audit-logs for details.
 """

--- a/slack_sdk/audit_logs/v1/async_client.py
+++ b/slack_sdk/audit_logs/v1/async_client.py
@@ -1,6 +1,6 @@
 """Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.
 
-Refer to https://slack.dev/python-slack-sdk/audit-logs/ for details.
+Refer to https://docs.slack.dev/tools/python-slack-sdk/audit-logs for details.
 """
 
 import json
@@ -59,7 +59,7 @@ class AsyncAuditLogsClient:
         retry_handlers: Optional[List[AsyncRetryHandler]] = None,
     ):
         """API client for Audit Logs API
-        See https://api.slack.com/admins/audit-logs for more details
+        See https://docs.slack.dev/admins/audit-logs-api/ for more details
 
         Args:
             token: An admin user's token, which starts with `xoxp-`

--- a/slack_sdk/audit_logs/v1/client.py
+++ b/slack_sdk/audit_logs/v1/client.py
@@ -1,6 +1,6 @@
 """Audit Logs API is a set of APIs for monitoring what’s happening in your Enterprise Grid organization.
 
-Refer to https://slack.dev/python-slack-sdk/audit-logs/ for details.
+Refer to https://docs.slack.dev/tools/python-slack-sdk/audit-logs for details.
 """
 
 import json
@@ -54,7 +54,7 @@ class AuditLogsClient:
         retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         """API client for Audit Logs API
-        See https://api.slack.com/admins/audit-logs for more details
+        See https://docs.slack.dev/admins/audit-logs-api/ for more details
 
         Args:
             token: An admin user's token, which starts with `xoxp-`

--- a/slack_sdk/models/attachments/__init__.py
+++ b/slack_sdk/models/attachments/__init__.py
@@ -19,8 +19,8 @@ from slack_sdk.models.blocks import (
 
 class Action(JsonObject):
     """Action in attachments
-    https://api.slack.com/messaging/composing/layouts#attachments
-    https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields
+    https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts
+    https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields
     """
 
     attributes = {"name", "text", "url"}
@@ -66,7 +66,7 @@ class ActionButton(Action):
     ):
         """Simple button for use inside attachments
 
-        https://api.slack.com/legacy/message-buttons
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/
 
         Args:
             name: Name this specific action. The name will be returned to your
@@ -108,7 +108,7 @@ class ActionLinkButton(Action):
     def __init__(self, *, text: str, url: str):
         """A simple interactive button that just opens a URL
 
-        https://api.slack.com/messaging/composing/layouts#attachments
+        https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts
 
         Args:
           text: text to display on the button, eg 'Click Me!"
@@ -150,7 +150,7 @@ class ActionUserSelector(AbstractActionSelector):
     def __init__(self, name: str, text: str, selected_user: Optional[Option] = None):
         """Automatically populate the selector with a list of users in the workspace.
 
-        https://api.slack.com/legacy/message-menus#allow_users_to_select_from_a_list_of_members
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_team_members
 
         Args:
             name: Name this specific action. The name will be returned to your
@@ -172,7 +172,7 @@ class ActionChannelSelector(AbstractActionSelector):
         Automatically populate the selector with a list of public channels in the
         workspace.
 
-        https://api.slack.com/legacy/message-menus#let_users_choose_one_of_their_workspace_s_channels
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_channels
 
         Args:
             name: Name this specific action. The name will be returned to your
@@ -194,7 +194,7 @@ class ActionConversationSelector(AbstractActionSelector):
         Automatically populate the selector with a list of conversations they have in
         the workspace.
 
-        https://api.slack.com/legacy/message-menus#let_users_choose_one_of_their_conversations
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_conversations
 
         Args:
             name: Name this specific action. The name will be returned to your
@@ -226,7 +226,7 @@ class ActionExternalSelector(AbstractActionSelector):
         """
         Populate a message select menu from your own application dynamically.
 
-        https://api.slack.com/legacy/message-menus#populate_message_menus_dynamically
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_dynamic
 
         Args:
             name: Name this specific action. The name will be returned to your
@@ -312,7 +312,7 @@ class Attachment(JsonObject):
         A supplemental object that will display after the rest of the message.
         Considered legacy - recommended replacement is to use message blocks instead.
 
-        https://api.slack.com/reference/messaging/attachments#fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields
 
         Args:
             text: The main body text of the attachment. It can be formatted as
@@ -444,7 +444,7 @@ class BlockAttachment(Attachment):
         A bridge between legacy attachments and Block Kit formatting - pass a list of
         Block objects directly to this attachment.
 
-        https://api.slack.com/reference/messaging/attachments#fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields
 
         Args:
             blocks: a sequence of Block objects
@@ -501,8 +501,8 @@ class InteractiveAttachment(Attachment):
         An Attachment, but designed to contain interactive Actions
         Considered legacy - recommended replacement is to use message blocks instead.
 
-        https://api.slack.com/legacy/interactive-message-field-guide#attachment_fields
-        https://api.slack.com/reference/messaging/attachments#fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#attachment_fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields
 
         Args:
             actions: A collection of Action objects to include in the attachment.

--- a/slack_sdk/models/blocks/__init__.py
+++ b/slack_sdk/models/blocks/__init__.py
@@ -2,8 +2,8 @@
 
 To learn more about Block Kit, please check the following resources and tools:
 
-* https://api.slack.com/block-kit
-* https://api.slack.com/reference/block-kit/blocks
+* https://docs.slack.dev/block-kit/
+* https://docs.slack.dev/reference/block-kit/blocks
 * https://app.slack.com/block-kit-builder
 """
 from .basic_components import ButtonStyles

--- a/slack_sdk/models/blocks/basic_components.py
+++ b/slack_sdk/models/blocks/basic_components.py
@@ -85,7 +85,7 @@ class PlainTextObject(TextObject):
     def __init__(self, *, text: str, emoji: Optional[bool] = None):
         """A plain text object, meaning markdown characters will not be parsed as
         formatting information.
-        https://api.slack.com/reference/block-kit/composition-objects#text
+        https://docs.slack.dev/reference/block-kit/composition-objects/text-object
 
         Args:
             text (required): The text for the block. This field accepts any of the standard text formatting markup
@@ -118,7 +118,7 @@ class MarkdownTextObject(TextObject):
     def __init__(self, *, text: str, verbatim: Optional[bool] = None):
         """A Markdown text object, meaning markdown characters will be parsed as
         formatting information.
-        https://api.slack.com/reference/block-kit/composition-objects#text
+        https://docs.slack.dev/reference/block-kit/composition-objects/text-object
 
         Args:
             text (required): The text for the block. This field accepts any of the standard text formatting markup
@@ -188,13 +188,13 @@ class Option(JsonObject):
         (StaticDialogSelectElement)
 
         Blocks:
-        https://api.slack.com/reference/block-kit/composition-objects#option
+        https://docs.slack.dev/reference/block-kit/composition-objects/option-object
 
         Dialogs:
-        https://api.slack.com/dialogs#select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
 
         Legacy interactive attachments:
-        https://api.slack.com/legacy/interactive-message-field-guide#option_fields
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_fields
 
         Args:
             label: A short, user-facing string to label this option to users.
@@ -330,13 +330,13 @@ class OptionGroup(JsonObject):
         UI) and a list of Option objects.
 
         Blocks:
-        https://api.slack.com/reference/block-kit/composition-objects#option-group
+        https://docs.slack.dev/reference/block-kit/composition-objects/option-group-object
 
         Dialogs:
-        https://api.slack.com/dialogs#select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
 
         Legacy interactive attachments:
-        https://api.slack.com/legacy/interactive-message-field-guide#option_groups_to_place_within_message_menu_actions
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_groups
 
         Args:
             label: Text to display at the top of this group of options.
@@ -427,7 +427,7 @@ class ConfirmObject(JsonObject):
         An object that defines a dialog that provides a confirmation step to any
         interactive element. This dialog will ask the user to confirm their action by
         offering a confirm and deny button.
-        https://api.slack.com/reference/block-kit/composition-objects#confirm
+        https://docs.slack.dev/reference/block-kit/composition-objects/confirmation-dialog-object/
         """
         self._title = TextObject.parse(title, default_type=PlainTextObject.type)
         self._text = TextObject.parse(text, default_type=MarkdownTextObject.type)
@@ -514,7 +514,7 @@ class DispatchActionConfig(JsonObject):
     ):
         """
         Determines when a plain-text input element will return a block_actions interaction payload.
-        https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config
+        https://docs.slack.dev/reference/block-kit/composition-objects/dispatch-action-configuration-object
         """
         self._trigger_actions_on = trigger_actions_on or []
 
@@ -571,7 +571,7 @@ class SlackFile(JsonObject):
         url: Optional[str] = None,
     ):
         """An object containing Slack file information to be used in an image block or image element.
-        https://api.slack.com/reference/block-kit/composition-objects#slack_file
+        https://docs.slack.dev/reference/block-kit/composition-objects/slack-file-object
 
         Args:
             id: Slack ID of the file.

--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -28,7 +28,7 @@ from .basic_components import TextObject
 
 class BlockElement(JsonObject, metaclass=ABCMeta):
     """Block Elements are things that exists inside of your Blocks.
-    https://api.slack.com/reference/block-kit/block-elements
+    https://docs.slack.dev/reference/block-kit/block-elements/
     """
 
     attributes = {"type"}
@@ -205,7 +205,7 @@ class ButtonElement(InteractiveElement):
     ):
         """An interactive element that inserts a button. The button can be a trigger for
         anything from opening a simple link to starting a complex workflow.
-        https://api.slack.com/reference/block-kit/block-elements#button
+        https://docs.slack.dev/reference/block-kit/block-elements/button-element/
 
         Args:
             text (required): A text object that defines the button's text.
@@ -277,7 +277,7 @@ class LinkButtonElement(ButtonElement):
         """A simple button that simply opens a given URL. You will still receive an
         interaction payload and will need to send an acknowledgement response.
         This is a helper class that makes creating links simpler.
-        https://api.slack.com/reference/block-kit/block-elements#button
+        https://docs.slack.dev/reference/block-kit/block-elements/button-element/
 
         Args:
             text (required): A text object that defines the button's text.
@@ -332,7 +332,7 @@ class CheckboxesElement(InputInteractiveElement):
         **others: dict,
     ):
         """A checkbox group that allows a user to choose multiple items from a list of possible options.
-        https://api.slack.com/reference/block-kit/block-elements#checkboxes
+        https://docs.slack.dev/reference/block-kit/block-elements/checkboxes-element/
 
         Args:
             action_id (required): An identifier for the action triggered when the checkbox group is changed.
@@ -384,7 +384,7 @@ class DatePickerElement(InputInteractiveElement):
         """
         An element which lets users easily select a date from a calendar style UI.
         Date picker elements can be used inside of SectionBlocks and ActionsBlocks.
-        https://api.slack.com/reference/block-kit/block-elements#datepicker
+        https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -447,7 +447,7 @@ class TimePickerElement(InputInteractiveElement):
         On desktop clients, this time picker will take the form of a dropdown list
         with free-text entry for precise choices.
         On mobile clients, the time picker will use native time picker UIs.
-        https://api.slack.com/reference/block-kit/block-elements#timepicker
+        https://docs.slack.dev/reference/block-kit/block-elements/time-picker-element
 
         Args:
             action_id (required): An identifier for the action triggered when a time is selected.
@@ -509,7 +509,7 @@ class DateTimePickerElement(InputInteractiveElement):
         date picker will take the form of a dropdown calendar. Both options will have free-text
         entry for precise choices. On mobile clients, the time picker and date
         picker will use native UIs.
-        https://api.slack.com/reference/block-kit/block-elements#datetimepicker
+        https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element/
 
         Args:
             action_id (required): An identifier for the action triggered when a time is selected. You can use this
@@ -564,7 +564,7 @@ class ImageElement(BlockElement):
         """An element to insert an image - this element can be used in section and
         context blocks only. If you want a block with only an image in it,
         you're looking for the image block.
-        https://api.slack.com/reference/block-kit/block-elements#image
+        https://docs.slack.dev/reference/block-kit/block-elements/image-element
 
         Args:
             alt_text (required): A plain-text summary of the image. This should not contain any markup.
@@ -614,7 +614,7 @@ class StaticSelectElement(InputInteractiveElement):
         **others: dict,
     ):
         """This is the simplest form of select menu, with a static list of options passed in when defining the element.
-        https://api.slack.com/reference/block-kit/block-elements#static_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -690,7 +690,7 @@ class StaticMultiSelectElement(InputInteractiveElement):
     ):
         """
         This is the simplest form of select menu, with a static list of options passed in when defining the element.
-        https://api.slack.com/reference/block-kit/block-elements#static_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#static_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -768,7 +768,7 @@ class SelectElement(InputInteractiveElement):
         **others: dict,
     ):
         """This is the simplest form of select menu, with a static list of options passed in when defining the element.
-        https://api.slack.com/reference/block-kit/block-elements#static_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -846,7 +846,7 @@ class ExternalDataSelectElement(InputInteractiveElement):
         """
         This select menu will load its options from an external data source, allowing
         for a dynamic list of options.
-        https://api.slack.com/reference/block-kit/block-elements#external_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -903,7 +903,7 @@ class ExternalDataMultiSelectElement(InputInteractiveElement):
         """
         This select menu will load its options from an external data source, allowing
         for a dynamic list of options.
-        https://api.slack.com/reference/block-kit/block-elements#external_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -965,7 +965,7 @@ class UserSelectElement(InputInteractiveElement):
         """
         This select menu will populate its options with a list of Slack users visible to
         the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#users_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#users_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -1013,7 +1013,7 @@ class UserMultiSelectElement(InputInteractiveElement):
         """
         This select menu will populate its options with a list of Slack users visible to
         the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#users_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#users_multi_select
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -1061,7 +1061,7 @@ class ConversationFilter(JsonObject):
     ):
         """Provides a way to filter the list of options in a conversations select menu
         or conversations multi-select menu.
-        https://api.slack.com/reference/block-kit/composition-objects#filter_conversations
+        https://docs.slack.dev/reference/block-kit/composition-objects/conversation-filter-object
 
         Args:
             include: Indicates which type of conversations should be included in the list.
@@ -1120,7 +1120,7 @@ class ConversationSelectElement(InputInteractiveElement):
         """
         This select menu will populate its options with a list of public and private
         channels, DMs, and MPIMs visible to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#conversation_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#conversations_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -1188,7 +1188,7 @@ class ConversationMultiSelectElement(InputInteractiveElement):
         """
         This multi-select menu will populate its options with a list of public and private channels,
         DMs, and MPIMs visible to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element/#conversation_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -1251,7 +1251,7 @@ class ChannelSelectElement(InputInteractiveElement):
         """
         This select menu will populate its options with a list of public channels
         visible to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#channel_select
+        https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#channels_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -1304,7 +1304,7 @@ class ChannelMultiSelectElement(InputInteractiveElement):
         """
         This multi-select menu will populate its options with a list of public channels visible
         to the current user in the active workspace.
-        https://api.slack.com/reference/block-kit/block-elements#channel_multi_select
+        https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#channel_multi_select
 
         Args:
             placeholder (required): A plain_text only text object that defines the placeholder text shown on the menu.
@@ -1413,7 +1413,7 @@ class PlainTextInputElement(InputInteractiveElement):
         where a user can enter freeform data. It can appear as a single-line
         field or a larger textarea using the multiline flag. Plain-text input
         elements can be used inside of SectionBlocks and ActionsBlocks.
-        https://api.slack.com/reference/block-kit/block-elements#input
+        https://docs.slack.dev/reference/block-kit/block-elements/plain-text-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -1477,7 +1477,7 @@ class EmailInputElement(InputInteractiveElement):
         **others: dict,
     ):
         """
-        https://api.slack.com/reference/block-kit/block-elements#email
+        https://docs.slack.dev/reference/block-kit/block-elements/email-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -1534,7 +1534,7 @@ class UrlInputElement(InputInteractiveElement):
         """
         A URL input element, similar to the Plain-text input element,
         creates a single line field where a user can enter URL-encoded data.
-        https://api.slack.com/reference/block-kit/block-elements#url
+        https://docs.slack.dev/reference/block-kit/block-elements/url-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -1595,7 +1595,7 @@ class NumberInputElement(InputInteractiveElement):
         **others: dict,
     ):
         """
-        https://api.slack.com/reference/block-kit/block-elements#number
+        https://docs.slack.dev/reference/block-kit/block-elements/number-input-element/
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -1655,7 +1655,7 @@ class FileInputElement(InputInteractiveElement):
         **others: dict,
     ):
         """
-        https://api.slack.com/reference/block-kit/block-elements#file_input
+        https://docs.slack.dev/reference/block-kit/block-elements/file-input-element
 
         Args:
             action_id (required): An identifier for the input value when the parent modal is submitted.
@@ -1701,7 +1701,7 @@ class RadioButtonsElement(InputInteractiveElement):
         **others: dict,
     ):
         """A radio button group that allows a user to choose one item from a list of possible options.
-        https://api.slack.com/reference/block-kit/block-elements#radio
+        https://docs.slack.dev/reference/block-kit/block-elements/radio-button-group-element
 
         Args:
             action_id (required): An identifier for the action triggered when the radio button group is changed.
@@ -1761,7 +1761,7 @@ class OverflowMenuElement(InteractiveElement):
         buttons. You can also specify simple URL links as overflow menu options,
         instead of actions.
 
-        https://api.slack.com/reference/block-kit/block-elements#overflow
+        https://docs.slack.dev/reference/block-kit/block-elements/overflow-menu-element
 
         Args:
             action_id (required): An identifier for the action triggered when a menu option is selected.
@@ -1809,7 +1809,7 @@ class WorkflowButtonElement(InteractiveElement):
         """Allows users to run a link trigger with customizable inputs
         Interactive component - but interactions with workflow button elements will not send block_actions events,
         since these are used to start new workflow runs.
-        https://api.slack.com/reference/block-kit/block-elements#workflow_button
+        https://docs.slack.dev/reference/block-kit/block-elements/workflow-button-element
 
         Args:
             text (required): A text object that defines the button's text.

--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -26,7 +26,7 @@ from ...errors import SlackObjectFormationError
 class Block(JsonObject):
     """Blocks are a series of components that can be combined
     to create visually rich and compellingly interactive messages.
-    https://api.slack.com/reference/block-kit/blocks
+    https://docs.slack.dev/reference/block-kit/blocks
     """
 
     attributes = {"block_id", "type"}
@@ -130,7 +130,7 @@ class SectionBlock(Block):
         **others: dict,
     ):
         """A section is one of the most flexible blocks available.
-        https://api.slack.com/reference/block-kit/blocks#section
+        https://docs.slack.dev/reference/block-kit/blocks/section-block
 
         Args:
             block_id (required): A string acting as a unique identifier for a block.
@@ -198,7 +198,7 @@ class DividerBlock(Block):
         **others: dict,
     ):
         """A content divider, like an <hr>, to split up different blocks inside of a message.
-        https://api.slack.com/reference/block-kit/blocks#divider
+        https://docs.slack.dev/reference/block-kit/blocks/divider-block
 
         Args:
             block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
@@ -233,7 +233,7 @@ class ImageBlock(Block):
         **others: dict,
     ):
         """A simple image block, designed to make those cat photos really pop.
-        https://api.slack.com/reference/block-kit/blocks#image
+        https://docs.slack.dev/reference/block-kit/blocks/image-block
 
         Args:
             alt_text (required): A plain-text summary of the image. This should not contain any markup.
@@ -300,7 +300,7 @@ class ActionsBlock(Block):
         **others: dict,
     ):
         """A block that is used to hold interactive elements.
-        https://api.slack.com/reference/block-kit/blocks#actions
+        https://docs.slack.dev/reference/block-kit/blocks/actions-block
 
         Args:
             elements (required): An array of interactive element objects - buttons, select menus, overflow menus,
@@ -338,7 +338,7 @@ class ContextBlock(Block):
         **others: dict,
     ):
         """Displays message context, which can include both images and text.
-        https://api.slack.com/reference/block-kit/blocks#context
+        https://docs.slack.dev/reference/block-kit/blocks/context-block
 
         Args:
             elements (required): An array of image elements and text objects. Maximum number of items is 10.
@@ -379,7 +379,7 @@ class InputBlock(Block):
     ):
         """A block that collects information from users - it can hold a plain-text input element,
         a select menu element, a multi-select menu element, or a datepicker.
-        https://api.slack.com/reference/block-kit/blocks#input
+        https://docs.slack.dev/reference/block-kit/blocks/input-block
 
         Args:
             label (required): A label that appears above an input element in the form of a text object
@@ -441,7 +441,7 @@ class FileBlock(Block):
         **others: dict,
     ):
         """Displays a remote file.
-        https://api.slack.com/reference/block-kit/blocks#file
+        https://docs.slack.dev/reference/block-kit/blocks/file-block
 
         Args:
             external_id (required): The external unique ID for this file.
@@ -475,7 +475,7 @@ class CallBlock(Block):
         **others: dict,
     ):
         """Displays a call information
-        https://api.slack.com/reference/block-kit/blocks#call
+        https://docs.slack.dev/reference/block-kit/blocks#call
         """
         super().__init__(type=self.type, block_id=block_id)
         show_unknown_key_warning(self, others)
@@ -501,7 +501,7 @@ class HeaderBlock(Block):
         **others: dict,
     ):
         """A header is a plain-text block that displays in a larger, bold font.
-        https://api.slack.com/reference/block-kit/blocks#header
+        https://docs.slack.dev/reference/block-kit/blocks/header-block
 
         Args:
             block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
@@ -604,7 +604,7 @@ class VideoBlock(Block):
         (e.g. link unfurls, messages, modals, App Home) —
         anywhere you can put blocks! To use the video block within your app,
         you must have the links.embed:write scope.
-        https://api.slack.com/reference/block-kit/blocks#video
+        https://docs.slack.dev/reference/block-kit/blocks/video-block
 
         Args:
             block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
@@ -676,7 +676,7 @@ class RichTextBlock(Block):
         **others: dict,
     ):
         """A block that is used to hold interactive elements.
-        https://api.slack.com/reference/block-kit/blocks#rich_text
+        https://docs.slack.dev/reference/block-kit/blocks/rich-text-block
 
         Args:
             elements (required): An array of rich text objects -

--- a/slack_sdk/models/dialogs/__init__.py
+++ b/slack_sdk/models/dialogs/__init__.py
@@ -111,7 +111,7 @@ class DialogTextField(DialogTextComponent):
     """
     Text elements are single-line plain text fields.
 
-    https://api.slack.com/dialogs#text_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#text_elements
     """
 
     type = "text"
@@ -125,7 +125,7 @@ class DialogTextArea(DialogTextComponent):
     answer from users. The element UI provides a remaining character count to the
     max_length you have set or the default, 3000.
 
-    https://api.slack.com/dialogs#textarea_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#textarea_elements
     """
 
     type = "textarea"
@@ -199,7 +199,7 @@ class DialogStaticSelector(AbstractDialogSelector):
     single item from a list. True to web roots, this selection is displayed as a
     dropdown menu.
 
-    https://api.slack.com/dialogs#select_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
     """
 
     data_source = "static"
@@ -224,7 +224,7 @@ class DialogStaticSelector(AbstractDialogSelector):
         A select element may contain up to 100 selections, provided as a list of
         Option or OptionGroup objects
 
-        https://api.slack.com/dialogs#attributes_select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -277,7 +277,7 @@ class DialogUserSelector(AbstractDialogSelector):
         assignee. Slack pre-populates the user list in client-side, so your app
         doesn't need access to a related OAuth scope.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_users
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -313,7 +313,7 @@ class DialogChannelSelector(AbstractDialogSelector):
         You can also provide a select menu with a list of channels. Specify your
         data_source as channels to limit only to public channels
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -350,7 +350,7 @@ class DialogConversationSelector(AbstractDialogSelector):
         private channels, direct messages, MPIMs, and whatever else we consider a
         conversation-like thing.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -395,7 +395,7 @@ class DialogExternalSelector(AbstractDialogSelector):
         A list of options can be loaded from an external URL and used in your dialog
         menus.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_external
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -522,7 +522,7 @@ class DialogBuilder(JsonObject):
         """
         Text elements are single-line plain text fields.
 
-        https://api.slack.com/dialogs#attributes_text_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_text_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -577,7 +577,7 @@ class DialogBuilder(JsonObject):
         character count to the max_length you have set or the default,
         3000.
 
-        https://api.slack.com/dialogs#attributes_textarea_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_textarea_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -630,7 +630,7 @@ class DialogBuilder(JsonObject):
         A select element may contain up to 100 selections, provided as a list of
         Option or OptionGroup objects
 
-        https://api.slack.com/dialogs#attributes_select_elements
+        https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -673,7 +673,7 @@ class DialogBuilder(JsonObject):
         A list of options can be loaded from an external URL and used in your dialog
         menus.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_external
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -716,7 +716,7 @@ class DialogBuilder(JsonObject):
         assignee. Slack pre-populates the user list in client-side, so your app
         doesn't need access to a related OAuth scope.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_users
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -751,7 +751,7 @@ class DialogBuilder(JsonObject):
         You can also provide a select menu with a list of channels. Specify your
         data_source as channels to limit only to public channels
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -787,7 +787,7 @@ class DialogBuilder(JsonObject):
         private channels, direct messages, MPIMs, and whatever else we consider a
         conversation-like thing.
 
-        https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations
+        https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
 
         Args:
             name: Name of form element. Required. No more than 300 characters.
@@ -858,7 +858,7 @@ class ActionStaticSelector(AbstractActionSelector):
     single item from a list. True to web roots, this selection is displayed as a
     dropdown menu.
 
-    https://api.slack.com/dialogs#select_elements
+    https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
     """
 
     data_source = "static"
@@ -877,7 +877,7 @@ class ActionStaticSelector(AbstractActionSelector):
         Help users make clear, concise decisions by providing a menu of options
         within messages.
 
-        https://api.slack.com/docs/message-menus
+        https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/
 
         Args:
             name: Name this specific action. The name will be returned to your

--- a/slack_sdk/models/messages/__init__.py
+++ b/slack_sdk/models/messages/__init__.py
@@ -7,7 +7,7 @@ from slack_sdk.models.basic_objects import BaseObject
 class Link(BaseObject):
     def __init__(self, *, url: str, text: str):
         """Base class used to generate links in Slack's not-quite Markdown, not quite HTML syntax
-        https://api.slack.com/reference/surfaces/formatting#linking_to_urls
+        https://docs.slack.dev/messaging/formatting-message-text/#linking_to_urls
         """
         self.url = url
         self.text = text
@@ -30,7 +30,7 @@ class DateLink(Link):
         link: Optional[str] = None,
     ):
         """Text containing a date or time should display that date in the local timezone of the person seeing the text.
-        https://api.slack.com/reference/surfaces/formatting#date-formatting
+        https://docs.slack.dev/messaging/formatting-message-text/#date-formatting
         """
         if isinstance(date, datetime):
             epoch = int(date.timestamp())
@@ -55,7 +55,7 @@ class ObjectLink(Link):
 
     def __init__(self, *, object_id: str, text: str = ""):
         """Convenience class to create links to specific object types
-        https://api.slack.com/reference/surfaces/formatting#linking-channels
+        https://docs.slack.dev/messaging/formatting-message-text/#linking-channels
         """
         prefix = self.prefix_mapping.get(object_id[0].upper(), "@")
         super().__init__(url=f"{prefix}{object_id}", text=text)
@@ -64,7 +64,7 @@ class ObjectLink(Link):
 class ChannelLink(Link):
     def __init__(self):
         """Represents an @channel link, which notifies everyone present in this channel.
-        https://api.slack.com/reference/surfaces/formatting
+        https://docs.slack.dev/messaging/formatting-message-text/
         """
         super().__init__(url="!channel", text="channel")
 
@@ -72,7 +72,7 @@ class ChannelLink(Link):
 class HereLink(Link):
     def __init__(self):
         """Represents an @here link, which notifies all online users of this channel.
-        https://api.slack.com/reference/surfaces/formatting
+        https://docs.slack.dev/messaging/formatting-message-text/
         """
         super().__init__(url="!here", text="here")
 
@@ -80,6 +80,6 @@ class HereLink(Link):
 class EveryoneLink(Link):
     def __init__(self):
         """Represents an @everyone link, which notifies all users of this workspace.
-        https://api.slack.com/reference/surfaces/formatting
+        https://docs.slack.dev/messaging/formatting-message-text/
         """
         super().__init__(url="!everyone", text="everyone")

--- a/slack_sdk/models/messages/message.py
+++ b/slack_sdk/models/messages/message.py
@@ -35,7 +35,7 @@ class Message(JsonObject):
         """
         Create a message.
 
-        https://api.slack.com/messaging/composing#message-structure
+        https://docs.slack.dev/messaging/#message-structure
 
         Args:
             text: Plain or Slack Markdown-like text to display in the message.

--- a/slack_sdk/models/metadata/__init__.py
+++ b/slack_sdk/models/metadata/__init__.py
@@ -5,7 +5,7 @@ from slack_sdk.models.basic_objects import JsonObject
 class Metadata(JsonObject):
     """Message metadata
 
-    https://api.slack.com/metadata
+    https://docs.slack.dev/messaging/message-metadata/
     """
 
     attributes = {

--- a/slack_sdk/models/views/__init__.py
+++ b/slack_sdk/models/views/__init__.py
@@ -9,7 +9,7 @@ from slack_sdk.models.blocks import Block, TextObject, PlainTextObject, Option
 class View(JsonObject):
     """View object for modals and Home tabs.
 
-    https://api.slack.com/reference/surfaces/views
+    https://docs.slack.dev/reference/views/
     """
 
     types = ["modal", "home", "workflow_step"]

--- a/slack_sdk/oauth/__init__.py
+++ b/slack_sdk/oauth/__init__.py
@@ -1,6 +1,6 @@
 """Modules for implementing the Slack OAuth flow
 
-https://slack.dev/python-slack-sdk/oauth/
+https://docs.slack.dev/tools/python-slack-sdk/oauth
 """
 from .authorize_url_generator import AuthorizeUrlGenerator
 from .authorize_url_generator import OpenIDConnectAuthorizeUrlGenerator

--- a/slack_sdk/oauth/installation_store/installation_store.py
+++ b/slack_sdk/oauth/installation_store/installation_store.py
@@ -1,6 +1,6 @@
 """Slack installation data store
 
-Refer to https://slack.dev/python-slack-sdk/oauth/ for details.
+Refer to https://docs.slack.dev/tools/python-slack-sdk/oauth for details.
 """
 from logging import Logger
 from typing import Optional

--- a/slack_sdk/oauth/state_store/__init__.py
+++ b/slack_sdk/oauth/state_store/__init__.py
@@ -1,6 +1,6 @@
 """OAuth state parameter data store
 
-Refer to https://slack.dev/python-slack-sdk/oauth/ for details.
+Refer to https://docs.slack.dev/tools/python-slack-sdk/oauth for details.
 """
 # from .amazon_s3_state_store import AmazonS3OAuthStateStore
 from .file import FileOAuthStateStore

--- a/slack_sdk/scim/__init__.py
+++ b/slack_sdk/scim/__init__.py
@@ -2,7 +2,7 @@
 SCIM is used by Single Sign-On (SSO) services and identity providers to manage people across a variety of tools,
 including Slack.
 
-Refer to https://slack.dev/python-slack-sdk/scim/ for details.
+Refer to https://docs.slack.dev/tools/python-slack-sdk/scim for details.
 """
 from .v1.client import SCIMClient
 from .v1.response import SCIMResponse

--- a/slack_sdk/scim/v1/__init__.py
+++ b/slack_sdk/scim/v1/__init__.py
@@ -2,5 +2,5 @@
 SCIM is used by Single Sign-On (SSO) services and identity providers to manage people across a variety of tools,
 including Slack.
 
-Refer to https://slack.dev/python-slack-sdk/scim/ for details.
+Refer to https://docs.slack.dev/tools/python-slack-sdk/scim for details.
 """

--- a/slack_sdk/scim/v1/async_client.py
+++ b/slack_sdk/scim/v1/async_client.py
@@ -73,7 +73,7 @@ class AsyncSCIMClient:
         retry_handlers: Optional[List[AsyncRetryHandler]] = None,
     ):
         """API client for SCIM API
-        See https://api.slack.com/scim for more details
+        See https://docs.slack.dev/admins/scim-api/ for more details
 
         Args:
             token: An admin user's token, which starts with `xoxp-`

--- a/slack_sdk/scim/v1/client.py
+++ b/slack_sdk/scim/v1/client.py
@@ -2,7 +2,7 @@
 SCIM is used by Single Sign-On (SSO) services and identity providers to manage people across a variety of tools,
 including Slack.
 
-Refer to https://slack.dev/python-slack-sdk/scim/ for details.
+Refer to https://docs.slack.dev/tools/python-slack-sdk/scim/ for details.
 """
 
 import json
@@ -76,7 +76,7 @@ class SCIMClient:
         retry_handlers: Optional[List[RetryHandler]] = None,
     ):
         """API client for SCIM API
-        See https://api.slack.com/scim for more details
+        See https://docs.slack.dev/admins/scim-api/ for more details
 
         Args:
             token: An admin user's token, which starts with `xoxp-`

--- a/slack_sdk/signature/__init__.py
+++ b/slack_sdk/signature/__init__.py
@@ -18,7 +18,7 @@ class SignatureVerifier:
         Slack signs its requests using a secret that's unique to your app.
         With the help of signing secrets, your app can more confidently verify
         whether requests from us are authentic.
-        https://api.slack.com/authentication/verifying-requests-from-slack
+        https://docs.slack.dev/authentication/verifying-requests-from-slack/
         """
         self.signing_secret = signing_secret
         self.clock = clock

--- a/slack_sdk/socket_mode/__init__.py
+++ b/slack_sdk/socket_mode/__init__.py
@@ -2,7 +2,7 @@
 You can use slack_sdk.socket_mode.SocketModeClient for managing Socket Mode connections
 and performing interactions with Slack.
 
-https://api.slack.com/apis/connections/socket
+https://docs.slack.dev/apis/events-api/using-socket-mode/
 """
 from .builtin import SocketModeClient
 

--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -1,7 +1,7 @@
 """aiohttp based Socket Mode client
 
-* https://api.slack.com/apis/connections/socket
-* https://slack.dev/python-slack-sdk/socket-mode/
+* https://docs.slack.dev/apis/events-api/using-socket-mode/
+* https://docs.slack.dev/tools/python-slack-sdk/socket-mode/
 * https://pypi.org/project/aiohttp/
 
 """

--- a/slack_sdk/socket_mode/builtin/client.py
+++ b/slack_sdk/socket_mode/builtin/client.py
@@ -1,7 +1,7 @@
 """The built-in Socket Mode client
 
-* https://api.slack.com/apis/connections/socket
-* https://slack.dev/python-slack-sdk/socket-mode/
+* https://docs.slack.dev/apis/events-api/using-socket-mode/
+* https://docs.slack.dev/tools/python-slack-sdk/socket-mode/
 
 """
 

--- a/slack_sdk/socket_mode/websocket_client/__init__.py
+++ b/slack_sdk/socket_mode/websocket_client/__init__.py
@@ -1,7 +1,7 @@
 """websocket-client bassd Socket Mode client
 
-* https://api.slack.com/apis/connections/socket
-* https://slack.dev/python-slack-sdk/socket-mode/
+* https://docs.slack.dev/apis/events-api/using-socket-mode/
+* https://docs.slack.dev/tools/python-slack-sdk/socket-mode/
 * https://pypi.org/project/websocket-client/
 
 """

--- a/slack_sdk/socket_mode/websockets/__init__.py
+++ b/slack_sdk/socket_mode/websockets/__init__.py
@@ -1,7 +1,7 @@
 """websockets bassd Socket Mode client
 
-* https://api.slack.com/apis/connections/socket
-* https://slack.dev/python-slack-sdk/socket-mode/
+* https://docs.slack.dev/apis/events-api/using-socket-mode/
+* https://docs.slack.dev/tools/python-slack-sdk/socket-mode/
 * https://pypi.org/project/websockets/
 
 """

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -37,7 +37,7 @@ from .internal_utils import (
 class AsyncWebClient(AsyncBaseClient):
     """A WebClient allows apps to communicate with the Slack Platform's Web API.
 
-    https://api.slack.com/methods
+    https://docs.slack.dev/reference/methods
 
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
@@ -108,7 +108,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieve analytics data for a given date, presented as a compressed JSON file
-        https://api.slack.com/methods/admin.analytics.getFile
+        https://docs.slack.dev/reference/methods/admin.analytics.getFile
         """
         kwargs.update({"type": type})
         if date is not None:
@@ -130,7 +130,7 @@ class AsyncWebClient(AsyncBaseClient):
         Either app_id or request_id is required.
         These IDs can be obtained either directly via the app_requested event,
         or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.approve
+        https://docs.slack.dev/reference/methods/admin.apps.approve
         """
         if app_id:
             kwargs.update({"app_id": app_id})
@@ -157,7 +157,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List approved apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.approved.list
+        https://docs.slack.dev/reference/methods/admin.apps.approved.list
         """
         kwargs.update(
             {
@@ -178,7 +178,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Clear an app resolution
-        https://api.slack.com/methods/admin.apps.clearResolution
+        https://docs.slack.dev/reference/methods/admin.apps.clearResolution
         """
         kwargs.update(
             {
@@ -198,7 +198,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.cancel
+        https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
         """
         kwargs.update(
             {
@@ -218,7 +218,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.list
+        https://docs.slack.dev/reference/methods/admin.apps.requests.list
         """
         kwargs.update(
             {
@@ -242,7 +242,7 @@ class AsyncWebClient(AsyncBaseClient):
         Exactly one of the team_id or enterprise_id arguments is required, not both.
         Either app_id or request_id is required. These IDs can be obtained either directly
         via the app_requested event, or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.restrict
+        https://docs.slack.dev/reference/methods/admin.apps.restrict
         """
         if app_id:
             kwargs.update({"app_id": app_id})
@@ -269,7 +269,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List restricted apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.restricted.list
+        https://docs.slack.dev/reference/methods/admin.apps.restricted.list
         """
         kwargs.update(
             {
@@ -291,7 +291,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Uninstall an app from one or many workspaces, or an entire enterprise organization.
         With an org-level token, enterprise_id or team_ids is required.
-        https://api.slack.com/methods/admin.apps.uninstall
+        https://docs.slack.dev/reference/methods/admin.apps.uninstall
         """
         kwargs.update({"app_id": app_id})
         if enterprise_id is not None:
@@ -322,7 +322,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Get logs for a specified team/org
-        https://api.slack.com/methods/admin.apps.activities.list
+        https://docs.slack.dev/reference/methods/admin.apps.activities.list
         """
         kwargs.update(
             {
@@ -350,7 +350,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Look up the app config for connectors by their IDs
-        https://api.slack.com/methods/admin.apps.config.lookup
+        https://docs.slack.dev/reference/methods/admin.apps.config.lookup
         """
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({"app_ids": ",".join(app_ids)})
@@ -367,7 +367,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set the app config for a connector
-        https://api.slack.com/methods/admin.apps.config.set
+        https://docs.slack.dev/reference/methods/admin.apps.config.set
         """
         kwargs.update(
             {
@@ -389,7 +389,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Fetch all the entities assigned to a particular authentication policy by name.
-        https://api.slack.com/methods/admin.auth.policy.getEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
         """
         kwargs.update({"policy_name": policy_name})
         if cursor is not None:
@@ -409,7 +409,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Assign entities to a particular authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.assignEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
         """
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({"entity_ids": ",".join(entity_ids)})
@@ -428,7 +428,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Remove specified entities from a specified authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.removeEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
         """
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({"entity_ids": ",".join(entity_ids)})
@@ -447,7 +447,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Create a Salesforce channel for the corresponding object provided.
-        https://api.slack.com/methods/admin.conversations.createForObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
         """
         kwargs.update(
             {"object_id": object_id, "salesforce_org_id": salesforce_org_id, "invite_object_team": invite_object_team}
@@ -463,7 +463,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Link a Salesforce record to a channel.
-        https://api.slack.com/methods/admin.conversations.linkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
         """
         kwargs.update(
             {
@@ -482,7 +482,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Unlink a Salesforce record from a channel.
-        https://api.slack.com/methods/admin.conversations.unlinkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
         """
         kwargs.update(
             {
@@ -501,7 +501,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Create an Information Barrier
-        https://api.slack.com/methods/admin.barriers.create
+        https://docs.slack.dev/reference/methods/admin.barriers.create
         """
         kwargs.update({"primary_usergroup_id": primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -521,7 +521,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Delete an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.delete
+        https://docs.slack.dev/reference/methods/admin.barriers.delete
         """
         kwargs.update({"barrier_id": barrier_id})
         return await self.api_call("admin.barriers.delete", http_verb="POST", params=kwargs)
@@ -536,7 +536,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Update an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.update
+        https://docs.slack.dev/reference/methods/admin.barriers.update
         """
         kwargs.update({"barrier_id": barrier_id, "primary_usergroup_id": primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -557,7 +557,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Get all Information Barriers for your organization
-        https://api.slack.com/methods/admin.barriers.list"""
+        https://docs.slack.dev/reference/methods/admin.barriers.list"""
         kwargs.update(
             {
                 "cursor": cursor,
@@ -577,7 +577,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Create a public or private channel-based conversation.
-        https://api.slack.com/methods/admin.conversations.create
+        https://docs.slack.dev/reference/methods/admin.conversations.create
         """
         kwargs.update(
             {
@@ -597,7 +597,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Delete a public or private channel.
-        https://api.slack.com/methods/admin.conversations.delete
+        https://docs.slack.dev/reference/methods/admin.conversations.delete
         """
         kwargs.update({"channel_id": channel_id})
         return await self.api_call("admin.conversations.delete", params=kwargs)
@@ -610,7 +610,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Invite a user to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.invite
+        https://docs.slack.dev/reference/methods/admin.conversations.invite
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(user_ids, (list, tuple)):
@@ -627,7 +627,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Archive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         """
         kwargs.update({"channel_id": channel_id})
         return await self.api_call("admin.conversations.archive", params=kwargs)
@@ -639,7 +639,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Unarchive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         """
         kwargs.update({"channel_id": channel_id})
         return await self.api_call("admin.conversations.unarchive", params=kwargs)
@@ -652,7 +652,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Rename a public or private channel.
-        https://api.slack.com/methods/admin.conversations.rename
+        https://docs.slack.dev/reference/methods/admin.conversations.rename
         """
         kwargs.update({"channel_id": channel_id, "name": name})
         return await self.api_call("admin.conversations.rename", params=kwargs)
@@ -670,7 +670,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Search for public or private channels in an Enterprise organization.
-        https://api.slack.com/methods/admin.conversations.search
+        https://docs.slack.dev/reference/methods/admin.conversations.search
         """
         kwargs.update(
             {
@@ -701,7 +701,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Convert a public channel to a private channel.
-        https://api.slack.com/methods/admin.conversations.convertToPrivate
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
         """
         kwargs.update({"channel_id": channel_id})
         return await self.api_call("admin.conversations.convertToPrivate", params=kwargs)
@@ -713,7 +713,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Convert a privte channel to a public channel.
-        https://api.slack.com/methods/admin.conversations.convertToPublic
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
         """
         kwargs.update({"channel_id": channel_id})
         return await self.api_call("admin.conversations.convertToPublic", params=kwargs)
@@ -726,7 +726,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set the posting permissions for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(prefs, dict):
@@ -742,7 +742,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Get conversation preferences for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.getConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
         """
         kwargs.update({"channel_id": channel_id})
         return await self.api_call("admin.conversations.getConversationPrefs", params=kwargs)
@@ -755,7 +755,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Disconnect a connected channel from one or more workspaces.
-        https://api.slack.com/methods/admin.conversations.disconnectShared
+        https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(leaving_team_ids, (list, tuple)):
@@ -775,7 +775,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Returns channels on the given team using the filters.
-        https://api.slack.com/methods/admin.conversations.lookup
+        https://docs.slack.dev/reference/methods/admin.conversations.lookup
         """
         kwargs.update(
             {
@@ -803,7 +803,7 @@ class AsyncWebClient(AsyncBaseClient):
         """List all disconnected channels—i.e.,
         channels that were once connected to other workspaces and then disconnected—and
         the corresponding original channel IDs for key revocation with EKM.
-        https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+        https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
         """
         kwargs.update(
             {
@@ -830,7 +830,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Add an allowlist of IDP groups for accessing a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
         """
         kwargs.update(
             {
@@ -853,7 +853,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List all IDP Groups linked to a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
         """
         kwargs.update(
             {
@@ -876,7 +876,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Remove a linked IDP group linked from a private channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
         """
         kwargs.update(
             {
@@ -901,7 +901,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.setTeams
         """
         kwargs.update(
             {
@@ -925,7 +925,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set the workspaces in an Enterprise grid org that connect to a channel.
-        https://api.slack.com/methods/admin.conversations.getTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.getTeams
         """
         kwargs.update(
             {
@@ -943,7 +943,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Get a channel's retention policy
-        https://api.slack.com/methods/admin.conversations.getCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
         """
         kwargs.update({"channel_id": channel_id})
         return await self.api_call("admin.conversations.getCustomRetention", params=kwargs)
@@ -955,7 +955,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Remove a channel's retention policy
-        https://api.slack.com/methods/admin.conversations.removeCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
         """
         kwargs.update({"channel_id": channel_id})
         return await self.api_call("admin.conversations.removeCustomRetention", params=kwargs)
@@ -968,7 +968,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set a channel's retention policy
-        https://api.slack.com/methods/admin.conversations.setCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
         """
         kwargs.update({"channel_id": channel_id, "duration_days": duration_days})
         return await self.api_call("admin.conversations.setCustomRetention", params=kwargs)
@@ -980,7 +980,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Archive public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkArchive
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
         """
         kwargs.update({"channel_ids": ",".join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
         return await self.api_call("admin.conversations.bulkArchive", params=kwargs)
@@ -1005,7 +1005,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Move public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkMove
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
         """
         kwargs.update(
             {
@@ -1023,7 +1023,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Add an emoji.
-        https://api.slack.com/methods/admin.emoji.add
+        https://docs.slack.dev/reference/methods/admin.emoji.add
         """
         kwargs.update({"name": name, "url": url})
         return await self.api_call("admin.emoji.add", http_verb="GET", params=kwargs)
@@ -1036,7 +1036,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Add an emoji alias.
-        https://api.slack.com/methods/admin.emoji.addAlias
+        https://docs.slack.dev/reference/methods/admin.emoji.addAlias
         """
         kwargs.update({"alias_for": alias_for, "name": name})
         return await self.api_call("admin.emoji.addAlias", http_verb="GET", params=kwargs)
@@ -1049,7 +1049,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List emoji for an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.list
+        https://docs.slack.dev/reference/methods/admin.emoji.list
         """
         kwargs.update({"cursor": cursor, "limit": limit})
         return await self.api_call("admin.emoji.list", http_verb="GET", params=kwargs)
@@ -1061,7 +1061,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Remove an emoji across an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.remove
+        https://docs.slack.dev/reference/methods/admin.emoji.remove
         """
         kwargs.update({"name": name})
         return await self.api_call("admin.emoji.remove", http_verb="GET", params=kwargs)
@@ -1074,7 +1074,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Rename an emoji.
-        https://api.slack.com/methods/admin.emoji.rename
+        https://docs.slack.dev/reference/methods/admin.emoji.rename
         """
         kwargs.update({"name": name, "new_name": new_name})
         return await self.api_call("admin.emoji.rename", http_verb="GET", params=kwargs)
@@ -1089,7 +1089,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Look up functions by a set of apps
-        https://api.slack.com/methods/admin.functions.list
+        https://docs.slack.dev/reference/methods/admin.functions.list
         """
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({"app_ids": ",".join(app_ids)})
@@ -1112,7 +1112,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Lookup the visibility of multiple Slack functions
         and include the users if it is limited to particular named entities.
-        https://api.slack.com/methods/admin.functions.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
         """
         if isinstance(function_ids, (list, tuple)):
             kwargs.update({"function_ids": ",".join(function_ids)})
@@ -1130,7 +1130,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Set the visibility of a Slack function
         and define the users or workspaces if it is set to named_entities
-        https://api.slack.com/methods/admin.functions.permissions.set
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.set
         """
         kwargs.update(
             {
@@ -1154,7 +1154,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Adds members to the specified role with the specified scopes
-        https://api.slack.com/methods/admin.roles.addAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.addAssignments
         """
         kwargs.update({"role_id": role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1179,7 +1179,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Lists assignments for all roles across entities.
             Options to scope results by any combination of roles or entities
-        https://api.slack.com/methods/admin.roles.listAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.listAssignments
         """
         kwargs.update({"cursor": cursor, "limit": limit, "sort_dir": sort_dir})
         if isinstance(entity_ids, (list, tuple)):
@@ -1201,7 +1201,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Removes a set of users from a role for the given scopes and entities
-        https://api.slack.com/methods/admin.roles.removeAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
         """
         kwargs.update({"role_id": role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1223,7 +1223,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Wipes all valid sessions on all devices for a given user.
-        https://api.slack.com/methods/admin.users.session.reset
+        https://docs.slack.dev/reference/methods/admin.users.session.reset
         """
         kwargs.update(
             {
@@ -1243,7 +1243,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-        https://api.slack.com/methods/admin.users.session.resetBulk
+        https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1265,7 +1265,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Invalidate a single session for a user by session_id.
-        https://api.slack.com/methods/admin.users.session.invalidate
+        https://docs.slack.dev/reference/methods/admin.users.session.invalidate
         """
         kwargs.update({"session_id": session_id, "team_id": team_id})
         return await self.api_call("admin.users.session.invalidate", params=kwargs)
@@ -1280,7 +1280,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists all active user sessions for an organization
-        https://api.slack.com/methods/admin.users.session.list
+        https://docs.slack.dev/reference/methods/admin.users.session.list
         """
         kwargs.update(
             {
@@ -1300,7 +1300,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set the default channels of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
         """
         kwargs.update({"team_id": team_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1317,7 +1317,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Get user-specific session settings—the session duration
         and what happens when the client closes—given a list of users.
-        https://api.slack.com/methods/admin.users.session.getSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.getSettings
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1335,7 +1335,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Configure the user-level session settings—the session duration
         and what happens when the client closes—for one or more users.
-        https://api.slack.com/methods/admin.users.session.setSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.setSettings
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1357,7 +1357,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Clear user-specific session settings—the session duration
         and what happens when the client closes—for a list of users.
-        https://api.slack.com/methods/admin.users.session.clearSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1374,7 +1374,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Ask Slackbot to send you an export listing all workspace members using unsupported software,
         presented as a zipped CSV file.
-        https://api.slack.com/methods/admin.users.unsupportedVersions.export
+        https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
         """
         kwargs.update(
             {
@@ -1392,7 +1392,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Approve a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.approve
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
         """
         kwargs.update({"invite_request_id": invite_request_id, "team_id": team_id})
         return await self.api_call("admin.inviteRequests.approve", params=kwargs)
@@ -1406,7 +1406,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List all approved workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.approved.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
         """
         kwargs.update(
             {
@@ -1426,7 +1426,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List all denied workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.denied.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
         """
         kwargs.update(
             {
@@ -1445,7 +1445,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Deny a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.deny
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
         """
         kwargs.update({"invite_request_id": invite_request_id, "team_id": team_id})
         return await self.api_call("admin.inviteRequests.deny", params=kwargs)
@@ -1466,7 +1466,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.inviteRequests.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.list
         """
         kwargs.update(
             {
@@ -1487,7 +1487,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Create an Enterprise team.
-        https://api.slack.com/methods/admin.teams.create
+        https://docs.slack.dev/reference/methods/admin.teams.create
         """
         kwargs.update(
             {
@@ -1507,7 +1507,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List all teams on an Enterprise organization.
-        https://api.slack.com/methods/admin.teams.list
+        https://docs.slack.dev/reference/methods/admin.teams.list
         """
         kwargs.update({"cursor": cursor, "limit": limit})
         return await self.api_call("admin.teams.list", params=kwargs)
@@ -1521,7 +1521,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.teams.owners.list
+        https://docs.slack.dev/reference/methods/admin.teams.owners.list
         """
         kwargs.update({"team_id": team_id, "cursor": cursor, "limit": limit})
         return await self.api_call("admin.teams.owners.list", http_verb="GET", params=kwargs)
@@ -1533,7 +1533,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Fetch information about settings in a workspace
-        https://api.slack.com/methods/admin.teams.settings.info
+        https://docs.slack.dev/reference/methods/admin.teams.settings.info
         """
         kwargs.update({"team_id": team_id})
         return await self.api_call("admin.teams.settings.info", params=kwargs)
@@ -1546,7 +1546,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set the description of a given workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDescription
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
         """
         kwargs.update({"team_id": team_id, "description": description})
         return await self.api_call("admin.teams.settings.setDescription", params=kwargs)
@@ -1559,7 +1559,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
         """
         kwargs.update({"team_id": team_id, "discoverability": discoverability})
         return await self.api_call("admin.teams.settings.setDiscoverability", params=kwargs)
@@ -1572,7 +1572,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setIcon
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
         """
         kwargs.update({"team_id": team_id, "image_url": image_url})
         return await self.api_call("admin.teams.settings.setIcon", http_verb="GET", params=kwargs)
@@ -1585,7 +1585,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setName
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setName
         """
         kwargs.update({"team_id": team_id, "name": name})
         return await self.api_call("admin.teams.settings.setName", params=kwargs)
@@ -1599,7 +1599,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.addChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
         """
         kwargs.update({"team_id": team_id, "usergroup_id": usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1617,7 +1617,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Associate one or more default workspaces with an organization-wide IDP group.
-        https://api.slack.com/methods/admin.usergroups.addTeams
+        https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
         """
         kwargs.update({"usergroup_id": usergroup_id, "auto_provision": auto_provision})
         if isinstance(team_ids, (list, tuple)):
@@ -1635,7 +1635,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.listChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
         """
         kwargs.update(
             {
@@ -1654,7 +1654,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.removeChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
         """
         kwargs.update({"usergroup_id": usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1674,7 +1674,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Add an Enterprise user to a workspace.
-        https://api.slack.com/methods/admin.users.assign
+        https://docs.slack.dev/reference/methods/admin.users.assign
         """
         kwargs.update(
             {
@@ -1706,7 +1706,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Invite a user to a workspace.
-        https://api.slack.com/methods/admin.users.invite
+        https://docs.slack.dev/reference/methods/admin.users.invite
         """
         kwargs.update(
             {
@@ -1738,7 +1738,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List users on a workspace
-        https://api.slack.com/methods/admin.users.list
+        https://docs.slack.dev/reference/methods/admin.users.list
         """
         kwargs.update(
             {
@@ -1759,7 +1759,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Remove a user from a workspace.
-        https://api.slack.com/methods/admin.users.remove
+        https://docs.slack.dev/reference/methods/admin.users.remove
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return await self.api_call("admin.users.remove", params=kwargs)
@@ -1772,7 +1772,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set an existing guest, regular user, or owner to be an admin user.
-        https://api.slack.com/methods/admin.users.setAdmin
+        https://docs.slack.dev/reference/methods/admin.users.setAdmin
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return await self.api_call("admin.users.setAdmin", params=kwargs)
@@ -1786,7 +1786,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set an expiration for a guest user.
-        https://api.slack.com/methods/admin.users.setExpiration
+        https://docs.slack.dev/reference/methods/admin.users.setExpiration
         """
         kwargs.update({"expiration_ts": expiration_ts, "team_id": team_id, "user_id": user_id})
         return await self.api_call("admin.users.setExpiration", params=kwargs)
@@ -1799,7 +1799,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set an existing guest, regular user, or admin user to be a workspace owner.
-        https://api.slack.com/methods/admin.users.setOwner
+        https://docs.slack.dev/reference/methods/admin.users.setOwner
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return await self.api_call("admin.users.setOwner", params=kwargs)
@@ -1812,7 +1812,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set an existing guest user, admin user, or owner to be a regular user.
-        https://api.slack.com/methods/admin.users.setRegular
+        https://docs.slack.dev/reference/methods/admin.users.setRegular
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return await self.api_call("admin.users.setRegular", params=kwargs)
@@ -1833,7 +1833,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Search workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.search
+        https://docs.slack.dev/reference/methods/admin.workflows.search
         """
         if collaborator_ids is not None:
             if isinstance(collaborator_ids, (list, tuple)):
@@ -1863,7 +1863,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Look up the permissions for a set of workflows
-        https://api.slack.com/methods/admin.workflows.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
         """
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({"workflow_ids": ",".join(workflow_ids)})
@@ -1884,7 +1884,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Add collaborators to workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.add
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
         """
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({"collaborator_ids": ",".join(collaborator_ids)})
@@ -1904,7 +1904,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Remove collaborators from workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.remove
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
         """
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({"collaborator_ids": ",".join(collaborator_ids)})
@@ -1923,7 +1923,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Unpublish workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.unpublish
+        https://docs.slack.dev/reference/methods/admin.workflows.unpublish
         """
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({"workflow_ids": ",".join(workflow_ids)})
@@ -1938,7 +1938,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Checks API calling code.
-        https://api.slack.com/methods/api.test
+        https://docs.slack.dev/reference/methods/api.test
         """
         kwargs.update({"error": error})
         return await self.api_call("api.test", params=kwargs)
@@ -1951,7 +1951,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Generate a temporary Socket Mode WebSocket URL that your app can connect to
         in order to receive events and interactive payloads
-        https://api.slack.com/methods/apps.connections.open
+        https://docs.slack.dev/reference/methods/apps.connections.open
         """
         kwargs.update({"token": app_token})
         return await self.api_call("apps.connections.open", http_verb="POST", params=kwargs)
@@ -1966,7 +1966,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Get a list of authorizations for the given event context.
         Each authorization represents an app installation that the event is visible to.
-        https://api.slack.com/methods/apps.event.authorizations.list
+        https://docs.slack.dev/reference/methods/apps.event.authorizations.list
         """
         kwargs.update({"event_context": event_context, "cursor": cursor, "limit": limit})
         return await self.api_call("apps.event.authorizations.list", params=kwargs)
@@ -1979,7 +1979,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Uninstalls your app from a workspace.
-        https://api.slack.com/methods/apps.uninstall
+        https://docs.slack.dev/reference/methods/apps.uninstall
         """
         kwargs.update({"client_id": client_id, "client_secret": client_secret})
         return await self.api_call("apps.uninstall", params=kwargs)
@@ -1991,7 +1991,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Create an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.create
+        https://docs.slack.dev/reference/methods/apps.manifest.create
         """
         if isinstance(manifest, str):
             kwargs.update({"manifest": manifest})
@@ -2006,7 +2006,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Permanently deletes an app created through app manifests
-        https://api.slack.com/methods/apps.manifest.delete
+        https://docs.slack.dev/reference/methods/apps.manifest.delete
         """
         kwargs.update({"app_id": app_id})
         return await self.api_call("apps.manifest.delete", params=kwargs)
@@ -2018,7 +2018,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Export an app manifest from an existing app
-        https://api.slack.com/methods/apps.manifest.export
+        https://docs.slack.dev/reference/methods/apps.manifest.export
         """
         kwargs.update({"app_id": app_id})
         return await self.api_call("apps.manifest.export", params=kwargs)
@@ -2031,7 +2031,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Update an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.update
+        https://docs.slack.dev/reference/methods/apps.manifest.update
         """
         if isinstance(manifest, str):
             kwargs.update({"manifest": manifest})
@@ -2048,7 +2048,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Validate an app manifest
-        https://api.slack.com/methods/apps.manifest.validate
+        https://docs.slack.dev/reference/methods/apps.manifest.validate
         """
         if isinstance(manifest, str):
             kwargs.update({"manifest": manifest})
@@ -2064,7 +2064,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Exchanges a refresh token for a new app configuration token
-        https://api.slack.com/methods/tooling.tokens.rotate
+        https://docs.slack.dev/reference/methods/tooling.tokens.rotate
         """
         kwargs.update({"refresh_token": refresh_token})
         return await self.api_call("tooling.tokens.rotate", params=kwargs)
@@ -2078,7 +2078,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setStatus
+        https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         """
         kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "status": status})
         return await self.api_call("assistant.threads.setStatus", params=kwargs)
@@ -2092,7 +2092,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setTitle
+        https://docs.slack.dev/reference/methods/assistant.threads.setTitle
         """
         kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "title": title})
         return await self.api_call("assistant.threads.setTitle", params=kwargs)
@@ -2107,7 +2107,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+        https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         """
         kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "prompts": prompts})
         if title is not None:
@@ -2121,7 +2121,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Revokes a token.
-        https://api.slack.com/methods/auth.revoke
+        https://docs.slack.dev/reference/methods/auth.revoke
         """
         kwargs.update({"test": test})
         return await self.api_call("auth.revoke", http_verb="GET", params=kwargs)
@@ -2131,7 +2131,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Checks authentication & identity.
-        https://api.slack.com/methods/auth.test
+        https://docs.slack.dev/reference/methods/auth.test
         """
         return await self.api_call("auth.test", params=kwargs)
 
@@ -2143,7 +2143,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List the workspaces a token can access.
-        https://api.slack.com/methods/auth.teams.list
+        https://docs.slack.dev/reference/methods/auth.teams.list
         """
         kwargs.update({"cursor": cursor, "limit": limit, "include_icon": include_icon})
         return await self.api_call("auth.teams.list", params=kwargs)
@@ -2161,7 +2161,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Add bookmark to a channel.
-        https://api.slack.com/methods/bookmarks.add
+        https://docs.slack.dev/reference/methods/bookmarks.add
         """
         kwargs.update(
             {
@@ -2187,7 +2187,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Edit bookmark.
-        https://api.slack.com/methods/bookmarks.edit
+        https://docs.slack.dev/reference/methods/bookmarks.edit
         """
         kwargs.update(
             {
@@ -2207,7 +2207,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List bookmark for the channel.
-        https://api.slack.com/methods/bookmarks.list
+        https://docs.slack.dev/reference/methods/bookmarks.list
         """
         kwargs.update({"channel_id": channel_id})
         return await self.api_call("bookmarks.list", http_verb="POST", params=kwargs)
@@ -2220,7 +2220,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Remove bookmark from the channel.
-        https://api.slack.com/methods/bookmarks.remove
+        https://docs.slack.dev/reference/methods/bookmarks.remove
         """
         kwargs.update({"bookmark_id": bookmark_id, "channel_id": channel_id})
         return await self.api_call("bookmarks.remove", http_verb="POST", params=kwargs)
@@ -2233,7 +2233,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets information about a bot user.
-        https://api.slack.com/methods/bots.info
+        https://docs.slack.dev/reference/methods/bots.info
         """
         kwargs.update({"bot": bot, "team_id": team_id})
         return await self.api_call("bots.info", http_verb="GET", params=kwargs)
@@ -2252,7 +2252,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Registers a new Call.
-        https://api.slack.com/methods/calls.add
+        https://docs.slack.dev/reference/methods/calls.add
         """
         kwargs.update(
             {
@@ -2279,7 +2279,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Ends a Call.
-        https://api.slack.com/methods/calls.end
+        https://docs.slack.dev/reference/methods/calls.end
         """
         kwargs.update({"id": id, "duration": duration})
         return await self.api_call("calls.end", http_verb="POST", params=kwargs)
@@ -2291,7 +2291,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Returns information about a Call.
-        https://api.slack.com/methods/calls.info
+        https://docs.slack.dev/reference/methods/calls.info
         """
         kwargs.update({"id": id})
         return await self.api_call("calls.info", http_verb="POST", params=kwargs)
@@ -2304,7 +2304,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Registers new participants added to a Call.
-        https://api.slack.com/methods/calls.participants.add
+        https://docs.slack.dev/reference/methods/calls.participants.add
         """
         kwargs.update({"id": id})
         _update_call_participants(kwargs, users)
@@ -2318,7 +2318,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Registers participants removed from a Call.
-        https://api.slack.com/methods/calls.participants.remove
+        https://docs.slack.dev/reference/methods/calls.participants.remove
         """
         kwargs.update({"id": id})
         _update_call_participants(kwargs, users)
@@ -2334,7 +2334,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Updates information about a Call.
-        https://api.slack.com/methods/calls.update
+        https://docs.slack.dev/reference/methods/calls.update
         """
         kwargs.update(
             {
@@ -2354,7 +2354,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Create Canvas for a user
-        https://api.slack.com/methods/canvases.create
+        https://docs.slack.dev/reference/methods/canvases.create
         """
         kwargs.update({"title": title, "document_content": document_content})
         return await self.api_call("canvases.create", json=kwargs)
@@ -2367,7 +2367,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Update an existing canvas
-        https://api.slack.com/methods/canvases.edit
+        https://docs.slack.dev/reference/methods/canvases.edit
         """
         kwargs.update({"canvas_id": canvas_id, "changes": changes})
         return await self.api_call("canvases.edit", json=kwargs)
@@ -2379,7 +2379,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Deletes a canvas
-        https://api.slack.com/methods/canvases.delete
+        https://docs.slack.dev/reference/methods/canvases.delete
         """
         kwargs.update({"canvas_id": canvas_id})
         return await self.api_call("canvases.delete", params=kwargs)
@@ -2394,7 +2394,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sets the access level to a canvas for specified entities
-        https://api.slack.com/methods/canvases.access.set
+        https://docs.slack.dev/reference/methods/canvases.access.set
         """
         kwargs.update({"canvas_id": canvas_id, "access_level": access_level})
         if channel_ids is not None:
@@ -2419,7 +2419,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Create a Channel Canvas for a channel
-        https://api.slack.com/methods/canvases.access.delete
+        https://docs.slack.dev/reference/methods/canvases.access.delete
         """
         kwargs.update({"canvas_id": canvas_id})
         if channel_ids is not None:
@@ -2442,7 +2442,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Find sections matching the provided criteria
-        https://api.slack.com/methods/canvases.sections.lookup
+        https://docs.slack.dev/reference/methods/canvases.sections.lookup
         """
         kwargs.update({"canvas_id": canvas_id, "criteria": json.dumps(criteria)})
         return await self.api_call("canvases.sections.lookup", params=kwargs)
@@ -2450,7 +2450,7 @@ class AsyncWebClient(AsyncBaseClient):
     # --------------------------
     # Deprecated: channels.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     async def channels_archive(
@@ -2629,7 +2629,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Deletes a message.
-        https://api.slack.com/methods/chat.delete
+        https://docs.slack.dev/reference/methods/chat.delete
         """
         kwargs.update({"channel": channel, "ts": ts, "as_user": as_user})
         return await self.api_call("chat.delete", params=kwargs)
@@ -2643,7 +2643,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Deletes a scheduled message.
-        https://api.slack.com/methods/chat.deleteScheduledMessage
+        https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
         """
         kwargs.update(
             {
@@ -2662,7 +2662,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieve a permalink URL for a specific extant message
-        https://api.slack.com/methods/chat.getPermalink
+        https://docs.slack.dev/reference/methods/chat.getPermalink
         """
         kwargs.update({"channel": channel, "message_ts": message_ts})
         return await self.api_call("chat.getPermalink", http_verb="GET", params=kwargs)
@@ -2675,7 +2675,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Share a me message into a channel.
-        https://api.slack.com/methods/chat.meMessage
+        https://docs.slack.dev/reference/methods/chat.meMessage
         """
         kwargs.update({"channel": channel, "text": text})
         return await self.api_call("chat.meMessage", params=kwargs)
@@ -2699,7 +2699,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sends an ephemeral message to a user in a channel.
-        https://api.slack.com/methods/chat.postEphemeral
+        https://docs.slack.dev/reference/methods/chat.postEphemeral
         """
         kwargs.update(
             {
@@ -2748,7 +2748,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sends a message to a channel.
-        https://api.slack.com/methods/chat.postMessage
+        https://docs.slack.dev/reference/methods/chat.postMessage
         """
         kwargs.update(
             {
@@ -2798,7 +2798,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Schedules a message.
-        https://api.slack.com/methods/chat.scheduleMessage
+        https://docs.slack.dev/reference/methods/chat.scheduleMessage
         """
         kwargs.update(
             {
@@ -2839,7 +2839,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Provide custom unfurl behavior for user-posted URLs.
-        https://api.slack.com/methods/chat.unfurl
+        https://docs.slack.dev/reference/methods/chat.unfurl
         """
         kwargs.update(
             {
@@ -2877,7 +2877,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Updates a message in a channel.
-        https://api.slack.com/methods/chat.update
+        https://docs.slack.dev/reference/methods/chat.update
         """
         kwargs.update(
             {
@@ -2916,7 +2916,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists all scheduled messages.
-        https://api.slack.com/methods/chat.scheduledMessages.list
+        https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
         """
         kwargs.update(
             {
@@ -2942,7 +2942,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Accepts an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.acceptSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
         """
         if channel_id is None and invite_id is None:
             raise e.SlackRequestError("Either channel_id or invite_id must be provided.")
@@ -2966,7 +2966,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Approves an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.approveSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
         """
         kwargs.update({"invite_id": invite_id, "target_team": target_team})
         return await self.api_call("conversations.approveSharedInvite", http_verb="POST", params=kwargs)
@@ -2978,7 +2978,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Archives a conversation.
-        https://api.slack.com/methods/conversations.archive
+        https://docs.slack.dev/reference/methods/conversations.archive
         """
         kwargs.update({"channel": channel})
         return await self.api_call("conversations.archive", params=kwargs)
@@ -2990,7 +2990,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Closes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.close
+        https://docs.slack.dev/reference/methods/conversations.close
         """
         kwargs.update({"channel": channel})
         return await self.api_call("conversations.close", params=kwargs)
@@ -3004,7 +3004,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Initiates a public or private channel-based conversation
-        https://api.slack.com/methods/conversations.create
+        https://docs.slack.dev/reference/methods/conversations.create
         """
         kwargs.update({"name": name, "is_private": is_private, "team_id": team_id})
         return await self.api_call("conversations.create", params=kwargs)
@@ -3017,7 +3017,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Declines a Slack Connect channel invite.
-        https://api.slack.com/methods/conversations.declineSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
         """
         kwargs.update({"invite_id": invite_id, "target_team": target_team})
         return await self.api_call("conversations.declineSharedInvite", http_verb="GET", params=kwargs)
@@ -3026,7 +3026,7 @@ class AsyncWebClient(AsyncBaseClient):
         self, *, action: str, channel: str, target_team: str, **kwargs
     ) -> AsyncSlackResponse:
         """Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-        https://api.slack.com/methods/conversations.externalInvitePermissions.set
+        https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
         """
         kwargs.update(
             {
@@ -3050,7 +3050,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Fetches a conversation's history of messages and events.
-        https://api.slack.com/methods/conversations.history
+        https://docs.slack.dev/reference/methods/conversations.history
         """
         kwargs.update(
             {
@@ -3074,7 +3074,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieve information about a conversation.
-        https://api.slack.com/methods/conversations.info
+        https://docs.slack.dev/reference/methods/conversations.info
         """
         kwargs.update(
             {
@@ -3094,7 +3094,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Invites users to a channel.
-        https://api.slack.com/methods/conversations.invite
+        https://docs.slack.dev/reference/methods/conversations.invite
         """
         kwargs.update(
             {
@@ -3117,7 +3117,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sends an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.inviteShared
+        https://docs.slack.dev/reference/methods/conversations.inviteShared
         """
         if emails is None and user_ids is None:
             raise e.SlackRequestError("Either emails or user ids must be provided.")
@@ -3139,7 +3139,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Joins an existing conversation.
-        https://api.slack.com/methods/conversations.join
+        https://docs.slack.dev/reference/methods/conversations.join
         """
         kwargs.update({"channel": channel})
         return await self.api_call("conversations.join", params=kwargs)
@@ -3152,7 +3152,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Removes a user from a conversation.
-        https://api.slack.com/methods/conversations.kick
+        https://docs.slack.dev/reference/methods/conversations.kick
         """
         kwargs.update({"channel": channel, "user": user})
         return await self.api_call("conversations.kick", params=kwargs)
@@ -3164,7 +3164,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Leaves a conversation.
-        https://api.slack.com/methods/conversations.leave
+        https://docs.slack.dev/reference/methods/conversations.leave
         """
         kwargs.update({"channel": channel})
         return await self.api_call("conversations.leave", params=kwargs)
@@ -3180,7 +3180,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists all channels in a Slack team.
-        https://api.slack.com/methods/conversations.list
+        https://docs.slack.dev/reference/methods/conversations.list
         """
         kwargs.update(
             {
@@ -3206,7 +3206,7 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """List shared channel invites that have been generated
         or received but have not yet been approved by all parties.
-        https://api.slack.com/methods/conversations.listConnectInvites
+        https://docs.slack.dev/reference/methods/conversations.listConnectInvites
         """
         kwargs.update({"count": count, "cursor": cursor, "team_id": team_id})
         return await self.api_call("conversations.listConnectInvites", params=kwargs)
@@ -3219,7 +3219,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sets the read cursor in a channel.
-        https://api.slack.com/methods/conversations.mark
+        https://docs.slack.dev/reference/methods/conversations.mark
         """
         kwargs.update({"channel": channel, "ts": ts})
         return await self.api_call("conversations.mark", params=kwargs)
@@ -3233,7 +3233,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieve members of a conversation.
-        https://api.slack.com/methods/conversations.members
+        https://docs.slack.dev/reference/methods/conversations.members
         """
         kwargs.update({"channel": channel, "cursor": cursor, "limit": limit})
         return await self.api_call("conversations.members", http_verb="GET", params=kwargs)
@@ -3247,7 +3247,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Opens or resumes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.open
+        https://docs.slack.dev/reference/methods/conversations.open
         """
         if channel is None and users is None:
             raise e.SlackRequestError("Either channel or users must be provided.")
@@ -3266,7 +3266,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Renames a conversation.
-        https://api.slack.com/methods/conversations.rename
+        https://docs.slack.dev/reference/methods/conversations.rename
         """
         kwargs.update({"channel": channel, "name": name})
         return await self.api_call("conversations.rename", params=kwargs)
@@ -3285,7 +3285,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieve a thread of messages posted to a conversation
-        https://api.slack.com/methods/conversations.replies
+        https://docs.slack.dev/reference/methods/conversations.replies
         """
         kwargs.update(
             {
@@ -3311,7 +3311,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-        https://api.slack.com/methods/conversations.requestSharedInvite.approve
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
         """
         kwargs.update(
             {
@@ -3332,7 +3332,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Deny a request to invite an external user to a channel.
-        https://api.slack.com/methods/conversations.requestSharedInvite.deny
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
         """
         kwargs.update({"invite_id": invite_id, "message": message})
         return await self.api_call("conversations.requestSharedInvite.deny", params=kwargs)
@@ -3350,7 +3350,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists requests to add external users to channels with ability to filter.
-        https://api.slack.com/methods/conversations.requestSharedInvite.list
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
         """
         kwargs.update(
             {
@@ -3377,7 +3377,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sets the purpose for a conversation.
-        https://api.slack.com/methods/conversations.setPurpose
+        https://docs.slack.dev/reference/methods/conversations.setPurpose
         """
         kwargs.update({"channel": channel, "purpose": purpose})
         return await self.api_call("conversations.setPurpose", params=kwargs)
@@ -3390,7 +3390,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Sets the topic for a conversation.
-        https://api.slack.com/methods/conversations.setTopic
+        https://docs.slack.dev/reference/methods/conversations.setTopic
         """
         kwargs.update({"channel": channel, "topic": topic})
         return await self.api_call("conversations.setTopic", params=kwargs)
@@ -3402,7 +3402,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Reverses conversation archival.
-        https://api.slack.com/methods/conversations.unarchive
+        https://docs.slack.dev/reference/methods/conversations.unarchive
         """
         kwargs.update({"channel": channel})
         return await self.api_call("conversations.unarchive", params=kwargs)
@@ -3415,7 +3415,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Create a Channel Canvas for a channel
-        https://api.slack.com/methods/conversations.canvases.create
+        https://docs.slack.dev/reference/methods/conversations.canvases.create
         """
         kwargs.update({"channel_id": channel_id, "document_content": document_content})
         return await self.api_call("conversations.canvases.create", json=kwargs)
@@ -3428,7 +3428,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Open a dialog with a user.
-        https://api.slack.com/methods/dialog.open
+        https://docs.slack.dev/reference/methods/dialog.open
         """
         kwargs.update({"dialog": dialog, "trigger_id": trigger_id})
         kwargs = _remove_none_values(kwargs)
@@ -3440,7 +3440,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Ends the current user's Do Not Disturb session immediately.
-        https://api.slack.com/methods/dnd.endDnd
+        https://docs.slack.dev/reference/methods/dnd.endDnd
         """
         return await self.api_call("dnd.endDnd", params=kwargs)
 
@@ -3449,7 +3449,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Ends the current user's snooze mode immediately.
-        https://api.slack.com/methods/dnd.endSnooze
+        https://docs.slack.dev/reference/methods/dnd.endSnooze
         """
         return await self.api_call("dnd.endSnooze", params=kwargs)
 
@@ -3461,7 +3461,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieves a user's current Do Not Disturb status.
-        https://api.slack.com/methods/dnd.info
+        https://docs.slack.dev/reference/methods/dnd.info
         """
         kwargs.update({"team_id": team_id, "user": user})
         return await self.api_call("dnd.info", http_verb="GET", params=kwargs)
@@ -3473,7 +3473,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Turns on Do Not Disturb mode for the current user, or changes its duration.
-        https://api.slack.com/methods/dnd.setSnooze
+        https://docs.slack.dev/reference/methods/dnd.setSnooze
         """
         kwargs.update({"num_minutes": num_minutes})
         return await self.api_call("dnd.setSnooze", http_verb="GET", params=kwargs)
@@ -3485,7 +3485,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieves the Do Not Disturb status for users on a team.
-        https://api.slack.com/methods/dnd.teamInfo
+        https://docs.slack.dev/reference/methods/dnd.teamInfo
         """
         if isinstance(users, (list, tuple)):
             kwargs.update({"users": ",".join(users)})
@@ -3500,7 +3500,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists custom emoji for a team.
-        https://api.slack.com/methods/emoji.list
+        https://docs.slack.dev/reference/methods/emoji.list
         """
         kwargs.update({"include_categories": include_categories})
         return await self.api_call("emoji.list", http_verb="GET", params=kwargs)
@@ -3513,7 +3513,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Deletes an existing comment on a file.
-        https://api.slack.com/methods/files.comments.delete
+        https://docs.slack.dev/reference/methods/files.comments.delete
         """
         kwargs.update({"file": file, "id": id})
         return await self.api_call("files.comments.delete", params=kwargs)
@@ -3525,7 +3525,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Deletes a file.
-        https://api.slack.com/methods/files.delete
+        https://docs.slack.dev/reference/methods/files.delete
         """
         kwargs.update({"file": file})
         return await self.api_call("files.delete", params=kwargs)
@@ -3541,7 +3541,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets information about a team file.
-        https://api.slack.com/methods/files.info
+        https://docs.slack.dev/reference/methods/files.info
         """
         kwargs.update(
             {
@@ -3569,7 +3569,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists & filters team files.
-        https://api.slack.com/methods/files.list
+        https://docs.slack.dev/reference/methods/files.list
         """
         kwargs.update(
             {
@@ -3597,7 +3597,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.info
+        https://docs.slack.dev/reference/methods/files.remote.info
         """
         kwargs.update({"external_id": external_id, "file": file})
         return await self.api_call("files.remote.info", http_verb="GET", params=kwargs)
@@ -3613,7 +3613,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.list
+        https://docs.slack.dev/reference/methods/files.remote.list
         """
         kwargs.update(
             {
@@ -3638,7 +3638,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Adds a file from a remote service.
-        https://api.slack.com/methods/files.remote.add
+        https://docs.slack.dev/reference/methods/files.remote.add
         """
         kwargs.update(
             {
@@ -3677,7 +3677,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Updates an existing remote file.
-        https://api.slack.com/methods/files.remote.update
+        https://docs.slack.dev/reference/methods/files.remote.update
         """
         kwargs.update(
             {
@@ -3712,7 +3712,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Remove a remote file.
-        https://api.slack.com/methods/files.remote.remove
+        https://docs.slack.dev/reference/methods/files.remote.remove
         """
         kwargs.update({"external_id": external_id, "file": file})
         return await self.api_call("files.remote.remove", http_verb="POST", params=kwargs)
@@ -3726,7 +3726,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Share a remote file into a channel.
-        https://api.slack.com/methods/files.remote.share
+        https://docs.slack.dev/reference/methods/files.remote.share
         """
         if external_id is None and file is None:
             raise e.SlackRequestError("Either external_id or file must be provided.")
@@ -3744,7 +3744,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Revokes public/external sharing access for a file
-        https://api.slack.com/methods/files.revokePublicURL
+        https://docs.slack.dev/reference/methods/files.revokePublicURL
         """
         kwargs.update({"file": file})
         return await self.api_call("files.revokePublicURL", params=kwargs)
@@ -3756,7 +3756,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Enables a file for public/external sharing.
-        https://api.slack.com/methods/files.sharedPublicURL
+        https://docs.slack.dev/reference/methods/files.sharedPublicURL
         """
         kwargs.update({"file": file})
         return await self.api_call("files.sharedPublicURL", params=kwargs)
@@ -3775,7 +3775,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Uploads or creates a file.
-        https://api.slack.com/methods/files.upload
+        https://docs.slack.dev/reference/methods/files.upload
         """
         _print_files_upload_v2_suggestion()
 
@@ -3828,12 +3828,12 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """This wrapper method provides an easy way to upload files using the following endpoints:
 
-        - step1: https://api.slack.com/methods/files.getUploadURLExternal
+        - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
         - step2: "https://files.slack.com/upload/v1/..." URLs returned from files.getUploadURLExternal API
 
-        - step3: https://api.slack.com/methods/files.completeUploadExternal
-            and https://api.slack.com/methods/files.info
+        - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+            and https://docs.slack.dev/reference/methods/files.info
 
         """
         if file is None and content is None and file_uploads is None:
@@ -3919,7 +3919,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets a URL for an edge external upload.
-        https://api.slack.com/methods/files.getUploadURLExternal
+        https://docs.slack.dev/reference/methods/files.getUploadURLExternal
         """
         kwargs.update(
             {
@@ -3942,7 +3942,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Finishes an upload started with files.getUploadURLExternal.
-        https://api.slack.com/methods/files.completeUploadExternal
+        https://docs.slack.dev/reference/methods/files.completeUploadExternal
         """
         _files = [{k: v for k, v in f.items() if v is not None} for f in files]
         kwargs.update(
@@ -3965,7 +3965,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Signal the successful completion of a function
-        https://api.slack.com/methods/functions.completeSuccess
+        https://docs.slack.dev/reference/methods/functions.completeSuccess
         """
         kwargs.update({"function_execution_id": function_execution_id, "outputs": json.dumps(outputs)})
         return await self.api_call("functions.completeSuccess", params=kwargs)
@@ -3978,7 +3978,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Signal the failure to execute a function
-        https://api.slack.com/methods/functions.completeError
+        https://docs.slack.dev/reference/methods/functions.completeError
         """
         kwargs.update({"function_execution_id": function_execution_id, "error": error})
         return await self.api_call("functions.completeError", params=kwargs)
@@ -3986,7 +3986,7 @@ class AsyncWebClient(AsyncBaseClient):
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     async def groups_archive(
@@ -4167,7 +4167,7 @@ class AsyncWebClient(AsyncBaseClient):
     # --------------------------
     # Deprecated: im.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     async def im_close(
@@ -4243,7 +4243,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """For Enterprise Grid workspaces, map local user IDs to global user IDs
-        https://api.slack.com/methods/migration.exchange
+        https://docs.slack.dev/reference/methods/migration.exchange
         """
         if isinstance(users, (list, tuple)):
             kwargs.update({"users": ",".join(users)})
@@ -4255,7 +4255,7 @@ class AsyncWebClient(AsyncBaseClient):
     # --------------------------
     # Deprecated: mpim.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     async def mpim_close(
@@ -4342,7 +4342,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.v2.access
+        https://docs.slack.dev/reference/methods/oauth.v2.access
         """
         if redirect_uri is not None:
             kwargs.update({"redirect_uri": redirect_uri})
@@ -4368,7 +4368,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.access
+        https://docs.slack.dev/reference/methods/oauth.access
         """
         if redirect_uri is not None:
             kwargs.update({"redirect_uri": redirect_uri})
@@ -4388,7 +4388,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Exchanges a legacy access token for a new expiring access token and refresh token
-        https://api.slack.com/methods/oauth.v2.exchange
+        https://docs.slack.dev/reference/methods/oauth.v2.exchange
         """
         kwargs.update({"client_id": client_id, "client_secret": client_secret, "token": token})
         return await self.api_call("oauth.v2.exchange", params=kwargs)
@@ -4404,7 +4404,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.token
+        https://docs.slack.dev/reference/methods/openid.connect.token
         """
         if redirect_uri is not None:
             kwargs.update({"redirect_uri": redirect_uri})
@@ -4425,7 +4425,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Get the identity of a user who has authorized Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.userInfo
+        https://docs.slack.dev/reference/methods/openid.connect.userInfo
         """
         return await self.api_call("openid.connect.userInfo", params=kwargs)
 
@@ -4437,7 +4437,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Pins an item to a channel.
-        https://api.slack.com/methods/pins.add
+        https://docs.slack.dev/reference/methods/pins.add
         """
         kwargs.update({"channel": channel, "timestamp": timestamp})
         return await self.api_call("pins.add", params=kwargs)
@@ -4449,7 +4449,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists items pinned to a channel.
-        https://api.slack.com/methods/pins.list
+        https://docs.slack.dev/reference/methods/pins.list
         """
         kwargs.update({"channel": channel})
         return await self.api_call("pins.list", http_verb="GET", params=kwargs)
@@ -4462,7 +4462,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Un-pins an item from a channel.
-        https://api.slack.com/methods/pins.remove
+        https://docs.slack.dev/reference/methods/pins.remove
         """
         kwargs.update({"channel": channel, "timestamp": timestamp})
         return await self.api_call("pins.remove", params=kwargs)
@@ -4476,7 +4476,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Adds a reaction to an item.
-        https://api.slack.com/methods/reactions.add
+        https://docs.slack.dev/reference/methods/reactions.add
         """
         kwargs.update({"channel": channel, "name": name, "timestamp": timestamp})
         return await self.api_call("reactions.add", params=kwargs)
@@ -4492,7 +4492,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets reactions for an item.
-        https://api.slack.com/methods/reactions.get
+        https://docs.slack.dev/reference/methods/reactions.get
         """
         kwargs.update(
             {
@@ -4518,7 +4518,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists reactions made by a user.
-        https://api.slack.com/methods/reactions.list
+        https://docs.slack.dev/reference/methods/reactions.list
         """
         kwargs.update(
             {
@@ -4544,7 +4544,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Removes a reaction from an item.
-        https://api.slack.com/methods/reactions.remove
+        https://docs.slack.dev/reference/methods/reactions.remove
         """
         kwargs.update(
             {
@@ -4568,7 +4568,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Creates a reminder.
-        https://api.slack.com/methods/reminders.add
+        https://docs.slack.dev/reference/methods/reminders.add
         """
         kwargs.update(
             {
@@ -4589,7 +4589,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Marks a reminder as complete.
-        https://api.slack.com/methods/reminders.complete
+        https://docs.slack.dev/reference/methods/reminders.complete
         """
         kwargs.update({"reminder": reminder, "team_id": team_id})
         return await self.api_call("reminders.complete", params=kwargs)
@@ -4602,7 +4602,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Deletes a reminder.
-        https://api.slack.com/methods/reminders.delete
+        https://docs.slack.dev/reference/methods/reminders.delete
         """
         kwargs.update({"reminder": reminder, "team_id": team_id})
         return await self.api_call("reminders.delete", params=kwargs)
@@ -4615,7 +4615,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets information about a reminder.
-        https://api.slack.com/methods/reminders.info
+        https://docs.slack.dev/reference/methods/reminders.info
         """
         kwargs.update({"reminder": reminder, "team_id": team_id})
         return await self.api_call("reminders.info", http_verb="GET", params=kwargs)
@@ -4627,7 +4627,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists all reminders created by or for a given user.
-        https://api.slack.com/methods/reminders.list
+        https://docs.slack.dev/reference/methods/reminders.list
         """
         kwargs.update({"team_id": team_id})
         return await self.api_call("reminders.list", http_verb="GET", params=kwargs)
@@ -4640,7 +4640,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.connect
+        https://docs.slack.dev/reference/methods/rtm.connect
         """
         kwargs.update({"batch_presence_aware": batch_presence_aware, "presence_sub": presence_sub})
         return await self.api_call("rtm.connect", http_verb="GET", params=kwargs)
@@ -4658,7 +4658,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.start
+        https://docs.slack.dev/reference/methods/rtm.start
         """
         kwargs.update(
             {
@@ -4686,7 +4686,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Searches for messages and files matching a query.
-        https://api.slack.com/methods/search.all
+        https://docs.slack.dev/reference/methods/search.all
         """
         kwargs.update(
             {
@@ -4714,7 +4714,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Searches for files matching a query.
-        https://api.slack.com/methods/search.files
+        https://docs.slack.dev/reference/methods/search.files
         """
         kwargs.update(
             {
@@ -4743,7 +4743,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Searches for messages matching a query.
-        https://api.slack.com/methods/search.messages
+        https://docs.slack.dev/reference/methods/search.messages
         """
         kwargs.update(
             {
@@ -4769,7 +4769,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Adds a star to an item.
-        https://api.slack.com/methods/stars.add
+        https://docs.slack.dev/reference/methods/stars.add
         """
         kwargs.update(
             {
@@ -4792,7 +4792,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists stars for a user.
-        https://api.slack.com/methods/stars.list
+        https://docs.slack.dev/reference/methods/stars.list
         """
         kwargs.update(
             {
@@ -4815,7 +4815,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Removes a star from an item.
-        https://api.slack.com/methods/stars.remove
+        https://docs.slack.dev/reference/methods/stars.remove
         """
         kwargs.update(
             {
@@ -4839,7 +4839,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets the access logs for the current team.
-        https://api.slack.com/methods/team.accessLogs
+        https://docs.slack.dev/reference/methods/team.accessLogs
         """
         kwargs.update(
             {
@@ -4861,7 +4861,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets billable users information for the current team.
-        https://api.slack.com/methods/team.billableInfo
+        https://docs.slack.dev/reference/methods/team.billableInfo
         """
         kwargs.update({"team_id": team_id, "user": user})
         return await self.api_call("team.billableInfo", http_verb="GET", params=kwargs)
@@ -4871,7 +4871,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Reads a workspace's billing plan information.
-        https://api.slack.com/methods/team.billing.info
+        https://docs.slack.dev/reference/methods/team.billing.info
         """
         return await self.api_call("team.billing.info", params=kwargs)
 
@@ -4882,7 +4882,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Disconnects an external organization.
-        https://api.slack.com/methods/team.externalTeams.disconnect
+        https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
         """
         kwargs.update(
             {
@@ -4904,7 +4904,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Returns a list of all the external teams connected and details about the connection.
-        https://api.slack.com/methods/team.externalTeams.list
+        https://docs.slack.dev/reference/methods/team.externalTeams.list
         """
         kwargs.update(
             {
@@ -4935,7 +4935,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets information about the current team.
-        https://api.slack.com/methods/team.info
+        https://docs.slack.dev/reference/methods/team.info
         """
         kwargs.update({"team": team, "domain": domain})
         return await self.api_call("team.info", http_verb="GET", params=kwargs)
@@ -4953,7 +4953,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets the integration logs for the current team.
-        https://api.slack.com/methods/team.integrationLogs
+        https://docs.slack.dev/reference/methods/team.integrationLogs
         """
         kwargs.update(
             {
@@ -4975,7 +4975,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieve a team's profile.
-        https://api.slack.com/methods/team.profile.get
+        https://docs.slack.dev/reference/methods/team.profile.get
         """
         kwargs.update({"visibility": visibility})
         return await self.api_call("team.profile.get", http_verb="GET", params=kwargs)
@@ -4985,7 +4985,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieve a list of a workspace's team preferences.
-        https://api.slack.com/methods/team.preferences.list
+        https://docs.slack.dev/reference/methods/team.preferences.list
         """
         return await self.api_call("team.preferences.list", params=kwargs)
 
@@ -5001,7 +5001,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Create a User Group
-        https://api.slack.com/methods/usergroups.create
+        https://docs.slack.dev/reference/methods/usergroups.create
         """
         kwargs.update(
             {
@@ -5027,7 +5027,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Disable an existing User Group
-        https://api.slack.com/methods/usergroups.disable
+        https://docs.slack.dev/reference/methods/usergroups.disable
         """
         kwargs.update({"usergroup": usergroup, "include_count": include_count, "team_id": team_id})
         return await self.api_call("usergroups.disable", params=kwargs)
@@ -5041,7 +5041,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Enable a User Group
-        https://api.slack.com/methods/usergroups.enable
+        https://docs.slack.dev/reference/methods/usergroups.enable
         """
         kwargs.update({"usergroup": usergroup, "include_count": include_count, "team_id": team_id})
         return await self.api_call("usergroups.enable", params=kwargs)
@@ -5056,7 +5056,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List all User Groups for a team
-        https://api.slack.com/methods/usergroups.list
+        https://docs.slack.dev/reference/methods/usergroups.list
         """
         kwargs.update(
             {
@@ -5081,7 +5081,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Update an existing User Group
-        https://api.slack.com/methods/usergroups.update
+        https://docs.slack.dev/reference/methods/usergroups.update
         """
         kwargs.update(
             {
@@ -5108,7 +5108,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List all users in a User Group
-        https://api.slack.com/methods/usergroups.users.list
+        https://docs.slack.dev/reference/methods/usergroups.users.list
         """
         kwargs.update(
             {
@@ -5129,7 +5129,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Update the list of users for a User Group
-        https://api.slack.com/methods/usergroups.users.update
+        https://docs.slack.dev/reference/methods/usergroups.users.update
         """
         kwargs.update(
             {
@@ -5156,7 +5156,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List conversations the calling user may access.
-        https://api.slack.com/methods/users.conversations
+        https://docs.slack.dev/reference/methods/users.conversations
         """
         kwargs.update(
             {
@@ -5178,7 +5178,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Delete the user profile photo
-        https://api.slack.com/methods/users.deletePhoto
+        https://docs.slack.dev/reference/methods/users.deletePhoto
         """
         return await self.api_call("users.deletePhoto", http_verb="GET", params=kwargs)
 
@@ -5189,7 +5189,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets user presence information.
-        https://api.slack.com/methods/users.getPresence
+        https://docs.slack.dev/reference/methods/users.getPresence
         """
         kwargs.update({"user": user})
         return await self.api_call("users.getPresence", http_verb="GET", params=kwargs)
@@ -5199,7 +5199,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Get a user's identity.
-        https://api.slack.com/methods/users.identity
+        https://docs.slack.dev/reference/methods/users.identity
         """
         return await self.api_call("users.identity", http_verb="GET", params=kwargs)
 
@@ -5211,7 +5211,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Gets information about a user.
-        https://api.slack.com/methods/users.info
+        https://docs.slack.dev/reference/methods/users.info
         """
         kwargs.update({"user": user, "include_locale": include_locale})
         return await self.api_call("users.info", http_verb="GET", params=kwargs)
@@ -5226,7 +5226,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lists all users in a Slack team.
-        https://api.slack.com/methods/users.list
+        https://docs.slack.dev/reference/methods/users.list
         """
         kwargs.update(
             {
@@ -5245,7 +5245,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Find a user with an email address.
-        https://api.slack.com/methods/users.lookupByEmail
+        https://docs.slack.dev/reference/methods/users.lookupByEmail
         """
         kwargs.update({"email": email})
         return await self.api_call("users.lookupByEmail", http_verb="GET", params=kwargs)
@@ -5260,7 +5260,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set the user profile photo
-        https://api.slack.com/methods/users.setPhoto
+        https://docs.slack.dev/reference/methods/users.setPhoto
         """
         kwargs.update({"crop_w": crop_w, "crop_x": crop_x, "crop_y": crop_y})
         return await self.api_call("users.setPhoto", files={"image": image}, data=kwargs)
@@ -5272,7 +5272,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Manually sets user presence.
-        https://api.slack.com/methods/users.setPresence
+        https://docs.slack.dev/reference/methods/users.setPresence
         """
         kwargs.update({"presence": presence})
         return await self.api_call("users.setPresence", params=kwargs)
@@ -5283,7 +5283,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Lookup an email address to see if someone is on Slack
-        https://api.slack.com/methods/users.discoverableContacts.lookup
+        https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
         """
         kwargs.update({"email": email})
         return await self.api_call("users.discoverableContacts.lookup", params=kwargs)
@@ -5296,7 +5296,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Retrieves a user's profile information.
-        https://api.slack.com/methods/users.profile.get
+        https://docs.slack.dev/reference/methods/users.profile.get
         """
         kwargs.update({"user": user, "include_labels": include_labels})
         return await self.api_call("users.profile.get", http_verb="GET", params=kwargs)
@@ -5311,7 +5311,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set the profile information for a user.
-        https://api.slack.com/methods/users.profile.set
+        https://docs.slack.dev/reference/methods/users.profile.set
         """
         kwargs.update(
             {
@@ -5334,8 +5334,8 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Open a view for a user.
-        https://api.slack.com/methods/views.open
-        See https://api.slack.com/surfaces/modals for details.
+        https://docs.slack.dev/reference/methods/views.open
+        See https://docs.slack.dev/surfaces/modals/ for details.
         """
         kwargs.update({"trigger_id": trigger_id, "interactivity_pointer": interactivity_pointer})
         if isinstance(view, View):
@@ -5358,9 +5358,9 @@ class AsyncWebClient(AsyncBaseClient):
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/surfaces/modals)
+        Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
         to learn more about the lifecycle and intricacies of views.
-        https://api.slack.com/methods/views.push
+        https://docs.slack.dev/reference/methods/views.push
         """
         kwargs.update({"trigger_id": trigger_id, "interactivity_pointer": interactivity_pointer})
         if isinstance(view, View):
@@ -5383,9 +5383,9 @@ class AsyncWebClient(AsyncBaseClient):
         """Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+        See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
-        https://api.slack.com/methods/views.update
+        https://docs.slack.dev/reference/methods/views.update
         """
         if isinstance(view, View):
             kwargs.update({"view": view.to_dict()})
@@ -5412,8 +5412,8 @@ class AsyncWebClient(AsyncBaseClient):
     ) -> AsyncSlackResponse:
         """Publish a static view for a User.
         Create or update the view that comprises an
-        app's Home tab (https://api.slack.com/surfaces/tabs)
-        https://api.slack.com/methods/views.publish
+        app's Home tab (https://docs.slack.dev/surfaces/app-home/)
+        https://docs.slack.dev/reference/methods/views.publish
         """
         kwargs.update({"user_id": user_id, "hash": hash})
         if isinstance(view, View):
@@ -5432,7 +5432,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Add featured workflows to a channel.
-        https://api.slack.com/methods/workflows.featured.add
+        https://docs.slack.dev/reference/methods/workflows.featured.add
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(trigger_ids, (list, tuple)):
@@ -5448,7 +5448,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """List the featured workflows for specified channels.
-        https://api.slack.com/methods/workflows.featured.list
+        https://docs.slack.dev/reference/methods/workflows.featured.list
         """
         if isinstance(channel_ids, (list, tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
@@ -5464,7 +5464,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Remove featured workflows from a channel.
-        https://api.slack.com/methods/workflows.featured.remove
+        https://docs.slack.dev/reference/methods/workflows.featured.remove
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(trigger_ids, (list, tuple)):
@@ -5481,7 +5481,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set featured workflows for a channel.
-        https://api.slack.com/methods/workflows.featured.set
+        https://docs.slack.dev/reference/methods/workflows.featured.set
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(trigger_ids, (list, tuple)):
@@ -5498,7 +5498,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Indicate a successful outcome of a workflow step's execution.
-        https://api.slack.com/methods/workflows.stepCompleted
+        https://docs.slack.dev/reference/methods/workflows.stepCompleted
         """
         kwargs.update({"workflow_step_execute_id": workflow_step_execute_id})
         if outputs is not None:
@@ -5515,7 +5515,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Indicate an unsuccessful outcome of a workflow step's execution.
-        https://api.slack.com/methods/workflows.stepFailed
+        https://docs.slack.dev/reference/methods/workflows.stepFailed
         """
         kwargs.update(
             {
@@ -5536,7 +5536,7 @@ class AsyncWebClient(AsyncBaseClient):
         **kwargs,
     ) -> AsyncSlackResponse:
         """Update the configuration for a workflow extension step.
-        https://api.slack.com/methods/workflows.updateStep
+        https://docs.slack.dev/reference/methods/workflows.updateStep
         """
         kwargs.update({"workflow_step_edit_id": workflow_step_edit_id})
         if inputs is not None:

--- a/slack_sdk/web/base_client.py
+++ b/slack_sdk/web/base_client.py
@@ -615,7 +615,7 @@ class BaseClient:
         header. The signature is created by combining the signing secret with the
         body of the request we're sending using a standard HMAC-SHA256 keyed hash.
 
-        https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview
+        https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview
 
         Args:
             signing_secret: Your application's signing secret, available in the

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -27,7 +27,7 @@ from .internal_utils import (
 class WebClient(BaseClient):
     """A WebClient allows apps to communicate with the Slack Platform's Web API.
 
-    https://api.slack.com/methods
+    https://docs.slack.dev/reference/methods
 
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
@@ -98,7 +98,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieve analytics data for a given date, presented as a compressed JSON file
-        https://api.slack.com/methods/admin.analytics.getFile
+        https://docs.slack.dev/reference/methods/admin.analytics.getFile
         """
         kwargs.update({"type": type})
         if date is not None:
@@ -120,7 +120,7 @@ class WebClient(BaseClient):
         Either app_id or request_id is required.
         These IDs can be obtained either directly via the app_requested event,
         or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.approve
+        https://docs.slack.dev/reference/methods/admin.apps.approve
         """
         if app_id:
             kwargs.update({"app_id": app_id})
@@ -147,7 +147,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List approved apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.approved.list
+        https://docs.slack.dev/reference/methods/admin.apps.approved.list
         """
         kwargs.update(
             {
@@ -168,7 +168,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Clear an app resolution
-        https://api.slack.com/methods/admin.apps.clearResolution
+        https://docs.slack.dev/reference/methods/admin.apps.clearResolution
         """
         kwargs.update(
             {
@@ -188,7 +188,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.cancel
+        https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
         """
         kwargs.update(
             {
@@ -208,7 +208,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.list
+        https://docs.slack.dev/reference/methods/admin.apps.requests.list
         """
         kwargs.update(
             {
@@ -232,7 +232,7 @@ class WebClient(BaseClient):
         Exactly one of the team_id or enterprise_id arguments is required, not both.
         Either app_id or request_id is required. These IDs can be obtained either directly
         via the app_requested event, or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.restrict
+        https://docs.slack.dev/reference/methods/admin.apps.restrict
         """
         if app_id:
             kwargs.update({"app_id": app_id})
@@ -259,7 +259,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List restricted apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.restricted.list
+        https://docs.slack.dev/reference/methods/admin.apps.restricted.list
         """
         kwargs.update(
             {
@@ -281,7 +281,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Uninstall an app from one or many workspaces, or an entire enterprise organization.
         With an org-level token, enterprise_id or team_ids is required.
-        https://api.slack.com/methods/admin.apps.uninstall
+        https://docs.slack.dev/reference/methods/admin.apps.uninstall
         """
         kwargs.update({"app_id": app_id})
         if enterprise_id is not None:
@@ -312,7 +312,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Get logs for a specified team/org
-        https://api.slack.com/methods/admin.apps.activities.list
+        https://docs.slack.dev/reference/methods/admin.apps.activities.list
         """
         kwargs.update(
             {
@@ -340,7 +340,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Look up the app config for connectors by their IDs
-        https://api.slack.com/methods/admin.apps.config.lookup
+        https://docs.slack.dev/reference/methods/admin.apps.config.lookup
         """
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({"app_ids": ",".join(app_ids)})
@@ -357,7 +357,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set the app config for a connector
-        https://api.slack.com/methods/admin.apps.config.set
+        https://docs.slack.dev/reference/methods/admin.apps.config.set
         """
         kwargs.update(
             {
@@ -379,7 +379,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Fetch all the entities assigned to a particular authentication policy by name.
-        https://api.slack.com/methods/admin.auth.policy.getEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
         """
         kwargs.update({"policy_name": policy_name})
         if cursor is not None:
@@ -399,7 +399,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Assign entities to a particular authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.assignEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
         """
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({"entity_ids": ",".join(entity_ids)})
@@ -418,7 +418,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Remove specified entities from a specified authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.removeEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
         """
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({"entity_ids": ",".join(entity_ids)})
@@ -437,7 +437,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Create a Salesforce channel for the corresponding object provided.
-        https://api.slack.com/methods/admin.conversations.createForObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
         """
         kwargs.update(
             {"object_id": object_id, "salesforce_org_id": salesforce_org_id, "invite_object_team": invite_object_team}
@@ -453,7 +453,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Link a Salesforce record to a channel.
-        https://api.slack.com/methods/admin.conversations.linkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
         """
         kwargs.update(
             {
@@ -472,7 +472,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Unlink a Salesforce record from a channel.
-        https://api.slack.com/methods/admin.conversations.unlinkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
         """
         kwargs.update(
             {
@@ -491,7 +491,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Create an Information Barrier
-        https://api.slack.com/methods/admin.barriers.create
+        https://docs.slack.dev/reference/methods/admin.barriers.create
         """
         kwargs.update({"primary_usergroup_id": primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -511,7 +511,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Delete an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.delete
+        https://docs.slack.dev/reference/methods/admin.barriers.delete
         """
         kwargs.update({"barrier_id": barrier_id})
         return self.api_call("admin.barriers.delete", http_verb="POST", params=kwargs)
@@ -526,7 +526,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Update an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.update
+        https://docs.slack.dev/reference/methods/admin.barriers.update
         """
         kwargs.update({"barrier_id": barrier_id, "primary_usergroup_id": primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -547,7 +547,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Get all Information Barriers for your organization
-        https://api.slack.com/methods/admin.barriers.list"""
+        https://docs.slack.dev/reference/methods/admin.barriers.list"""
         kwargs.update(
             {
                 "cursor": cursor,
@@ -567,7 +567,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Create a public or private channel-based conversation.
-        https://api.slack.com/methods/admin.conversations.create
+        https://docs.slack.dev/reference/methods/admin.conversations.create
         """
         kwargs.update(
             {
@@ -587,7 +587,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Delete a public or private channel.
-        https://api.slack.com/methods/admin.conversations.delete
+        https://docs.slack.dev/reference/methods/admin.conversations.delete
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.delete", params=kwargs)
@@ -600,7 +600,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Invite a user to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.invite
+        https://docs.slack.dev/reference/methods/admin.conversations.invite
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(user_ids, (list, tuple)):
@@ -617,7 +617,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Archive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.archive", params=kwargs)
@@ -629,7 +629,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Unarchive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.unarchive", params=kwargs)
@@ -642,7 +642,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Rename a public or private channel.
-        https://api.slack.com/methods/admin.conversations.rename
+        https://docs.slack.dev/reference/methods/admin.conversations.rename
         """
         kwargs.update({"channel_id": channel_id, "name": name})
         return self.api_call("admin.conversations.rename", params=kwargs)
@@ -660,7 +660,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Search for public or private channels in an Enterprise organization.
-        https://api.slack.com/methods/admin.conversations.search
+        https://docs.slack.dev/reference/methods/admin.conversations.search
         """
         kwargs.update(
             {
@@ -691,7 +691,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Convert a public channel to a private channel.
-        https://api.slack.com/methods/admin.conversations.convertToPrivate
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.convertToPrivate", params=kwargs)
@@ -703,7 +703,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Convert a privte channel to a public channel.
-        https://api.slack.com/methods/admin.conversations.convertToPublic
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.convertToPublic", params=kwargs)
@@ -716,7 +716,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set the posting permissions for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(prefs, dict):
@@ -732,7 +732,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Get conversation preferences for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.getConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.getConversationPrefs", params=kwargs)
@@ -745,7 +745,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Disconnect a connected channel from one or more workspaces.
-        https://api.slack.com/methods/admin.conversations.disconnectShared
+        https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(leaving_team_ids, (list, tuple)):
@@ -765,7 +765,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Returns channels on the given team using the filters.
-        https://api.slack.com/methods/admin.conversations.lookup
+        https://docs.slack.dev/reference/methods/admin.conversations.lookup
         """
         kwargs.update(
             {
@@ -793,7 +793,7 @@ class WebClient(BaseClient):
         """List all disconnected channels—i.e.,
         channels that were once connected to other workspaces and then disconnected—and
         the corresponding original channel IDs for key revocation with EKM.
-        https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+        https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
         """
         kwargs.update(
             {
@@ -820,7 +820,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Add an allowlist of IDP groups for accessing a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
         """
         kwargs.update(
             {
@@ -843,7 +843,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List all IDP Groups linked to a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
         """
         kwargs.update(
             {
@@ -866,7 +866,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Remove a linked IDP group linked from a private channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
         """
         kwargs.update(
             {
@@ -891,7 +891,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.setTeams
         """
         kwargs.update(
             {
@@ -915,7 +915,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set the workspaces in an Enterprise grid org that connect to a channel.
-        https://api.slack.com/methods/admin.conversations.getTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.getTeams
         """
         kwargs.update(
             {
@@ -933,7 +933,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Get a channel's retention policy
-        https://api.slack.com/methods/admin.conversations.getCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.getCustomRetention", params=kwargs)
@@ -945,7 +945,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Remove a channel's retention policy
-        https://api.slack.com/methods/admin.conversations.removeCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.removeCustomRetention", params=kwargs)
@@ -958,7 +958,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set a channel's retention policy
-        https://api.slack.com/methods/admin.conversations.setCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
         """
         kwargs.update({"channel_id": channel_id, "duration_days": duration_days})
         return self.api_call("admin.conversations.setCustomRetention", params=kwargs)
@@ -970,7 +970,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Archive public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkArchive
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
         """
         kwargs.update({"channel_ids": ",".join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
         return self.api_call("admin.conversations.bulkArchive", params=kwargs)
@@ -995,7 +995,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Move public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkMove
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
         """
         kwargs.update(
             {
@@ -1013,7 +1013,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Add an emoji.
-        https://api.slack.com/methods/admin.emoji.add
+        https://docs.slack.dev/reference/methods/admin.emoji.add
         """
         kwargs.update({"name": name, "url": url})
         return self.api_call("admin.emoji.add", http_verb="GET", params=kwargs)
@@ -1026,7 +1026,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Add an emoji alias.
-        https://api.slack.com/methods/admin.emoji.addAlias
+        https://docs.slack.dev/reference/methods/admin.emoji.addAlias
         """
         kwargs.update({"alias_for": alias_for, "name": name})
         return self.api_call("admin.emoji.addAlias", http_verb="GET", params=kwargs)
@@ -1039,7 +1039,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List emoji for an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.list
+        https://docs.slack.dev/reference/methods/admin.emoji.list
         """
         kwargs.update({"cursor": cursor, "limit": limit})
         return self.api_call("admin.emoji.list", http_verb="GET", params=kwargs)
@@ -1051,7 +1051,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Remove an emoji across an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.remove
+        https://docs.slack.dev/reference/methods/admin.emoji.remove
         """
         kwargs.update({"name": name})
         return self.api_call("admin.emoji.remove", http_verb="GET", params=kwargs)
@@ -1064,7 +1064,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Rename an emoji.
-        https://api.slack.com/methods/admin.emoji.rename
+        https://docs.slack.dev/reference/methods/admin.emoji.rename
         """
         kwargs.update({"name": name, "new_name": new_name})
         return self.api_call("admin.emoji.rename", http_verb="GET", params=kwargs)
@@ -1079,7 +1079,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Look up functions by a set of apps
-        https://api.slack.com/methods/admin.functions.list
+        https://docs.slack.dev/reference/methods/admin.functions.list
         """
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({"app_ids": ",".join(app_ids)})
@@ -1102,7 +1102,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Lookup the visibility of multiple Slack functions
         and include the users if it is limited to particular named entities.
-        https://api.slack.com/methods/admin.functions.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
         """
         if isinstance(function_ids, (list, tuple)):
             kwargs.update({"function_ids": ",".join(function_ids)})
@@ -1120,7 +1120,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Set the visibility of a Slack function
         and define the users or workspaces if it is set to named_entities
-        https://api.slack.com/methods/admin.functions.permissions.set
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.set
         """
         kwargs.update(
             {
@@ -1144,7 +1144,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Adds members to the specified role with the specified scopes
-        https://api.slack.com/methods/admin.roles.addAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.addAssignments
         """
         kwargs.update({"role_id": role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1169,7 +1169,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Lists assignments for all roles across entities.
             Options to scope results by any combination of roles or entities
-        https://api.slack.com/methods/admin.roles.listAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.listAssignments
         """
         kwargs.update({"cursor": cursor, "limit": limit, "sort_dir": sort_dir})
         if isinstance(entity_ids, (list, tuple)):
@@ -1191,7 +1191,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Removes a set of users from a role for the given scopes and entities
-        https://api.slack.com/methods/admin.roles.removeAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
         """
         kwargs.update({"role_id": role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1213,7 +1213,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Wipes all valid sessions on all devices for a given user.
-        https://api.slack.com/methods/admin.users.session.reset
+        https://docs.slack.dev/reference/methods/admin.users.session.reset
         """
         kwargs.update(
             {
@@ -1233,7 +1233,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-        https://api.slack.com/methods/admin.users.session.resetBulk
+        https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1255,7 +1255,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Invalidate a single session for a user by session_id.
-        https://api.slack.com/methods/admin.users.session.invalidate
+        https://docs.slack.dev/reference/methods/admin.users.session.invalidate
         """
         kwargs.update({"session_id": session_id, "team_id": team_id})
         return self.api_call("admin.users.session.invalidate", params=kwargs)
@@ -1270,7 +1270,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists all active user sessions for an organization
-        https://api.slack.com/methods/admin.users.session.list
+        https://docs.slack.dev/reference/methods/admin.users.session.list
         """
         kwargs.update(
             {
@@ -1290,7 +1290,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set the default channels of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
         """
         kwargs.update({"team_id": team_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1307,7 +1307,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Get user-specific session settings—the session duration
         and what happens when the client closes—given a list of users.
-        https://api.slack.com/methods/admin.users.session.getSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.getSettings
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1325,7 +1325,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Configure the user-level session settings—the session duration
         and what happens when the client closes—for one or more users.
-        https://api.slack.com/methods/admin.users.session.setSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.setSettings
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1347,7 +1347,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Clear user-specific session settings—the session duration
         and what happens when the client closes—for a list of users.
-        https://api.slack.com/methods/admin.users.session.clearSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1364,7 +1364,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Ask Slackbot to send you an export listing all workspace members using unsupported software,
         presented as a zipped CSV file.
-        https://api.slack.com/methods/admin.users.unsupportedVersions.export
+        https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
         """
         kwargs.update(
             {
@@ -1382,7 +1382,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Approve a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.approve
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
         """
         kwargs.update({"invite_request_id": invite_request_id, "team_id": team_id})
         return self.api_call("admin.inviteRequests.approve", params=kwargs)
@@ -1396,7 +1396,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List all approved workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.approved.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
         """
         kwargs.update(
             {
@@ -1416,7 +1416,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List all denied workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.denied.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
         """
         kwargs.update(
             {
@@ -1435,7 +1435,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Deny a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.deny
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
         """
         kwargs.update({"invite_request_id": invite_request_id, "team_id": team_id})
         return self.api_call("admin.inviteRequests.deny", params=kwargs)
@@ -1456,7 +1456,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.inviteRequests.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.list
         """
         kwargs.update(
             {
@@ -1477,7 +1477,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Create an Enterprise team.
-        https://api.slack.com/methods/admin.teams.create
+        https://docs.slack.dev/reference/methods/admin.teams.create
         """
         kwargs.update(
             {
@@ -1497,7 +1497,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List all teams on an Enterprise organization.
-        https://api.slack.com/methods/admin.teams.list
+        https://docs.slack.dev/reference/methods/admin.teams.list
         """
         kwargs.update({"cursor": cursor, "limit": limit})
         return self.api_call("admin.teams.list", params=kwargs)
@@ -1511,7 +1511,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.teams.owners.list
+        https://docs.slack.dev/reference/methods/admin.teams.owners.list
         """
         kwargs.update({"team_id": team_id, "cursor": cursor, "limit": limit})
         return self.api_call("admin.teams.owners.list", http_verb="GET", params=kwargs)
@@ -1523,7 +1523,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Fetch information about settings in a workspace
-        https://api.slack.com/methods/admin.teams.settings.info
+        https://docs.slack.dev/reference/methods/admin.teams.settings.info
         """
         kwargs.update({"team_id": team_id})
         return self.api_call("admin.teams.settings.info", params=kwargs)
@@ -1536,7 +1536,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set the description of a given workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDescription
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
         """
         kwargs.update({"team_id": team_id, "description": description})
         return self.api_call("admin.teams.settings.setDescription", params=kwargs)
@@ -1549,7 +1549,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
         """
         kwargs.update({"team_id": team_id, "discoverability": discoverability})
         return self.api_call("admin.teams.settings.setDiscoverability", params=kwargs)
@@ -1562,7 +1562,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setIcon
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
         """
         kwargs.update({"team_id": team_id, "image_url": image_url})
         return self.api_call("admin.teams.settings.setIcon", http_verb="GET", params=kwargs)
@@ -1575,7 +1575,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setName
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setName
         """
         kwargs.update({"team_id": team_id, "name": name})
         return self.api_call("admin.teams.settings.setName", params=kwargs)
@@ -1589,7 +1589,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.addChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
         """
         kwargs.update({"team_id": team_id, "usergroup_id": usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1607,7 +1607,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Associate one or more default workspaces with an organization-wide IDP group.
-        https://api.slack.com/methods/admin.usergroups.addTeams
+        https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
         """
         kwargs.update({"usergroup_id": usergroup_id, "auto_provision": auto_provision})
         if isinstance(team_ids, (list, tuple)):
@@ -1625,7 +1625,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.listChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
         """
         kwargs.update(
             {
@@ -1644,7 +1644,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.removeChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
         """
         kwargs.update({"usergroup_id": usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1664,7 +1664,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Add an Enterprise user to a workspace.
-        https://api.slack.com/methods/admin.users.assign
+        https://docs.slack.dev/reference/methods/admin.users.assign
         """
         kwargs.update(
             {
@@ -1696,7 +1696,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Invite a user to a workspace.
-        https://api.slack.com/methods/admin.users.invite
+        https://docs.slack.dev/reference/methods/admin.users.invite
         """
         kwargs.update(
             {
@@ -1728,7 +1728,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List users on a workspace
-        https://api.slack.com/methods/admin.users.list
+        https://docs.slack.dev/reference/methods/admin.users.list
         """
         kwargs.update(
             {
@@ -1749,7 +1749,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Remove a user from a workspace.
-        https://api.slack.com/methods/admin.users.remove
+        https://docs.slack.dev/reference/methods/admin.users.remove
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return self.api_call("admin.users.remove", params=kwargs)
@@ -1762,7 +1762,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set an existing guest, regular user, or owner to be an admin user.
-        https://api.slack.com/methods/admin.users.setAdmin
+        https://docs.slack.dev/reference/methods/admin.users.setAdmin
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return self.api_call("admin.users.setAdmin", params=kwargs)
@@ -1776,7 +1776,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set an expiration for a guest user.
-        https://api.slack.com/methods/admin.users.setExpiration
+        https://docs.slack.dev/reference/methods/admin.users.setExpiration
         """
         kwargs.update({"expiration_ts": expiration_ts, "team_id": team_id, "user_id": user_id})
         return self.api_call("admin.users.setExpiration", params=kwargs)
@@ -1789,7 +1789,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set an existing guest, regular user, or admin user to be a workspace owner.
-        https://api.slack.com/methods/admin.users.setOwner
+        https://docs.slack.dev/reference/methods/admin.users.setOwner
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return self.api_call("admin.users.setOwner", params=kwargs)
@@ -1802,7 +1802,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set an existing guest user, admin user, or owner to be a regular user.
-        https://api.slack.com/methods/admin.users.setRegular
+        https://docs.slack.dev/reference/methods/admin.users.setRegular
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return self.api_call("admin.users.setRegular", params=kwargs)
@@ -1823,7 +1823,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Search workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.search
+        https://docs.slack.dev/reference/methods/admin.workflows.search
         """
         if collaborator_ids is not None:
             if isinstance(collaborator_ids, (list, tuple)):
@@ -1853,7 +1853,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Look up the permissions for a set of workflows
-        https://api.slack.com/methods/admin.workflows.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
         """
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({"workflow_ids": ",".join(workflow_ids)})
@@ -1874,7 +1874,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Add collaborators to workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.add
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
         """
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({"collaborator_ids": ",".join(collaborator_ids)})
@@ -1894,7 +1894,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Remove collaborators from workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.remove
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
         """
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({"collaborator_ids": ",".join(collaborator_ids)})
@@ -1913,7 +1913,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Unpublish workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.unpublish
+        https://docs.slack.dev/reference/methods/admin.workflows.unpublish
         """
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({"workflow_ids": ",".join(workflow_ids)})
@@ -1928,7 +1928,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Checks API calling code.
-        https://api.slack.com/methods/api.test
+        https://docs.slack.dev/reference/methods/api.test
         """
         kwargs.update({"error": error})
         return self.api_call("api.test", params=kwargs)
@@ -1941,7 +1941,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Generate a temporary Socket Mode WebSocket URL that your app can connect to
         in order to receive events and interactive payloads
-        https://api.slack.com/methods/apps.connections.open
+        https://docs.slack.dev/reference/methods/apps.connections.open
         """
         kwargs.update({"token": app_token})
         return self.api_call("apps.connections.open", http_verb="POST", params=kwargs)
@@ -1956,7 +1956,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Get a list of authorizations for the given event context.
         Each authorization represents an app installation that the event is visible to.
-        https://api.slack.com/methods/apps.event.authorizations.list
+        https://docs.slack.dev/reference/methods/apps.event.authorizations.list
         """
         kwargs.update({"event_context": event_context, "cursor": cursor, "limit": limit})
         return self.api_call("apps.event.authorizations.list", params=kwargs)
@@ -1969,7 +1969,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Uninstalls your app from a workspace.
-        https://api.slack.com/methods/apps.uninstall
+        https://docs.slack.dev/reference/methods/apps.uninstall
         """
         kwargs.update({"client_id": client_id, "client_secret": client_secret})
         return self.api_call("apps.uninstall", params=kwargs)
@@ -1981,7 +1981,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Create an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.create
+        https://docs.slack.dev/reference/methods/apps.manifest.create
         """
         if isinstance(manifest, str):
             kwargs.update({"manifest": manifest})
@@ -1996,7 +1996,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Permanently deletes an app created through app manifests
-        https://api.slack.com/methods/apps.manifest.delete
+        https://docs.slack.dev/reference/methods/apps.manifest.delete
         """
         kwargs.update({"app_id": app_id})
         return self.api_call("apps.manifest.delete", params=kwargs)
@@ -2008,7 +2008,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Export an app manifest from an existing app
-        https://api.slack.com/methods/apps.manifest.export
+        https://docs.slack.dev/reference/methods/apps.manifest.export
         """
         kwargs.update({"app_id": app_id})
         return self.api_call("apps.manifest.export", params=kwargs)
@@ -2021,7 +2021,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Update an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.update
+        https://docs.slack.dev/reference/methods/apps.manifest.update
         """
         if isinstance(manifest, str):
             kwargs.update({"manifest": manifest})
@@ -2038,7 +2038,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Validate an app manifest
-        https://api.slack.com/methods/apps.manifest.validate
+        https://docs.slack.dev/reference/methods/apps.manifest.validate
         """
         if isinstance(manifest, str):
             kwargs.update({"manifest": manifest})
@@ -2054,7 +2054,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Exchanges a refresh token for a new app configuration token
-        https://api.slack.com/methods/tooling.tokens.rotate
+        https://docs.slack.dev/reference/methods/tooling.tokens.rotate
         """
         kwargs.update({"refresh_token": refresh_token})
         return self.api_call("tooling.tokens.rotate", params=kwargs)
@@ -2068,7 +2068,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setStatus
+        https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         """
         kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "status": status})
         return self.api_call("assistant.threads.setStatus", params=kwargs)
@@ -2082,7 +2082,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setTitle
+        https://docs.slack.dev/reference/methods/assistant.threads.setTitle
         """
         kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "title": title})
         return self.api_call("assistant.threads.setTitle", params=kwargs)
@@ -2097,7 +2097,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+        https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         """
         kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "prompts": prompts})
         if title is not None:
@@ -2111,7 +2111,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Revokes a token.
-        https://api.slack.com/methods/auth.revoke
+        https://docs.slack.dev/reference/methods/auth.revoke
         """
         kwargs.update({"test": test})
         return self.api_call("auth.revoke", http_verb="GET", params=kwargs)
@@ -2121,7 +2121,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Checks authentication & identity.
-        https://api.slack.com/methods/auth.test
+        https://docs.slack.dev/reference/methods/auth.test
         """
         return self.api_call("auth.test", params=kwargs)
 
@@ -2133,7 +2133,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List the workspaces a token can access.
-        https://api.slack.com/methods/auth.teams.list
+        https://docs.slack.dev/reference/methods/auth.teams.list
         """
         kwargs.update({"cursor": cursor, "limit": limit, "include_icon": include_icon})
         return self.api_call("auth.teams.list", params=kwargs)
@@ -2151,7 +2151,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Add bookmark to a channel.
-        https://api.slack.com/methods/bookmarks.add
+        https://docs.slack.dev/reference/methods/bookmarks.add
         """
         kwargs.update(
             {
@@ -2177,7 +2177,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Edit bookmark.
-        https://api.slack.com/methods/bookmarks.edit
+        https://docs.slack.dev/reference/methods/bookmarks.edit
         """
         kwargs.update(
             {
@@ -2197,7 +2197,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List bookmark for the channel.
-        https://api.slack.com/methods/bookmarks.list
+        https://docs.slack.dev/reference/methods/bookmarks.list
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("bookmarks.list", http_verb="POST", params=kwargs)
@@ -2210,7 +2210,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Remove bookmark from the channel.
-        https://api.slack.com/methods/bookmarks.remove
+        https://docs.slack.dev/reference/methods/bookmarks.remove
         """
         kwargs.update({"bookmark_id": bookmark_id, "channel_id": channel_id})
         return self.api_call("bookmarks.remove", http_verb="POST", params=kwargs)
@@ -2223,7 +2223,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets information about a bot user.
-        https://api.slack.com/methods/bots.info
+        https://docs.slack.dev/reference/methods/bots.info
         """
         kwargs.update({"bot": bot, "team_id": team_id})
         return self.api_call("bots.info", http_verb="GET", params=kwargs)
@@ -2242,7 +2242,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Registers a new Call.
-        https://api.slack.com/methods/calls.add
+        https://docs.slack.dev/reference/methods/calls.add
         """
         kwargs.update(
             {
@@ -2269,7 +2269,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Ends a Call.
-        https://api.slack.com/methods/calls.end
+        https://docs.slack.dev/reference/methods/calls.end
         """
         kwargs.update({"id": id, "duration": duration})
         return self.api_call("calls.end", http_verb="POST", params=kwargs)
@@ -2281,7 +2281,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Returns information about a Call.
-        https://api.slack.com/methods/calls.info
+        https://docs.slack.dev/reference/methods/calls.info
         """
         kwargs.update({"id": id})
         return self.api_call("calls.info", http_verb="POST", params=kwargs)
@@ -2294,7 +2294,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Registers new participants added to a Call.
-        https://api.slack.com/methods/calls.participants.add
+        https://docs.slack.dev/reference/methods/calls.participants.add
         """
         kwargs.update({"id": id})
         _update_call_participants(kwargs, users)
@@ -2308,7 +2308,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Registers participants removed from a Call.
-        https://api.slack.com/methods/calls.participants.remove
+        https://docs.slack.dev/reference/methods/calls.participants.remove
         """
         kwargs.update({"id": id})
         _update_call_participants(kwargs, users)
@@ -2324,7 +2324,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Updates information about a Call.
-        https://api.slack.com/methods/calls.update
+        https://docs.slack.dev/reference/methods/calls.update
         """
         kwargs.update(
             {
@@ -2344,7 +2344,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Create Canvas for a user
-        https://api.slack.com/methods/canvases.create
+        https://docs.slack.dev/reference/methods/canvases.create
         """
         kwargs.update({"title": title, "document_content": document_content})
         return self.api_call("canvases.create", json=kwargs)
@@ -2357,7 +2357,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Update an existing canvas
-        https://api.slack.com/methods/canvases.edit
+        https://docs.slack.dev/reference/methods/canvases.edit
         """
         kwargs.update({"canvas_id": canvas_id, "changes": changes})
         return self.api_call("canvases.edit", json=kwargs)
@@ -2369,7 +2369,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Deletes a canvas
-        https://api.slack.com/methods/canvases.delete
+        https://docs.slack.dev/reference/methods/canvases.delete
         """
         kwargs.update({"canvas_id": canvas_id})
         return self.api_call("canvases.delete", params=kwargs)
@@ -2384,7 +2384,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Sets the access level to a canvas for specified entities
-        https://api.slack.com/methods/canvases.access.set
+        https://docs.slack.dev/reference/methods/canvases.access.set
         """
         kwargs.update({"canvas_id": canvas_id, "access_level": access_level})
         if channel_ids is not None:
@@ -2409,7 +2409,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Create a Channel Canvas for a channel
-        https://api.slack.com/methods/canvases.access.delete
+        https://docs.slack.dev/reference/methods/canvases.access.delete
         """
         kwargs.update({"canvas_id": canvas_id})
         if channel_ids is not None:
@@ -2432,7 +2432,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Find sections matching the provided criteria
-        https://api.slack.com/methods/canvases.sections.lookup
+        https://docs.slack.dev/reference/methods/canvases.sections.lookup
         """
         kwargs.update({"canvas_id": canvas_id, "criteria": json.dumps(criteria)})
         return self.api_call("canvases.sections.lookup", params=kwargs)
@@ -2440,7 +2440,7 @@ class WebClient(BaseClient):
     # --------------------------
     # Deprecated: channels.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def channels_archive(
@@ -2619,7 +2619,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Deletes a message.
-        https://api.slack.com/methods/chat.delete
+        https://docs.slack.dev/reference/methods/chat.delete
         """
         kwargs.update({"channel": channel, "ts": ts, "as_user": as_user})
         return self.api_call("chat.delete", params=kwargs)
@@ -2633,7 +2633,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Deletes a scheduled message.
-        https://api.slack.com/methods/chat.deleteScheduledMessage
+        https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
         """
         kwargs.update(
             {
@@ -2652,7 +2652,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieve a permalink URL for a specific extant message
-        https://api.slack.com/methods/chat.getPermalink
+        https://docs.slack.dev/reference/methods/chat.getPermalink
         """
         kwargs.update({"channel": channel, "message_ts": message_ts})
         return self.api_call("chat.getPermalink", http_verb="GET", params=kwargs)
@@ -2665,7 +2665,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Share a me message into a channel.
-        https://api.slack.com/methods/chat.meMessage
+        https://docs.slack.dev/reference/methods/chat.meMessage
         """
         kwargs.update({"channel": channel, "text": text})
         return self.api_call("chat.meMessage", params=kwargs)
@@ -2689,7 +2689,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Sends an ephemeral message to a user in a channel.
-        https://api.slack.com/methods/chat.postEphemeral
+        https://docs.slack.dev/reference/methods/chat.postEphemeral
         """
         kwargs.update(
             {
@@ -2738,7 +2738,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Sends a message to a channel.
-        https://api.slack.com/methods/chat.postMessage
+        https://docs.slack.dev/reference/methods/chat.postMessage
         """
         kwargs.update(
             {
@@ -2788,7 +2788,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Schedules a message.
-        https://api.slack.com/methods/chat.scheduleMessage
+        https://docs.slack.dev/reference/methods/chat.scheduleMessage
         """
         kwargs.update(
             {
@@ -2829,7 +2829,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Provide custom unfurl behavior for user-posted URLs.
-        https://api.slack.com/methods/chat.unfurl
+        https://docs.slack.dev/reference/methods/chat.unfurl
         """
         kwargs.update(
             {
@@ -2867,7 +2867,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Updates a message in a channel.
-        https://api.slack.com/methods/chat.update
+        https://docs.slack.dev/reference/methods/chat.update
         """
         kwargs.update(
             {
@@ -2906,7 +2906,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists all scheduled messages.
-        https://api.slack.com/methods/chat.scheduledMessages.list
+        https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
         """
         kwargs.update(
             {
@@ -2932,7 +2932,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Accepts an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.acceptSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
         """
         if channel_id is None and invite_id is None:
             raise e.SlackRequestError("Either channel_id or invite_id must be provided.")
@@ -2956,7 +2956,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Approves an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.approveSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
         """
         kwargs.update({"invite_id": invite_id, "target_team": target_team})
         return self.api_call("conversations.approveSharedInvite", http_verb="POST", params=kwargs)
@@ -2968,7 +2968,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Archives a conversation.
-        https://api.slack.com/methods/conversations.archive
+        https://docs.slack.dev/reference/methods/conversations.archive
         """
         kwargs.update({"channel": channel})
         return self.api_call("conversations.archive", params=kwargs)
@@ -2980,7 +2980,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Closes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.close
+        https://docs.slack.dev/reference/methods/conversations.close
         """
         kwargs.update({"channel": channel})
         return self.api_call("conversations.close", params=kwargs)
@@ -2994,7 +2994,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Initiates a public or private channel-based conversation
-        https://api.slack.com/methods/conversations.create
+        https://docs.slack.dev/reference/methods/conversations.create
         """
         kwargs.update({"name": name, "is_private": is_private, "team_id": team_id})
         return self.api_call("conversations.create", params=kwargs)
@@ -3007,7 +3007,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Declines a Slack Connect channel invite.
-        https://api.slack.com/methods/conversations.declineSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
         """
         kwargs.update({"invite_id": invite_id, "target_team": target_team})
         return self.api_call("conversations.declineSharedInvite", http_verb="GET", params=kwargs)
@@ -3016,7 +3016,7 @@ class WebClient(BaseClient):
         self, *, action: str, channel: str, target_team: str, **kwargs
     ) -> SlackResponse:
         """Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-        https://api.slack.com/methods/conversations.externalInvitePermissions.set
+        https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
         """
         kwargs.update(
             {
@@ -3040,7 +3040,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Fetches a conversation's history of messages and events.
-        https://api.slack.com/methods/conversations.history
+        https://docs.slack.dev/reference/methods/conversations.history
         """
         kwargs.update(
             {
@@ -3064,7 +3064,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieve information about a conversation.
-        https://api.slack.com/methods/conversations.info
+        https://docs.slack.dev/reference/methods/conversations.info
         """
         kwargs.update(
             {
@@ -3084,7 +3084,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Invites users to a channel.
-        https://api.slack.com/methods/conversations.invite
+        https://docs.slack.dev/reference/methods/conversations.invite
         """
         kwargs.update(
             {
@@ -3107,7 +3107,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Sends an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.inviteShared
+        https://docs.slack.dev/reference/methods/conversations.inviteShared
         """
         if emails is None and user_ids is None:
             raise e.SlackRequestError("Either emails or user ids must be provided.")
@@ -3129,7 +3129,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Joins an existing conversation.
-        https://api.slack.com/methods/conversations.join
+        https://docs.slack.dev/reference/methods/conversations.join
         """
         kwargs.update({"channel": channel})
         return self.api_call("conversations.join", params=kwargs)
@@ -3142,7 +3142,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Removes a user from a conversation.
-        https://api.slack.com/methods/conversations.kick
+        https://docs.slack.dev/reference/methods/conversations.kick
         """
         kwargs.update({"channel": channel, "user": user})
         return self.api_call("conversations.kick", params=kwargs)
@@ -3154,7 +3154,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Leaves a conversation.
-        https://api.slack.com/methods/conversations.leave
+        https://docs.slack.dev/reference/methods/conversations.leave
         """
         kwargs.update({"channel": channel})
         return self.api_call("conversations.leave", params=kwargs)
@@ -3170,7 +3170,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists all channels in a Slack team.
-        https://api.slack.com/methods/conversations.list
+        https://docs.slack.dev/reference/methods/conversations.list
         """
         kwargs.update(
             {
@@ -3196,7 +3196,7 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """List shared channel invites that have been generated
         or received but have not yet been approved by all parties.
-        https://api.slack.com/methods/conversations.listConnectInvites
+        https://docs.slack.dev/reference/methods/conversations.listConnectInvites
         """
         kwargs.update({"count": count, "cursor": cursor, "team_id": team_id})
         return self.api_call("conversations.listConnectInvites", params=kwargs)
@@ -3209,7 +3209,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Sets the read cursor in a channel.
-        https://api.slack.com/methods/conversations.mark
+        https://docs.slack.dev/reference/methods/conversations.mark
         """
         kwargs.update({"channel": channel, "ts": ts})
         return self.api_call("conversations.mark", params=kwargs)
@@ -3223,7 +3223,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieve members of a conversation.
-        https://api.slack.com/methods/conversations.members
+        https://docs.slack.dev/reference/methods/conversations.members
         """
         kwargs.update({"channel": channel, "cursor": cursor, "limit": limit})
         return self.api_call("conversations.members", http_verb="GET", params=kwargs)
@@ -3237,7 +3237,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Opens or resumes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.open
+        https://docs.slack.dev/reference/methods/conversations.open
         """
         if channel is None and users is None:
             raise e.SlackRequestError("Either channel or users must be provided.")
@@ -3256,7 +3256,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Renames a conversation.
-        https://api.slack.com/methods/conversations.rename
+        https://docs.slack.dev/reference/methods/conversations.rename
         """
         kwargs.update({"channel": channel, "name": name})
         return self.api_call("conversations.rename", params=kwargs)
@@ -3275,7 +3275,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieve a thread of messages posted to a conversation
-        https://api.slack.com/methods/conversations.replies
+        https://docs.slack.dev/reference/methods/conversations.replies
         """
         kwargs.update(
             {
@@ -3301,7 +3301,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-        https://api.slack.com/methods/conversations.requestSharedInvite.approve
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
         """
         kwargs.update(
             {
@@ -3322,7 +3322,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Deny a request to invite an external user to a channel.
-        https://api.slack.com/methods/conversations.requestSharedInvite.deny
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
         """
         kwargs.update({"invite_id": invite_id, "message": message})
         return self.api_call("conversations.requestSharedInvite.deny", params=kwargs)
@@ -3340,7 +3340,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists requests to add external users to channels with ability to filter.
-        https://api.slack.com/methods/conversations.requestSharedInvite.list
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
         """
         kwargs.update(
             {
@@ -3367,7 +3367,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Sets the purpose for a conversation.
-        https://api.slack.com/methods/conversations.setPurpose
+        https://docs.slack.dev/reference/methods/conversations.setPurpose
         """
         kwargs.update({"channel": channel, "purpose": purpose})
         return self.api_call("conversations.setPurpose", params=kwargs)
@@ -3380,7 +3380,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Sets the topic for a conversation.
-        https://api.slack.com/methods/conversations.setTopic
+        https://docs.slack.dev/reference/methods/conversations.setTopic
         """
         kwargs.update({"channel": channel, "topic": topic})
         return self.api_call("conversations.setTopic", params=kwargs)
@@ -3392,7 +3392,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Reverses conversation archival.
-        https://api.slack.com/methods/conversations.unarchive
+        https://docs.slack.dev/reference/methods/conversations.unarchive
         """
         kwargs.update({"channel": channel})
         return self.api_call("conversations.unarchive", params=kwargs)
@@ -3405,7 +3405,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Create a Channel Canvas for a channel
-        https://api.slack.com/methods/conversations.canvases.create
+        https://docs.slack.dev/reference/methods/conversations.canvases.create
         """
         kwargs.update({"channel_id": channel_id, "document_content": document_content})
         return self.api_call("conversations.canvases.create", json=kwargs)
@@ -3418,7 +3418,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Open a dialog with a user.
-        https://api.slack.com/methods/dialog.open
+        https://docs.slack.dev/reference/methods/dialog.open
         """
         kwargs.update({"dialog": dialog, "trigger_id": trigger_id})
         kwargs = _remove_none_values(kwargs)
@@ -3430,7 +3430,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Ends the current user's Do Not Disturb session immediately.
-        https://api.slack.com/methods/dnd.endDnd
+        https://docs.slack.dev/reference/methods/dnd.endDnd
         """
         return self.api_call("dnd.endDnd", params=kwargs)
 
@@ -3439,7 +3439,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Ends the current user's snooze mode immediately.
-        https://api.slack.com/methods/dnd.endSnooze
+        https://docs.slack.dev/reference/methods/dnd.endSnooze
         """
         return self.api_call("dnd.endSnooze", params=kwargs)
 
@@ -3451,7 +3451,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieves a user's current Do Not Disturb status.
-        https://api.slack.com/methods/dnd.info
+        https://docs.slack.dev/reference/methods/dnd.info
         """
         kwargs.update({"team_id": team_id, "user": user})
         return self.api_call("dnd.info", http_verb="GET", params=kwargs)
@@ -3463,7 +3463,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Turns on Do Not Disturb mode for the current user, or changes its duration.
-        https://api.slack.com/methods/dnd.setSnooze
+        https://docs.slack.dev/reference/methods/dnd.setSnooze
         """
         kwargs.update({"num_minutes": num_minutes})
         return self.api_call("dnd.setSnooze", http_verb="GET", params=kwargs)
@@ -3475,7 +3475,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieves the Do Not Disturb status for users on a team.
-        https://api.slack.com/methods/dnd.teamInfo
+        https://docs.slack.dev/reference/methods/dnd.teamInfo
         """
         if isinstance(users, (list, tuple)):
             kwargs.update({"users": ",".join(users)})
@@ -3490,7 +3490,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists custom emoji for a team.
-        https://api.slack.com/methods/emoji.list
+        https://docs.slack.dev/reference/methods/emoji.list
         """
         kwargs.update({"include_categories": include_categories})
         return self.api_call("emoji.list", http_verb="GET", params=kwargs)
@@ -3503,7 +3503,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Deletes an existing comment on a file.
-        https://api.slack.com/methods/files.comments.delete
+        https://docs.slack.dev/reference/methods/files.comments.delete
         """
         kwargs.update({"file": file, "id": id})
         return self.api_call("files.comments.delete", params=kwargs)
@@ -3515,7 +3515,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Deletes a file.
-        https://api.slack.com/methods/files.delete
+        https://docs.slack.dev/reference/methods/files.delete
         """
         kwargs.update({"file": file})
         return self.api_call("files.delete", params=kwargs)
@@ -3531,7 +3531,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets information about a team file.
-        https://api.slack.com/methods/files.info
+        https://docs.slack.dev/reference/methods/files.info
         """
         kwargs.update(
             {
@@ -3559,7 +3559,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists & filters team files.
-        https://api.slack.com/methods/files.list
+        https://docs.slack.dev/reference/methods/files.list
         """
         kwargs.update(
             {
@@ -3587,7 +3587,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.info
+        https://docs.slack.dev/reference/methods/files.remote.info
         """
         kwargs.update({"external_id": external_id, "file": file})
         return self.api_call("files.remote.info", http_verb="GET", params=kwargs)
@@ -3603,7 +3603,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.list
+        https://docs.slack.dev/reference/methods/files.remote.list
         """
         kwargs.update(
             {
@@ -3628,7 +3628,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Adds a file from a remote service.
-        https://api.slack.com/methods/files.remote.add
+        https://docs.slack.dev/reference/methods/files.remote.add
         """
         kwargs.update(
             {
@@ -3667,7 +3667,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Updates an existing remote file.
-        https://api.slack.com/methods/files.remote.update
+        https://docs.slack.dev/reference/methods/files.remote.update
         """
         kwargs.update(
             {
@@ -3702,7 +3702,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Remove a remote file.
-        https://api.slack.com/methods/files.remote.remove
+        https://docs.slack.dev/reference/methods/files.remote.remove
         """
         kwargs.update({"external_id": external_id, "file": file})
         return self.api_call("files.remote.remove", http_verb="POST", params=kwargs)
@@ -3716,7 +3716,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Share a remote file into a channel.
-        https://api.slack.com/methods/files.remote.share
+        https://docs.slack.dev/reference/methods/files.remote.share
         """
         if external_id is None and file is None:
             raise e.SlackRequestError("Either external_id or file must be provided.")
@@ -3734,7 +3734,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Revokes public/external sharing access for a file
-        https://api.slack.com/methods/files.revokePublicURL
+        https://docs.slack.dev/reference/methods/files.revokePublicURL
         """
         kwargs.update({"file": file})
         return self.api_call("files.revokePublicURL", params=kwargs)
@@ -3746,7 +3746,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Enables a file for public/external sharing.
-        https://api.slack.com/methods/files.sharedPublicURL
+        https://docs.slack.dev/reference/methods/files.sharedPublicURL
         """
         kwargs.update({"file": file})
         return self.api_call("files.sharedPublicURL", params=kwargs)
@@ -3765,7 +3765,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Uploads or creates a file.
-        https://api.slack.com/methods/files.upload
+        https://docs.slack.dev/reference/methods/files.upload
         """
         _print_files_upload_v2_suggestion()
 
@@ -3818,12 +3818,12 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """This wrapper method provides an easy way to upload files using the following endpoints:
 
-        - step1: https://api.slack.com/methods/files.getUploadURLExternal
+        - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
         - step2: "https://files.slack.com/upload/v1/..." URLs returned from files.getUploadURLExternal API
 
-        - step3: https://api.slack.com/methods/files.completeUploadExternal
-            and https://api.slack.com/methods/files.info
+        - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+            and https://docs.slack.dev/reference/methods/files.info
 
         """
         if file is None and content is None and file_uploads is None:
@@ -3909,7 +3909,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets a URL for an edge external upload.
-        https://api.slack.com/methods/files.getUploadURLExternal
+        https://docs.slack.dev/reference/methods/files.getUploadURLExternal
         """
         kwargs.update(
             {
@@ -3932,7 +3932,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Finishes an upload started with files.getUploadURLExternal.
-        https://api.slack.com/methods/files.completeUploadExternal
+        https://docs.slack.dev/reference/methods/files.completeUploadExternal
         """
         _files = [{k: v for k, v in f.items() if v is not None} for f in files]
         kwargs.update(
@@ -3955,7 +3955,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Signal the successful completion of a function
-        https://api.slack.com/methods/functions.completeSuccess
+        https://docs.slack.dev/reference/methods/functions.completeSuccess
         """
         kwargs.update({"function_execution_id": function_execution_id, "outputs": json.dumps(outputs)})
         return self.api_call("functions.completeSuccess", params=kwargs)
@@ -3968,7 +3968,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Signal the failure to execute a function
-        https://api.slack.com/methods/functions.completeError
+        https://docs.slack.dev/reference/methods/functions.completeError
         """
         kwargs.update({"function_execution_id": function_execution_id, "error": error})
         return self.api_call("functions.completeError", params=kwargs)
@@ -3976,7 +3976,7 @@ class WebClient(BaseClient):
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def groups_archive(
@@ -4157,7 +4157,7 @@ class WebClient(BaseClient):
     # --------------------------
     # Deprecated: im.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def im_close(
@@ -4233,7 +4233,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """For Enterprise Grid workspaces, map local user IDs to global user IDs
-        https://api.slack.com/methods/migration.exchange
+        https://docs.slack.dev/reference/methods/migration.exchange
         """
         if isinstance(users, (list, tuple)):
             kwargs.update({"users": ",".join(users)})
@@ -4245,7 +4245,7 @@ class WebClient(BaseClient):
     # --------------------------
     # Deprecated: mpim.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def mpim_close(
@@ -4332,7 +4332,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.v2.access
+        https://docs.slack.dev/reference/methods/oauth.v2.access
         """
         if redirect_uri is not None:
             kwargs.update({"redirect_uri": redirect_uri})
@@ -4358,7 +4358,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.access
+        https://docs.slack.dev/reference/methods/oauth.access
         """
         if redirect_uri is not None:
             kwargs.update({"redirect_uri": redirect_uri})
@@ -4378,7 +4378,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Exchanges a legacy access token for a new expiring access token and refresh token
-        https://api.slack.com/methods/oauth.v2.exchange
+        https://docs.slack.dev/reference/methods/oauth.v2.exchange
         """
         kwargs.update({"client_id": client_id, "client_secret": client_secret, "token": token})
         return self.api_call("oauth.v2.exchange", params=kwargs)
@@ -4394,7 +4394,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.token
+        https://docs.slack.dev/reference/methods/openid.connect.token
         """
         if redirect_uri is not None:
             kwargs.update({"redirect_uri": redirect_uri})
@@ -4415,7 +4415,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Get the identity of a user who has authorized Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.userInfo
+        https://docs.slack.dev/reference/methods/openid.connect.userInfo
         """
         return self.api_call("openid.connect.userInfo", params=kwargs)
 
@@ -4427,7 +4427,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Pins an item to a channel.
-        https://api.slack.com/methods/pins.add
+        https://docs.slack.dev/reference/methods/pins.add
         """
         kwargs.update({"channel": channel, "timestamp": timestamp})
         return self.api_call("pins.add", params=kwargs)
@@ -4439,7 +4439,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists items pinned to a channel.
-        https://api.slack.com/methods/pins.list
+        https://docs.slack.dev/reference/methods/pins.list
         """
         kwargs.update({"channel": channel})
         return self.api_call("pins.list", http_verb="GET", params=kwargs)
@@ -4452,7 +4452,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Un-pins an item from a channel.
-        https://api.slack.com/methods/pins.remove
+        https://docs.slack.dev/reference/methods/pins.remove
         """
         kwargs.update({"channel": channel, "timestamp": timestamp})
         return self.api_call("pins.remove", params=kwargs)
@@ -4466,7 +4466,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Adds a reaction to an item.
-        https://api.slack.com/methods/reactions.add
+        https://docs.slack.dev/reference/methods/reactions.add
         """
         kwargs.update({"channel": channel, "name": name, "timestamp": timestamp})
         return self.api_call("reactions.add", params=kwargs)
@@ -4482,7 +4482,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets reactions for an item.
-        https://api.slack.com/methods/reactions.get
+        https://docs.slack.dev/reference/methods/reactions.get
         """
         kwargs.update(
             {
@@ -4508,7 +4508,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists reactions made by a user.
-        https://api.slack.com/methods/reactions.list
+        https://docs.slack.dev/reference/methods/reactions.list
         """
         kwargs.update(
             {
@@ -4534,7 +4534,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Removes a reaction from an item.
-        https://api.slack.com/methods/reactions.remove
+        https://docs.slack.dev/reference/methods/reactions.remove
         """
         kwargs.update(
             {
@@ -4558,7 +4558,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Creates a reminder.
-        https://api.slack.com/methods/reminders.add
+        https://docs.slack.dev/reference/methods/reminders.add
         """
         kwargs.update(
             {
@@ -4579,7 +4579,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Marks a reminder as complete.
-        https://api.slack.com/methods/reminders.complete
+        https://docs.slack.dev/reference/methods/reminders.complete
         """
         kwargs.update({"reminder": reminder, "team_id": team_id})
         return self.api_call("reminders.complete", params=kwargs)
@@ -4592,7 +4592,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Deletes a reminder.
-        https://api.slack.com/methods/reminders.delete
+        https://docs.slack.dev/reference/methods/reminders.delete
         """
         kwargs.update({"reminder": reminder, "team_id": team_id})
         return self.api_call("reminders.delete", params=kwargs)
@@ -4605,7 +4605,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets information about a reminder.
-        https://api.slack.com/methods/reminders.info
+        https://docs.slack.dev/reference/methods/reminders.info
         """
         kwargs.update({"reminder": reminder, "team_id": team_id})
         return self.api_call("reminders.info", http_verb="GET", params=kwargs)
@@ -4617,7 +4617,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists all reminders created by or for a given user.
-        https://api.slack.com/methods/reminders.list
+        https://docs.slack.dev/reference/methods/reminders.list
         """
         kwargs.update({"team_id": team_id})
         return self.api_call("reminders.list", http_verb="GET", params=kwargs)
@@ -4630,7 +4630,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.connect
+        https://docs.slack.dev/reference/methods/rtm.connect
         """
         kwargs.update({"batch_presence_aware": batch_presence_aware, "presence_sub": presence_sub})
         return self.api_call("rtm.connect", http_verb="GET", params=kwargs)
@@ -4648,7 +4648,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.start
+        https://docs.slack.dev/reference/methods/rtm.start
         """
         kwargs.update(
             {
@@ -4676,7 +4676,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Searches for messages and files matching a query.
-        https://api.slack.com/methods/search.all
+        https://docs.slack.dev/reference/methods/search.all
         """
         kwargs.update(
             {
@@ -4704,7 +4704,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Searches for files matching a query.
-        https://api.slack.com/methods/search.files
+        https://docs.slack.dev/reference/methods/search.files
         """
         kwargs.update(
             {
@@ -4733,7 +4733,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Searches for messages matching a query.
-        https://api.slack.com/methods/search.messages
+        https://docs.slack.dev/reference/methods/search.messages
         """
         kwargs.update(
             {
@@ -4759,7 +4759,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Adds a star to an item.
-        https://api.slack.com/methods/stars.add
+        https://docs.slack.dev/reference/methods/stars.add
         """
         kwargs.update(
             {
@@ -4782,7 +4782,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists stars for a user.
-        https://api.slack.com/methods/stars.list
+        https://docs.slack.dev/reference/methods/stars.list
         """
         kwargs.update(
             {
@@ -4805,7 +4805,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Removes a star from an item.
-        https://api.slack.com/methods/stars.remove
+        https://docs.slack.dev/reference/methods/stars.remove
         """
         kwargs.update(
             {
@@ -4829,7 +4829,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets the access logs for the current team.
-        https://api.slack.com/methods/team.accessLogs
+        https://docs.slack.dev/reference/methods/team.accessLogs
         """
         kwargs.update(
             {
@@ -4851,7 +4851,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets billable users information for the current team.
-        https://api.slack.com/methods/team.billableInfo
+        https://docs.slack.dev/reference/methods/team.billableInfo
         """
         kwargs.update({"team_id": team_id, "user": user})
         return self.api_call("team.billableInfo", http_verb="GET", params=kwargs)
@@ -4861,7 +4861,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Reads a workspace's billing plan information.
-        https://api.slack.com/methods/team.billing.info
+        https://docs.slack.dev/reference/methods/team.billing.info
         """
         return self.api_call("team.billing.info", params=kwargs)
 
@@ -4872,7 +4872,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Disconnects an external organization.
-        https://api.slack.com/methods/team.externalTeams.disconnect
+        https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
         """
         kwargs.update(
             {
@@ -4894,7 +4894,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Returns a list of all the external teams connected and details about the connection.
-        https://api.slack.com/methods/team.externalTeams.list
+        https://docs.slack.dev/reference/methods/team.externalTeams.list
         """
         kwargs.update(
             {
@@ -4925,7 +4925,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets information about the current team.
-        https://api.slack.com/methods/team.info
+        https://docs.slack.dev/reference/methods/team.info
         """
         kwargs.update({"team": team, "domain": domain})
         return self.api_call("team.info", http_verb="GET", params=kwargs)
@@ -4943,7 +4943,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets the integration logs for the current team.
-        https://api.slack.com/methods/team.integrationLogs
+        https://docs.slack.dev/reference/methods/team.integrationLogs
         """
         kwargs.update(
             {
@@ -4965,7 +4965,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieve a team's profile.
-        https://api.slack.com/methods/team.profile.get
+        https://docs.slack.dev/reference/methods/team.profile.get
         """
         kwargs.update({"visibility": visibility})
         return self.api_call("team.profile.get", http_verb="GET", params=kwargs)
@@ -4975,7 +4975,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieve a list of a workspace's team preferences.
-        https://api.slack.com/methods/team.preferences.list
+        https://docs.slack.dev/reference/methods/team.preferences.list
         """
         return self.api_call("team.preferences.list", params=kwargs)
 
@@ -4991,7 +4991,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Create a User Group
-        https://api.slack.com/methods/usergroups.create
+        https://docs.slack.dev/reference/methods/usergroups.create
         """
         kwargs.update(
             {
@@ -5017,7 +5017,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Disable an existing User Group
-        https://api.slack.com/methods/usergroups.disable
+        https://docs.slack.dev/reference/methods/usergroups.disable
         """
         kwargs.update({"usergroup": usergroup, "include_count": include_count, "team_id": team_id})
         return self.api_call("usergroups.disable", params=kwargs)
@@ -5031,7 +5031,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Enable a User Group
-        https://api.slack.com/methods/usergroups.enable
+        https://docs.slack.dev/reference/methods/usergroups.enable
         """
         kwargs.update({"usergroup": usergroup, "include_count": include_count, "team_id": team_id})
         return self.api_call("usergroups.enable", params=kwargs)
@@ -5046,7 +5046,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List all User Groups for a team
-        https://api.slack.com/methods/usergroups.list
+        https://docs.slack.dev/reference/methods/usergroups.list
         """
         kwargs.update(
             {
@@ -5071,7 +5071,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Update an existing User Group
-        https://api.slack.com/methods/usergroups.update
+        https://docs.slack.dev/reference/methods/usergroups.update
         """
         kwargs.update(
             {
@@ -5098,7 +5098,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List all users in a User Group
-        https://api.slack.com/methods/usergroups.users.list
+        https://docs.slack.dev/reference/methods/usergroups.users.list
         """
         kwargs.update(
             {
@@ -5119,7 +5119,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Update the list of users for a User Group
-        https://api.slack.com/methods/usergroups.users.update
+        https://docs.slack.dev/reference/methods/usergroups.users.update
         """
         kwargs.update(
             {
@@ -5146,7 +5146,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List conversations the calling user may access.
-        https://api.slack.com/methods/users.conversations
+        https://docs.slack.dev/reference/methods/users.conversations
         """
         kwargs.update(
             {
@@ -5168,7 +5168,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Delete the user profile photo
-        https://api.slack.com/methods/users.deletePhoto
+        https://docs.slack.dev/reference/methods/users.deletePhoto
         """
         return self.api_call("users.deletePhoto", http_verb="GET", params=kwargs)
 
@@ -5179,7 +5179,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets user presence information.
-        https://api.slack.com/methods/users.getPresence
+        https://docs.slack.dev/reference/methods/users.getPresence
         """
         kwargs.update({"user": user})
         return self.api_call("users.getPresence", http_verb="GET", params=kwargs)
@@ -5189,7 +5189,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Get a user's identity.
-        https://api.slack.com/methods/users.identity
+        https://docs.slack.dev/reference/methods/users.identity
         """
         return self.api_call("users.identity", http_verb="GET", params=kwargs)
 
@@ -5201,7 +5201,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Gets information about a user.
-        https://api.slack.com/methods/users.info
+        https://docs.slack.dev/reference/methods/users.info
         """
         kwargs.update({"user": user, "include_locale": include_locale})
         return self.api_call("users.info", http_verb="GET", params=kwargs)
@@ -5216,7 +5216,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lists all users in a Slack team.
-        https://api.slack.com/methods/users.list
+        https://docs.slack.dev/reference/methods/users.list
         """
         kwargs.update(
             {
@@ -5235,7 +5235,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Find a user with an email address.
-        https://api.slack.com/methods/users.lookupByEmail
+        https://docs.slack.dev/reference/methods/users.lookupByEmail
         """
         kwargs.update({"email": email})
         return self.api_call("users.lookupByEmail", http_verb="GET", params=kwargs)
@@ -5250,7 +5250,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set the user profile photo
-        https://api.slack.com/methods/users.setPhoto
+        https://docs.slack.dev/reference/methods/users.setPhoto
         """
         kwargs.update({"crop_w": crop_w, "crop_x": crop_x, "crop_y": crop_y})
         return self.api_call("users.setPhoto", files={"image": image}, data=kwargs)
@@ -5262,7 +5262,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Manually sets user presence.
-        https://api.slack.com/methods/users.setPresence
+        https://docs.slack.dev/reference/methods/users.setPresence
         """
         kwargs.update({"presence": presence})
         return self.api_call("users.setPresence", params=kwargs)
@@ -5273,7 +5273,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Lookup an email address to see if someone is on Slack
-        https://api.slack.com/methods/users.discoverableContacts.lookup
+        https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
         """
         kwargs.update({"email": email})
         return self.api_call("users.discoverableContacts.lookup", params=kwargs)
@@ -5286,7 +5286,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Retrieves a user's profile information.
-        https://api.slack.com/methods/users.profile.get
+        https://docs.slack.dev/reference/methods/users.profile.get
         """
         kwargs.update({"user": user, "include_labels": include_labels})
         return self.api_call("users.profile.get", http_verb="GET", params=kwargs)
@@ -5301,7 +5301,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set the profile information for a user.
-        https://api.slack.com/methods/users.profile.set
+        https://docs.slack.dev/reference/methods/users.profile.set
         """
         kwargs.update(
             {
@@ -5324,8 +5324,8 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Open a view for a user.
-        https://api.slack.com/methods/views.open
-        See https://api.slack.com/surfaces/modals for details.
+        https://docs.slack.dev/reference/methods/views.open
+        See https://docs.slack.dev/surfaces/modals/ for details.
         """
         kwargs.update({"trigger_id": trigger_id, "interactivity_pointer": interactivity_pointer})
         if isinstance(view, View):
@@ -5348,9 +5348,9 @@ class WebClient(BaseClient):
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/surfaces/modals)
+        Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
         to learn more about the lifecycle and intricacies of views.
-        https://api.slack.com/methods/views.push
+        https://docs.slack.dev/reference/methods/views.push
         """
         kwargs.update({"trigger_id": trigger_id, "interactivity_pointer": interactivity_pointer})
         if isinstance(view, View):
@@ -5373,9 +5373,9 @@ class WebClient(BaseClient):
         """Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+        See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
-        https://api.slack.com/methods/views.update
+        https://docs.slack.dev/reference/methods/views.update
         """
         if isinstance(view, View):
             kwargs.update({"view": view.to_dict()})
@@ -5402,8 +5402,8 @@ class WebClient(BaseClient):
     ) -> SlackResponse:
         """Publish a static view for a User.
         Create or update the view that comprises an
-        app's Home tab (https://api.slack.com/surfaces/tabs)
-        https://api.slack.com/methods/views.publish
+        app's Home tab (https://docs.slack.dev/surfaces/app-home/)
+        https://docs.slack.dev/reference/methods/views.publish
         """
         kwargs.update({"user_id": user_id, "hash": hash})
         if isinstance(view, View):
@@ -5422,7 +5422,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Add featured workflows to a channel.
-        https://api.slack.com/methods/workflows.featured.add
+        https://docs.slack.dev/reference/methods/workflows.featured.add
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(trigger_ids, (list, tuple)):
@@ -5438,7 +5438,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """List the featured workflows for specified channels.
-        https://api.slack.com/methods/workflows.featured.list
+        https://docs.slack.dev/reference/methods/workflows.featured.list
         """
         if isinstance(channel_ids, (list, tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
@@ -5454,7 +5454,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Remove featured workflows from a channel.
-        https://api.slack.com/methods/workflows.featured.remove
+        https://docs.slack.dev/reference/methods/workflows.featured.remove
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(trigger_ids, (list, tuple)):
@@ -5471,7 +5471,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Set featured workflows for a channel.
-        https://api.slack.com/methods/workflows.featured.set
+        https://docs.slack.dev/reference/methods/workflows.featured.set
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(trigger_ids, (list, tuple)):
@@ -5488,7 +5488,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Indicate a successful outcome of a workflow step's execution.
-        https://api.slack.com/methods/workflows.stepCompleted
+        https://docs.slack.dev/reference/methods/workflows.stepCompleted
         """
         kwargs.update({"workflow_step_execute_id": workflow_step_execute_id})
         if outputs is not None:
@@ -5505,7 +5505,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Indicate an unsuccessful outcome of a workflow step's execution.
-        https://api.slack.com/methods/workflows.stepFailed
+        https://docs.slack.dev/reference/methods/workflows.stepFailed
         """
         kwargs.update(
             {
@@ -5526,7 +5526,7 @@ class WebClient(BaseClient):
         **kwargs,
     ) -> SlackResponse:
         """Update the configuration for a workflow extension step.
-        https://api.slack.com/methods/workflows.updateStep
+        https://docs.slack.dev/reference/methods/workflows.updateStep
         """
         kwargs.update({"workflow_step_edit_id": workflow_step_edit_id})
         if inputs is not None:

--- a/slack_sdk/web/deprecation.py
+++ b/slack_sdk/web/deprecation.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 
-# https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+# https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
 deprecated_method_prefixes_2020_01 = [
     "channels.",
     "groups.",
@@ -30,7 +30,7 @@ def show_deprecation_warning_if_any(method_name: str):
         message = (
             f"{method_name} is deprecated. Please use the Conversations API instead. "
             "For more info, go to "
-            "https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api"
+            "https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/"
         )
         warnings.warn(message)
 
@@ -39,7 +39,7 @@ def show_deprecation_warning_if_any(method_name: str):
     if len(matched_prefixes) > 0:
         message = (
             f"{method_name} is deprecated. For more info, go to "
-            "https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders"
+            "https://docs.slack.dev/changelog/2023-07-its-later-already-for-stars-and-reminders/"
         )
         warnings.warn(message)
 
@@ -48,6 +48,6 @@ def show_deprecation_warning_if_any(method_name: str):
     if len(matched_prefixes) > 0:
         message = (
             f"{method_name} is deprecated. For more info, go to "
-            "https://api.slack.com/changelog/2023-08-workflow-steps-from-apps-step-back"
+            "https://docs.slack.dev/changelog/2023-08-workflow-steps-from-apps-step-back/"
         )
         warnings.warn(message)

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -272,19 +272,19 @@ def _warn_if_message_text_content_is_missing(endpoint: str, kwargs: Dict[str, An
         "system push notifications, assistive technology such as screen readers, etc."
     )
 
-    # https://api.slack.com/reference/messaging/attachments
+    # https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments
     # Check if the fallback field exists for all the attachments
     # Not all attachments have a fallback property; warn about this too!
     missing_fallback_message = (
         f"Additionally, the attachment-level `fallback` argument is missing in the request payload for a {endpoint} call"
         " - To avoid this warning, it is recommended to always provide a top-level `text` argument when posting a"
         " message. Alternatively you can provide an attachment-level `fallback` argument, though this is now considered"
-        " a legacy field (see https://api.slack.com/reference/messaging/attachments#legacy_fields for more details)."
+        " a legacy field (see https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#legacy_fields for more details)."  # noqa: E501
     )
 
     # Additionally, specifically for attachments, there is a legacy field available at the attachment level called `fallback`
     # Even with a missing text, one can provide a `fallback` per attachment.
-    # More details here: https://api.slack.com/reference/messaging/attachments#legacy_fields
+    # More details here: https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#legacy_fields
     attachments = kwargs.get("attachments")
     # Note that this method does not verify attachments
     # if the value is already serialized as a single str value.

--- a/slack_sdk/web/legacy_base_client.py
+++ b/slack_sdk/web/legacy_base_client.py
@@ -565,7 +565,7 @@ class LegacyBaseClient:
         On each HTTP request that Slack sends, we add an X-Slack-Signature HTTP
         header. The signature is created by combining the signing secret with the
         body of the request we're sending using a standard HMAC-SHA256 keyed hash.
-        https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview
+        https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview
         Args:
             signing_secret: Your application's signing secret, available in the
                 Slack API dashboard

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -39,7 +39,7 @@ from .internal_utils import (
 class LegacyWebClient(LegacyBaseClient):
     """A WebClient allows apps to communicate with the Slack Platform's Web API.
 
-    https://api.slack.com/methods
+    https://docs.slack.dev/reference/methods
 
     The Slack Web API is an interface for querying information from
     and enacting change in a Slack workspace.
@@ -110,7 +110,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieve analytics data for a given date, presented as a compressed JSON file
-        https://api.slack.com/methods/admin.analytics.getFile
+        https://docs.slack.dev/reference/methods/admin.analytics.getFile
         """
         kwargs.update({"type": type})
         if date is not None:
@@ -132,7 +132,7 @@ class LegacyWebClient(LegacyBaseClient):
         Either app_id or request_id is required.
         These IDs can be obtained either directly via the app_requested event,
         or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.approve
+        https://docs.slack.dev/reference/methods/admin.apps.approve
         """
         if app_id:
             kwargs.update({"app_id": app_id})
@@ -159,7 +159,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List approved apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.approved.list
+        https://docs.slack.dev/reference/methods/admin.apps.approved.list
         """
         kwargs.update(
             {
@@ -180,7 +180,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Clear an app resolution
-        https://api.slack.com/methods/admin.apps.clearResolution
+        https://docs.slack.dev/reference/methods/admin.apps.clearResolution
         """
         kwargs.update(
             {
@@ -200,7 +200,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.cancel
+        https://docs.slack.dev/reference/methods/admin.apps.requests.cancel
         """
         kwargs.update(
             {
@@ -220,7 +220,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List app requests for a team/workspace.
-        https://api.slack.com/methods/admin.apps.requests.list
+        https://docs.slack.dev/reference/methods/admin.apps.requests.list
         """
         kwargs.update(
             {
@@ -244,7 +244,7 @@ class LegacyWebClient(LegacyBaseClient):
         Exactly one of the team_id or enterprise_id arguments is required, not both.
         Either app_id or request_id is required. These IDs can be obtained either directly
         via the app_requested event, or by the admin.apps.requests.list method.
-        https://api.slack.com/methods/admin.apps.restrict
+        https://docs.slack.dev/reference/methods/admin.apps.restrict
         """
         if app_id:
             kwargs.update({"app_id": app_id})
@@ -271,7 +271,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List restricted apps for an org or workspace.
-        https://api.slack.com/methods/admin.apps.restricted.list
+        https://docs.slack.dev/reference/methods/admin.apps.restricted.list
         """
         kwargs.update(
             {
@@ -293,7 +293,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Uninstall an app from one or many workspaces, or an entire enterprise organization.
         With an org-level token, enterprise_id or team_ids is required.
-        https://api.slack.com/methods/admin.apps.uninstall
+        https://docs.slack.dev/reference/methods/admin.apps.uninstall
         """
         kwargs.update({"app_id": app_id})
         if enterprise_id is not None:
@@ -324,7 +324,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Get logs for a specified team/org
-        https://api.slack.com/methods/admin.apps.activities.list
+        https://docs.slack.dev/reference/methods/admin.apps.activities.list
         """
         kwargs.update(
             {
@@ -352,7 +352,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Look up the app config for connectors by their IDs
-        https://api.slack.com/methods/admin.apps.config.lookup
+        https://docs.slack.dev/reference/methods/admin.apps.config.lookup
         """
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({"app_ids": ",".join(app_ids)})
@@ -369,7 +369,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set the app config for a connector
-        https://api.slack.com/methods/admin.apps.config.set
+        https://docs.slack.dev/reference/methods/admin.apps.config.set
         """
         kwargs.update(
             {
@@ -391,7 +391,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Fetch all the entities assigned to a particular authentication policy by name.
-        https://api.slack.com/methods/admin.auth.policy.getEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.getEntities
         """
         kwargs.update({"policy_name": policy_name})
         if cursor is not None:
@@ -411,7 +411,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Assign entities to a particular authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.assignEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.assignEntities
         """
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({"entity_ids": ",".join(entity_ids)})
@@ -430,7 +430,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Remove specified entities from a specified authentication policy.
-        https://api.slack.com/methods/admin.auth.policy.removeEntities
+        https://docs.slack.dev/reference/methods/admin.auth.policy.removeEntities
         """
         if isinstance(entity_ids, (list, tuple)):
             kwargs.update({"entity_ids": ",".join(entity_ids)})
@@ -449,7 +449,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Create a Salesforce channel for the corresponding object provided.
-        https://api.slack.com/methods/admin.conversations.createForObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.createForObjects
         """
         kwargs.update(
             {"object_id": object_id, "salesforce_org_id": salesforce_org_id, "invite_object_team": invite_object_team}
@@ -465,7 +465,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Link a Salesforce record to a channel.
-        https://api.slack.com/methods/admin.conversations.linkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.linkObjects
         """
         kwargs.update(
             {
@@ -484,7 +484,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Unlink a Salesforce record from a channel.
-        https://api.slack.com/methods/admin.conversations.unlinkObjects
+        https://docs.slack.dev/reference/methods/admin.conversations.unlinkObjects
         """
         kwargs.update(
             {
@@ -503,7 +503,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Create an Information Barrier
-        https://api.slack.com/methods/admin.barriers.create
+        https://docs.slack.dev/reference/methods/admin.barriers.create
         """
         kwargs.update({"primary_usergroup_id": primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -523,7 +523,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Delete an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.delete
+        https://docs.slack.dev/reference/methods/admin.barriers.delete
         """
         kwargs.update({"barrier_id": barrier_id})
         return self.api_call("admin.barriers.delete", http_verb="POST", params=kwargs)
@@ -538,7 +538,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Update an existing Information Barrier
-        https://api.slack.com/methods/admin.barriers.update
+        https://docs.slack.dev/reference/methods/admin.barriers.update
         """
         kwargs.update({"barrier_id": barrier_id, "primary_usergroup_id": primary_usergroup_id})
         if isinstance(barriered_from_usergroup_ids, (list, tuple)):
@@ -559,7 +559,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Get all Information Barriers for your organization
-        https://api.slack.com/methods/admin.barriers.list"""
+        https://docs.slack.dev/reference/methods/admin.barriers.list"""
         kwargs.update(
             {
                 "cursor": cursor,
@@ -579,7 +579,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Create a public or private channel-based conversation.
-        https://api.slack.com/methods/admin.conversations.create
+        https://docs.slack.dev/reference/methods/admin.conversations.create
         """
         kwargs.update(
             {
@@ -599,7 +599,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Delete a public or private channel.
-        https://api.slack.com/methods/admin.conversations.delete
+        https://docs.slack.dev/reference/methods/admin.conversations.delete
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.delete", params=kwargs)
@@ -612,7 +612,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Invite a user to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.invite
+        https://docs.slack.dev/reference/methods/admin.conversations.invite
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(user_ids, (list, tuple)):
@@ -629,7 +629,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Archive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.archive", params=kwargs)
@@ -641,7 +641,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Unarchive a public or private channel.
-        https://api.slack.com/methods/admin.conversations.archive
+        https://docs.slack.dev/reference/methods/admin.conversations.archive
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.unarchive", params=kwargs)
@@ -654,7 +654,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Rename a public or private channel.
-        https://api.slack.com/methods/admin.conversations.rename
+        https://docs.slack.dev/reference/methods/admin.conversations.rename
         """
         kwargs.update({"channel_id": channel_id, "name": name})
         return self.api_call("admin.conversations.rename", params=kwargs)
@@ -672,7 +672,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Search for public or private channels in an Enterprise organization.
-        https://api.slack.com/methods/admin.conversations.search
+        https://docs.slack.dev/reference/methods/admin.conversations.search
         """
         kwargs.update(
             {
@@ -703,7 +703,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Convert a public channel to a private channel.
-        https://api.slack.com/methods/admin.conversations.convertToPrivate
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPrivate
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.convertToPrivate", params=kwargs)
@@ -715,7 +715,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Convert a privte channel to a public channel.
-        https://api.slack.com/methods/admin.conversations.convertToPublic
+        https://docs.slack.dev/reference/methods/admin.conversations.convertToPublic
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.convertToPublic", params=kwargs)
@@ -728,7 +728,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set the posting permissions for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.setConversationPrefs
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(prefs, dict):
@@ -744,7 +744,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Get conversation preferences for a public or private channel.
-        https://api.slack.com/methods/admin.conversations.getConversationPrefs
+        https://docs.slack.dev/reference/methods/admin.conversations.getConversationPrefs
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.getConversationPrefs", params=kwargs)
@@ -757,7 +757,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Disconnect a connected channel from one or more workspaces.
-        https://api.slack.com/methods/admin.conversations.disconnectShared
+        https://docs.slack.dev/reference/methods/admin.conversations.disconnectShared
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(leaving_team_ids, (list, tuple)):
@@ -777,7 +777,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Returns channels on the given team using the filters.
-        https://api.slack.com/methods/admin.conversations.lookup
+        https://docs.slack.dev/reference/methods/admin.conversations.lookup
         """
         kwargs.update(
             {
@@ -805,7 +805,7 @@ class LegacyWebClient(LegacyBaseClient):
         """List all disconnected channels—i.e.,
         channels that were once connected to other workspaces and then disconnected—and
         the corresponding original channel IDs for key revocation with EKM.
-        https://api.slack.com/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
+        https://docs.slack.dev/reference/methods/admin.conversations.ekm.listOriginalConnectedChannelInfo
         """
         kwargs.update(
             {
@@ -832,7 +832,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Add an allowlist of IDP groups for accessing a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.addGroup
         """
         kwargs.update(
             {
@@ -855,7 +855,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List all IDP Groups linked to a channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.listGroups
         """
         kwargs.update(
             {
@@ -878,7 +878,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Remove a linked IDP group linked from a private channel.
-        https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
+        https://docs.slack.dev/reference/methods/admin.conversations.restrictAccess.removeGroup
         """
         kwargs.update(
             {
@@ -903,7 +903,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set the workspaces in an Enterprise grid org that connect to a public or private channel.
-        https://api.slack.com/methods/admin.conversations.setTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.setTeams
         """
         kwargs.update(
             {
@@ -927,7 +927,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set the workspaces in an Enterprise grid org that connect to a channel.
-        https://api.slack.com/methods/admin.conversations.getTeams
+        https://docs.slack.dev/reference/methods/admin.conversations.getTeams
         """
         kwargs.update(
             {
@@ -945,7 +945,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Get a channel's retention policy
-        https://api.slack.com/methods/admin.conversations.getCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.getCustomRetention
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.getCustomRetention", params=kwargs)
@@ -957,7 +957,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Remove a channel's retention policy
-        https://api.slack.com/methods/admin.conversations.removeCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.removeCustomRetention
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("admin.conversations.removeCustomRetention", params=kwargs)
@@ -970,7 +970,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set a channel's retention policy
-        https://api.slack.com/methods/admin.conversations.setCustomRetention
+        https://docs.slack.dev/reference/methods/admin.conversations.setCustomRetention
         """
         kwargs.update({"channel_id": channel_id, "duration_days": duration_days})
         return self.api_call("admin.conversations.setCustomRetention", params=kwargs)
@@ -982,7 +982,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Archive public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkArchive
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkArchive
         """
         kwargs.update({"channel_ids": ",".join(channel_ids) if isinstance(channel_ids, (list, tuple)) else channel_ids})
         return self.api_call("admin.conversations.bulkArchive", params=kwargs)
@@ -1007,7 +1007,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Move public or private channels in bulk.
-        https://api.slack.com/methods/admin.conversations.bulkMove
+        https://docs.slack.dev/reference/methods/admin.conversations.bulkMove
         """
         kwargs.update(
             {
@@ -1025,7 +1025,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Add an emoji.
-        https://api.slack.com/methods/admin.emoji.add
+        https://docs.slack.dev/reference/methods/admin.emoji.add
         """
         kwargs.update({"name": name, "url": url})
         return self.api_call("admin.emoji.add", http_verb="GET", params=kwargs)
@@ -1038,7 +1038,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Add an emoji alias.
-        https://api.slack.com/methods/admin.emoji.addAlias
+        https://docs.slack.dev/reference/methods/admin.emoji.addAlias
         """
         kwargs.update({"alias_for": alias_for, "name": name})
         return self.api_call("admin.emoji.addAlias", http_verb="GET", params=kwargs)
@@ -1051,7 +1051,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List emoji for an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.list
+        https://docs.slack.dev/reference/methods/admin.emoji.list
         """
         kwargs.update({"cursor": cursor, "limit": limit})
         return self.api_call("admin.emoji.list", http_verb="GET", params=kwargs)
@@ -1063,7 +1063,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Remove an emoji across an Enterprise Grid organization.
-        https://api.slack.com/methods/admin.emoji.remove
+        https://docs.slack.dev/reference/methods/admin.emoji.remove
         """
         kwargs.update({"name": name})
         return self.api_call("admin.emoji.remove", http_verb="GET", params=kwargs)
@@ -1076,7 +1076,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Rename an emoji.
-        https://api.slack.com/methods/admin.emoji.rename
+        https://docs.slack.dev/reference/methods/admin.emoji.rename
         """
         kwargs.update({"name": name, "new_name": new_name})
         return self.api_call("admin.emoji.rename", http_verb="GET", params=kwargs)
@@ -1091,7 +1091,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Look up functions by a set of apps
-        https://api.slack.com/methods/admin.functions.list
+        https://docs.slack.dev/reference/methods/admin.functions.list
         """
         if isinstance(app_ids, (list, tuple)):
             kwargs.update({"app_ids": ",".join(app_ids)})
@@ -1114,7 +1114,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Lookup the visibility of multiple Slack functions
         and include the users if it is limited to particular named entities.
-        https://api.slack.com/methods/admin.functions.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.lookup
         """
         if isinstance(function_ids, (list, tuple)):
             kwargs.update({"function_ids": ",".join(function_ids)})
@@ -1132,7 +1132,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Set the visibility of a Slack function
         and define the users or workspaces if it is set to named_entities
-        https://api.slack.com/methods/admin.functions.permissions.set
+        https://docs.slack.dev/reference/methods/admin.functions.permissions.set
         """
         kwargs.update(
             {
@@ -1156,7 +1156,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Adds members to the specified role with the specified scopes
-        https://api.slack.com/methods/admin.roles.addAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.addAssignments
         """
         kwargs.update({"role_id": role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1181,7 +1181,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Lists assignments for all roles across entities.
             Options to scope results by any combination of roles or entities
-        https://api.slack.com/methods/admin.roles.listAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.listAssignments
         """
         kwargs.update({"cursor": cursor, "limit": limit, "sort_dir": sort_dir})
         if isinstance(entity_ids, (list, tuple)):
@@ -1203,7 +1203,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Removes a set of users from a role for the given scopes and entities
-        https://api.slack.com/methods/admin.roles.removeAssignments
+        https://docs.slack.dev/reference/methods/admin.roles.removeAssignments
         """
         kwargs.update({"role_id": role_id})
         if isinstance(entity_ids, (list, tuple)):
@@ -1225,7 +1225,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Wipes all valid sessions on all devices for a given user.
-        https://api.slack.com/methods/admin.users.session.reset
+        https://docs.slack.dev/reference/methods/admin.users.session.reset
         """
         kwargs.update(
             {
@@ -1245,7 +1245,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Enqueues an asynchronous job to wipe all valid sessions on all devices for a given list of users
-        https://api.slack.com/methods/admin.users.session.resetBulk
+        https://docs.slack.dev/reference/methods/admin.users.session.resetBulk
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1267,7 +1267,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Invalidate a single session for a user by session_id.
-        https://api.slack.com/methods/admin.users.session.invalidate
+        https://docs.slack.dev/reference/methods/admin.users.session.invalidate
         """
         kwargs.update({"session_id": session_id, "team_id": team_id})
         return self.api_call("admin.users.session.invalidate", params=kwargs)
@@ -1282,7 +1282,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists all active user sessions for an organization
-        https://api.slack.com/methods/admin.users.session.list
+        https://docs.slack.dev/reference/methods/admin.users.session.list
         """
         kwargs.update(
             {
@@ -1302,7 +1302,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set the default channels of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDefaultChannels
         """
         kwargs.update({"team_id": team_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1319,7 +1319,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Get user-specific session settings—the session duration
         and what happens when the client closes—given a list of users.
-        https://api.slack.com/methods/admin.users.session.getSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.getSettings
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1337,7 +1337,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Configure the user-level session settings—the session duration
         and what happens when the client closes—for one or more users.
-        https://api.slack.com/methods/admin.users.session.setSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.setSettings
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1359,7 +1359,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Clear user-specific session settings—the session duration
         and what happens when the client closes—for a list of users.
-        https://api.slack.com/methods/admin.users.session.clearSettings
+        https://docs.slack.dev/reference/methods/admin.users.session.clearSettings
         """
         if isinstance(user_ids, (list, tuple)):
             kwargs.update({"user_ids": ",".join(user_ids)})
@@ -1376,7 +1376,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Ask Slackbot to send you an export listing all workspace members using unsupported software,
         presented as a zipped CSV file.
-        https://api.slack.com/methods/admin.users.unsupportedVersions.export
+        https://docs.slack.dev/reference/methods/admin.users.unsupportedVersions.export
         """
         kwargs.update(
             {
@@ -1394,7 +1394,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Approve a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.approve
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approve
         """
         kwargs.update({"invite_request_id": invite_request_id, "team_id": team_id})
         return self.api_call("admin.inviteRequests.approve", params=kwargs)
@@ -1408,7 +1408,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List all approved workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.approved.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.approved.list
         """
         kwargs.update(
             {
@@ -1428,7 +1428,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List all denied workspace invite requests.
-        https://api.slack.com/methods/admin.inviteRequests.denied.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.denied.list
         """
         kwargs.update(
             {
@@ -1447,7 +1447,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Deny a workspace invite request.
-        https://api.slack.com/methods/admin.inviteRequests.deny
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.deny
         """
         kwargs.update({"invite_request_id": invite_request_id, "team_id": team_id})
         return self.api_call("admin.inviteRequests.deny", params=kwargs)
@@ -1468,7 +1468,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.inviteRequests.list
+        https://docs.slack.dev/reference/methods/admin.inviteRequests.list
         """
         kwargs.update(
             {
@@ -1489,7 +1489,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Create an Enterprise team.
-        https://api.slack.com/methods/admin.teams.create
+        https://docs.slack.dev/reference/methods/admin.teams.create
         """
         kwargs.update(
             {
@@ -1509,7 +1509,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List all teams on an Enterprise organization.
-        https://api.slack.com/methods/admin.teams.list
+        https://docs.slack.dev/reference/methods/admin.teams.list
         """
         kwargs.update({"cursor": cursor, "limit": limit})
         return self.api_call("admin.teams.list", params=kwargs)
@@ -1523,7 +1523,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List all of the admins on a given workspace.
-        https://api.slack.com/methods/admin.teams.owners.list
+        https://docs.slack.dev/reference/methods/admin.teams.owners.list
         """
         kwargs.update({"team_id": team_id, "cursor": cursor, "limit": limit})
         return self.api_call("admin.teams.owners.list", http_verb="GET", params=kwargs)
@@ -1535,7 +1535,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Fetch information about settings in a workspace
-        https://api.slack.com/methods/admin.teams.settings.info
+        https://docs.slack.dev/reference/methods/admin.teams.settings.info
         """
         kwargs.update({"team_id": team_id})
         return self.api_call("admin.teams.settings.info", params=kwargs)
@@ -1548,7 +1548,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set the description of a given workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDescription
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDescription
         """
         kwargs.update({"team_id": team_id, "description": description})
         return self.api_call("admin.teams.settings.setDescription", params=kwargs)
@@ -1561,7 +1561,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setDiscoverability
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setDiscoverability
         """
         kwargs.update({"team_id": team_id, "discoverability": discoverability})
         return self.api_call("admin.teams.settings.setDiscoverability", params=kwargs)
@@ -1574,7 +1574,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setIcon
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setIcon
         """
         kwargs.update({"team_id": team_id, "image_url": image_url})
         return self.api_call("admin.teams.settings.setIcon", http_verb="GET", params=kwargs)
@@ -1587,7 +1587,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sets the icon of a workspace.
-        https://api.slack.com/methods/admin.teams.settings.setName
+        https://docs.slack.dev/reference/methods/admin.teams.settings.setName
         """
         kwargs.update({"team_id": team_id, "name": name})
         return self.api_call("admin.teams.settings.setName", params=kwargs)
@@ -1601,7 +1601,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.addChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.addChannels
         """
         kwargs.update({"team_id": team_id, "usergroup_id": usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1619,7 +1619,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Associate one or more default workspaces with an organization-wide IDP group.
-        https://api.slack.com/methods/admin.usergroups.addTeams
+        https://docs.slack.dev/reference/methods/admin.usergroups.addTeams
         """
         kwargs.update({"usergroup_id": usergroup_id, "auto_provision": auto_provision})
         if isinstance(team_ids, (list, tuple)):
@@ -1637,7 +1637,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.listChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.listChannels
         """
         kwargs.update(
             {
@@ -1656,7 +1656,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Add one or more default channels to an IDP group.
-        https://api.slack.com/methods/admin.usergroups.removeChannels
+        https://docs.slack.dev/reference/methods/admin.usergroups.removeChannels
         """
         kwargs.update({"usergroup_id": usergroup_id})
         if isinstance(channel_ids, (list, tuple)):
@@ -1676,7 +1676,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Add an Enterprise user to a workspace.
-        https://api.slack.com/methods/admin.users.assign
+        https://docs.slack.dev/reference/methods/admin.users.assign
         """
         kwargs.update(
             {
@@ -1708,7 +1708,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Invite a user to a workspace.
-        https://api.slack.com/methods/admin.users.invite
+        https://docs.slack.dev/reference/methods/admin.users.invite
         """
         kwargs.update(
             {
@@ -1740,7 +1740,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List users on a workspace
-        https://api.slack.com/methods/admin.users.list
+        https://docs.slack.dev/reference/methods/admin.users.list
         """
         kwargs.update(
             {
@@ -1761,7 +1761,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Remove a user from a workspace.
-        https://api.slack.com/methods/admin.users.remove
+        https://docs.slack.dev/reference/methods/admin.users.remove
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return self.api_call("admin.users.remove", params=kwargs)
@@ -1774,7 +1774,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set an existing guest, regular user, or owner to be an admin user.
-        https://api.slack.com/methods/admin.users.setAdmin
+        https://docs.slack.dev/reference/methods/admin.users.setAdmin
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return self.api_call("admin.users.setAdmin", params=kwargs)
@@ -1788,7 +1788,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set an expiration for a guest user.
-        https://api.slack.com/methods/admin.users.setExpiration
+        https://docs.slack.dev/reference/methods/admin.users.setExpiration
         """
         kwargs.update({"expiration_ts": expiration_ts, "team_id": team_id, "user_id": user_id})
         return self.api_call("admin.users.setExpiration", params=kwargs)
@@ -1801,7 +1801,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set an existing guest, regular user, or admin user to be a workspace owner.
-        https://api.slack.com/methods/admin.users.setOwner
+        https://docs.slack.dev/reference/methods/admin.users.setOwner
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return self.api_call("admin.users.setOwner", params=kwargs)
@@ -1814,7 +1814,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set an existing guest user, admin user, or owner to be a regular user.
-        https://api.slack.com/methods/admin.users.setRegular
+        https://docs.slack.dev/reference/methods/admin.users.setRegular
         """
         kwargs.update({"team_id": team_id, "user_id": user_id})
         return self.api_call("admin.users.setRegular", params=kwargs)
@@ -1835,7 +1835,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Search workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.search
+        https://docs.slack.dev/reference/methods/admin.workflows.search
         """
         if collaborator_ids is not None:
             if isinstance(collaborator_ids, (list, tuple)):
@@ -1865,7 +1865,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Look up the permissions for a set of workflows
-        https://api.slack.com/methods/admin.workflows.permissions.lookup
+        https://docs.slack.dev/reference/methods/admin.workflows.permissions.lookup
         """
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({"workflow_ids": ",".join(workflow_ids)})
@@ -1886,7 +1886,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Add collaborators to workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.add
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.add
         """
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({"collaborator_ids": ",".join(collaborator_ids)})
@@ -1906,7 +1906,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Remove collaborators from workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.collaborators.remove
+        https://docs.slack.dev/reference/methods/admin.workflows.collaborators.remove
         """
         if isinstance(collaborator_ids, (list, tuple)):
             kwargs.update({"collaborator_ids": ",".join(collaborator_ids)})
@@ -1925,7 +1925,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Unpublish workflows within the team or enterprise
-        https://api.slack.com/methods/admin.workflows.unpublish
+        https://docs.slack.dev/reference/methods/admin.workflows.unpublish
         """
         if isinstance(workflow_ids, (list, tuple)):
             kwargs.update({"workflow_ids": ",".join(workflow_ids)})
@@ -1940,7 +1940,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Checks API calling code.
-        https://api.slack.com/methods/api.test
+        https://docs.slack.dev/reference/methods/api.test
         """
         kwargs.update({"error": error})
         return self.api_call("api.test", params=kwargs)
@@ -1953,7 +1953,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Generate a temporary Socket Mode WebSocket URL that your app can connect to
         in order to receive events and interactive payloads
-        https://api.slack.com/methods/apps.connections.open
+        https://docs.slack.dev/reference/methods/apps.connections.open
         """
         kwargs.update({"token": app_token})
         return self.api_call("apps.connections.open", http_verb="POST", params=kwargs)
@@ -1968,7 +1968,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Get a list of authorizations for the given event context.
         Each authorization represents an app installation that the event is visible to.
-        https://api.slack.com/methods/apps.event.authorizations.list
+        https://docs.slack.dev/reference/methods/apps.event.authorizations.list
         """
         kwargs.update({"event_context": event_context, "cursor": cursor, "limit": limit})
         return self.api_call("apps.event.authorizations.list", params=kwargs)
@@ -1981,7 +1981,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Uninstalls your app from a workspace.
-        https://api.slack.com/methods/apps.uninstall
+        https://docs.slack.dev/reference/methods/apps.uninstall
         """
         kwargs.update({"client_id": client_id, "client_secret": client_secret})
         return self.api_call("apps.uninstall", params=kwargs)
@@ -1993,7 +1993,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Create an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.create
+        https://docs.slack.dev/reference/methods/apps.manifest.create
         """
         if isinstance(manifest, str):
             kwargs.update({"manifest": manifest})
@@ -2008,7 +2008,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Permanently deletes an app created through app manifests
-        https://api.slack.com/methods/apps.manifest.delete
+        https://docs.slack.dev/reference/methods/apps.manifest.delete
         """
         kwargs.update({"app_id": app_id})
         return self.api_call("apps.manifest.delete", params=kwargs)
@@ -2020,7 +2020,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Export an app manifest from an existing app
-        https://api.slack.com/methods/apps.manifest.export
+        https://docs.slack.dev/reference/methods/apps.manifest.export
         """
         kwargs.update({"app_id": app_id})
         return self.api_call("apps.manifest.export", params=kwargs)
@@ -2033,7 +2033,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Update an app from an app manifest
-        https://api.slack.com/methods/apps.manifest.update
+        https://docs.slack.dev/reference/methods/apps.manifest.update
         """
         if isinstance(manifest, str):
             kwargs.update({"manifest": manifest})
@@ -2050,7 +2050,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Validate an app manifest
-        https://api.slack.com/methods/apps.manifest.validate
+        https://docs.slack.dev/reference/methods/apps.manifest.validate
         """
         if isinstance(manifest, str):
             kwargs.update({"manifest": manifest})
@@ -2066,7 +2066,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Exchanges a refresh token for a new app configuration token
-        https://api.slack.com/methods/tooling.tokens.rotate
+        https://docs.slack.dev/reference/methods/tooling.tokens.rotate
         """
         kwargs.update({"refresh_token": refresh_token})
         return self.api_call("tooling.tokens.rotate", params=kwargs)
@@ -2080,7 +2080,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setStatus
+        https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         """
         kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "status": status})
         return self.api_call("assistant.threads.setStatus", params=kwargs)
@@ -2094,7 +2094,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setTitle
+        https://docs.slack.dev/reference/methods/assistant.threads.setTitle
         """
         kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "title": title})
         return self.api_call("assistant.threads.setTitle", params=kwargs)
@@ -2109,7 +2109,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Revokes a token.
-        https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+        https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         """
         kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "prompts": prompts})
         if title is not None:
@@ -2123,7 +2123,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Revokes a token.
-        https://api.slack.com/methods/auth.revoke
+        https://docs.slack.dev/reference/methods/auth.revoke
         """
         kwargs.update({"test": test})
         return self.api_call("auth.revoke", http_verb="GET", params=kwargs)
@@ -2133,7 +2133,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Checks authentication & identity.
-        https://api.slack.com/methods/auth.test
+        https://docs.slack.dev/reference/methods/auth.test
         """
         return self.api_call("auth.test", params=kwargs)
 
@@ -2145,7 +2145,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List the workspaces a token can access.
-        https://api.slack.com/methods/auth.teams.list
+        https://docs.slack.dev/reference/methods/auth.teams.list
         """
         kwargs.update({"cursor": cursor, "limit": limit, "include_icon": include_icon})
         return self.api_call("auth.teams.list", params=kwargs)
@@ -2163,7 +2163,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Add bookmark to a channel.
-        https://api.slack.com/methods/bookmarks.add
+        https://docs.slack.dev/reference/methods/bookmarks.add
         """
         kwargs.update(
             {
@@ -2189,7 +2189,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Edit bookmark.
-        https://api.slack.com/methods/bookmarks.edit
+        https://docs.slack.dev/reference/methods/bookmarks.edit
         """
         kwargs.update(
             {
@@ -2209,7 +2209,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List bookmark for the channel.
-        https://api.slack.com/methods/bookmarks.list
+        https://docs.slack.dev/reference/methods/bookmarks.list
         """
         kwargs.update({"channel_id": channel_id})
         return self.api_call("bookmarks.list", http_verb="POST", params=kwargs)
@@ -2222,7 +2222,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Remove bookmark from the channel.
-        https://api.slack.com/methods/bookmarks.remove
+        https://docs.slack.dev/reference/methods/bookmarks.remove
         """
         kwargs.update({"bookmark_id": bookmark_id, "channel_id": channel_id})
         return self.api_call("bookmarks.remove", http_verb="POST", params=kwargs)
@@ -2235,7 +2235,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets information about a bot user.
-        https://api.slack.com/methods/bots.info
+        https://docs.slack.dev/reference/methods/bots.info
         """
         kwargs.update({"bot": bot, "team_id": team_id})
         return self.api_call("bots.info", http_verb="GET", params=kwargs)
@@ -2254,7 +2254,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Registers a new Call.
-        https://api.slack.com/methods/calls.add
+        https://docs.slack.dev/reference/methods/calls.add
         """
         kwargs.update(
             {
@@ -2281,7 +2281,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Ends a Call.
-        https://api.slack.com/methods/calls.end
+        https://docs.slack.dev/reference/methods/calls.end
         """
         kwargs.update({"id": id, "duration": duration})
         return self.api_call("calls.end", http_verb="POST", params=kwargs)
@@ -2293,7 +2293,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Returns information about a Call.
-        https://api.slack.com/methods/calls.info
+        https://docs.slack.dev/reference/methods/calls.info
         """
         kwargs.update({"id": id})
         return self.api_call("calls.info", http_verb="POST", params=kwargs)
@@ -2306,7 +2306,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Registers new participants added to a Call.
-        https://api.slack.com/methods/calls.participants.add
+        https://docs.slack.dev/reference/methods/calls.participants.add
         """
         kwargs.update({"id": id})
         _update_call_participants(kwargs, users)
@@ -2320,7 +2320,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Registers participants removed from a Call.
-        https://api.slack.com/methods/calls.participants.remove
+        https://docs.slack.dev/reference/methods/calls.participants.remove
         """
         kwargs.update({"id": id})
         _update_call_participants(kwargs, users)
@@ -2336,7 +2336,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Updates information about a Call.
-        https://api.slack.com/methods/calls.update
+        https://docs.slack.dev/reference/methods/calls.update
         """
         kwargs.update(
             {
@@ -2356,7 +2356,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Create Canvas for a user
-        https://api.slack.com/methods/canvases.create
+        https://docs.slack.dev/reference/methods/canvases.create
         """
         kwargs.update({"title": title, "document_content": document_content})
         return self.api_call("canvases.create", json=kwargs)
@@ -2369,7 +2369,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Update an existing canvas
-        https://api.slack.com/methods/canvases.edit
+        https://docs.slack.dev/reference/methods/canvases.edit
         """
         kwargs.update({"canvas_id": canvas_id, "changes": changes})
         return self.api_call("canvases.edit", json=kwargs)
@@ -2381,7 +2381,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Deletes a canvas
-        https://api.slack.com/methods/canvases.delete
+        https://docs.slack.dev/reference/methods/canvases.delete
         """
         kwargs.update({"canvas_id": canvas_id})
         return self.api_call("canvases.delete", params=kwargs)
@@ -2396,7 +2396,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sets the access level to a canvas for specified entities
-        https://api.slack.com/methods/canvases.access.set
+        https://docs.slack.dev/reference/methods/canvases.access.set
         """
         kwargs.update({"canvas_id": canvas_id, "access_level": access_level})
         if channel_ids is not None:
@@ -2421,7 +2421,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Create a Channel Canvas for a channel
-        https://api.slack.com/methods/canvases.access.delete
+        https://docs.slack.dev/reference/methods/canvases.access.delete
         """
         kwargs.update({"canvas_id": canvas_id})
         if channel_ids is not None:
@@ -2444,7 +2444,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Find sections matching the provided criteria
-        https://api.slack.com/methods/canvases.sections.lookup
+        https://docs.slack.dev/reference/methods/canvases.sections.lookup
         """
         kwargs.update({"canvas_id": canvas_id, "criteria": json.dumps(criteria)})
         return self.api_call("canvases.sections.lookup", params=kwargs)
@@ -2452,7 +2452,7 @@ class LegacyWebClient(LegacyBaseClient):
     # --------------------------
     # Deprecated: channels.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def channels_archive(
@@ -2631,7 +2631,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Deletes a message.
-        https://api.slack.com/methods/chat.delete
+        https://docs.slack.dev/reference/methods/chat.delete
         """
         kwargs.update({"channel": channel, "ts": ts, "as_user": as_user})
         return self.api_call("chat.delete", params=kwargs)
@@ -2645,7 +2645,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Deletes a scheduled message.
-        https://api.slack.com/methods/chat.deleteScheduledMessage
+        https://docs.slack.dev/reference/methods/chat.deleteScheduledMessage
         """
         kwargs.update(
             {
@@ -2664,7 +2664,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieve a permalink URL for a specific extant message
-        https://api.slack.com/methods/chat.getPermalink
+        https://docs.slack.dev/reference/methods/chat.getPermalink
         """
         kwargs.update({"channel": channel, "message_ts": message_ts})
         return self.api_call("chat.getPermalink", http_verb="GET", params=kwargs)
@@ -2677,7 +2677,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Share a me message into a channel.
-        https://api.slack.com/methods/chat.meMessage
+        https://docs.slack.dev/reference/methods/chat.meMessage
         """
         kwargs.update({"channel": channel, "text": text})
         return self.api_call("chat.meMessage", params=kwargs)
@@ -2701,7 +2701,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sends an ephemeral message to a user in a channel.
-        https://api.slack.com/methods/chat.postEphemeral
+        https://docs.slack.dev/reference/methods/chat.postEphemeral
         """
         kwargs.update(
             {
@@ -2750,7 +2750,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sends a message to a channel.
-        https://api.slack.com/methods/chat.postMessage
+        https://docs.slack.dev/reference/methods/chat.postMessage
         """
         kwargs.update(
             {
@@ -2800,7 +2800,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Schedules a message.
-        https://api.slack.com/methods/chat.scheduleMessage
+        https://docs.slack.dev/reference/methods/chat.scheduleMessage
         """
         kwargs.update(
             {
@@ -2841,7 +2841,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Provide custom unfurl behavior for user-posted URLs.
-        https://api.slack.com/methods/chat.unfurl
+        https://docs.slack.dev/reference/methods/chat.unfurl
         """
         kwargs.update(
             {
@@ -2879,7 +2879,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Updates a message in a channel.
-        https://api.slack.com/methods/chat.update
+        https://docs.slack.dev/reference/methods/chat.update
         """
         kwargs.update(
             {
@@ -2918,7 +2918,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists all scheduled messages.
-        https://api.slack.com/methods/chat.scheduledMessages.list
+        https://docs.slack.dev/reference/methods/chat.scheduledMessages.list
         """
         kwargs.update(
             {
@@ -2944,7 +2944,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Accepts an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.acceptSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.acceptSharedInvite
         """
         if channel_id is None and invite_id is None:
             raise e.SlackRequestError("Either channel_id or invite_id must be provided.")
@@ -2968,7 +2968,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Approves an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.approveSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.approveSharedInvite
         """
         kwargs.update({"invite_id": invite_id, "target_team": target_team})
         return self.api_call("conversations.approveSharedInvite", http_verb="POST", params=kwargs)
@@ -2980,7 +2980,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Archives a conversation.
-        https://api.slack.com/methods/conversations.archive
+        https://docs.slack.dev/reference/methods/conversations.archive
         """
         kwargs.update({"channel": channel})
         return self.api_call("conversations.archive", params=kwargs)
@@ -2992,7 +2992,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Closes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.close
+        https://docs.slack.dev/reference/methods/conversations.close
         """
         kwargs.update({"channel": channel})
         return self.api_call("conversations.close", params=kwargs)
@@ -3006,7 +3006,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Initiates a public or private channel-based conversation
-        https://api.slack.com/methods/conversations.create
+        https://docs.slack.dev/reference/methods/conversations.create
         """
         kwargs.update({"name": name, "is_private": is_private, "team_id": team_id})
         return self.api_call("conversations.create", params=kwargs)
@@ -3019,7 +3019,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Declines a Slack Connect channel invite.
-        https://api.slack.com/methods/conversations.declineSharedInvite
+        https://docs.slack.dev/reference/methods/conversations.declineSharedInvite
         """
         kwargs.update({"invite_id": invite_id, "target_team": target_team})
         return self.api_call("conversations.declineSharedInvite", http_verb="GET", params=kwargs)
@@ -3028,7 +3028,7 @@ class LegacyWebClient(LegacyBaseClient):
         self, *, action: str, channel: str, target_team: str, **kwargs
     ) -> Union[Future, SlackResponse]:
         """Sets a team in a shared External Limited channel to a shared Slack Connect channel or vice versa.
-        https://api.slack.com/methods/conversations.externalInvitePermissions.set
+        https://docs.slack.dev/reference/methods/conversations.externalInvitePermissions.set
         """
         kwargs.update(
             {
@@ -3052,7 +3052,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Fetches a conversation's history of messages and events.
-        https://api.slack.com/methods/conversations.history
+        https://docs.slack.dev/reference/methods/conversations.history
         """
         kwargs.update(
             {
@@ -3076,7 +3076,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieve information about a conversation.
-        https://api.slack.com/methods/conversations.info
+        https://docs.slack.dev/reference/methods/conversations.info
         """
         kwargs.update(
             {
@@ -3096,7 +3096,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Invites users to a channel.
-        https://api.slack.com/methods/conversations.invite
+        https://docs.slack.dev/reference/methods/conversations.invite
         """
         kwargs.update(
             {
@@ -3119,7 +3119,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sends an invitation to a Slack Connect channel.
-        https://api.slack.com/methods/conversations.inviteShared
+        https://docs.slack.dev/reference/methods/conversations.inviteShared
         """
         if emails is None and user_ids is None:
             raise e.SlackRequestError("Either emails or user ids must be provided.")
@@ -3141,7 +3141,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Joins an existing conversation.
-        https://api.slack.com/methods/conversations.join
+        https://docs.slack.dev/reference/methods/conversations.join
         """
         kwargs.update({"channel": channel})
         return self.api_call("conversations.join", params=kwargs)
@@ -3154,7 +3154,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Removes a user from a conversation.
-        https://api.slack.com/methods/conversations.kick
+        https://docs.slack.dev/reference/methods/conversations.kick
         """
         kwargs.update({"channel": channel, "user": user})
         return self.api_call("conversations.kick", params=kwargs)
@@ -3166,7 +3166,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Leaves a conversation.
-        https://api.slack.com/methods/conversations.leave
+        https://docs.slack.dev/reference/methods/conversations.leave
         """
         kwargs.update({"channel": channel})
         return self.api_call("conversations.leave", params=kwargs)
@@ -3182,7 +3182,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists all channels in a Slack team.
-        https://api.slack.com/methods/conversations.list
+        https://docs.slack.dev/reference/methods/conversations.list
         """
         kwargs.update(
             {
@@ -3208,7 +3208,7 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """List shared channel invites that have been generated
         or received but have not yet been approved by all parties.
-        https://api.slack.com/methods/conversations.listConnectInvites
+        https://docs.slack.dev/reference/methods/conversations.listConnectInvites
         """
         kwargs.update({"count": count, "cursor": cursor, "team_id": team_id})
         return self.api_call("conversations.listConnectInvites", params=kwargs)
@@ -3221,7 +3221,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sets the read cursor in a channel.
-        https://api.slack.com/methods/conversations.mark
+        https://docs.slack.dev/reference/methods/conversations.mark
         """
         kwargs.update({"channel": channel, "ts": ts})
         return self.api_call("conversations.mark", params=kwargs)
@@ -3235,7 +3235,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieve members of a conversation.
-        https://api.slack.com/methods/conversations.members
+        https://docs.slack.dev/reference/methods/conversations.members
         """
         kwargs.update({"channel": channel, "cursor": cursor, "limit": limit})
         return self.api_call("conversations.members", http_verb="GET", params=kwargs)
@@ -3249,7 +3249,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Opens or resumes a direct message or multi-person direct message.
-        https://api.slack.com/methods/conversations.open
+        https://docs.slack.dev/reference/methods/conversations.open
         """
         if channel is None and users is None:
             raise e.SlackRequestError("Either channel or users must be provided.")
@@ -3268,7 +3268,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Renames a conversation.
-        https://api.slack.com/methods/conversations.rename
+        https://docs.slack.dev/reference/methods/conversations.rename
         """
         kwargs.update({"channel": channel, "name": name})
         return self.api_call("conversations.rename", params=kwargs)
@@ -3287,7 +3287,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieve a thread of messages posted to a conversation
-        https://api.slack.com/methods/conversations.replies
+        https://docs.slack.dev/reference/methods/conversations.replies
         """
         kwargs.update(
             {
@@ -3313,7 +3313,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Approve a request to add an external user to a channel. This also sends them a Slack Connect invite.
-        https://api.slack.com/methods/conversations.requestSharedInvite.approve
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.approve
         """
         kwargs.update(
             {
@@ -3334,7 +3334,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Deny a request to invite an external user to a channel.
-        https://api.slack.com/methods/conversations.requestSharedInvite.deny
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.deny
         """
         kwargs.update({"invite_id": invite_id, "message": message})
         return self.api_call("conversations.requestSharedInvite.deny", params=kwargs)
@@ -3352,7 +3352,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists requests to add external users to channels with ability to filter.
-        https://api.slack.com/methods/conversations.requestSharedInvite.list
+        https://docs.slack.dev/reference/methods/conversations.requestSharedInvite.list
         """
         kwargs.update(
             {
@@ -3379,7 +3379,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sets the purpose for a conversation.
-        https://api.slack.com/methods/conversations.setPurpose
+        https://docs.slack.dev/reference/methods/conversations.setPurpose
         """
         kwargs.update({"channel": channel, "purpose": purpose})
         return self.api_call("conversations.setPurpose", params=kwargs)
@@ -3392,7 +3392,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Sets the topic for a conversation.
-        https://api.slack.com/methods/conversations.setTopic
+        https://docs.slack.dev/reference/methods/conversations.setTopic
         """
         kwargs.update({"channel": channel, "topic": topic})
         return self.api_call("conversations.setTopic", params=kwargs)
@@ -3404,7 +3404,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Reverses conversation archival.
-        https://api.slack.com/methods/conversations.unarchive
+        https://docs.slack.dev/reference/methods/conversations.unarchive
         """
         kwargs.update({"channel": channel})
         return self.api_call("conversations.unarchive", params=kwargs)
@@ -3417,7 +3417,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Create a Channel Canvas for a channel
-        https://api.slack.com/methods/conversations.canvases.create
+        https://docs.slack.dev/reference/methods/conversations.canvases.create
         """
         kwargs.update({"channel_id": channel_id, "document_content": document_content})
         return self.api_call("conversations.canvases.create", json=kwargs)
@@ -3430,7 +3430,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Open a dialog with a user.
-        https://api.slack.com/methods/dialog.open
+        https://docs.slack.dev/reference/methods/dialog.open
         """
         kwargs.update({"dialog": dialog, "trigger_id": trigger_id})
         kwargs = _remove_none_values(kwargs)
@@ -3442,7 +3442,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Ends the current user's Do Not Disturb session immediately.
-        https://api.slack.com/methods/dnd.endDnd
+        https://docs.slack.dev/reference/methods/dnd.endDnd
         """
         return self.api_call("dnd.endDnd", params=kwargs)
 
@@ -3451,7 +3451,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Ends the current user's snooze mode immediately.
-        https://api.slack.com/methods/dnd.endSnooze
+        https://docs.slack.dev/reference/methods/dnd.endSnooze
         """
         return self.api_call("dnd.endSnooze", params=kwargs)
 
@@ -3463,7 +3463,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieves a user's current Do Not Disturb status.
-        https://api.slack.com/methods/dnd.info
+        https://docs.slack.dev/reference/methods/dnd.info
         """
         kwargs.update({"team_id": team_id, "user": user})
         return self.api_call("dnd.info", http_verb="GET", params=kwargs)
@@ -3475,7 +3475,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Turns on Do Not Disturb mode for the current user, or changes its duration.
-        https://api.slack.com/methods/dnd.setSnooze
+        https://docs.slack.dev/reference/methods/dnd.setSnooze
         """
         kwargs.update({"num_minutes": num_minutes})
         return self.api_call("dnd.setSnooze", http_verb="GET", params=kwargs)
@@ -3487,7 +3487,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieves the Do Not Disturb status for users on a team.
-        https://api.slack.com/methods/dnd.teamInfo
+        https://docs.slack.dev/reference/methods/dnd.teamInfo
         """
         if isinstance(users, (list, tuple)):
             kwargs.update({"users": ",".join(users)})
@@ -3502,7 +3502,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists custom emoji for a team.
-        https://api.slack.com/methods/emoji.list
+        https://docs.slack.dev/reference/methods/emoji.list
         """
         kwargs.update({"include_categories": include_categories})
         return self.api_call("emoji.list", http_verb="GET", params=kwargs)
@@ -3515,7 +3515,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Deletes an existing comment on a file.
-        https://api.slack.com/methods/files.comments.delete
+        https://docs.slack.dev/reference/methods/files.comments.delete
         """
         kwargs.update({"file": file, "id": id})
         return self.api_call("files.comments.delete", params=kwargs)
@@ -3527,7 +3527,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Deletes a file.
-        https://api.slack.com/methods/files.delete
+        https://docs.slack.dev/reference/methods/files.delete
         """
         kwargs.update({"file": file})
         return self.api_call("files.delete", params=kwargs)
@@ -3543,7 +3543,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets information about a team file.
-        https://api.slack.com/methods/files.info
+        https://docs.slack.dev/reference/methods/files.info
         """
         kwargs.update(
             {
@@ -3571,7 +3571,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists & filters team files.
-        https://api.slack.com/methods/files.list
+        https://docs.slack.dev/reference/methods/files.list
         """
         kwargs.update(
             {
@@ -3599,7 +3599,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.info
+        https://docs.slack.dev/reference/methods/files.remote.info
         """
         kwargs.update({"external_id": external_id, "file": file})
         return self.api_call("files.remote.info", http_verb="GET", params=kwargs)
@@ -3615,7 +3615,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieve information about a remote file added to Slack.
-        https://api.slack.com/methods/files.remote.list
+        https://docs.slack.dev/reference/methods/files.remote.list
         """
         kwargs.update(
             {
@@ -3640,7 +3640,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Adds a file from a remote service.
-        https://api.slack.com/methods/files.remote.add
+        https://docs.slack.dev/reference/methods/files.remote.add
         """
         kwargs.update(
             {
@@ -3679,7 +3679,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Updates an existing remote file.
-        https://api.slack.com/methods/files.remote.update
+        https://docs.slack.dev/reference/methods/files.remote.update
         """
         kwargs.update(
             {
@@ -3714,7 +3714,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Remove a remote file.
-        https://api.slack.com/methods/files.remote.remove
+        https://docs.slack.dev/reference/methods/files.remote.remove
         """
         kwargs.update({"external_id": external_id, "file": file})
         return self.api_call("files.remote.remove", http_verb="POST", params=kwargs)
@@ -3728,7 +3728,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Share a remote file into a channel.
-        https://api.slack.com/methods/files.remote.share
+        https://docs.slack.dev/reference/methods/files.remote.share
         """
         if external_id is None and file is None:
             raise e.SlackRequestError("Either external_id or file must be provided.")
@@ -3746,7 +3746,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Revokes public/external sharing access for a file
-        https://api.slack.com/methods/files.revokePublicURL
+        https://docs.slack.dev/reference/methods/files.revokePublicURL
         """
         kwargs.update({"file": file})
         return self.api_call("files.revokePublicURL", params=kwargs)
@@ -3758,7 +3758,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Enables a file for public/external sharing.
-        https://api.slack.com/methods/files.sharedPublicURL
+        https://docs.slack.dev/reference/methods/files.sharedPublicURL
         """
         kwargs.update({"file": file})
         return self.api_call("files.sharedPublicURL", params=kwargs)
@@ -3777,7 +3777,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Uploads or creates a file.
-        https://api.slack.com/methods/files.upload
+        https://docs.slack.dev/reference/methods/files.upload
         """
         _print_files_upload_v2_suggestion()
 
@@ -3830,12 +3830,12 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """This wrapper method provides an easy way to upload files using the following endpoints:
 
-        - step1: https://api.slack.com/methods/files.getUploadURLExternal
+        - step1: https://docs.slack.dev/reference/methods/files.getUploadURLExternal
 
         - step2: "https://files.slack.com/upload/v1/..." URLs returned from files.getUploadURLExternal API
 
-        - step3: https://api.slack.com/methods/files.completeUploadExternal
-            and https://api.slack.com/methods/files.info
+        - step3: https://docs.slack.dev/reference/methods/files.completeUploadExternal
+            and https://docs.slack.dev/reference/methods/files.info
 
         """
         if file is None and content is None and file_uploads is None:
@@ -3921,7 +3921,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets a URL for an edge external upload.
-        https://api.slack.com/methods/files.getUploadURLExternal
+        https://docs.slack.dev/reference/methods/files.getUploadURLExternal
         """
         kwargs.update(
             {
@@ -3944,7 +3944,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Finishes an upload started with files.getUploadURLExternal.
-        https://api.slack.com/methods/files.completeUploadExternal
+        https://docs.slack.dev/reference/methods/files.completeUploadExternal
         """
         _files = [{k: v for k, v in f.items() if v is not None} for f in files]
         kwargs.update(
@@ -3967,7 +3967,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Signal the successful completion of a function
-        https://api.slack.com/methods/functions.completeSuccess
+        https://docs.slack.dev/reference/methods/functions.completeSuccess
         """
         kwargs.update({"function_execution_id": function_execution_id, "outputs": json.dumps(outputs)})
         return self.api_call("functions.completeSuccess", params=kwargs)
@@ -3980,7 +3980,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Signal the failure to execute a function
-        https://api.slack.com/methods/functions.completeError
+        https://docs.slack.dev/reference/methods/functions.completeError
         """
         kwargs.update({"function_execution_id": function_execution_id, "error": error})
         return self.api_call("functions.completeError", params=kwargs)
@@ -3988,7 +3988,7 @@ class LegacyWebClient(LegacyBaseClient):
     # --------------------------
     # Deprecated: groups.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def groups_archive(
@@ -4169,7 +4169,7 @@ class LegacyWebClient(LegacyBaseClient):
     # --------------------------
     # Deprecated: im.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def im_close(
@@ -4245,7 +4245,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """For Enterprise Grid workspaces, map local user IDs to global user IDs
-        https://api.slack.com/methods/migration.exchange
+        https://docs.slack.dev/reference/methods/migration.exchange
         """
         if isinstance(users, (list, tuple)):
             kwargs.update({"users": ",".join(users)})
@@ -4257,7 +4257,7 @@ class LegacyWebClient(LegacyBaseClient):
     # --------------------------
     # Deprecated: mpim.*
     # You can use conversations.* APIs instead.
-    # https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
+    # https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
     # --------------------------
 
     def mpim_close(
@@ -4344,7 +4344,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.v2.access
+        https://docs.slack.dev/reference/methods/oauth.v2.access
         """
         if redirect_uri is not None:
             kwargs.update({"redirect_uri": redirect_uri})
@@ -4370,7 +4370,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Exchanges a temporary OAuth verifier code for an access token.
-        https://api.slack.com/methods/oauth.access
+        https://docs.slack.dev/reference/methods/oauth.access
         """
         if redirect_uri is not None:
             kwargs.update({"redirect_uri": redirect_uri})
@@ -4390,7 +4390,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Exchanges a legacy access token for a new expiring access token and refresh token
-        https://api.slack.com/methods/oauth.v2.exchange
+        https://docs.slack.dev/reference/methods/oauth.v2.exchange
         """
         kwargs.update({"client_id": client_id, "client_secret": client_secret, "token": token})
         return self.api_call("oauth.v2.exchange", params=kwargs)
@@ -4406,7 +4406,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.token
+        https://docs.slack.dev/reference/methods/openid.connect.token
         """
         if redirect_uri is not None:
             kwargs.update({"redirect_uri": redirect_uri})
@@ -4427,7 +4427,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Get the identity of a user who has authorized Sign in with Slack.
-        https://api.slack.com/methods/openid.connect.userInfo
+        https://docs.slack.dev/reference/methods/openid.connect.userInfo
         """
         return self.api_call("openid.connect.userInfo", params=kwargs)
 
@@ -4439,7 +4439,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Pins an item to a channel.
-        https://api.slack.com/methods/pins.add
+        https://docs.slack.dev/reference/methods/pins.add
         """
         kwargs.update({"channel": channel, "timestamp": timestamp})
         return self.api_call("pins.add", params=kwargs)
@@ -4451,7 +4451,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists items pinned to a channel.
-        https://api.slack.com/methods/pins.list
+        https://docs.slack.dev/reference/methods/pins.list
         """
         kwargs.update({"channel": channel})
         return self.api_call("pins.list", http_verb="GET", params=kwargs)
@@ -4464,7 +4464,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Un-pins an item from a channel.
-        https://api.slack.com/methods/pins.remove
+        https://docs.slack.dev/reference/methods/pins.remove
         """
         kwargs.update({"channel": channel, "timestamp": timestamp})
         return self.api_call("pins.remove", params=kwargs)
@@ -4478,7 +4478,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Adds a reaction to an item.
-        https://api.slack.com/methods/reactions.add
+        https://docs.slack.dev/reference/methods/reactions.add
         """
         kwargs.update({"channel": channel, "name": name, "timestamp": timestamp})
         return self.api_call("reactions.add", params=kwargs)
@@ -4494,7 +4494,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets reactions for an item.
-        https://api.slack.com/methods/reactions.get
+        https://docs.slack.dev/reference/methods/reactions.get
         """
         kwargs.update(
             {
@@ -4520,7 +4520,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists reactions made by a user.
-        https://api.slack.com/methods/reactions.list
+        https://docs.slack.dev/reference/methods/reactions.list
         """
         kwargs.update(
             {
@@ -4546,7 +4546,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Removes a reaction from an item.
-        https://api.slack.com/methods/reactions.remove
+        https://docs.slack.dev/reference/methods/reactions.remove
         """
         kwargs.update(
             {
@@ -4570,7 +4570,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Creates a reminder.
-        https://api.slack.com/methods/reminders.add
+        https://docs.slack.dev/reference/methods/reminders.add
         """
         kwargs.update(
             {
@@ -4591,7 +4591,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Marks a reminder as complete.
-        https://api.slack.com/methods/reminders.complete
+        https://docs.slack.dev/reference/methods/reminders.complete
         """
         kwargs.update({"reminder": reminder, "team_id": team_id})
         return self.api_call("reminders.complete", params=kwargs)
@@ -4604,7 +4604,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Deletes a reminder.
-        https://api.slack.com/methods/reminders.delete
+        https://docs.slack.dev/reference/methods/reminders.delete
         """
         kwargs.update({"reminder": reminder, "team_id": team_id})
         return self.api_call("reminders.delete", params=kwargs)
@@ -4617,7 +4617,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets information about a reminder.
-        https://api.slack.com/methods/reminders.info
+        https://docs.slack.dev/reference/methods/reminders.info
         """
         kwargs.update({"reminder": reminder, "team_id": team_id})
         return self.api_call("reminders.info", http_verb="GET", params=kwargs)
@@ -4629,7 +4629,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists all reminders created by or for a given user.
-        https://api.slack.com/methods/reminders.list
+        https://docs.slack.dev/reference/methods/reminders.list
         """
         kwargs.update({"team_id": team_id})
         return self.api_call("reminders.list", http_verb="GET", params=kwargs)
@@ -4642,7 +4642,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.connect
+        https://docs.slack.dev/reference/methods/rtm.connect
         """
         kwargs.update({"batch_presence_aware": batch_presence_aware, "presence_sub": presence_sub})
         return self.api_call("rtm.connect", http_verb="GET", params=kwargs)
@@ -4660,7 +4660,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Starts a Real Time Messaging session.
-        https://api.slack.com/methods/rtm.start
+        https://docs.slack.dev/reference/methods/rtm.start
         """
         kwargs.update(
             {
@@ -4688,7 +4688,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Searches for messages and files matching a query.
-        https://api.slack.com/methods/search.all
+        https://docs.slack.dev/reference/methods/search.all
         """
         kwargs.update(
             {
@@ -4716,7 +4716,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Searches for files matching a query.
-        https://api.slack.com/methods/search.files
+        https://docs.slack.dev/reference/methods/search.files
         """
         kwargs.update(
             {
@@ -4745,7 +4745,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Searches for messages matching a query.
-        https://api.slack.com/methods/search.messages
+        https://docs.slack.dev/reference/methods/search.messages
         """
         kwargs.update(
             {
@@ -4771,7 +4771,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Adds a star to an item.
-        https://api.slack.com/methods/stars.add
+        https://docs.slack.dev/reference/methods/stars.add
         """
         kwargs.update(
             {
@@ -4794,7 +4794,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists stars for a user.
-        https://api.slack.com/methods/stars.list
+        https://docs.slack.dev/reference/methods/stars.list
         """
         kwargs.update(
             {
@@ -4817,7 +4817,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Removes a star from an item.
-        https://api.slack.com/methods/stars.remove
+        https://docs.slack.dev/reference/methods/stars.remove
         """
         kwargs.update(
             {
@@ -4841,7 +4841,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets the access logs for the current team.
-        https://api.slack.com/methods/team.accessLogs
+        https://docs.slack.dev/reference/methods/team.accessLogs
         """
         kwargs.update(
             {
@@ -4863,7 +4863,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets billable users information for the current team.
-        https://api.slack.com/methods/team.billableInfo
+        https://docs.slack.dev/reference/methods/team.billableInfo
         """
         kwargs.update({"team_id": team_id, "user": user})
         return self.api_call("team.billableInfo", http_verb="GET", params=kwargs)
@@ -4873,7 +4873,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Reads a workspace's billing plan information.
-        https://api.slack.com/methods/team.billing.info
+        https://docs.slack.dev/reference/methods/team.billing.info
         """
         return self.api_call("team.billing.info", params=kwargs)
 
@@ -4884,7 +4884,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Disconnects an external organization.
-        https://api.slack.com/methods/team.externalTeams.disconnect
+        https://docs.slack.dev/reference/methods/team.externalTeams.disconnect
         """
         kwargs.update(
             {
@@ -4906,7 +4906,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Returns a list of all the external teams connected and details about the connection.
-        https://api.slack.com/methods/team.externalTeams.list
+        https://docs.slack.dev/reference/methods/team.externalTeams.list
         """
         kwargs.update(
             {
@@ -4937,7 +4937,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets information about the current team.
-        https://api.slack.com/methods/team.info
+        https://docs.slack.dev/reference/methods/team.info
         """
         kwargs.update({"team": team, "domain": domain})
         return self.api_call("team.info", http_verb="GET", params=kwargs)
@@ -4955,7 +4955,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets the integration logs for the current team.
-        https://api.slack.com/methods/team.integrationLogs
+        https://docs.slack.dev/reference/methods/team.integrationLogs
         """
         kwargs.update(
             {
@@ -4977,7 +4977,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieve a team's profile.
-        https://api.slack.com/methods/team.profile.get
+        https://docs.slack.dev/reference/methods/team.profile.get
         """
         kwargs.update({"visibility": visibility})
         return self.api_call("team.profile.get", http_verb="GET", params=kwargs)
@@ -4987,7 +4987,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieve a list of a workspace's team preferences.
-        https://api.slack.com/methods/team.preferences.list
+        https://docs.slack.dev/reference/methods/team.preferences.list
         """
         return self.api_call("team.preferences.list", params=kwargs)
 
@@ -5003,7 +5003,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Create a User Group
-        https://api.slack.com/methods/usergroups.create
+        https://docs.slack.dev/reference/methods/usergroups.create
         """
         kwargs.update(
             {
@@ -5029,7 +5029,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Disable an existing User Group
-        https://api.slack.com/methods/usergroups.disable
+        https://docs.slack.dev/reference/methods/usergroups.disable
         """
         kwargs.update({"usergroup": usergroup, "include_count": include_count, "team_id": team_id})
         return self.api_call("usergroups.disable", params=kwargs)
@@ -5043,7 +5043,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Enable a User Group
-        https://api.slack.com/methods/usergroups.enable
+        https://docs.slack.dev/reference/methods/usergroups.enable
         """
         kwargs.update({"usergroup": usergroup, "include_count": include_count, "team_id": team_id})
         return self.api_call("usergroups.enable", params=kwargs)
@@ -5058,7 +5058,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List all User Groups for a team
-        https://api.slack.com/methods/usergroups.list
+        https://docs.slack.dev/reference/methods/usergroups.list
         """
         kwargs.update(
             {
@@ -5083,7 +5083,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Update an existing User Group
-        https://api.slack.com/methods/usergroups.update
+        https://docs.slack.dev/reference/methods/usergroups.update
         """
         kwargs.update(
             {
@@ -5110,7 +5110,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List all users in a User Group
-        https://api.slack.com/methods/usergroups.users.list
+        https://docs.slack.dev/reference/methods/usergroups.users.list
         """
         kwargs.update(
             {
@@ -5131,7 +5131,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Update the list of users for a User Group
-        https://api.slack.com/methods/usergroups.users.update
+        https://docs.slack.dev/reference/methods/usergroups.users.update
         """
         kwargs.update(
             {
@@ -5158,7 +5158,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List conversations the calling user may access.
-        https://api.slack.com/methods/users.conversations
+        https://docs.slack.dev/reference/methods/users.conversations
         """
         kwargs.update(
             {
@@ -5180,7 +5180,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Delete the user profile photo
-        https://api.slack.com/methods/users.deletePhoto
+        https://docs.slack.dev/reference/methods/users.deletePhoto
         """
         return self.api_call("users.deletePhoto", http_verb="GET", params=kwargs)
 
@@ -5191,7 +5191,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets user presence information.
-        https://api.slack.com/methods/users.getPresence
+        https://docs.slack.dev/reference/methods/users.getPresence
         """
         kwargs.update({"user": user})
         return self.api_call("users.getPresence", http_verb="GET", params=kwargs)
@@ -5201,7 +5201,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Get a user's identity.
-        https://api.slack.com/methods/users.identity
+        https://docs.slack.dev/reference/methods/users.identity
         """
         return self.api_call("users.identity", http_verb="GET", params=kwargs)
 
@@ -5213,7 +5213,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Gets information about a user.
-        https://api.slack.com/methods/users.info
+        https://docs.slack.dev/reference/methods/users.info
         """
         kwargs.update({"user": user, "include_locale": include_locale})
         return self.api_call("users.info", http_verb="GET", params=kwargs)
@@ -5228,7 +5228,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lists all users in a Slack team.
-        https://api.slack.com/methods/users.list
+        https://docs.slack.dev/reference/methods/users.list
         """
         kwargs.update(
             {
@@ -5247,7 +5247,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Find a user with an email address.
-        https://api.slack.com/methods/users.lookupByEmail
+        https://docs.slack.dev/reference/methods/users.lookupByEmail
         """
         kwargs.update({"email": email})
         return self.api_call("users.lookupByEmail", http_verb="GET", params=kwargs)
@@ -5262,7 +5262,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set the user profile photo
-        https://api.slack.com/methods/users.setPhoto
+        https://docs.slack.dev/reference/methods/users.setPhoto
         """
         kwargs.update({"crop_w": crop_w, "crop_x": crop_x, "crop_y": crop_y})
         return self.api_call("users.setPhoto", files={"image": image}, data=kwargs)
@@ -5274,7 +5274,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Manually sets user presence.
-        https://api.slack.com/methods/users.setPresence
+        https://docs.slack.dev/reference/methods/users.setPresence
         """
         kwargs.update({"presence": presence})
         return self.api_call("users.setPresence", params=kwargs)
@@ -5285,7 +5285,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Lookup an email address to see if someone is on Slack
-        https://api.slack.com/methods/users.discoverableContacts.lookup
+        https://docs.slack.dev/reference/methods/users.discoverableContacts.lookup
         """
         kwargs.update({"email": email})
         return self.api_call("users.discoverableContacts.lookup", params=kwargs)
@@ -5298,7 +5298,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Retrieves a user's profile information.
-        https://api.slack.com/methods/users.profile.get
+        https://docs.slack.dev/reference/methods/users.profile.get
         """
         kwargs.update({"user": user, "include_labels": include_labels})
         return self.api_call("users.profile.get", http_verb="GET", params=kwargs)
@@ -5313,7 +5313,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set the profile information for a user.
-        https://api.slack.com/methods/users.profile.set
+        https://docs.slack.dev/reference/methods/users.profile.set
         """
         kwargs.update(
             {
@@ -5336,8 +5336,8 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Open a view for a user.
-        https://api.slack.com/methods/views.open
-        See https://api.slack.com/surfaces/modals for details.
+        https://docs.slack.dev/reference/methods/views.open
+        See https://docs.slack.dev/surfaces/modals/ for details.
         """
         kwargs.update({"trigger_id": trigger_id, "interactivity_pointer": interactivity_pointer})
         if isinstance(view, View):
@@ -5360,9 +5360,9 @@ class LegacyWebClient(LegacyBaseClient):
         Push a new view onto the existing view stack by passing a view
         payload and a valid trigger_id generated from an interaction
         within the existing modal.
-        Read the modals documentation (https://api.slack.com/surfaces/modals)
+        Read the modals documentation (https://docs.slack.dev/surfaces/modals/)
         to learn more about the lifecycle and intricacies of views.
-        https://api.slack.com/methods/views.push
+        https://docs.slack.dev/reference/methods/views.push
         """
         kwargs.update({"trigger_id": trigger_id, "interactivity_pointer": interactivity_pointer})
         if isinstance(view, View):
@@ -5385,9 +5385,9 @@ class LegacyWebClient(LegacyBaseClient):
         """Update an existing view.
         Update a view by passing a new view definition along with the
         view_id returned in views.open or the external_id.
-        See the modals documentation (https://api.slack.com/surfaces/modals#updating_views)
+        See the modals documentation (https://docs.slack.dev/surfaces/modals/#updating_views)
         to learn more about updating views and avoiding race conditions with the hash argument.
-        https://api.slack.com/methods/views.update
+        https://docs.slack.dev/reference/methods/views.update
         """
         if isinstance(view, View):
             kwargs.update({"view": view.to_dict()})
@@ -5414,8 +5414,8 @@ class LegacyWebClient(LegacyBaseClient):
     ) -> Union[Future, SlackResponse]:
         """Publish a static view for a User.
         Create or update the view that comprises an
-        app's Home tab (https://api.slack.com/surfaces/tabs)
-        https://api.slack.com/methods/views.publish
+        app's Home tab (https://docs.slack.dev/surfaces/app-home/)
+        https://docs.slack.dev/reference/methods/views.publish
         """
         kwargs.update({"user_id": user_id, "hash": hash})
         if isinstance(view, View):
@@ -5434,7 +5434,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Add featured workflows to a channel.
-        https://api.slack.com/methods/workflows.featured.add
+        https://docs.slack.dev/reference/methods/workflows.featured.add
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(trigger_ids, (list, tuple)):
@@ -5450,7 +5450,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """List the featured workflows for specified channels.
-        https://api.slack.com/methods/workflows.featured.list
+        https://docs.slack.dev/reference/methods/workflows.featured.list
         """
         if isinstance(channel_ids, (list, tuple)):
             kwargs.update({"channel_ids": ",".join(channel_ids)})
@@ -5466,7 +5466,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Remove featured workflows from a channel.
-        https://api.slack.com/methods/workflows.featured.remove
+        https://docs.slack.dev/reference/methods/workflows.featured.remove
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(trigger_ids, (list, tuple)):
@@ -5483,7 +5483,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set featured workflows for a channel.
-        https://api.slack.com/methods/workflows.featured.set
+        https://docs.slack.dev/reference/methods/workflows.featured.set
         """
         kwargs.update({"channel_id": channel_id})
         if isinstance(trigger_ids, (list, tuple)):
@@ -5500,7 +5500,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Indicate a successful outcome of a workflow step's execution.
-        https://api.slack.com/methods/workflows.stepCompleted
+        https://docs.slack.dev/reference/methods/workflows.stepCompleted
         """
         kwargs.update({"workflow_step_execute_id": workflow_step_execute_id})
         if outputs is not None:
@@ -5517,7 +5517,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Indicate an unsuccessful outcome of a workflow step's execution.
-        https://api.slack.com/methods/workflows.stepFailed
+        https://docs.slack.dev/reference/methods/workflows.stepFailed
         """
         kwargs.update(
             {
@@ -5538,7 +5538,7 @@ class LegacyWebClient(LegacyBaseClient):
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Update the configuration for a workflow extension step.
-        https://api.slack.com/methods/workflows.updateStep
+        https://docs.slack.dev/reference/methods/workflows.updateStep
         """
         kwargs.update({"workflow_step_edit_id": workflow_step_edit_id})
         if inputs is not None:

--- a/slack_sdk/webhook/async_client.py
+++ b/slack_sdk/webhook/async_client.py
@@ -53,7 +53,7 @@ class AsyncWebhookClient:
     ):
         """API client for Incoming Webhooks and `response_url`
 
-        https://api.slack.com/messaging/webhooks
+        https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/
 
         Args:
             url: Complete URL to send data (e.g., `https://hooks.slack.com/XXX`)

--- a/slack_sdk/webhook/client.py
+++ b/slack_sdk/webhook/client.py
@@ -48,7 +48,7 @@ class WebhookClient:
     ):
         """API client for Incoming Webhooks and `response_url`
 
-        https://api.slack.com/messaging/webhooks
+        https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/
 
         Args:
             url: Complete URL to send data (e.g., `https://hooks.slack.com/XXX`)

--- a/tests/signature/test_signature_verifier.py
+++ b/tests/signature/test_signature_verifier.py
@@ -15,7 +15,7 @@ class TestSignatureVerifier(unittest.TestCase):
     def tearDown(self):
         pass
 
-    # https://api.slack.com/authentication/verifying-requests-from-slack
+    # https://docs.slack.dev/authentication/verifying-requests-from-slack/
     signing_secret = "8f742231b10e8888abcd99yyyzzz85a5"
 
     body = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -34,7 +34,7 @@ from slack_sdk.models.blocks.basic_components import SlackFile
 
 from . import STRING_3001_CHARS
 
-# https://api.slack.com/reference/block-kit/blocks
+# https://docs.slack.dev/reference/block-kit/blocks
 
 
 class BlockTests(unittest.TestCase):

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -112,7 +112,7 @@ class ButtonElementTests(unittest.TestCase):
         input = {
             "type": "button",
             "text": {"type": "plain_text", "text": "Link Button"},
-            "url": "https://api.slack.com/block-kit",
+            "url": "https://docs.slack.dev/block-kit/",
         }
         self.assertDictEqual(input, ButtonElement(**input).to_dict())
         self.assertDictEqual(input, LinkButtonElement(**input).to_dict())
@@ -1039,7 +1039,7 @@ class OverflowMenuElementTests(unittest.TestCase):
                 },
                 {
                     "text": {"type": "plain_text", "text": "*this is plain_text text*"},
-                    # https://api.slack.com/reference/block-kit/composition-objects#option
+                    # https://docs.slack.dev/reference/block-kit/composition-objects/option-object
                     "url": "https://www.example.com",
                 },
             ],

--- a/tests/slack_sdk/signature/test_signature_verifier.py
+++ b/tests/slack_sdk/signature/test_signature_verifier.py
@@ -15,7 +15,7 @@ class TestSignatureVerifier(unittest.TestCase):
     def tearDown(self):
         pass
 
-    # https://api.slack.com/authentication/verifying-requests-from-slack
+    # https://docs.slack.dev/authentication/verifying-requests-from-slack/
     signing_secret = "8f742231b10e8888abcd99yyyzzz85a5"
 
     body = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"

--- a/tests/web/classes/test_blocks.py
+++ b/tests/web/classes/test_blocks.py
@@ -19,7 +19,7 @@ from slack.web.classes.objects import PlainTextObject, MarkdownTextObject
 from . import STRING_3001_CHARS
 
 
-# https://api.slack.com/reference/block-kit/blocks
+# https://docs.slack.dev/reference/block-kit/blocks
 
 
 class BlockTests(unittest.TestCase):

--- a/tests/web/classes/test_elements.py
+++ b/tests/web/classes/test_elements.py
@@ -60,7 +60,7 @@ class ButtonElementTests(unittest.TestCase):
         input = {
             "type": "button",
             "text": {"type": "plain_text", "text": "Link Button"},
-            "url": "https://api.slack.com/block-kit",
+            "url": "https://docs.slack.dev/block-kit/",
         }
         self.assertDictEqual(input, ButtonElement(**input).to_dict())
         self.assertDictEqual(input, LinkButtonElement(**input).to_dict())
@@ -635,7 +635,7 @@ class OverflowMenuElementTests(unittest.TestCase):
                 },
                 {
                     "text": {"type": "plain_text", "text": "*this is plain_text text*"},
-                    # https://api.slack.com/reference/block-kit/composition-objects#option
+                    # https://docs.slack.dev/reference/block-kit/composition-objects/option-object
                     "url": "https://www.example.com",
                 },
             ],

--- a/tutorial/01-creating-the-slack-app.md
+++ b/tutorial/01-creating-the-slack-app.md
@@ -9,7 +9,7 @@
 
 ### Give your app permissions
 
-[Scopes](https://api.slack.com/scopes) give your app permission to do things (for example, post messages) in your development workspace.
+[Scopes](https://docs.slack.dev/reference/scopes) give your app permission to do things (for example, post messages) in your development workspace.
 
 - Navigate to **OAuth & Permissions** on the sidebar to add scopes to your app
 
@@ -19,8 +19,8 @@
 
 For now, we'll only use one scope.
 
-- Add the [`chat:write` scope](https://api.slack.com/scopes/chat:write) to grant your app the permission to post messages in channels it's a member of.
-- Add the [`im:write` scope](https://api.slack.com/scopes/im:write) to grant your app the permission to post messages in DMs.
+- Add the [`chat:write` scope](https://docs.slack.dev/reference/scopes/chat.write/) to grant your app the permission to post messages in channels it's a member of.
+- Add the [`im:write` scope](https://docs.slack.dev/reference/scopes/im.write/) to grant your app the permission to post messages in DMs.
 
 🎉 You should briefly see a success banner.
 

--- a/tutorial/02-building-a-message.md
+++ b/tutorial/02-building-a-message.md
@@ -2,7 +2,7 @@
 
 The code for this step is available [here](PythOnBoardingBot/onboarding_tutorial.py).
 
-> 💡 **[Block Kit](https://api.slack.com/block-kit)** is a UI framework for Slack apps that offers a balance of control and flexibility when building experiences in messages and other surfaces. Customize the order and appearance of information and guide users through your app's capabilities by composing, updating, sequencing, and stacking blocks — reusable components that work almost everywhere in Slack. You can experiment and prototype with Block Kit using the [Block Kit Builder](https://api.slack.com/tools/block-kit-builder).
+> 💡 **[Block Kit](https://docs.slack.dev/block-kit/)** is a UI framework for Slack apps that offers a balance of control and flexibility when building experiences in messages and other surfaces. Customize the order and appearance of information and guide users through your app's capabilities by composing, updating, sequencing, and stacking blocks — reusable components that work almost everywhere in Slack. You can experiment and prototype with Block Kit using the [Block Kit Builder](https://api.slack.com/tools/block-kit-builder).
 
 We're going to be using Block Kit to build our onboarding tutorial messages.
 

--- a/tutorial/03-responding-to-slack-events.md
+++ b/tutorial/03-responding-to-slack-events.md
@@ -81,7 +81,7 @@ def start_onboarding(user_id: str, channel: str, client: WebClient):
 
 ### Responding to events in Slack
 
-When events occur in Slack there are two primary ways to be notified about them. We can send you an [HTTP Request through our Events API](https://api.slack.com/apis/connections/events-api), or you can stream events through a WebSocket connection with our [Socket Mode](https://api.slack.com/apis/connections/socket) API. If you're behind a firewall and cannot receive incoming web requests from Slack, we recommend going with Socket Mode.
+When events occur in Slack there are two primary ways to be notified about them. We can send you an [HTTP Request through our Events API](https://docs.slack.dev/apis/events-api/), or you can stream events through a WebSocket connection with our [Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode/) API. If you're behind a firewall and cannot receive incoming web requests from Slack, we recommend going with Socket Mode.
 
 In this tutorial we'll be using the Events API and the [Bolt for Python](https://github.com/slackapi/bolt-python).
 
@@ -96,7 +96,7 @@ Back to our application, it's time to link our onboarding functionality to Slack
 
 # Note: Bolt provides a WebClient instance as an argument to the listener function
 # we've defined here, which we then use to access Slack Web API methods like conversations_open.
-# For more info, checkout: https://slack.dev/bolt-python/concepts#message-listening
+# For more info, checkout: https://docs.slack.dev/tools/bolt-python/concepts/message-listening
 @app.event("team_join")
 def onboarding_message(event, client):
     """Create and send an onboarding welcome message to new users. Save the

--- a/tutorial/PythOnBoardingBot/app.py
+++ b/tutorial/PythOnBoardingBot/app.py
@@ -38,7 +38,7 @@ def start_onboarding(user_id: str, channel: str, client: WebClient):
 
 # Note: Bolt provides a WebClient instance as an argument to the listener function
 # we've defined here, which we then use to access Slack Web API methods like conversations_open.
-# For more info, checkout: https://slack.dev/bolt-python/concepts#message-listening
+# For more info, checkout: https://docs.slack.dev/tools/bolt-python/concepts/message-listening
 @app.event("team_join")
 def onboarding_message(event, client):
     """Create and send an onboarding welcome message to new users. Save the


### PR DESCRIPTION
## Summary

This PR replaces links from "api.slack.com" to "docs.slack.dev" redirects for the most current inline reference.

### Reviewers

Open each link! Or trust these replacements and a find and replacement:

<details>
<summary>Replacements</summary>

Note: This should be parsed from the bottom, ignoring lines without a substitute!

```
original_url,redirect_url
https://api.slack.com
https://api.slack.com/admins/audit-logs,https://docs.slack.dev/admins/audit-logs-api/
https://api.slack.com/admins/scim,https://docs.slack.dev/admins/scim-api/
https://api.slack.com/apis/connect,https://docs.slack.dev/apis/slack-connect/
https://api.slack.com/apis/connections/events-api,https://docs.slack.dev/apis/events-api/
https://api.slack.com/apis/connections/socket,https://docs.slack.dev/apis/events-api/using-socket-mode/
https://api.slack.com/apps
https://api.slack.com/apps?new_classic_app=1
https://api.slack.com/apps?new_granular_bot_app=1
https://api.slack.com/apps/new
https://api.slack.com/audit/v1/
https://api.slack.com/authentication/oauth-v2,https://docs.slack.dev/authentication/installing-with-oauth/
https://api.slack.com/authentication/verifying-requests-from-slack,https://docs.slack.dev/authentication/verifying-requests-from-slack/
https://api.slack.com/block-kit,https://docs.slack.dev/block-kit/
https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api,https://docs.slack.dev/changelog/2020-01-deprecating-antecedents-to-the-conversations-api/
https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders,https://docs.slack.dev/changelog/2023-07-its-later-already-for-stars-and-reminders/
https://api.slack.com/changelog/2023-08-workflow-steps-from-apps-step-back,https://docs.slack.dev/changelog/2023-08-workflow-steps-from-apps-step-back/
https://api.slack.com/dialogs#attributes_select_elements,https://docs.slack.dev/legacy/legacy-dialogs/#attributes_select_elements
https://api.slack.com/dialogs#attributes_text_elements,https://docs.slack.dev/legacy/legacy-dialogs/#attributes_text_elements
https://api.slack.com/dialogs#attributes_textarea_elements,https://docs.slack.dev/legacy/legacy-dialogs/#attributes_textarea_elements
https://api.slack.com/dialogs#dynamic_select_elements_channels_conversations,https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_channels_conversations
https://api.slack.com/dialogs#dynamic_select_elements_external,https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_external
https://api.slack.com/dialogs#dynamic_select_elements_users,https://docs.slack.dev/legacy/legacy-dialogs/#dynamic_select_elements_users
https://api.slack.com/dialogs#select_elements,https://docs.slack.dev/legacy/legacy-dialogs/#select_elements
https://api.slack.com/dialogs#text_elements,https://docs.slack.dev/legacy/legacy-dialogs/#text_elements
https://api.slack.com/dialogs#textarea_elements,https://docs.slack.dev/legacy/legacy-dialogs/#textarea_elements
https://api.slack.com/docs/message-menus,https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/
https://api.slack.com/docs/verifying-requests-from-slack#how_to_make_a_request_signature_in_4_easy_steps__an_overview,https://docs.slack.dev/authentication/verifying-requests-from-slack/#how_to_make_a_request_signature_in_4_easy_steps__an_overview
https://api.slack.com/events-api,https://docs.slack.dev/apis/events-api/
https://api.slack.com/img/blocks/bkb_template_images/beagle.png
https://api.slack.com/img/blocks/bkb_template_images/creditcard.png
https://api.slack.com/img/blocks/bkb_template_images/highpriority.png
https://api.slack.com/img/blocks/bkb_template_images/mediumpriority.png
https://api.slack.com/img/blocks/bkb_template_images/newfeature.png
https://api.slack.com/img/blocks/bkb_template_images/palmtree.png
https://api.slack.com/img/blocks/bkb_template_images/placeholder.png
https://api.slack.com/img/blocks/bkb_template_images/plane.png
https://api.slack.com/img/blocks/bkb_template_images/plants.png
https://api.slack.com/img/blocks/bkb_template_images/profile_1.png
https://api.slack.com/img/blocks/bkb_template_images/profile_2.png
https://api.slack.com/img/blocks/bkb_template_images/profile_3.png
https://api.slack.com/img/blocks/bkb_template_images/redwood-suite.png
https://api.slack.com/img/blocks/bkb_template_images/redwoodcabin.png
https://api.slack.com/img/blocks/bkb_template_images/Streamline-Beach.png
https://api.slack.com/img/blocks/bkb_template_images/task-icon.png
https://api.slack.com/img/blocks/bkb_template_images/tent.png
https://api.slack.com/interactivity/handling#message_responses,https://docs.slack.dev/interactivity/handling-user-interaction/#message_responses
https://api.slack.com/legacy/interactive-message-field-guide#attachment_fields,https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#attachment_fields
https://api.slack.com/legacy/interactive-message-field-guide#message_action_fields,https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#message_action_fields
https://api.slack.com/legacy/interactive-message-field-guide#option_fields,https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_fields
https://api.slack.com/legacy/interactive-message-field-guide#option_groups_to_place_within_message_menu_actions,https://docs.slack.dev/legacy/legacy-messaging/legacy-interactive-message-field-guide/#option_groups
https://api.slack.com/legacy/message-buttons,https://docs.slack.dev/legacy/legacy-messaging/legacy-message-buttons/
https://api.slack.com/legacy/message-menus#allow_users_to_select_from_a_list_of_members,https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_team_members
https://api.slack.com/legacy/message-menus#let_users_choose_one_of_their_conversations,https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_conversations
https://api.slack.com/legacy/message-menus#let_users_choose_one_of_their_workspace_s_channels,https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_channels
https://api.slack.com/legacy/message-menus#populate_message_menus_dynamically,https://docs.slack.dev/legacy/legacy-messaging/legacy-adding-menus-to-messages/#menu_dynamic
https://api.slack.com/messaging/composing/layouts#attachments,https://docs.slack.dev/messaging/formatting-message-text/#rich-layouts
https://api.slack.com/messaging/composing#message-structure,https://docs.slack.dev/messaging/#message-structure
https://api.slack.com/messaging/webhooks,https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/
https://api.slack.com/metadata,https://docs.slack.dev/messaging/message-metadata/
https://api.slack.com/methods,https://docs.slack.dev/reference/methods
https://api.slack.com/reference/block-kit/block-elements,https://docs.slack.dev/reference/block-kit/block-elements/
https://api.slack.com/reference/block-kit/block-elements#button,https://docs.slack.dev/reference/block-kit/block-elements/button-element/
https://api.slack.com/reference/block-kit/block-elements#channel_multi_select,https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#channel_multi_select
https://api.slack.com/reference/block-kit/block-elements#channel_select,https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#channels_select
https://api.slack.com/reference/block-kit/block-elements#checkboxes,https://docs.slack.dev/reference/block-kit/block-elements/checkboxes-element/
https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select,https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element/#conversation_multi_select
https://api.slack.com/reference/block-kit/block-elements#conversation_select,https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element/#conversations_select
https://api.slack.com/reference/block-kit/block-elements#datepicker,https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element
https://api.slack.com/reference/block-kit/block-elements#datetimepicker,https://docs.slack.dev/reference/block-kit/block-elements/date-picker-element/
https://api.slack.com/reference/block-kit/block-elements#email,https://docs.slack.dev/reference/block-kit/block-elements/email-input-element
https://api.slack.com/reference/block-kit/block-elements#external_multi_select,https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#external_multi_select
https://api.slack.com/reference/block-kit/block-elements#external_select,https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#external_select
https://api.slack.com/reference/block-kit/block-elements#file_input,https://docs.slack.dev/reference/block-kit/block-elements/file-input-element
https://api.slack.com/reference/block-kit/block-elements#image,https://docs.slack.dev/reference/block-kit/block-elements/image-element
https://api.slack.com/reference/block-kit/block-elements#input,https://docs.slack.dev/reference/block-kit/block-elements/plain-text-input-element
https://api.slack.com/reference/block-kit/block-elements#number,https://docs.slack.dev/reference/block-kit/block-elements/number-input-element/
https://api.slack.com/reference/block-kit/block-elements#overflow,https://docs.slack.dev/reference/block-kit/block-elements/overflow-menu-element
https://api.slack.com/reference/block-kit/block-elements#radio,https://docs.slack.dev/reference/block-kit/block-elements/radio-button-group-element
https://api.slack.com/reference/block-kit/block-elements#static_multi_select,https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#static_multi_select
https://api.slack.com/reference/block-kit/block-elements#static_select,https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#static_select
https://api.slack.com/reference/block-kit/block-elements#timepicker,https://docs.slack.dev/reference/block-kit/block-elements/time-picker-element
https://api.slack.com/reference/block-kit/block-elements#url,https://docs.slack.dev/reference/block-kit/block-elements/url-input-element
https://api.slack.com/reference/block-kit/block-elements#users_multi_select,https://docs.slack.dev/reference/block-kit/block-elements/multi-select-menu-element#users_multi_select
https://api.slack.com/reference/block-kit/block-elements#users_select,https://docs.slack.dev/reference/block-kit/block-elements/select-menu-element#users_select
https://api.slack.com/reference/block-kit/block-elements#workflow_button,https://docs.slack.dev/reference/block-kit/block-elements/workflow-button-element
https://api.slack.com/reference/block-kit/blocks,https://docs.slack.dev/reference/block-kit/blocks
https://api.slack.com/reference/block-kit/blocks#actions,https://docs.slack.dev/reference/block-kit/blocks/actions-block
https://api.slack.com/reference/block-kit/blocks#call
https://api.slack.com/reference/block-kit/blocks#context,https://docs.slack.dev/reference/block-kit/blocks/context-block
https://api.slack.com/reference/block-kit/blocks#divider,https://docs.slack.dev/reference/block-kit/blocks/divider-block
https://api.slack.com/reference/block-kit/blocks#file,https://docs.slack.dev/reference/block-kit/blocks/file-block
https://api.slack.com/reference/block-kit/blocks#header,https://docs.slack.dev/reference/block-kit/blocks/header-block
https://api.slack.com/reference/block-kit/blocks#image,https://docs.slack.dev/reference/block-kit/blocks/image-block
https://api.slack.com/reference/block-kit/blocks#input,https://docs.slack.dev/reference/block-kit/blocks/input-block
https://api.slack.com/reference/block-kit/blocks#rich_text,https://docs.slack.dev/reference/block-kit/blocks/rich-text-block
https://api.slack.com/reference/block-kit/blocks#section,https://docs.slack.dev/reference/block-kit/blocks/section-block
https://api.slack.com/reference/block-kit/blocks#video,https://docs.slack.dev/reference/block-kit/blocks/video-block
https://api.slack.com/reference/block-kit/composition-objects#confirm,https://docs.slack.dev/reference/block-kit/composition-objects/confirmation-dialog-object/
https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config,https://docs.slack.dev/reference/block-kit/composition-objects/dispatch-action-configuration-object
https://api.slack.com/reference/block-kit/composition-objects#filter_conversations,https://docs.slack.dev/reference/block-kit/composition-objects/conversation-filter-object
https://api.slack.com/reference/block-kit/composition-objects#option,https://docs.slack.dev/reference/block-kit/composition-objects/option-object
https://api.slack.com/reference/block-kit/composition-objects#option-group,https://docs.slack.dev/reference/block-kit/composition-objects/option-group-object
https://api.slack.com/reference/block-kit/composition-objects#slack_file,https://docs.slack.dev/reference/block-kit/composition-objects/slack-file-object
https://api.slack.com/reference/block-kit/composition-objects#text,https://docs.slack.dev/reference/block-kit/composition-objects/text-object
https://api.slack.com/reference/messaging/attachments,https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments
https://api.slack.com/reference/messaging/attachments#fields,https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#fields
https://api.slack.com/reference/messaging/attachments#legacy_fields,https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments#legacy_fields
https://api.slack.com/reference/surfaces/formatting,https://docs.slack.dev/messaging/formatting-message-text/
https://api.slack.com/reference/surfaces/formatting#date-formatting,https://docs.slack.dev/messaging/formatting-message-text/#date-formatting
https://api.slack.com/reference/surfaces/formatting#linking_to_urls,https://docs.slack.dev/messaging/formatting-message-text/#linking_to_urls
https://api.slack.com/reference/surfaces/formatting#linking-channels,https://docs.slack.dev/messaging/formatting-message-text/#linking-channels
https://api.slack.com/reference/surfaces/views,https://docs.slack.dev/reference/views/
https://api.slack.com/rtm,https://docs.slack.dev/legacy/legacy-rtm-api/
https://api.slack.com/scim,https://docs.slack.dev/admins/scim-api/
https://api.slack.com/scim/v1/
https://api.slack.com/scim/v1/Users/W111
https://api.slack.com/scopes,https://docs.slack.dev/reference/scopes
https://api.slack.com/scopes/chat:write,https://docs.slack.dev/reference/scopes/chat.write/
https://api.slack.com/scopes/im:write,https://docs.slack.dev/reference/scopes/im.write/
https://api.slack.com/socket-mode,https://docs.slack.dev/apis/events-api/using-socket-mode/
https://api.slack.com/surfaces/modals,https://docs.slack.dev/surfaces/modals/
https://api.slack.com/surfaces/modals#updating_views,https://docs.slack.dev/surfaces/modals/#updating_views
https://api.slack.com/surfaces/tabs,https://docs.slack.dev/surfaces/app-home/
https://api.slack.com/tools/block-kit-builder
https://slack.dev/bolt-python/concepts#message-listening,https://docs.slack.dev/tools/bolt-python/concepts/message-listening
https://slack.dev/python-slack-sdk/,https://docs.slack.dev/tools/python-slack-sdk
https://slack.dev/python-slack-sdk/audit-logs/,https://docs.slack.dev/tools/python-slack-sdk/audit-logs
https://slack.dev/python-slack-sdk/oauth/,https://docs.slack.dev/tools/python-slack-sdk/oauth
https://slack.dev/python-slack-sdk/scim/,https://docs.slack.dev/tools/python-slack-sdk/scim
https://slack.dev/python-slack-sdk/socket-mode/,https://docs.slack.dev/tools/python-slack-sdk/socket-mode/
https://slack.dev/python-slack-sdk/v3-migration/,https://docs.slack.dev/tools/python-slack-sdk/v3-migration
https://slack.dev/python-slackclient/
```

</details>

Confirming that no logic was changed - such as the `BASE_URL` of methods - would be so much appreciated! 👾 

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [x] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [x] **slack_sdk.scim** (SCIM API client)
- [x] **slack_sdk.audit_logs** (Audit Logs API client)
- [x] `/docs` (Documents)
- [x] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
