### PR TITLE
fix: remove unused mypy ignore type comments

### DIFF
--- a/slack_sdk/socket_mode/websocket_client/__init__.py
+++ b/slack_sdk/socket_mode/websocket_client/__init__.py
@@ -11,7 +11,7 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from logging import Logger
 from queue import Queue
 from threading import Lock
-from typing import Union, Optional, List, Callable, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 import websocket
 from websocket import WebSocketApp, WebSocketException
@@ -180,10 +180,10 @@ class SocketModeClient(BaseSocketModeClient):
 
         self.current_session = websocket.WebSocketApp(
             self.wss_uri,
-            on_open=on_open,  # type: ignore[arg-type]
-            on_message=on_message,  # type: ignore[arg-type]
-            on_error=on_error,  # type: ignore[arg-type]
-            on_close=on_close,  # type: ignore[arg-type]
+            on_open=on_open,
+            on_message=on_message,
+            on_error=on_error,
+            on_close=on_close,
         )
         self.auto_reconnect_enabled = self.default_auto_reconnect_enabled
 


### PR DESCRIPTION
## Summary

This PR fixes an issue surfaced in the latest `mypy` checks running on the **main** branch:

```
slack_sdk/socket_mode/websocket_client/__init__.py:183: error: Unused "type: ignore" comment  [unused-ignore]
slack_sdk/socket_mode/websocket_client/__init__.py:184: error: Unused "type: ignore" comment  [unused-ignore]
slack_sdk/socket_mode/websocket_client/__init__.py:185: error: Unused "type: ignore" comment  [unused-ignore]
slack_sdk/socket_mode/websocket_client/__init__.py:186: error: Unused "type: ignore" comment  [unused-ignore]
```

Example runs might be found in #1768.

### Testing

The results of CI might find a truth 🪬 

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.socket_mode** (Socket Mode client)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
