### PR TITLE
chore: add a formatter script for maintainers

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -65,19 +65,27 @@ our continuous integration](https://github.com/slackapi/python-slack-sdk/blob/v3
 
 ## Tasks
 
+### Formatting
+
+This project uses code formatting tools to maintain consistent style. You can format the codebase by running:
+
+```sh
+./scripts/format.sh
+```
+
 ### Testing
 
 #### Unit Tests
 
 When you make changes to this SDK, please write unit tests verifying if the changes work as you expected. You can easily run all the tests and formatting/linter with the below scripts.
 
-Run all the unit tests, code formatter, and code analyzer:
+Run all the unit tests, code linter, and code analyzer:
 
 ```sh
 ./scripts/run_validation.sh
 ```
 
-Run all the unit tests (no formatter nor code analyzer):
+Run all the unit tests (no linter nor code analyzer):
 
 ```sh
 ./scripts/run_unit_tests.sh

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,19 +3,13 @@ aiohttp<4  # used for a WebSocket server mock
 pytest>=7.0.1,<9
 pytest-asyncio<2  # for async
 pytest-cov>=2,<8
-# while flake8 5.x have issues with Python 3.12, flake8 6.x requires Python >= 3.8.1,
-# so 5.x should be kept in order to stay compatible with Python 3.7/3.8
-flake8>=5.0.4,<8
-#  Don't change this version without running CI builds;
-#  The latest version may not be available for older Python runtime
-black==23.3.0;
 click==8.0.4  # black is affected by https://github.com/pallets/click/issues/2225
 psutil>=6.0.0,<8
 #  used only under slack_sdk/*_store
 boto3<=2
 # For AWS tests
 moto>=4.0.13,<6
-mypy<=1.18.2
 # For AsyncSQLAlchemy tests
 greenlet<=4
 aiosqlite<=1
+-r tools.txt

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -1,0 +1,7 @@
+mypy<=1.18.2
+# while flake8 5.x have issues with Python 3.12, flake8 6.x requires Python >= 3.8.1,
+# so 5.x should be kept in order to stay compatible with Python 3.7/3.8
+flake8>=5.0.4,<8
+#  Don't change this version without running CI builds;
+#  The latest version may not be available for older Python runtime
+black==23.3.0;

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# ./scripts/format.sh
+
+script_dir=`dirname $0`
+cd ${script_dir}/..
+
+pip install -U pip
+pip install -U -r requirements/tools.txt
+
+black slack/ slack_sdk/ tests/ integration_tests/


### PR DESCRIPTION
## Summary

These changes add a helper script to format the project

### Testing

N/A

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
