### PR TITLE
feat(models): add underline to rich text section block element

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -2032,11 +2032,13 @@ class RichTextElementParts:
             italic: Optional[bool] = None,
             strike: Optional[bool] = None,
             code: Optional[bool] = None,
+            underline: Optional[bool] = None,
         ):
             self.bold = bold
             self.italic = italic
             self.strike = strike
             self.code = code
+            self.underline = underline
 
         def to_dict(self, *args) -> dict:
             result = {
@@ -2044,6 +2046,7 @@ class RichTextElementParts:
                 "italic": self.italic,
                 "strike": self.strike,
                 "code": self.code,
+                "underline": self.underline,
             }
             return {k: v for k, v in result.items() if v is not None}
 

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -1037,6 +1037,8 @@ class RichTextBlockTests(unittest.TestCase):
                         {"type": "text", "text": "block", "style": {"code": True}},
                         {"type": "text", "text": " "},
                         {"type": "text", "text": "test", "style": {"italic": True}},
+                        {"type": "text", "text": " "},
+                        {"type": "text", "text": "links", "style": {"underline": True}},
                         {"type": "link", "url": "https://slack.com", "text": "Slack website!"},
                     ],
                 },
@@ -1138,6 +1140,8 @@ class RichTextBlockTests(unittest.TestCase):
                         _.Text(text="block", style=_.TextStyle(code=True)),
                         _.Text(text=" "),
                         _.Text(text="test", style=_.TextStyle(italic=True)),
+                        _.Text(text=" "),
+                        _.Text(text="links", style=_.TextStyle(underline=True)),
                         _.Link(text="Slack website!", url="https://slack.com"),
                     ]
                 ),


### PR DESCRIPTION
## Summary

This PR adds `underline` to the rich text section block element style.

### Testing

This snippet might be useful in testing:

```python
from slack_sdk.models.blocks import (
    RichTextBlock,
    RichTextElementParts,
    RichTextSectionElement,
)

client.chat_postMessage(
    channel=channel_id,
    blocks=[
        RichTextBlock(
            elements=[
                RichTextSectionElement(
                    elements=[
                        RichTextElementParts.Text(
                            text="important",
                            style=RichTextElementParts.TextStyle(
                                bold=True,
                                underline=True,
                            ),
                        ),
                    ],
                ),
            ],
        )
    ],
)
```

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.models** (UI component builders)

### Notes

🏁 This style has not been released to all teams yet! Hoping to have this ready to release when this does go public!

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
