### PR TITLE
fix: dependabot config to ignore `black`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "black"
-        update-types: 
-          - version-update:semver-patch
-          - version-update:semver-minor
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Updates Dependabot config to ignore the black dependency. We're ignoring it because we are intentionally using the specific version compatible with the project's minimum supported Python version.

### Testing

The ci pipeline should pass

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
