### PR TITLE
chore(release): version 3.39.0

### DIFF
--- a/docs/reference/http_retry/async_handler.html
+++ b/docs/reference/http_retry/async_handler.html
@@ -193,7 +193,7 @@ see also: <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff
 </dd>
 <dt id="slack_sdk.http_retry.async_handler.HttpResponse"><code class="flex name class">
 <span>class <span class="ident">HttpResponse</span></span>
-<span>(</span><span>*,<br>status_code: str | int,<br>headers: Dict[str, str | List[str]],<br>body: Dict[str, Any] | None = None,<br>data: bytes | None = None)</span>
+<span>(</span><span>*,<br>status_code: int | str,<br>headers: Dict[str, str | List[str]],<br>body: Dict[str, Any] | None = None,<br>data: bytes | None = None)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/http_retry/index.html
+++ b/docs/reference/http_retry/index.html
@@ -388,7 +388,7 @@ see also: <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff
 </dd>
 <dt id="slack_sdk.http_retry.HttpResponse"><code class="flex name class">
 <span>class <span class="ident">HttpResponse</span></span>
-<span>(</span><span>*,<br>status_code: str | int,<br>headers: Dict[str, str | List[str]],<br>body: Dict[str, Any] | None = None,<br>data: bytes | None = None)</span>
+<span>(</span><span>*,<br>status_code: int | str,<br>headers: Dict[str, str | List[str]],<br>body: Dict[str, Any] | None = None,<br>data: bytes | None = None)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/http_retry/response.html
+++ b/docs/reference/http_retry/response.html
@@ -48,7 +48,7 @@ el.replaceWith(d);
 <dl>
 <dt id="slack_sdk.http_retry.response.HttpResponse"><code class="flex name class">
 <span>class <span class="ident">HttpResponse</span></span>
-<span>(</span><span>*,<br>status_code: str | int,<br>headers: Dict[str, str | List[str]],<br>body: Dict[str, Any] | None = None,<br>data: bytes | None = None)</span>
+<span>(</span><span>*,<br>status_code: int | str,<br>headers: Dict[str, str | List[str]],<br>body: Dict[str, Any] | None = None,<br>data: bytes | None = None)</span>
 </code></dt>
 <dd>
 <details class="source">

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -2894,7 +2894,7 @@ and message responses using response_url in payloads.</p></div>
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
-        metadata: Optional[Union[Dict, Metadata]] = None,
+        metadata: Optional[Union[Dict, Metadata, EventAndEntityMetadata]] = None,
         markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
@@ -3123,6 +3123,7 @@ and message responses using response_url in payloads.</p></div>
         source: Optional[str] = None,
         unfurl_id: Optional[str] = None,
         unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
+        metadata: Optional[Union[Dict, EventAndEntityMetadata]] = None,
         user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
         user_auth_message: Optional[str] = None,
         user_auth_required: Optional[bool] = None,
@@ -3139,6 +3140,7 @@ and message responses using response_url in payloads.</p></div>
                 &#34;source&#34;: source,
                 &#34;unfurl_id&#34;: unfurl_id,
                 &#34;unfurls&#34;: unfurls,
+                &#34;metadata&#34;: metadata,
                 &#34;user_auth_blocks&#34;: user_auth_blocks,
                 &#34;user_auth_message&#34;: user_auth_message,
                 &#34;user_auth_required&#34;: user_auth_required,
@@ -3769,6 +3771,30 @@ and message responses using response_url in payloads.</p></div>
         &#34;&#34;&#34;
         kwargs.update({&#34;include_categories&#34;: include_categories})
         return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
+    def entity_presentDetails(
+        self,
+        trigger_id: str,
+        metadata: Optional[Union[Dict, EntityMetadata]] = None,
+        user_auth_required: Optional[bool] = None,
+        user_auth_url: Optional[str] = None,
+        error: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Provides entity details for the flexpane.
+        https://docs.slack.dev/reference/methods/entity.presentDetails/
+        &#34;&#34;&#34;
+        kwargs.update({&#34;trigger_id&#34;: trigger_id})
+        if metadata is not None:
+            kwargs.update({&#34;metadata&#34;: metadata})
+        if user_auth_required is not None:
+            kwargs.update({&#34;user_auth_required&#34;: user_auth_required})
+        if user_auth_url is not None:
+            kwargs.update({&#34;user_auth_url&#34;: user_auth_url})
+        if error is not None:
+            kwargs.update({&#34;error&#34;: error})
+        _parse_web_class_objects(kwargs)
+        return self.api_call(&#34;entity.presentDetails&#34;, json=kwargs)
 
     def files_comments_delete(
         self,
@@ -5023,6 +5049,249 @@ and message responses using response_url in payloads.</p></div>
             }
         )
         return self.api_call(&#34;search.messages&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
+    def slackLists_access_delete(
+        self,
+        *,
+        list_id: str,
+        channel_ids: Optional[List[str]] = None,
+        user_ids: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Revoke access to a List for specified entities.
+        https://docs.slack.dev/reference/methods/slackLists.access.delete
+        &#34;&#34;&#34;
+        kwargs.update({&#34;list_id&#34;: list_id, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.access.delete&#34;, json=kwargs)
+
+    def slackLists_access_set(
+        self,
+        *,
+        list_id: str,
+        access_level: str,
+        channel_ids: Optional[List[str]] = None,
+        user_ids: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Set the access level to a List for specified entities.
+        https://docs.slack.dev/reference/methods/slackLists.access.set
+        &#34;&#34;&#34;
+        kwargs.update({&#34;list_id&#34;: list_id, &#34;access_level&#34;: access_level, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.access.set&#34;, json=kwargs)
+
+    def slackLists_create(
+        self,
+        *,
+        name: str,
+        description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+        schema: Optional[List[Dict[str, Any]]] = None,
+        copy_from_list_id: Optional[str] = None,
+        include_copied_list_records: Optional[bool] = None,
+        todo_mode: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Creates a List.
+        https://docs.slack.dev/reference/methods/slackLists.create
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;name&#34;: name,
+                &#34;description_blocks&#34;: description_blocks,
+                &#34;schema&#34;: schema,
+                &#34;copy_from_list_id&#34;: copy_from_list_id,
+                &#34;include_copied_list_records&#34;: include_copied_list_records,
+                &#34;todo_mode&#34;: todo_mode,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.create&#34;, json=kwargs)
+
+    def slackLists_download_get(
+        self,
+        *,
+        list_id: str,
+        job_id: str,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Retrieve List download URL from an export job to download List contents.
+        https://docs.slack.dev/reference/methods/slackLists.download.get
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;job_id&#34;: job_id,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.download.get&#34;, json=kwargs)
+
+    def slackLists_download_start(
+        self,
+        *,
+        list_id: str,
+        include_archived: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Initiate a job to export List contents.
+        https://docs.slack.dev/reference/methods/slackLists.download.start
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;include_archived&#34;: include_archived,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.download.start&#34;, json=kwargs)
+
+    def slackLists_items_create(
+        self,
+        *,
+        list_id: str,
+        duplicated_item_id: Optional[str] = None,
+        parent_item_id: Optional[str] = None,
+        initial_fields: Optional[List[Dict[str, Any]]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Add a new item to an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.create
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;duplicated_item_id&#34;: duplicated_item_id,
+                &#34;parent_item_id&#34;: parent_item_id,
+                &#34;initial_fields&#34;: initial_fields,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.create&#34;, json=kwargs)
+
+    def slackLists_items_delete(
+        self,
+        *,
+        list_id: str,
+        id: str,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Deletes an item from an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.delete
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;id&#34;: id,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.delete&#34;, json=kwargs)
+
+    def slackLists_items_deleteMultiple(
+        self,
+        *,
+        list_id: str,
+        ids: List[str],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Deletes multiple items from an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;ids&#34;: ids,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.deleteMultiple&#34;, json=kwargs)
+
+    def slackLists_items_info(
+        self,
+        *,
+        list_id: str,
+        id: str,
+        include_is_subscribed: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Get a row from a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.info
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;id&#34;: id,
+                &#34;include_is_subscribed&#34;: include_is_subscribed,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.info&#34;, json=kwargs)
+
+    def slackLists_items_list(
+        self,
+        *,
+        list_id: str,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        archived: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Get records from a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;limit&#34;: limit,
+                &#34;cursor&#34;: cursor,
+                &#34;archived&#34;: archived,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.list&#34;, json=kwargs)
+
+    def slackLists_items_update(
+        self,
+        *,
+        list_id: str,
+        cells: List[Dict[str, Any]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Updates cells in a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.update
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;cells&#34;: cells,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.update&#34;, json=kwargs)
+
+    def slackLists_update(
+        self,
+        *,
+        id: str,
+        name: Optional[str] = None,
+        description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+        todo_mode: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Update a List.
+        https://docs.slack.dev/reference/methods/slackLists.update
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;id&#34;: id,
+                &#34;name&#34;: name,
+                &#34;description_blocks&#34;: description_blocks,
+                &#34;todo_mode&#34;: todo_mode,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.update&#34;, json=kwargs)
 
     def stars_add(
         self,
@@ -10170,7 +10439,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/chat.postEphemeral">https://docs.slack.dev/reference/methods/chat.postEphemeral</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_postMessage"><code class="name flex">
-<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | <a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="models/metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10196,7 +10465,7 @@ Each authorization represents an app installation that the event is visible to.
     link_names: Optional[bool] = None,
     username: Optional[str] = None,
     parse: Optional[str] = None,  # none, full
-    metadata: Optional[Union[Dict, Metadata]] = None,
+    metadata: Optional[Union[Dict, Metadata, EventAndEntityMetadata]] = None,
     markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
@@ -10518,7 +10787,7 @@ streamer.stop()
 </code></pre></div>
 </dd>
 <dt id="slack_sdk.WebClient.chat_unfurl"><code class="name flex">
-<span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="models/metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a> | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10533,6 +10802,7 @@ streamer.stop()
     source: Optional[str] = None,
     unfurl_id: Optional[str] = None,
     unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
+    metadata: Optional[Union[Dict, EventAndEntityMetadata]] = None,
     user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
     user_auth_message: Optional[str] = None,
     user_auth_required: Optional[bool] = None,
@@ -10549,6 +10819,7 @@ streamer.stop()
             &#34;source&#34;: source,
             &#34;unfurl_id&#34;: unfurl_id,
             &#34;unfurls&#34;: unfurls,
+            &#34;metadata&#34;: metadata,
             &#34;user_auth_blocks&#34;: user_auth_blocks,
             &#34;user_auth_message&#34;: user_auth_message,
             &#34;user_auth_required&#34;: user_auth_required,
@@ -11579,6 +11850,41 @@ or received but have not yet been approved by all parties.
 </details>
 <div class="desc"><p>Lists custom emoji for a team.
 <a href="https://docs.slack.dev/reference/methods/emoji.list">https://docs.slack.dev/reference/methods/emoji.list</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.entity_presentDetails"><code class="name flex">
+<span>def <span class="ident">entity_presentDetails</span></span>(<span>self,<br>trigger_id: str,<br>metadata: Dict | <a title="slack_sdk.models.metadata.EntityMetadata" href="models/metadata/index.html#slack_sdk.models.metadata.EntityMetadata">EntityMetadata</a> | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>error: Dict[str, Any] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def entity_presentDetails(
+    self,
+    trigger_id: str,
+    metadata: Optional[Union[Dict, EntityMetadata]] = None,
+    user_auth_required: Optional[bool] = None,
+    user_auth_url: Optional[str] = None,
+    error: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Provides entity details for the flexpane.
+    https://docs.slack.dev/reference/methods/entity.presentDetails/
+    &#34;&#34;&#34;
+    kwargs.update({&#34;trigger_id&#34;: trigger_id})
+    if metadata is not None:
+        kwargs.update({&#34;metadata&#34;: metadata})
+    if user_auth_required is not None:
+        kwargs.update({&#34;user_auth_required&#34;: user_auth_required})
+    if user_auth_url is not None:
+        kwargs.update({&#34;user_auth_url&#34;: user_auth_url})
+    if error is not None:
+        kwargs.update({&#34;error&#34;: error})
+    _parse_web_class_objects(kwargs)
+    return self.api_call(&#34;entity.presentDetails&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Provides entity details for the flexpane.
+<a href="https://docs.slack.dev/reference/methods/entity.presentDetails/">https://docs.slack.dev/reference/methods/entity.presentDetails/</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.files_comments_delete"><code class="name flex">
 <span>def <span class="ident">files_comments_delete</span></span>(<span>self, *, file: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13554,6 +13860,381 @@ multiparty direct message.</p></div>
 </details>
 <div class="desc"><p>Searches for messages matching a query.
 <a href="https://docs.slack.dev/reference/methods/search.messages">https://docs.slack.dev/reference/methods/search.messages</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_access_delete"><code class="name flex">
+<span>def <span class="ident">slackLists_access_delete</span></span>(<span>self,<br>*,<br>list_id: str,<br>channel_ids: List[str] | None = None,<br>user_ids: List[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_access_delete(
+    self,
+    *,
+    list_id: str,
+    channel_ids: Optional[List[str]] = None,
+    user_ids: Optional[List[str]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Revoke access to a List for specified entities.
+    https://docs.slack.dev/reference/methods/slackLists.access.delete
+    &#34;&#34;&#34;
+    kwargs.update({&#34;list_id&#34;: list_id, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.access.delete&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Revoke access to a List for specified entities.
+<a href="https://docs.slack.dev/reference/methods/slackLists.access.delete">https://docs.slack.dev/reference/methods/slackLists.access.delete</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_access_set"><code class="name flex">
+<span>def <span class="ident">slackLists_access_set</span></span>(<span>self,<br>*,<br>list_id: str,<br>access_level: str,<br>channel_ids: List[str] | None = None,<br>user_ids: List[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_access_set(
+    self,
+    *,
+    list_id: str,
+    access_level: str,
+    channel_ids: Optional[List[str]] = None,
+    user_ids: Optional[List[str]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Set the access level to a List for specified entities.
+    https://docs.slack.dev/reference/methods/slackLists.access.set
+    &#34;&#34;&#34;
+    kwargs.update({&#34;list_id&#34;: list_id, &#34;access_level&#34;: access_level, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.access.set&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Set the access level to a List for specified entities.
+<a href="https://docs.slack.dev/reference/methods/slackLists.access.set">https://docs.slack.dev/reference/methods/slackLists.access.set</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_create"><code class="name flex">
+<span>def <span class="ident">slackLists_create</span></span>(<span>self,<br>*,<br>name: str,<br>description_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a>] | None = None,<br>schema: List[Dict[str, Any]] | None = None,<br>copy_from_list_id: str | None = None,<br>include_copied_list_records: bool | None = None,<br>todo_mode: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_create(
+    self,
+    *,
+    name: str,
+    description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+    schema: Optional[List[Dict[str, Any]]] = None,
+    copy_from_list_id: Optional[str] = None,
+    include_copied_list_records: Optional[bool] = None,
+    todo_mode: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Creates a List.
+    https://docs.slack.dev/reference/methods/slackLists.create
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;name&#34;: name,
+            &#34;description_blocks&#34;: description_blocks,
+            &#34;schema&#34;: schema,
+            &#34;copy_from_list_id&#34;: copy_from_list_id,
+            &#34;include_copied_list_records&#34;: include_copied_list_records,
+            &#34;todo_mode&#34;: todo_mode,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.create&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Creates a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.create">https://docs.slack.dev/reference/methods/slackLists.create</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_download_get"><code class="name flex">
+<span>def <span class="ident">slackLists_download_get</span></span>(<span>self, *, list_id: str, job_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_download_get(
+    self,
+    *,
+    list_id: str,
+    job_id: str,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Retrieve List download URL from an export job to download List contents.
+    https://docs.slack.dev/reference/methods/slackLists.download.get
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;job_id&#34;: job_id,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.download.get&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Retrieve List download URL from an export job to download List contents.
+<a href="https://docs.slack.dev/reference/methods/slackLists.download.get">https://docs.slack.dev/reference/methods/slackLists.download.get</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_download_start"><code class="name flex">
+<span>def <span class="ident">slackLists_download_start</span></span>(<span>self, *, list_id: str, include_archived: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_download_start(
+    self,
+    *,
+    list_id: str,
+    include_archived: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Initiate a job to export List contents.
+    https://docs.slack.dev/reference/methods/slackLists.download.start
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;include_archived&#34;: include_archived,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.download.start&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Initiate a job to export List contents.
+<a href="https://docs.slack.dev/reference/methods/slackLists.download.start">https://docs.slack.dev/reference/methods/slackLists.download.start</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_items_create"><code class="name flex">
+<span>def <span class="ident">slackLists_items_create</span></span>(<span>self,<br>*,<br>list_id: str,<br>duplicated_item_id: str | None = None,<br>parent_item_id: str | None = None,<br>initial_fields: List[Dict[str, Any]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_create(
+    self,
+    *,
+    list_id: str,
+    duplicated_item_id: Optional[str] = None,
+    parent_item_id: Optional[str] = None,
+    initial_fields: Optional[List[Dict[str, Any]]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Add a new item to an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.create
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;duplicated_item_id&#34;: duplicated_item_id,
+            &#34;parent_item_id&#34;: parent_item_id,
+            &#34;initial_fields&#34;: initial_fields,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.create&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Add a new item to an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.create">https://docs.slack.dev/reference/methods/slackLists.items.create</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_items_delete"><code class="name flex">
+<span>def <span class="ident">slackLists_items_delete</span></span>(<span>self, *, list_id: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_delete(
+    self,
+    *,
+    list_id: str,
+    id: str,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Deletes an item from an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.delete
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;id&#34;: id,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.delete&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Deletes an item from an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.delete">https://docs.slack.dev/reference/methods/slackLists.items.delete</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_items_deleteMultiple"><code class="name flex">
+<span>def <span class="ident">slackLists_items_deleteMultiple</span></span>(<span>self, *, list_id: str, ids: List[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_deleteMultiple(
+    self,
+    *,
+    list_id: str,
+    ids: List[str],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Deletes multiple items from an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;ids&#34;: ids,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.deleteMultiple&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Deletes multiple items from an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple">https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_items_info"><code class="name flex">
+<span>def <span class="ident">slackLists_items_info</span></span>(<span>self, *, list_id: str, id: str, include_is_subscribed: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_info(
+    self,
+    *,
+    list_id: str,
+    id: str,
+    include_is_subscribed: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Get a row from a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.info
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;id&#34;: id,
+            &#34;include_is_subscribed&#34;: include_is_subscribed,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.info&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Get a row from a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.info">https://docs.slack.dev/reference/methods/slackLists.items.info</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_items_list"><code class="name flex">
+<span>def <span class="ident">slackLists_items_list</span></span>(<span>self,<br>*,<br>list_id: str,<br>limit: int | None = None,<br>cursor: str | None = None,<br>archived: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_list(
+    self,
+    *,
+    list_id: str,
+    limit: Optional[int] = None,
+    cursor: Optional[str] = None,
+    archived: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Get records from a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.list
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;limit&#34;: limit,
+            &#34;cursor&#34;: cursor,
+            &#34;archived&#34;: archived,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.list&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Get records from a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.list">https://docs.slack.dev/reference/methods/slackLists.items.list</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_items_update"><code class="name flex">
+<span>def <span class="ident">slackLists_items_update</span></span>(<span>self, *, list_id: str, cells: List[Dict[str, Any]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_update(
+    self,
+    *,
+    list_id: str,
+    cells: List[Dict[str, Any]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Updates cells in a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.update
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;cells&#34;: cells,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.update&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Updates cells in a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.update">https://docs.slack.dev/reference/methods/slackLists.items.update</a></p></div>
+</dd>
+<dt id="slack_sdk.WebClient.slackLists_update"><code class="name flex">
+<span>def <span class="ident">slackLists_update</span></span>(<span>self,<br>*,<br>id: str,<br>name: str | None = None,<br>description_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="models/blocks/blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a>] | None = None,<br>todo_mode: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_update(
+    self,
+    *,
+    id: str,
+    name: Optional[str] = None,
+    description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+    todo_mode: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Update a List.
+    https://docs.slack.dev/reference/methods/slackLists.update
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;id&#34;: id,
+            &#34;name&#34;: name,
+            &#34;description_blocks&#34;: description_blocks,
+            &#34;todo_mode&#34;: todo_mode,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.update&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Update a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.update">https://docs.slack.dev/reference/methods/slackLists.update</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.stars_add"><code class="name flex">
 <span>def <span class="ident">stars_add</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -15532,6 +16213,7 @@ if you give this argument, body_params and files will be skipped</dd>
 <li><code><a title="slack_sdk.WebClient.dnd_setSnooze" href="#slack_sdk.WebClient.dnd_setSnooze">dnd_setSnooze</a></code></li>
 <li><code><a title="slack_sdk.WebClient.dnd_teamInfo" href="#slack_sdk.WebClient.dnd_teamInfo">dnd_teamInfo</a></code></li>
 <li><code><a title="slack_sdk.WebClient.emoji_list" href="#slack_sdk.WebClient.emoji_list">emoji_list</a></code></li>
+<li><code><a title="slack_sdk.WebClient.entity_presentDetails" href="#slack_sdk.WebClient.entity_presentDetails">entity_presentDetails</a></code></li>
 <li><code><a title="slack_sdk.WebClient.files_comments_delete" href="#slack_sdk.WebClient.files_comments_delete">files_comments_delete</a></code></li>
 <li><code><a title="slack_sdk.WebClient.files_completeUploadExternal" href="#slack_sdk.WebClient.files_completeUploadExternal">files_completeUploadExternal</a></code></li>
 <li><code><a title="slack_sdk.WebClient.files_delete" href="#slack_sdk.WebClient.files_delete">files_delete</a></code></li>
@@ -15601,6 +16283,18 @@ if you give this argument, body_params and files will be skipped</dd>
 <li><code><a title="slack_sdk.WebClient.search_all" href="#slack_sdk.WebClient.search_all">search_all</a></code></li>
 <li><code><a title="slack_sdk.WebClient.search_files" href="#slack_sdk.WebClient.search_files">search_files</a></code></li>
 <li><code><a title="slack_sdk.WebClient.search_messages" href="#slack_sdk.WebClient.search_messages">search_messages</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_access_delete" href="#slack_sdk.WebClient.slackLists_access_delete">slackLists_access_delete</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_access_set" href="#slack_sdk.WebClient.slackLists_access_set">slackLists_access_set</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_create" href="#slack_sdk.WebClient.slackLists_create">slackLists_create</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_download_get" href="#slack_sdk.WebClient.slackLists_download_get">slackLists_download_get</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_download_start" href="#slack_sdk.WebClient.slackLists_download_start">slackLists_download_start</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_items_create" href="#slack_sdk.WebClient.slackLists_items_create">slackLists_items_create</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_items_delete" href="#slack_sdk.WebClient.slackLists_items_delete">slackLists_items_delete</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_items_deleteMultiple" href="#slack_sdk.WebClient.slackLists_items_deleteMultiple">slackLists_items_deleteMultiple</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_items_info" href="#slack_sdk.WebClient.slackLists_items_info">slackLists_items_info</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_items_list" href="#slack_sdk.WebClient.slackLists_items_list">slackLists_items_list</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_items_update" href="#slack_sdk.WebClient.slackLists_items_update">slackLists_items_update</a></code></li>
+<li><code><a title="slack_sdk.WebClient.slackLists_update" href="#slack_sdk.WebClient.slackLists_update">slackLists_update</a></code></li>
 <li><code><a title="slack_sdk.WebClient.stars_add" href="#slack_sdk.WebClient.stars_add">stars_add</a></code></li>
 <li><code><a title="slack_sdk.WebClient.stars_list" href="#slack_sdk.WebClient.stars_list">stars_list</a></code></li>
 <li><code><a title="slack_sdk.WebClient.stars_remove" href="#slack_sdk.WebClient.stars_remove">stars_remove</a></code></li>

--- a/docs/reference/models/basic_objects.html
+++ b/docs/reference/models/basic_objects.html
@@ -119,6 +119,9 @@ functions should return true if valid, false if not.</p>
             if callable(method) and hasattr(method, &#34;validator&#34;):
                 method()
 
+    def get_object_attribute(self, key: str):
+        return getattr(self, key, None)
+
     def get_non_null_attributes(self) -&gt; dict:
         &#34;&#34;&#34;
         Construct a dictionary out of non-null keys (from attributes property)
@@ -136,7 +139,7 @@ functions should return true if valid, false if not.</p>
                     return value
 
         def is_not_empty(self, key: str) -&gt; bool:
-            value = getattr(self, key, None)
+            value = self.get_object_attribute(key)
             if value is None:
                 return False
 
@@ -154,7 +157,9 @@ functions should return true if valid, false if not.</p>
                 return value is not None
 
         return {
-            key: to_dict_compatible(getattr(self, key, None)) for key in sorted(self.attributes) if is_not_empty(self, key)
+            key: to_dict_compatible(value=self.get_object_attribute(key))
+            for key in sorted(self.attributes)
+            if is_not_empty(self, key)
         }
 
     def to_dict(self, *args) -&gt; dict:
@@ -208,7 +213,40 @@ functions should return true if valid, false if not.</p>
 <li><a title="slack_sdk.models.dialogs.DialogBuilder" href="dialogs/index.html#slack_sdk.models.dialogs.DialogBuilder">DialogBuilder</a></li>
 <li><a title="slack_sdk.models.dialogs.DialogTextComponent" href="dialogs/index.html#slack_sdk.models.dialogs.DialogTextComponent">DialogTextComponent</a></li>
 <li><a title="slack_sdk.models.messages.message.Message" href="messages/message.html#slack_sdk.models.messages.message.Message">Message</a></li>
+<li><a title="slack_sdk.models.metadata.ContentItemEntityFields" href="metadata/index.html#slack_sdk.models.metadata.ContentItemEntityFields">ContentItemEntityFields</a></li>
+<li><a title="slack_sdk.models.metadata.EntityActionButton" href="metadata/index.html#slack_sdk.models.metadata.EntityActionButton">EntityActionButton</a></li>
+<li><a title="slack_sdk.models.metadata.EntityActionProcessingState" href="metadata/index.html#slack_sdk.models.metadata.EntityActionProcessingState">EntityActionProcessingState</a></li>
+<li><a title="slack_sdk.models.metadata.EntityActions" href="metadata/index.html#slack_sdk.models.metadata.EntityActions">EntityActions</a></li>
+<li><a title="slack_sdk.models.metadata.EntityArrayItemField" href="metadata/index.html#slack_sdk.models.metadata.EntityArrayItemField">EntityArrayItemField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityAttributes" href="metadata/index.html#slack_sdk.models.metadata.EntityAttributes">EntityAttributes</a></li>
+<li><a title="slack_sdk.models.metadata.EntityBooleanCheckboxField" href="metadata/index.html#slack_sdk.models.metadata.EntityBooleanCheckboxField">EntityBooleanCheckboxField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityBooleanTextField" href="metadata/index.html#slack_sdk.models.metadata.EntityBooleanTextField">EntityBooleanTextField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityCustomField" href="metadata/index.html#slack_sdk.models.metadata.EntityCustomField">EntityCustomField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityEditNumberConfig" href="metadata/index.html#slack_sdk.models.metadata.EntityEditNumberConfig">EntityEditNumberConfig</a></li>
+<li><a title="slack_sdk.models.metadata.EntityEditSelectConfig" href="metadata/index.html#slack_sdk.models.metadata.EntityEditSelectConfig">EntityEditSelectConfig</a></li>
+<li><a title="slack_sdk.models.metadata.EntityEditSupport" href="metadata/index.html#slack_sdk.models.metadata.EntityEditSupport">EntityEditSupport</a></li>
+<li><a title="slack_sdk.models.metadata.EntityEditTextConfig" href="metadata/index.html#slack_sdk.models.metadata.EntityEditTextConfig">EntityEditTextConfig</a></li>
+<li><a title="slack_sdk.models.metadata.EntityFullSizePreview" href="metadata/index.html#slack_sdk.models.metadata.EntityFullSizePreview">EntityFullSizePreview</a></li>
+<li><a title="slack_sdk.models.metadata.EntityFullSizePreviewError" href="metadata/index.html#slack_sdk.models.metadata.EntityFullSizePreviewError">EntityFullSizePreviewError</a></li>
+<li><a title="slack_sdk.models.metadata.EntityIconField" href="metadata/index.html#slack_sdk.models.metadata.EntityIconField">EntityIconField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityIconSlackFile" href="metadata/index.html#slack_sdk.models.metadata.EntityIconSlackFile">EntityIconSlackFile</a></li>
+<li><a title="slack_sdk.models.metadata.EntityImageField" href="metadata/index.html#slack_sdk.models.metadata.EntityImageField">EntityImageField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityMetadata" href="metadata/index.html#slack_sdk.models.metadata.EntityMetadata">EntityMetadata</a></li>
+<li><a title="slack_sdk.models.metadata.EntityPayload" href="metadata/index.html#slack_sdk.models.metadata.EntityPayload">EntityPayload</a></li>
+<li><a title="slack_sdk.models.metadata.EntityRefField" href="metadata/index.html#slack_sdk.models.metadata.EntityRefField">EntityRefField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityStringField" href="metadata/index.html#slack_sdk.models.metadata.EntityStringField">EntityStringField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityTimestampField" href="metadata/index.html#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityTitle" href="metadata/index.html#slack_sdk.models.metadata.EntityTitle">EntityTitle</a></li>
+<li><a title="slack_sdk.models.metadata.EntityTypedField" href="metadata/index.html#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityUserField" href="metadata/index.html#slack_sdk.models.metadata.EntityUserField">EntityUserField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityUserIDField" href="metadata/index.html#slack_sdk.models.metadata.EntityUserIDField">EntityUserIDField</a></li>
+<li><a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a></li>
+<li><a title="slack_sdk.models.metadata.ExternalRef" href="metadata/index.html#slack_sdk.models.metadata.ExternalRef">ExternalRef</a></li>
+<li><a title="slack_sdk.models.metadata.FileEntityFields" href="metadata/index.html#slack_sdk.models.metadata.FileEntityFields">FileEntityFields</a></li>
+<li><a title="slack_sdk.models.metadata.FileEntitySlackFile" href="metadata/index.html#slack_sdk.models.metadata.FileEntitySlackFile">FileEntitySlackFile</a></li>
+<li><a title="slack_sdk.models.metadata.IncidentEntityFields" href="metadata/index.html#slack_sdk.models.metadata.IncidentEntityFields">IncidentEntityFields</a></li>
 <li><a title="slack_sdk.models.metadata.Metadata" href="metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a></li>
+<li><a title="slack_sdk.models.metadata.TaskEntityFields" href="metadata/index.html#slack_sdk.models.metadata.TaskEntityFields">TaskEntityFields</a></li>
 <li><a title="slack_sdk.models.views.View" href="views/index.html#slack_sdk.models.views.View">View</a></li>
 <li><a title="slack_sdk.models.views.ViewState" href="views/index.html#slack_sdk.models.views.ViewState">ViewState</a></li>
 <li><a title="slack_sdk.models.views.ViewStateValue" href="views/index.html#slack_sdk.models.views.ViewStateValue">ViewStateValue</a></li>
@@ -257,7 +295,7 @@ def attributes(self) -&gt; Set[str]:
                 return value
 
     def is_not_empty(self, key: str) -&gt; bool:
-        value = getattr(self, key, None)
+        value = self.get_object_attribute(key)
         if value is None:
             return False
 
@@ -275,11 +313,26 @@ def attributes(self) -&gt; Set[str]:
             return value is not None
 
     return {
-        key: to_dict_compatible(getattr(self, key, None)) for key in sorted(self.attributes) if is_not_empty(self, key)
+        key: to_dict_compatible(value=self.get_object_attribute(key))
+        for key in sorted(self.attributes)
+        if is_not_empty(self, key)
     }</code></pre>
 </details>
 <div class="desc"><p>Construct a dictionary out of non-null keys (from attributes property)
 present on this object</p></div>
+</dd>
+<dt id="slack_sdk.models.basic_objects.JsonObject.get_object_attribute"><code class="name flex">
+<span>def <span class="ident">get_object_attribute</span></span>(<span>self, key: str)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_object_attribute(self, key: str):
+    return getattr(self, key, None)</code></pre>
+</details>
+<div class="desc"></div>
 </dd>
 <dt id="slack_sdk.models.basic_objects.JsonObject.to_dict"><code class="name flex">
 <span>def <span class="ident">to_dict</span></span>(<span>self, *args) ‑> dict</span>
@@ -401,6 +454,7 @@ functions should return true if valid, false if not.</p>
 <ul class="">
 <li><code><a title="slack_sdk.models.basic_objects.JsonObject.attributes" href="#slack_sdk.models.basic_objects.JsonObject.attributes">attributes</a></code></li>
 <li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_object_attribute" href="#slack_sdk.models.basic_objects.JsonObject.get_object_attribute">get_object_attribute</a></code></li>
 <li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
 <li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
 </ul>

--- a/docs/reference/models/blocks/basic_components.html
+++ b/docs/reference/models/blocks/basic_components.html
@@ -1248,6 +1248,130 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </li>
 </ul>
 </dd>
+<dt id="slack_sdk.models.blocks.basic_components.RawTextObject"><code class="flex name class">
+<span>class <span class="ident">RawTextObject</span></span>
+<span>(</span><span>*, text: str)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class RawTextObject(TextObject):
+    &#34;&#34;&#34;raw_text typed text object&#34;&#34;&#34;
+
+    type = &#34;raw_text&#34;
+
+    @property
+    def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+        return {&#34;text&#34;, &#34;type&#34;}
+
+    def __init__(self, *, text: str):
+        &#34;&#34;&#34;A raw text object used in table block cells.
+        https://docs.slack.dev/reference/block-kit/composition-objects/text-object/
+        https://docs.slack.dev/reference/block-kit/blocks/table-block
+
+        Args:
+            text (required): The text content for the table block cell.
+        &#34;&#34;&#34;
+        super().__init__(text=text, type=self.type)
+
+    @staticmethod
+    def from_str(text: str) -&gt; &#34;RawTextObject&#34;:
+        &#34;&#34;&#34;Transforms a string into a RawTextObject&#34;&#34;&#34;
+        return RawTextObject(text=text)
+
+    @staticmethod
+    def direct_from_string(text: str) -&gt; Dict[str, Any]:
+        &#34;&#34;&#34;Transforms a string into the required object shape to act as a RawTextObject&#34;&#34;&#34;
+        return RawTextObject.from_str(text).to_dict()
+
+    @JsonValidator(&#34;text attribute must have at least 1 character&#34;)
+    def _validate_text_min_length(self):
+        return len(self.text) &gt;= 1</code></pre>
+</details>
+<div class="desc"><p>raw_text typed text object</p>
+<p>A raw text object used in table block cells.
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/text-object/">https://docs.slack.dev/reference/block-kit/composition-objects/text-object/</a>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/table-block">https://docs.slack.dev/reference/block-kit/blocks/table-block</a></p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
+<dd>The text content for the table block cell.</dd>
+</dl></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.blocks.basic_components.TextObject" href="#slack_sdk.models.blocks.basic_components.TextObject">TextObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.basic_components.RawTextObject.type"><code class="name">var <span class="ident">type</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Static methods</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.basic_components.RawTextObject.direct_from_string"><code class="name flex">
+<span>def <span class="ident">direct_from_string</span></span>(<span>text: str) ‑> Dict[str, Any]</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def direct_from_string(text: str) -&gt; Dict[str, Any]:
+    &#34;&#34;&#34;Transforms a string into the required object shape to act as a RawTextObject&#34;&#34;&#34;
+    return RawTextObject.from_str(text).to_dict()</code></pre>
+</details>
+<div class="desc"><p>Transforms a string into the required object shape to act as a RawTextObject</p></div>
+</dd>
+<dt id="slack_sdk.models.blocks.basic_components.RawTextObject.from_str"><code class="name flex">
+<span>def <span class="ident">from_str</span></span>(<span>text: str) ‑> <a title="slack_sdk.models.blocks.basic_components.RawTextObject" href="#slack_sdk.models.blocks.basic_components.RawTextObject">RawTextObject</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def from_str(text: str) -&gt; &#34;RawTextObject&#34;:
+    &#34;&#34;&#34;Transforms a string into a RawTextObject&#34;&#34;&#34;
+    return RawTextObject(text=text)</code></pre>
+</details>
+<div class="desc"><p>Transforms a string into a RawTextObject</p></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.basic_components.RawTextObject.attributes"><code class="name">prop <span class="ident">attributes</span> : Set[str]</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+    return {&#34;text&#34;, &#34;type&#34;}</code></pre>
+</details>
+<div class="desc"><p>Build an unordered collection of unique elements.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.blocks.basic_components.TextObject" href="#slack_sdk.models.blocks.basic_components.TextObject">TextObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.blocks.basic_components.TextObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.basic_components.TextObject.logger" href="#slack_sdk.models.blocks.basic_components.TextObject.logger">logger</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.basic_components.TextObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.basic_components.TextObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
 <dt id="slack_sdk.models.blocks.basic_components.SlackFile"><code class="flex name class">
 <span>class <span class="ident">SlackFile</span></span>
 <span>(</span><span>*, id: str | None = None, url: str | None = None)</span>
@@ -1396,6 +1520,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.basic_components.MarkdownTextObject" href="#slack_sdk.models.blocks.basic_components.MarkdownTextObject">MarkdownTextObject</a></li>
 <li><a title="slack_sdk.models.blocks.basic_components.PlainTextObject" href="#slack_sdk.models.blocks.basic_components.PlainTextObject">PlainTextObject</a></li>
+<li><a title="slack_sdk.models.blocks.basic_components.RawTextObject" href="#slack_sdk.models.blocks.basic_components.RawTextObject">RawTextObject</a></li>
 </ul>
 <h3>Class variables</h3>
 <dl>
@@ -1630,6 +1755,15 @@ def subtype(self) -&gt; Optional[str]:
 <li><code><a title="slack_sdk.models.blocks.basic_components.PlainTextObject.direct_from_string" href="#slack_sdk.models.blocks.basic_components.PlainTextObject.direct_from_string">direct_from_string</a></code></li>
 <li><code><a title="slack_sdk.models.blocks.basic_components.PlainTextObject.from_str" href="#slack_sdk.models.blocks.basic_components.PlainTextObject.from_str">from_str</a></code></li>
 <li><code><a title="slack_sdk.models.blocks.basic_components.PlainTextObject.type" href="#slack_sdk.models.blocks.basic_components.PlainTextObject.type">type</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.blocks.basic_components.RawTextObject" href="#slack_sdk.models.blocks.basic_components.RawTextObject">RawTextObject</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.blocks.basic_components.RawTextObject.attributes" href="#slack_sdk.models.blocks.basic_components.RawTextObject.attributes">attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.basic_components.RawTextObject.direct_from_string" href="#slack_sdk.models.blocks.basic_components.RawTextObject.direct_from_string">direct_from_string</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.basic_components.RawTextObject.from_str" href="#slack_sdk.models.blocks.basic_components.RawTextObject.from_str">from_str</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.basic_components.RawTextObject.type" href="#slack_sdk.models.blocks.basic_components.RawTextObject.type">type</a></code></li>
 </ul>
 </li>
 <li>

--- a/docs/reference/models/blocks/blocks.html
+++ b/docs/reference/models/blocks/blocks.html
@@ -236,6 +236,8 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
                     return VideoBlock(**block)
                 elif type == RichTextBlock.type:
                     return RichTextBlock(**block)
+                elif type == TableBlock.type:
+                    return TableBlock(**block)
                 else:
                     cls.logger.warning(f&#34;Unknown block detected and skipped ({block})&#34;)
                     return None
@@ -269,6 +271,7 @@ to create visually rich and compellingly interactive messages.
 <li><a title="slack_sdk.models.blocks.blocks.MarkdownBlock" href="#slack_sdk.models.blocks.blocks.MarkdownBlock">MarkdownBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.SectionBlock" href="#slack_sdk.models.blocks.blocks.SectionBlock">SectionBlock</a></li>
+<li><a title="slack_sdk.models.blocks.blocks.TableBlock" href="#slack_sdk.models.blocks.blocks.TableBlock">TableBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.VideoBlock" href="#slack_sdk.models.blocks.blocks.VideoBlock">VideoBlock</a></li>
 </ul>
 <h3>Class variables</h3>
@@ -1580,6 +1583,123 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </li>
 </ul>
 </dd>
+<dt id="slack_sdk.models.blocks.blocks.TableBlock"><code class="flex name class">
+<span>class <span class="ident">TableBlock</span></span>
+<span>(</span><span>*,<br>rows: Sequence[Sequence[Dict[str, Any]]],<br>column_settings: Sequence[Dict[str, Any] | None] | None = None,<br>block_id: str | None = None,<br>**others: dict)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TableBlock(Block):
+    type = &#34;table&#34;
+
+    @property
+    def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+        return super().attributes.union({&#34;rows&#34;, &#34;column_settings&#34;})
+
+    def __init__(
+        self,
+        *,
+        rows: Sequence[Sequence[Dict[str, Any]]],
+        column_settings: Optional[Sequence[Optional[Dict[str, Any]]]] = None,
+        block_id: Optional[str] = None,
+        **others: dict,
+    ):
+        &#34;&#34;&#34;Displays structured information in a table.
+        https://docs.slack.dev/reference/block-kit/blocks/table-block
+
+        Args:
+            rows (required): An array consisting of table rows. Maximum 100 rows.
+                Each row object is an array with a max of 20 table cells.
+                Table cells can have a type of raw_text or rich_text.
+            column_settings: An array describing column behavior. If there are fewer items in the column_settings array
+                than there are columns in the table, then the items in the the column_settings array will describe
+                the same number of columns in the table as there are in the array itself.
+                Any additional columns will have the default behavior. Maximum 20 items.
+                See below for column settings schema.
+            block_id: A unique identifier for a block. If not specified, a block_id will be generated.
+                You can use this block_id when you receive an interaction payload to identify the source of the action.
+                Maximum length for this field is 255 characters.
+                block_id should be unique for each message and each iteration of a message.
+                If a message is updated, use a new block_id.
+        &#34;&#34;&#34;
+        super().__init__(type=self.type, block_id=block_id)
+        show_unknown_key_warning(self, others)
+
+        self.rows = rows
+        self.column_settings = column_settings
+
+    @JsonValidator(&#34;rows attribute must be specified&#34;)
+    def _validate_rows(self):
+        return self.rows is not None and len(self.rows) &gt; 0</code></pre>
+</details>
+<div class="desc"><p>Blocks are a series of components that can be combined
+to create visually rich and compellingly interactive messages.
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
+<p>Displays structured information in a table.
+<a href="https://docs.slack.dev/reference/block-kit/blocks/table-block">https://docs.slack.dev/reference/block-kit/blocks/table-block</a></p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>rows</code></strong> :&ensp;<code>required</code></dt>
+<dd>An array consisting of table rows. Maximum 100 rows.
+Each row object is an array with a max of 20 table cells.
+Table cells can have a type of raw_text or rich_text.</dd>
+<dt><strong><code>column_settings</code></strong></dt>
+<dd>An array describing column behavior. If there are fewer items in the column_settings array
+than there are columns in the table, then the items in the the column_settings array will describe
+the same number of columns in the table as there are in the array itself.
+Any additional columns will have the default behavior. Maximum 20 items.
+See below for column settings schema.</dd>
+<dt><strong><code>block_id</code></strong></dt>
+<dd>A unique identifier for a block. If not specified, a block_id will be generated.
+You can use this block_id when you receive an interaction payload to identify the source of the action.
+Maximum length for this field is 255 characters.
+block_id should be unique for each message and each iteration of a message.
+If a message is updated, use a new block_id.</dd>
+</dl></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.blocks.blocks.Block" href="#slack_sdk.models.blocks.blocks.Block">Block</a></li>
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.blocks.TableBlock.type"><code class="name">var <span class="ident">type</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.blocks.TableBlock.attributes"><code class="name">prop <span class="ident">attributes</span> : Set[str]</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+    return super().attributes.union({&#34;rows&#34;, &#34;column_settings&#34;})</code></pre>
+</details>
+<div class="desc"><p>Build an unordered collection of unique elements.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.blocks.blocks.Block" href="#slack_sdk.models.blocks.blocks.Block">Block</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.block_id_max_length" href="#slack_sdk.models.blocks.blocks.Block.block_id_max_length">block_id_max_length</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.logger" href="#slack_sdk.models.blocks.blocks.Block.logger">logger</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
 <dt id="slack_sdk.models.blocks.blocks.VideoBlock"><code class="flex name class">
 <span>class <span class="ident">VideoBlock</span></span>
 <span>(</span><span>*,<br>block_id: str | None = None,<br>alt_text: str | None = None,<br>video_url: str | None = None,<br>thumbnail_url: str | None = None,<br>title: str | dict | <a title="slack_sdk.models.blocks.basic_components.PlainTextObject" href="basic_components.html#slack_sdk.models.blocks.basic_components.PlainTextObject">PlainTextObject</a> | None = None,<br>title_url: str | None = None,<br>description: str | dict | <a title="slack_sdk.models.blocks.basic_components.PlainTextObject" href="basic_components.html#slack_sdk.models.blocks.basic_components.PlainTextObject">PlainTextObject</a> | None = None,<br>provider_icon_url: str | None = None,<br>provider_name: str | None = None,<br>author_name: str | None = None,<br>**others: dict)</span>
@@ -1901,6 +2021,13 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <li><code><a title="slack_sdk.models.blocks.blocks.SectionBlock.fields_max_length" href="#slack_sdk.models.blocks.blocks.SectionBlock.fields_max_length">fields_max_length</a></code></li>
 <li><code><a title="slack_sdk.models.blocks.blocks.SectionBlock.text_max_length" href="#slack_sdk.models.blocks.blocks.SectionBlock.text_max_length">text_max_length</a></code></li>
 <li><code><a title="slack_sdk.models.blocks.blocks.SectionBlock.type" href="#slack_sdk.models.blocks.blocks.SectionBlock.type">type</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.blocks.blocks.TableBlock" href="#slack_sdk.models.blocks.blocks.TableBlock">TableBlock</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.blocks.blocks.TableBlock.attributes" href="#slack_sdk.models.blocks.blocks.TableBlock.attributes">attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.TableBlock.type" href="#slack_sdk.models.blocks.blocks.TableBlock.type">type</a></code></li>
 </ul>
 </li>
 <li>

--- a/docs/reference/models/blocks/index.html
+++ b/docs/reference/models/blocks/index.html
@@ -258,6 +258,8 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
                     return VideoBlock(**block)
                 elif type == RichTextBlock.type:
                     return RichTextBlock(**block)
+                elif type == TableBlock.type:
+                    return TableBlock(**block)
                 else:
                     cls.logger.warning(f&#34;Unknown block detected and skipped ({block})&#34;)
                     return None
@@ -291,6 +293,7 @@ to create visually rich and compellingly interactive messages.
 <li><a title="slack_sdk.models.blocks.blocks.MarkdownBlock" href="blocks.html#slack_sdk.models.blocks.blocks.MarkdownBlock">MarkdownBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.SectionBlock" href="blocks.html#slack_sdk.models.blocks.blocks.SectionBlock">SectionBlock</a></li>
+<li><a title="slack_sdk.models.blocks.blocks.TableBlock" href="blocks.html#slack_sdk.models.blocks.blocks.TableBlock">TableBlock</a></li>
 <li><a title="slack_sdk.models.blocks.blocks.VideoBlock" href="blocks.html#slack_sdk.models.blocks.blocks.VideoBlock">VideoBlock</a></li>
 </ul>
 <h3>Class variables</h3>
@@ -5462,6 +5465,130 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </li>
 </ul>
 </dd>
+<dt id="slack_sdk.models.blocks.RawTextObject"><code class="flex name class">
+<span>class <span class="ident">RawTextObject</span></span>
+<span>(</span><span>*, text: str)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class RawTextObject(TextObject):
+    &#34;&#34;&#34;raw_text typed text object&#34;&#34;&#34;
+
+    type = &#34;raw_text&#34;
+
+    @property
+    def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+        return {&#34;text&#34;, &#34;type&#34;}
+
+    def __init__(self, *, text: str):
+        &#34;&#34;&#34;A raw text object used in table block cells.
+        https://docs.slack.dev/reference/block-kit/composition-objects/text-object/
+        https://docs.slack.dev/reference/block-kit/blocks/table-block
+
+        Args:
+            text (required): The text content for the table block cell.
+        &#34;&#34;&#34;
+        super().__init__(text=text, type=self.type)
+
+    @staticmethod
+    def from_str(text: str) -&gt; &#34;RawTextObject&#34;:
+        &#34;&#34;&#34;Transforms a string into a RawTextObject&#34;&#34;&#34;
+        return RawTextObject(text=text)
+
+    @staticmethod
+    def direct_from_string(text: str) -&gt; Dict[str, Any]:
+        &#34;&#34;&#34;Transforms a string into the required object shape to act as a RawTextObject&#34;&#34;&#34;
+        return RawTextObject.from_str(text).to_dict()
+
+    @JsonValidator(&#34;text attribute must have at least 1 character&#34;)
+    def _validate_text_min_length(self):
+        return len(self.text) &gt;= 1</code></pre>
+</details>
+<div class="desc"><p>raw_text typed text object</p>
+<p>A raw text object used in table block cells.
+<a href="https://docs.slack.dev/reference/block-kit/composition-objects/text-object/">https://docs.slack.dev/reference/block-kit/composition-objects/text-object/</a>
+<a href="https://docs.slack.dev/reference/block-kit/blocks/table-block">https://docs.slack.dev/reference/block-kit/blocks/table-block</a></p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>text</code></strong> :&ensp;<code>required</code></dt>
+<dd>The text content for the table block cell.</dd>
+</dl></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.blocks.basic_components.TextObject" href="basic_components.html#slack_sdk.models.blocks.basic_components.TextObject">TextObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.RawTextObject.type"><code class="name">var <span class="ident">type</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Static methods</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.RawTextObject.direct_from_string"><code class="name flex">
+<span>def <span class="ident">direct_from_string</span></span>(<span>text: str) ‑> Dict[str, Any]</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def direct_from_string(text: str) -&gt; Dict[str, Any]:
+    &#34;&#34;&#34;Transforms a string into the required object shape to act as a RawTextObject&#34;&#34;&#34;
+    return RawTextObject.from_str(text).to_dict()</code></pre>
+</details>
+<div class="desc"><p>Transforms a string into the required object shape to act as a RawTextObject</p></div>
+</dd>
+<dt id="slack_sdk.models.blocks.RawTextObject.from_str"><code class="name flex">
+<span>def <span class="ident">from_str</span></span>(<span>text: str) ‑> <a title="slack_sdk.models.blocks.basic_components.RawTextObject" href="basic_components.html#slack_sdk.models.blocks.basic_components.RawTextObject">RawTextObject</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def from_str(text: str) -&gt; &#34;RawTextObject&#34;:
+    &#34;&#34;&#34;Transforms a string into a RawTextObject&#34;&#34;&#34;
+    return RawTextObject(text=text)</code></pre>
+</details>
+<div class="desc"><p>Transforms a string into a RawTextObject</p></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.RawTextObject.attributes"><code class="name">prop <span class="ident">attributes</span> : Set[str]</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+    return {&#34;text&#34;, &#34;type&#34;}</code></pre>
+</details>
+<div class="desc"><p>Build an unordered collection of unique elements.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.blocks.basic_components.TextObject" href="basic_components.html#slack_sdk.models.blocks.basic_components.TextObject">TextObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.blocks.basic_components.TextObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.basic_components.TextObject.logger" href="basic_components.html#slack_sdk.models.blocks.basic_components.TextObject.logger">logger</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.basic_components.TextObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.basic_components.TextObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
 <dt id="slack_sdk.models.blocks.RichTextBlock"><code class="flex name class">
 <span>class <span class="ident">RichTextBlock</span></span>
 <span>(</span><span>*,<br>elements: Sequence[dict | <a title="slack_sdk.models.blocks.block_elements.RichTextElement" href="block_elements.html#slack_sdk.models.blocks.block_elements.RichTextElement">RichTextElement</a>],<br>block_id: str | None = None,<br>**others: dict)</span>
@@ -6952,6 +7079,123 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </li>
 </ul>
 </dd>
+<dt id="slack_sdk.models.blocks.TableBlock"><code class="flex name class">
+<span>class <span class="ident">TableBlock</span></span>
+<span>(</span><span>*,<br>rows: Sequence[Sequence[Dict[str, Any]]],<br>column_settings: Sequence[Dict[str, Any] | None] | None = None,<br>block_id: str | None = None,<br>**others: dict)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TableBlock(Block):
+    type = &#34;table&#34;
+
+    @property
+    def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+        return super().attributes.union({&#34;rows&#34;, &#34;column_settings&#34;})
+
+    def __init__(
+        self,
+        *,
+        rows: Sequence[Sequence[Dict[str, Any]]],
+        column_settings: Optional[Sequence[Optional[Dict[str, Any]]]] = None,
+        block_id: Optional[str] = None,
+        **others: dict,
+    ):
+        &#34;&#34;&#34;Displays structured information in a table.
+        https://docs.slack.dev/reference/block-kit/blocks/table-block
+
+        Args:
+            rows (required): An array consisting of table rows. Maximum 100 rows.
+                Each row object is an array with a max of 20 table cells.
+                Table cells can have a type of raw_text or rich_text.
+            column_settings: An array describing column behavior. If there are fewer items in the column_settings array
+                than there are columns in the table, then the items in the the column_settings array will describe
+                the same number of columns in the table as there are in the array itself.
+                Any additional columns will have the default behavior. Maximum 20 items.
+                See below for column settings schema.
+            block_id: A unique identifier for a block. If not specified, a block_id will be generated.
+                You can use this block_id when you receive an interaction payload to identify the source of the action.
+                Maximum length for this field is 255 characters.
+                block_id should be unique for each message and each iteration of a message.
+                If a message is updated, use a new block_id.
+        &#34;&#34;&#34;
+        super().__init__(type=self.type, block_id=block_id)
+        show_unknown_key_warning(self, others)
+
+        self.rows = rows
+        self.column_settings = column_settings
+
+    @JsonValidator(&#34;rows attribute must be specified&#34;)
+    def _validate_rows(self):
+        return self.rows is not None and len(self.rows) &gt; 0</code></pre>
+</details>
+<div class="desc"><p>Blocks are a series of components that can be combined
+to create visually rich and compellingly interactive messages.
+<a href="https://docs.slack.dev/reference/block-kit/blocks">https://docs.slack.dev/reference/block-kit/blocks</a></p>
+<p>Displays structured information in a table.
+<a href="https://docs.slack.dev/reference/block-kit/blocks/table-block">https://docs.slack.dev/reference/block-kit/blocks/table-block</a></p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>rows</code></strong> :&ensp;<code>required</code></dt>
+<dd>An array consisting of table rows. Maximum 100 rows.
+Each row object is an array with a max of 20 table cells.
+Table cells can have a type of raw_text or rich_text.</dd>
+<dt><strong><code>column_settings</code></strong></dt>
+<dd>An array describing column behavior. If there are fewer items in the column_settings array
+than there are columns in the table, then the items in the the column_settings array will describe
+the same number of columns in the table as there are in the array itself.
+Any additional columns will have the default behavior. Maximum 20 items.
+See below for column settings schema.</dd>
+<dt><strong><code>block_id</code></strong></dt>
+<dd>A unique identifier for a block. If not specified, a block_id will be generated.
+You can use this block_id when you receive an interaction payload to identify the source of the action.
+Maximum length for this field is 255 characters.
+block_id should be unique for each message and each iteration of a message.
+If a message is updated, use a new block_id.</dd>
+</dl></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.blocks.blocks.Block" href="blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a></li>
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.TableBlock.type"><code class="name">var <span class="ident">type</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="slack_sdk.models.blocks.TableBlock.attributes"><code class="name">prop <span class="ident">attributes</span> : Set[str]</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def attributes(self) -&gt; Set[str]:  # type: ignore[override]
+    return super().attributes.union({&#34;rows&#34;, &#34;column_settings&#34;})</code></pre>
+</details>
+<div class="desc"><p>Build an unordered collection of unique elements.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.blocks.blocks.Block" href="blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.block_id_max_length" href="blocks.html#slack_sdk.models.blocks.blocks.Block.block_id_max_length">block_id_max_length</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.logger" href="blocks.html#slack_sdk.models.blocks.blocks.Block.logger">logger</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.blocks.Block.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
 <dt id="slack_sdk.models.blocks.TextObject"><code class="flex name class">
 <span>class <span class="ident">TextObject</span></span>
 <span>(</span><span>text: str,<br>type: str | None = None,<br>subtype: str | None = None,<br>emoji: bool | None = None,<br>**kwargs)</span>
@@ -7030,6 +7274,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <ul class="hlist">
 <li><a title="slack_sdk.models.blocks.basic_components.MarkdownTextObject" href="basic_components.html#slack_sdk.models.blocks.basic_components.MarkdownTextObject">MarkdownTextObject</a></li>
 <li><a title="slack_sdk.models.blocks.basic_components.PlainTextObject" href="basic_components.html#slack_sdk.models.blocks.basic_components.PlainTextObject">PlainTextObject</a></li>
+<li><a title="slack_sdk.models.blocks.basic_components.RawTextObject" href="basic_components.html#slack_sdk.models.blocks.basic_components.RawTextObject">RawTextObject</a></li>
 </ul>
 <h3>Class variables</h3>
 <dl>
@@ -8151,6 +8396,15 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 </ul>
 </li>
 <li>
+<h4><code><a title="slack_sdk.models.blocks.RawTextObject" href="#slack_sdk.models.blocks.RawTextObject">RawTextObject</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.blocks.RawTextObject.attributes" href="#slack_sdk.models.blocks.RawTextObject.attributes">attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.RawTextObject.direct_from_string" href="#slack_sdk.models.blocks.RawTextObject.direct_from_string">direct_from_string</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.RawTextObject.from_str" href="#slack_sdk.models.blocks.RawTextObject.from_str">from_str</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.RawTextObject.type" href="#slack_sdk.models.blocks.RawTextObject.type">type</a></code></li>
+</ul>
+</li>
+<li>
 <h4><code><a title="slack_sdk.models.blocks.RichTextBlock" href="#slack_sdk.models.blocks.RichTextBlock">RichTextBlock</a></code></h4>
 <ul class="">
 <li><code><a title="slack_sdk.models.blocks.RichTextBlock.attributes" href="#slack_sdk.models.blocks.RichTextBlock.attributes">attributes</a></code></li>
@@ -8245,6 +8499,13 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 <li><code><a title="slack_sdk.models.blocks.StaticSelectElement.option_groups_max_length" href="#slack_sdk.models.blocks.StaticSelectElement.option_groups_max_length">option_groups_max_length</a></code></li>
 <li><code><a title="slack_sdk.models.blocks.StaticSelectElement.options_max_length" href="#slack_sdk.models.blocks.StaticSelectElement.options_max_length">options_max_length</a></code></li>
 <li><code><a title="slack_sdk.models.blocks.StaticSelectElement.type" href="#slack_sdk.models.blocks.StaticSelectElement.type">type</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.blocks.TableBlock" href="#slack_sdk.models.blocks.TableBlock">TableBlock</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.blocks.TableBlock.attributes" href="#slack_sdk.models.blocks.TableBlock.attributes">attributes</a></code></li>
+<li><code><a title="slack_sdk.models.blocks.TableBlock.type" href="#slack_sdk.models.blocks.TableBlock.type">type</a></code></li>
 </ul>
 </li>
 <li>

--- a/docs/reference/models/index.html
+++ b/docs/reference/models/index.html
@@ -223,6 +223,9 @@ functions should return true if valid, false if not.</p>
             if callable(method) and hasattr(method, &#34;validator&#34;):
                 method()
 
+    def get_object_attribute(self, key: str):
+        return getattr(self, key, None)
+
     def get_non_null_attributes(self) -&gt; dict:
         &#34;&#34;&#34;
         Construct a dictionary out of non-null keys (from attributes property)
@@ -240,7 +243,7 @@ functions should return true if valid, false if not.</p>
                     return value
 
         def is_not_empty(self, key: str) -&gt; bool:
-            value = getattr(self, key, None)
+            value = self.get_object_attribute(key)
             if value is None:
                 return False
 
@@ -258,7 +261,9 @@ functions should return true if valid, false if not.</p>
                 return value is not None
 
         return {
-            key: to_dict_compatible(getattr(self, key, None)) for key in sorted(self.attributes) if is_not_empty(self, key)
+            key: to_dict_compatible(value=self.get_object_attribute(key))
+            for key in sorted(self.attributes)
+            if is_not_empty(self, key)
         }
 
     def to_dict(self, *args) -&gt; dict:
@@ -312,7 +317,40 @@ functions should return true if valid, false if not.</p>
 <li><a title="slack_sdk.models.dialogs.DialogBuilder" href="dialogs/index.html#slack_sdk.models.dialogs.DialogBuilder">DialogBuilder</a></li>
 <li><a title="slack_sdk.models.dialogs.DialogTextComponent" href="dialogs/index.html#slack_sdk.models.dialogs.DialogTextComponent">DialogTextComponent</a></li>
 <li><a title="slack_sdk.models.messages.message.Message" href="messages/message.html#slack_sdk.models.messages.message.Message">Message</a></li>
+<li><a title="slack_sdk.models.metadata.ContentItemEntityFields" href="metadata/index.html#slack_sdk.models.metadata.ContentItemEntityFields">ContentItemEntityFields</a></li>
+<li><a title="slack_sdk.models.metadata.EntityActionButton" href="metadata/index.html#slack_sdk.models.metadata.EntityActionButton">EntityActionButton</a></li>
+<li><a title="slack_sdk.models.metadata.EntityActionProcessingState" href="metadata/index.html#slack_sdk.models.metadata.EntityActionProcessingState">EntityActionProcessingState</a></li>
+<li><a title="slack_sdk.models.metadata.EntityActions" href="metadata/index.html#slack_sdk.models.metadata.EntityActions">EntityActions</a></li>
+<li><a title="slack_sdk.models.metadata.EntityArrayItemField" href="metadata/index.html#slack_sdk.models.metadata.EntityArrayItemField">EntityArrayItemField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityAttributes" href="metadata/index.html#slack_sdk.models.metadata.EntityAttributes">EntityAttributes</a></li>
+<li><a title="slack_sdk.models.metadata.EntityBooleanCheckboxField" href="metadata/index.html#slack_sdk.models.metadata.EntityBooleanCheckboxField">EntityBooleanCheckboxField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityBooleanTextField" href="metadata/index.html#slack_sdk.models.metadata.EntityBooleanTextField">EntityBooleanTextField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityCustomField" href="metadata/index.html#slack_sdk.models.metadata.EntityCustomField">EntityCustomField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityEditNumberConfig" href="metadata/index.html#slack_sdk.models.metadata.EntityEditNumberConfig">EntityEditNumberConfig</a></li>
+<li><a title="slack_sdk.models.metadata.EntityEditSelectConfig" href="metadata/index.html#slack_sdk.models.metadata.EntityEditSelectConfig">EntityEditSelectConfig</a></li>
+<li><a title="slack_sdk.models.metadata.EntityEditSupport" href="metadata/index.html#slack_sdk.models.metadata.EntityEditSupport">EntityEditSupport</a></li>
+<li><a title="slack_sdk.models.metadata.EntityEditTextConfig" href="metadata/index.html#slack_sdk.models.metadata.EntityEditTextConfig">EntityEditTextConfig</a></li>
+<li><a title="slack_sdk.models.metadata.EntityFullSizePreview" href="metadata/index.html#slack_sdk.models.metadata.EntityFullSizePreview">EntityFullSizePreview</a></li>
+<li><a title="slack_sdk.models.metadata.EntityFullSizePreviewError" href="metadata/index.html#slack_sdk.models.metadata.EntityFullSizePreviewError">EntityFullSizePreviewError</a></li>
+<li><a title="slack_sdk.models.metadata.EntityIconField" href="metadata/index.html#slack_sdk.models.metadata.EntityIconField">EntityIconField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityIconSlackFile" href="metadata/index.html#slack_sdk.models.metadata.EntityIconSlackFile">EntityIconSlackFile</a></li>
+<li><a title="slack_sdk.models.metadata.EntityImageField" href="metadata/index.html#slack_sdk.models.metadata.EntityImageField">EntityImageField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityMetadata" href="metadata/index.html#slack_sdk.models.metadata.EntityMetadata">EntityMetadata</a></li>
+<li><a title="slack_sdk.models.metadata.EntityPayload" href="metadata/index.html#slack_sdk.models.metadata.EntityPayload">EntityPayload</a></li>
+<li><a title="slack_sdk.models.metadata.EntityRefField" href="metadata/index.html#slack_sdk.models.metadata.EntityRefField">EntityRefField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityStringField" href="metadata/index.html#slack_sdk.models.metadata.EntityStringField">EntityStringField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityTimestampField" href="metadata/index.html#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityTitle" href="metadata/index.html#slack_sdk.models.metadata.EntityTitle">EntityTitle</a></li>
+<li><a title="slack_sdk.models.metadata.EntityTypedField" href="metadata/index.html#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityUserField" href="metadata/index.html#slack_sdk.models.metadata.EntityUserField">EntityUserField</a></li>
+<li><a title="slack_sdk.models.metadata.EntityUserIDField" href="metadata/index.html#slack_sdk.models.metadata.EntityUserIDField">EntityUserIDField</a></li>
+<li><a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a></li>
+<li><a title="slack_sdk.models.metadata.ExternalRef" href="metadata/index.html#slack_sdk.models.metadata.ExternalRef">ExternalRef</a></li>
+<li><a title="slack_sdk.models.metadata.FileEntityFields" href="metadata/index.html#slack_sdk.models.metadata.FileEntityFields">FileEntityFields</a></li>
+<li><a title="slack_sdk.models.metadata.FileEntitySlackFile" href="metadata/index.html#slack_sdk.models.metadata.FileEntitySlackFile">FileEntitySlackFile</a></li>
+<li><a title="slack_sdk.models.metadata.IncidentEntityFields" href="metadata/index.html#slack_sdk.models.metadata.IncidentEntityFields">IncidentEntityFields</a></li>
 <li><a title="slack_sdk.models.metadata.Metadata" href="metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a></li>
+<li><a title="slack_sdk.models.metadata.TaskEntityFields" href="metadata/index.html#slack_sdk.models.metadata.TaskEntityFields">TaskEntityFields</a></li>
 <li><a title="slack_sdk.models.views.View" href="views/index.html#slack_sdk.models.views.View">View</a></li>
 <li><a title="slack_sdk.models.views.ViewState" href="views/index.html#slack_sdk.models.views.ViewState">ViewState</a></li>
 <li><a title="slack_sdk.models.views.ViewStateValue" href="views/index.html#slack_sdk.models.views.ViewStateValue">ViewStateValue</a></li>
@@ -361,7 +399,7 @@ def attributes(self) -&gt; Set[str]:
                 return value
 
     def is_not_empty(self, key: str) -&gt; bool:
-        value = getattr(self, key, None)
+        value = self.get_object_attribute(key)
         if value is None:
             return False
 
@@ -379,11 +417,26 @@ def attributes(self) -&gt; Set[str]:
             return value is not None
 
     return {
-        key: to_dict_compatible(getattr(self, key, None)) for key in sorted(self.attributes) if is_not_empty(self, key)
+        key: to_dict_compatible(value=self.get_object_attribute(key))
+        for key in sorted(self.attributes)
+        if is_not_empty(self, key)
     }</code></pre>
 </details>
 <div class="desc"><p>Construct a dictionary out of non-null keys (from attributes property)
 present on this object</p></div>
+</dd>
+<dt id="slack_sdk.models.JsonObject.get_object_attribute"><code class="name flex">
+<span>def <span class="ident">get_object_attribute</span></span>(<span>self, key: str)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_object_attribute(self, key: str):
+    return getattr(self, key, None)</code></pre>
+</details>
+<div class="desc"></div>
 </dd>
 <dt id="slack_sdk.models.JsonObject.to_dict"><code class="name flex">
 <span>def <span class="ident">to_dict</span></span>(<span>self, *args) ‑> dict</span>
@@ -523,6 +576,7 @@ functions should return true if valid, false if not.</p>
 <ul class="">
 <li><code><a title="slack_sdk.models.JsonObject.attributes" href="#slack_sdk.models.JsonObject.attributes">attributes</a></code></li>
 <li><code><a title="slack_sdk.models.JsonObject.get_non_null_attributes" href="#slack_sdk.models.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.JsonObject.get_object_attribute" href="#slack_sdk.models.JsonObject.get_object_attribute">get_object_attribute</a></code></li>
 <li><code><a title="slack_sdk.models.JsonObject.to_dict" href="#slack_sdk.models.JsonObject.to_dict">to_dict</a></code></li>
 <li><code><a title="slack_sdk.models.JsonObject.validate_json" href="#slack_sdk.models.JsonObject.validate_json">validate_json</a></code></li>
 </ul>

--- a/docs/reference/models/metadata/index.html
+++ b/docs/reference/models/metadata/index.html
@@ -40,12 +40,2270 @@ el.replaceWith(d);
 <section>
 </section>
 <section>
+<h2 class="section-title" id="header-variables">Global variables</h2>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityType"><code class="name">var <span class="ident">EntityType</span></code></dt>
+<dd>
+<div class="desc"><p>Custom field types</p></div>
+</dd>
+</dl>
 </section>
 <section>
 </section>
 <section>
 <h2 class="section-title" id="header-classes">Classes</h2>
 <dl>
+<dt id="slack_sdk.models.metadata.ContentItemEntityFields"><code class="flex name class">
+<span>class <span class="ident">ContentItemEntityFields</span></span>
+<span>(</span><span>preview: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityImageField" href="#slack_sdk.models.metadata.EntityImageField">EntityImageField</a> | None = None,<br>description: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>created_by: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTypedField" href="#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a> | None = None,<br>date_created: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTimestampField" href="#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a> | None = None,<br>date_updated: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTimestampField" href="#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a> | None = None,<br>last_modified_by: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTypedField" href="#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ContentItemEntityFields(JsonObject):
+    &#34;&#34;&#34;Fields specific to content item entities&#34;&#34;&#34;
+
+    attributes = {
+        &#34;preview&#34;,
+        &#34;description&#34;,
+        &#34;created_by&#34;,
+        &#34;date_created&#34;,
+        &#34;date_updated&#34;,
+        &#34;last_modified_by&#34;,
+    }
+
+    def __init__(
+        self,
+        preview: Optional[Union[Dict[str, Any], EntityImageField]] = None,
+        description: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        created_by: Optional[Union[Dict[str, Any], EntityTypedField]] = None,
+        date_created: Optional[Union[Dict[str, Any], EntityTimestampField]] = None,
+        date_updated: Optional[Union[Dict[str, Any], EntityTimestampField]] = None,
+        last_modified_by: Optional[Union[Dict[str, Any], EntityTypedField]] = None,
+        **kwargs,
+    ):
+        self.preview = preview
+        self.description = description
+        self.created_by = created_by
+        self.date_created = date_created
+        self.date_updated = date_updated
+        self.last_modified_by = last_modified_by
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Fields specific to content item entities</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.ContentItemEntityFields.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityActionButton"><code class="flex name class">
+<span>class <span class="ident">EntityActionButton</span></span>
+<span>(</span><span>text: str,<br>action_id: str,<br>value: str | None = None,<br>style: str | None = None,<br>url: str | None = None,<br>accessibility_label: str | None = None,<br>processing_state: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityActionProcessingState" href="#slack_sdk.models.metadata.EntityActionProcessingState">EntityActionProcessingState</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityActionButton(JsonObject):
+    &#34;&#34;&#34;Action button for entity&#34;&#34;&#34;
+
+    attributes = {
+        &#34;text&#34;,
+        &#34;action_id&#34;,
+        &#34;value&#34;,
+        &#34;style&#34;,
+        &#34;url&#34;,
+        &#34;accessibility_label&#34;,
+        &#34;processing_state&#34;,
+    }
+
+    def __init__(
+        self,
+        text: str,
+        action_id: str,
+        value: Optional[str] = None,
+        style: Optional[str] = None,
+        url: Optional[str] = None,
+        accessibility_label: Optional[str] = None,
+        processing_state: Optional[Union[Dict[str, Any], EntityActionProcessingState]] = None,
+        **kwargs,
+    ):
+        self.text = text
+        self.action_id = action_id
+        self.value = value
+        self.style = style
+        self.url = url
+        self.accessibility_label = accessibility_label
+        self.processing_state = processing_state
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Action button for entity</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityActionButton.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityActionProcessingState"><code class="flex name class">
+<span>class <span class="ident">EntityActionProcessingState</span></span>
+<span>(</span><span>enabled: bool, interstitial_text: str | None = None, **kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityActionProcessingState(JsonObject):
+    &#34;&#34;&#34;Processing state configuration for entity action button&#34;&#34;&#34;
+
+    attributes = {
+        &#34;enabled&#34;,
+        &#34;interstitial_text&#34;,
+    }
+
+    def __init__(
+        self,
+        enabled: bool,
+        interstitial_text: Optional[str] = None,
+        **kwargs,
+    ):
+        self.enabled = enabled
+        self.interstitial_text = interstitial_text
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Processing state configuration for entity action button</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityActionProcessingState.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityActions"><code class="flex name class">
+<span>class <span class="ident">EntityActions</span></span>
+<span>(</span><span>primary_actions: List[Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityActionButton" href="#slack_sdk.models.metadata.EntityActionButton">EntityActionButton</a>] | None = None,<br>overflow_actions: List[Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityActionButton" href="#slack_sdk.models.metadata.EntityActionButton">EntityActionButton</a>] | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityActions(JsonObject):
+    &#34;&#34;&#34;Actions configuration for entity&#34;&#34;&#34;
+
+    attributes = {
+        &#34;primary_actions&#34;,
+        &#34;overflow_actions&#34;,
+    }
+
+    def __init__(
+        self,
+        primary_actions: Optional[List[Union[Dict[str, Any], EntityActionButton]]] = None,
+        overflow_actions: Optional[List[Union[Dict[str, Any], EntityActionButton]]] = None,
+        **kwargs,
+    ):
+        self.primary_actions = primary_actions
+        self.overflow_actions = overflow_actions
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Actions configuration for entity</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityActions.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityArrayItemField"><code class="flex name class">
+<span>class <span class="ident">EntityArrayItemField</span></span>
+<span>(</span><span>type: str | None = None,<br>label: str | None = None,<br>value: str | int | None = None,<br>link: str | None = None,<br>icon: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityIconField" href="#slack_sdk.models.metadata.EntityIconField">EntityIconField</a> | None = None,<br>long: bool | None = None,<br>format: str | None = None,<br>image_url: str | None = None,<br>slack_file: Dict[str, Any] | None = None,<br>alt_text: str | None = None,<br>edit: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityEditSupport" href="#slack_sdk.models.metadata.EntityEditSupport">EntityEditSupport</a> | None = None,<br>tag_color: str | None = None,<br>user: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityUserIDField" href="#slack_sdk.models.metadata.EntityUserIDField">EntityUserIDField</a> | <a title="slack_sdk.models.metadata.EntityUserField" href="#slack_sdk.models.metadata.EntityUserField">EntityUserField</a> | None = None,<br>entity_ref: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityRefField" href="#slack_sdk.models.metadata.EntityRefField">EntityRefField</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityArrayItemField(JsonObject):
+    &#34;&#34;&#34;Array item field for entity (similar to EntityTypedField but with optional type)&#34;&#34;&#34;
+
+    attributes = {
+        &#34;type&#34;,
+        &#34;label&#34;,
+        &#34;value&#34;,
+        &#34;link&#34;,
+        &#34;icon&#34;,
+        &#34;long&#34;,
+        &#34;format&#34;,
+        &#34;image_url&#34;,
+        &#34;slack_file&#34;,
+        &#34;alt_text&#34;,
+        &#34;edit&#34;,
+        &#34;tag_color&#34;,
+        &#34;user&#34;,
+        &#34;entity_ref&#34;,
+    }
+
+    def __init__(
+        self,
+        type: Optional[str] = None,
+        label: Optional[str] = None,
+        value: Optional[Union[str, int]] = None,
+        link: Optional[str] = None,
+        icon: Optional[Union[Dict[str, Any], EntityIconField]] = None,
+        long: Optional[bool] = None,
+        format: Optional[str] = None,
+        image_url: Optional[str] = None,
+        slack_file: Optional[Dict[str, Any]] = None,
+        alt_text: Optional[str] = None,
+        edit: Optional[Union[Dict[str, Any], EntityEditSupport]] = None,
+        tag_color: Optional[str] = None,
+        user: Optional[Union[Dict[str, Any], EntityUserIDField, EntityUserField]] = None,
+        entity_ref: Optional[Union[Dict[str, Any], EntityRefField]] = None,
+        **kwargs,
+    ):
+        self.type = type
+        self.label = label
+        self.value = value
+        self.link = link
+        self.icon = icon
+        self.long = long
+        self.format = format
+        self.image_url = image_url
+        self.slack_file = slack_file
+        self.alt_text = alt_text
+        self.edit = edit
+        self.tag_color = tag_color
+        self.user = user
+        self.entity_ref = entity_ref
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Array item field for entity (similar to EntityTypedField but with optional type)</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityArrayItemField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityAttributes"><code class="flex name class">
+<span>class <span class="ident">EntityAttributes</span></span>
+<span>(</span><span>title: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTitle" href="#slack_sdk.models.metadata.EntityTitle">EntityTitle</a>,<br>display_type: str | None = None,<br>display_id: str | None = None,<br>product_icon: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityIconField" href="#slack_sdk.models.metadata.EntityIconField">EntityIconField</a> | None = None,<br>product_name: str | None = None,<br>locale: str | None = None,<br>full_size_preview: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityFullSizePreview" href="#slack_sdk.models.metadata.EntityFullSizePreview">EntityFullSizePreview</a> | None = None,<br>metadata_last_modified: int | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityAttributes(JsonObject):
+    &#34;&#34;&#34;Attributes for an entity&#34;&#34;&#34;
+
+    attributes = {
+        &#34;title&#34;,
+        &#34;display_type&#34;,
+        &#34;display_id&#34;,
+        &#34;product_icon&#34;,
+        &#34;product_name&#34;,
+        &#34;locale&#34;,
+        &#34;full_size_preview&#34;,
+        &#34;metadata_last_modified&#34;,
+    }
+
+    def __init__(
+        self,
+        title: Union[Dict[str, Any], EntityTitle],
+        display_type: Optional[str] = None,
+        display_id: Optional[str] = None,
+        product_icon: Optional[Union[Dict[str, Any], EntityIconField]] = None,
+        product_name: Optional[str] = None,
+        locale: Optional[str] = None,
+        full_size_preview: Optional[Union[Dict[str, Any], EntityFullSizePreview]] = None,
+        metadata_last_modified: Optional[int] = None,
+        **kwargs,
+    ):
+        self.title = title
+        self.display_type = display_type
+        self.display_id = display_id
+        self.product_icon = product_icon
+        self.product_name = product_name
+        self.locale = locale
+        self.full_size_preview = full_size_preview
+        self.metadata_last_modified = metadata_last_modified
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Attributes for an entity</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityAttributes.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityBooleanCheckboxField"><code class="flex name class">
+<span>class <span class="ident">EntityBooleanCheckboxField</span></span>
+<span>(</span><span>type: str, text: str, description: str | None, **kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityBooleanCheckboxField(JsonObject):
+    &#34;&#34;&#34;Boolean checkbox properties&#34;&#34;&#34;
+
+    attributes = {&#34;type&#34;, &#34;text&#34;, &#34;description&#34;}
+
+    def __init__(
+        self,
+        type: str,
+        text: str,
+        description: Optional[str],
+        **kwargs,
+    ):
+        self.type = type
+        self.text = text
+        self.description = description
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Boolean checkbox properties</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityBooleanCheckboxField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityBooleanTextField"><code class="flex name class">
+<span>class <span class="ident">EntityBooleanTextField</span></span>
+<span>(</span><span>type: str,<br>true_text: str,<br>false_text: str,<br>true_description: str | None,<br>false_description: str | None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityBooleanTextField(JsonObject):
+    &#34;&#34;&#34;Boolean text properties&#34;&#34;&#34;
+
+    attributes = {&#34;type&#34;, &#34;true_text&#34;, &#34;false_text&#34;, &#34;true_description&#34;, &#34;false_description&#34;}
+
+    def __init__(
+        self,
+        type: str,
+        true_text: str,
+        false_text: str,
+        true_description: Optional[str],
+        false_description: Optional[str],
+        **kwargs,
+    ):
+        self.type = type
+        self.true_text = (true_text,)
+        self.false_text = (false_text,)
+        self.true_description = (true_description,)
+        self.false_description = (false_description,)
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Boolean text properties</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityBooleanTextField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityCustomField"><code class="flex name class">
+<span>class <span class="ident">EntityCustomField</span></span>
+<span>(</span><span>label: str,<br>key: str,<br>type: str,<br>value: str | int | List[Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityArrayItemField" href="#slack_sdk.models.metadata.EntityArrayItemField">EntityArrayItemField</a>] | None = None,<br>link: str | None = None,<br>icon: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityIconField" href="#slack_sdk.models.metadata.EntityIconField">EntityIconField</a> | None = None,<br>long: bool | None = None,<br>format: str | None = None,<br>image_url: str | None = None,<br>slack_file: Dict[str, Any] | None = None,<br>alt_text: str | None = None,<br>tag_color: str | None = None,<br>edit: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityEditSupport" href="#slack_sdk.models.metadata.EntityEditSupport">EntityEditSupport</a> | None = None,<br>item_type: str | None = None,<br>user: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityUserIDField" href="#slack_sdk.models.metadata.EntityUserIDField">EntityUserIDField</a> | <a title="slack_sdk.models.metadata.EntityUserField" href="#slack_sdk.models.metadata.EntityUserField">EntityUserField</a> | None = None,<br>entity_ref: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityRefField" href="#slack_sdk.models.metadata.EntityRefField">EntityRefField</a> | None = None,<br>boolean: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityBooleanCheckboxField" href="#slack_sdk.models.metadata.EntityBooleanCheckboxField">EntityBooleanCheckboxField</a> | <a title="slack_sdk.models.metadata.EntityBooleanTextField" href="#slack_sdk.models.metadata.EntityBooleanTextField">EntityBooleanTextField</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityCustomField(JsonObject):
+    &#34;&#34;&#34;Custom field for entity with flexible types&#34;&#34;&#34;
+
+    attributes = {
+        &#34;label&#34;,
+        &#34;key&#34;,
+        &#34;type&#34;,
+        &#34;value&#34;,
+        &#34;link&#34;,
+        &#34;icon&#34;,
+        &#34;long&#34;,
+        &#34;format&#34;,
+        &#34;image_url&#34;,
+        &#34;slack_file&#34;,
+        &#34;alt_text&#34;,
+        &#34;tag_color&#34;,
+        &#34;edit&#34;,
+        &#34;item_type&#34;,
+        &#34;user&#34;,
+        &#34;entity_ref&#34;,
+        &#34;boolean&#34;,
+    }
+
+    def __init__(
+        self,
+        label: str,
+        key: str,
+        type: str,
+        value: Optional[Union[str, int, List[Union[Dict[str, Any], EntityArrayItemField]]]] = None,
+        link: Optional[str] = None,
+        icon: Optional[Union[Dict[str, Any], EntityIconField]] = None,
+        long: Optional[bool] = None,
+        format: Optional[str] = None,
+        image_url: Optional[str] = None,
+        slack_file: Optional[Dict[str, Any]] = None,
+        alt_text: Optional[str] = None,
+        tag_color: Optional[str] = None,
+        edit: Optional[Union[Dict[str, Any], EntityEditSupport]] = None,
+        item_type: Optional[str] = None,
+        user: Optional[Union[Dict[str, Any], EntityUserIDField, EntityUserField]] = None,
+        entity_ref: Optional[Union[Dict[str, Any], EntityRefField]] = None,
+        boolean: Optional[Union[Dict[str, Any], EntityBooleanCheckboxField, EntityBooleanTextField]] = None,
+        **kwargs,
+    ):
+        self.label = label
+        self.key = key
+        self.type = type
+        self.value = value
+        self.link = link
+        self.icon = icon
+        self.long = long
+        self.format = format
+        self.image_url = image_url
+        self.slack_file = slack_file
+        self.alt_text = alt_text
+        self.tag_color = tag_color
+        self.edit = edit
+        self.item_type = item_type
+        self.user = user
+        self.entity_ref = entity_ref
+        self.boolean = boolean
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()
+
+    @EnumValidator(&#34;type&#34;, CustomFieldType)
+    def type_valid(self):
+        return self.type is None or self.type in CustomFieldType</code></pre>
+</details>
+<div class="desc"><p>Custom field for entity with flexible types</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityCustomField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityCustomField.type_valid"><code class="name flex">
+<span>def <span class="ident">type_valid</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@EnumValidator(&#34;type&#34;, CustomFieldType)
+def type_valid(self):
+    return self.type is None or self.type in CustomFieldType</code></pre>
+</details>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityEditNumberConfig"><code class="flex name class">
+<span>class <span class="ident">EntityEditNumberConfig</span></span>
+<span>(</span><span>is_decimal_allowed: bool | None = None,<br>min_value: int | float | None = None,<br>max_value: int | float | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityEditNumberConfig(JsonObject):
+    &#34;&#34;&#34;Number configuration for entity edit support&#34;&#34;&#34;
+
+    attributes = {
+        &#34;is_decimal_allowed&#34;,
+        &#34;min_value&#34;,
+        &#34;max_value&#34;,
+    }
+
+    def __init__(
+        self,
+        is_decimal_allowed: Optional[bool] = None,
+        min_value: Optional[Union[int, float]] = None,
+        max_value: Optional[Union[int, float]] = None,
+        **kwargs,
+    ):
+        self.is_decimal_allowed = is_decimal_allowed
+        self.min_value = min_value
+        self.max_value = max_value
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Number configuration for entity edit support</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityEditNumberConfig.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityEditSelectConfig"><code class="flex name class">
+<span>class <span class="ident">EntityEditSelectConfig</span></span>
+<span>(</span><span>current_value: str | None = None,<br>current_values: List[str] | None = None,<br>static_options: List[Dict[str, Any]] | None = None,<br>fetch_options_dynamically: bool | None = None,<br>min_query_length: int | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityEditSelectConfig(JsonObject):
+    &#34;&#34;&#34;Select configuration for entity edit support&#34;&#34;&#34;
+
+    attributes = {
+        &#34;current_value&#34;,
+        &#34;current_values&#34;,
+        &#34;static_options&#34;,
+        &#34;fetch_options_dynamically&#34;,
+        &#34;min_query_length&#34;,
+    }
+
+    def __init__(
+        self,
+        current_value: Optional[str] = None,
+        current_values: Optional[List[str]] = None,
+        static_options: Optional[List[Dict[str, Any]]] = None,  # Option[]
+        fetch_options_dynamically: Optional[bool] = None,
+        min_query_length: Optional[int] = None,
+        **kwargs,
+    ):
+        self.current_value = current_value
+        self.current_values = current_values
+        self.static_options = static_options
+        self.fetch_options_dynamically = fetch_options_dynamically
+        self.min_query_length = min_query_length
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Select configuration for entity edit support</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityEditSelectConfig.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityEditSupport"><code class="flex name class">
+<span>class <span class="ident">EntityEditSupport</span></span>
+<span>(</span><span>enabled: bool,<br>placeholder: Dict[str, Any] | None = None,<br>hint: Dict[str, Any] | None = None,<br>optional: bool | None = None,<br>select: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityEditSelectConfig" href="#slack_sdk.models.metadata.EntityEditSelectConfig">EntityEditSelectConfig</a> | None = None,<br>number: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityEditNumberConfig" href="#slack_sdk.models.metadata.EntityEditNumberConfig">EntityEditNumberConfig</a> | None = None,<br>text: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityEditTextConfig" href="#slack_sdk.models.metadata.EntityEditTextConfig">EntityEditTextConfig</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityEditSupport(JsonObject):
+    &#34;&#34;&#34;Edit support configuration for entity fields&#34;&#34;&#34;
+
+    attributes = {
+        &#34;enabled&#34;,
+        &#34;placeholder&#34;,
+        &#34;hint&#34;,
+        &#34;optional&#34;,
+        &#34;select&#34;,
+        &#34;number&#34;,
+        &#34;text&#34;,
+    }
+
+    def __init__(
+        self,
+        enabled: bool,
+        placeholder: Optional[Dict[str, Any]] = None,  # PlainTextElement
+        hint: Optional[Dict[str, Any]] = None,  # PlainTextElement
+        optional: Optional[bool] = None,
+        select: Optional[Union[Dict[str, Any], EntityEditSelectConfig]] = None,
+        number: Optional[Union[Dict[str, Any], EntityEditNumberConfig]] = None,
+        text: Optional[Union[Dict[str, Any], EntityEditTextConfig]] = None,
+        **kwargs,
+    ):
+        self.enabled = enabled
+        self.placeholder = placeholder
+        self.hint = hint
+        self.optional = optional
+        self.select = select
+        self.number = number
+        self.text = text
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Edit support configuration for entity fields</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityEditSupport.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityEditTextConfig"><code class="flex name class">
+<span>class <span class="ident">EntityEditTextConfig</span></span>
+<span>(</span><span>min_length: int | None = None, max_length: int | None = None, **kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityEditTextConfig(JsonObject):
+    &#34;&#34;&#34;Text configuration for entity edit support&#34;&#34;&#34;
+
+    attributes = {
+        &#34;min_length&#34;,
+        &#34;max_length&#34;,
+    }
+
+    def __init__(
+        self,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+        **kwargs,
+    ):
+        self.min_length = min_length
+        self.max_length = max_length
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Text configuration for entity edit support</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityEditTextConfig.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityFullSizePreview"><code class="flex name class">
+<span>class <span class="ident">EntityFullSizePreview</span></span>
+<span>(</span><span>is_supported: bool,<br>preview_url: str | None = None,<br>mime_type: str | None = None,<br>error: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityFullSizePreviewError" href="#slack_sdk.models.metadata.EntityFullSizePreviewError">EntityFullSizePreviewError</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityFullSizePreview(JsonObject):
+    &#34;&#34;&#34;Full-size preview configuration for entity&#34;&#34;&#34;
+
+    attributes = {
+        &#34;is_supported&#34;,
+        &#34;preview_url&#34;,
+        &#34;mime_type&#34;,
+        &#34;error&#34;,
+    }
+
+    def __init__(
+        self,
+        is_supported: bool,
+        preview_url: Optional[str] = None,
+        mime_type: Optional[str] = None,
+        error: Optional[Union[Dict[str, Any], EntityFullSizePreviewError]] = None,
+        **kwargs,
+    ):
+        self.is_supported = is_supported
+        self.preview_url = preview_url
+        self.mime_type = mime_type
+        self.error = error
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Full-size preview configuration for entity</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityFullSizePreview.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityFullSizePreviewError"><code class="flex name class">
+<span>class <span class="ident">EntityFullSizePreviewError</span></span>
+<span>(</span><span>code: str, message: str | None = None, **kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityFullSizePreviewError(JsonObject):
+    &#34;&#34;&#34;Error information for full-size preview&#34;&#34;&#34;
+
+    attributes = {
+        &#34;code&#34;,
+        &#34;message&#34;,
+    }
+
+    def __init__(
+        self,
+        code: str,
+        message: Optional[str] = None,
+        **kwargs,
+    ):
+        self.code = code
+        self.message = message
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Error information for full-size preview</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityFullSizePreviewError.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityIconField"><code class="flex name class">
+<span>class <span class="ident">EntityIconField</span></span>
+<span>(</span><span>alt_text: str,<br>url: str | None = None,<br>slack_file: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityIconSlackFile" href="#slack_sdk.models.metadata.EntityIconSlackFile">EntityIconSlackFile</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityIconField(JsonObject):
+    &#34;&#34;&#34;Icon field for entity attributes&#34;&#34;&#34;
+
+    attributes = {
+        &#34;alt_text&#34;,
+        &#34;url&#34;,
+        &#34;slack_file&#34;,
+    }
+
+    def __init__(
+        self,
+        alt_text: str,
+        url: Optional[str] = None,
+        slack_file: Optional[Union[Dict[str, Any], EntityIconSlackFile]] = None,
+        **kwargs,
+    ):
+        self.alt_text = alt_text
+        self.url = url
+        self.slack_file = slack_file
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Icon field for entity attributes</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityIconField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityIconSlackFile"><code class="flex name class">
+<span>class <span class="ident">EntityIconSlackFile</span></span>
+<span>(</span><span>id: str | None = None, url: str | None = None, **kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityIconSlackFile(JsonObject):
+    &#34;&#34;&#34;Slack file reference for entity icon&#34;&#34;&#34;
+
+    attributes = {
+        &#34;id&#34;,
+        &#34;url&#34;,
+    }
+
+    def __init__(
+        self,
+        id: Optional[str] = None,
+        url: Optional[str] = None,
+        **kwargs,
+    ):
+        self.id = id
+        self.url = url
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Slack file reference for entity icon</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityIconSlackFile.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityImageField"><code class="flex name class">
+<span>class <span class="ident">EntityImageField</span></span>
+<span>(</span><span>alt_text: str,<br>label: str | None = None,<br>image_url: str | None = None,<br>slack_file: Dict[str, Any] | None = None,<br>title: str | None = None,<br>type: str | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityImageField(JsonObject):
+    &#34;&#34;&#34;Image field for entity&#34;&#34;&#34;
+
+    attributes = {
+        &#34;alt_text&#34;,
+        &#34;label&#34;,
+        &#34;image_url&#34;,
+        &#34;slack_file&#34;,
+        &#34;title&#34;,
+        &#34;type&#34;,
+    }
+
+    def __init__(
+        self,
+        alt_text: str,
+        label: Optional[str] = None,
+        image_url: Optional[str] = None,
+        slack_file: Optional[Dict[str, Any]] = None,
+        title: Optional[str] = None,
+        type: Optional[str] = None,
+        **kwargs,
+    ):
+        self.alt_text = alt_text
+        self.label = label
+        self.image_url = image_url
+        self.slack_file = slack_file
+        self.title = title
+        self.type = type
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Image field for entity</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityImageField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityMetadata"><code class="flex name class">
+<span>class <span class="ident">EntityMetadata</span></span>
+<span>(</span><span>entity_type: str,<br>entity_payload: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityPayload" href="#slack_sdk.models.metadata.EntityPayload">EntityPayload</a>,<br>external_ref: Dict[str, Any] | <a title="slack_sdk.models.metadata.ExternalRef" href="#slack_sdk.models.metadata.ExternalRef">ExternalRef</a>,<br>url: str,<br>app_unfurl_url: str | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityMetadata(JsonObject):
+    &#34;&#34;&#34;Work object entity metadata
+
+    https://docs.slack.dev/messaging/work-objects/
+    &#34;&#34;&#34;
+
+    attributes = {
+        &#34;entity_type&#34;,
+        &#34;entity_payload&#34;,
+        &#34;external_ref&#34;,
+        &#34;url&#34;,
+        &#34;app_unfurl_url&#34;,
+    }
+
+    def __init__(
+        self,
+        entity_type: str,
+        entity_payload: Union[Dict[str, Any], EntityPayload],
+        external_ref: Union[Dict[str, Any], ExternalRef],
+        url: str,
+        app_unfurl_url: Optional[str] = None,
+        **kwargs,
+    ):
+        self.entity_type = entity_type
+        self.entity_payload = entity_payload
+        self.external_ref = external_ref
+        self.url = url
+        self.app_unfurl_url = app_unfurl_url
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()
+
+    @EnumValidator(&#34;entity_type&#34;, EntityType)
+    def entity_type_valid(self):
+        return self.entity_type is None or self.entity_type in EntityType</code></pre>
+</details>
+<div class="desc"><p>Work object entity metadata</p>
+<p><a href="https://docs.slack.dev/messaging/work-objects/">https://docs.slack.dev/messaging/work-objects/</a></p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityMetadata.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityMetadata.entity_type_valid"><code class="name flex">
+<span>def <span class="ident">entity_type_valid</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@EnumValidator(&#34;entity_type&#34;, EntityType)
+def entity_type_valid(self):
+    return self.entity_type is None or self.entity_type in EntityType</code></pre>
+</details>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityPayload"><code class="flex name class">
+<span>class <span class="ident">EntityPayload</span></span>
+<span>(</span><span>attributes: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityAttributes" href="#slack_sdk.models.metadata.EntityAttributes">EntityAttributes</a>,<br>fields: Dict[str, Any] | <a title="slack_sdk.models.metadata.ContentItemEntityFields" href="#slack_sdk.models.metadata.ContentItemEntityFields">ContentItemEntityFields</a> | <a title="slack_sdk.models.metadata.FileEntityFields" href="#slack_sdk.models.metadata.FileEntityFields">FileEntityFields</a> | <a title="slack_sdk.models.metadata.IncidentEntityFields" href="#slack_sdk.models.metadata.IncidentEntityFields">IncidentEntityFields</a> | <a title="slack_sdk.models.metadata.TaskEntityFields" href="#slack_sdk.models.metadata.TaskEntityFields">TaskEntityFields</a> | None = None,<br>custom_fields: List[Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityCustomField" href="#slack_sdk.models.metadata.EntityCustomField">EntityCustomField</a>] | None = None,<br>slack_file: Dict[str, Any] | <a title="slack_sdk.models.metadata.FileEntitySlackFile" href="#slack_sdk.models.metadata.FileEntitySlackFile">FileEntitySlackFile</a> | None = None,<br>display_order: List[str] | None = None,<br>actions: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityActions" href="#slack_sdk.models.metadata.EntityActions">EntityActions</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityPayload(JsonObject):
+    &#34;&#34;&#34;Payload schema for an entity&#34;&#34;&#34;
+
+    attributes = {
+        &#34;attributes&#34;,
+        &#34;fields&#34;,
+        &#34;custom_fields&#34;,
+        &#34;slack_file&#34;,
+        &#34;display_order&#34;,
+        &#34;actions&#34;,
+    }
+
+    def __init__(
+        self,
+        attributes: Union[Dict[str, Any], EntityAttributes],
+        fields: Optional[
+            Union[Dict[str, Any], ContentItemEntityFields, FileEntityFields, IncidentEntityFields, TaskEntityFields]
+        ] = None,
+        custom_fields: Optional[List[Union[Dict[str, Any], EntityCustomField]]] = None,
+        slack_file: Optional[Union[Dict[str, Any], FileEntitySlackFile]] = None,
+        display_order: Optional[List[str]] = None,
+        actions: Optional[Union[Dict[str, Any], EntityActions]] = None,
+        **kwargs,
+    ):
+        # Store entity attributes data with a different internal name to avoid
+        # shadowing the class-level &#39;attributes&#39; set used for JSON serialization
+        self._entity_attributes = attributes
+        self.fields = fields
+        self.custom_fields = custom_fields
+        self.slack_file = slack_file
+        self.display_order = display_order
+        self.actions = actions
+        self.additional_attributes = kwargs
+
+    @property
+    def entity_attributes(self) -&gt; Union[Dict[str, Any], EntityAttributes]:
+        &#34;&#34;&#34;Get the entity attributes data.
+
+        Note: Use this property to access the attributes data. The class-level
+        &#39;attributes&#39; is reserved for the JSON serialization schema.
+        &#34;&#34;&#34;
+        return self._entity_attributes
+
+    @entity_attributes.setter
+    def entity_attributes(self, value: Union[Dict[str, Any], EntityAttributes]):
+        &#34;&#34;&#34;Set the entity attributes data.&#34;&#34;&#34;
+        self._entity_attributes = value
+
+    def get_object_attribute(self, key: str):
+        if key == &#34;attributes&#34;:
+            return self._entity_attributes
+        else:
+            return getattr(self, key, None)
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Payload schema for an entity</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityPayload.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityPayload.entity_attributes"><code class="name">prop <span class="ident">entity_attributes</span> : Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityAttributes" href="#slack_sdk.models.metadata.EntityAttributes">EntityAttributes</a></code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def entity_attributes(self) -&gt; Union[Dict[str, Any], EntityAttributes]:
+    &#34;&#34;&#34;Get the entity attributes data.
+
+    Note: Use this property to access the attributes data. The class-level
+    &#39;attributes&#39; is reserved for the JSON serialization schema.
+    &#34;&#34;&#34;
+    return self._entity_attributes</code></pre>
+</details>
+<div class="desc"><p>Get the entity attributes data.</p>
+<p>Note: Use this property to access the attributes data. The class-level
+'attributes' is reserved for the JSON serialization schema.</p></div>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityPayload.get_object_attribute"><code class="name flex">
+<span>def <span class="ident">get_object_attribute</span></span>(<span>self, key: str)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get_object_attribute(self, key: str):
+    if key == &#34;attributes&#34;:
+        return self._entity_attributes
+    else:
+        return getattr(self, key, None)</code></pre>
+</details>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityRefField"><code class="flex name class">
+<span>class <span class="ident">EntityRefField</span></span>
+<span>(</span><span>entity_url: str,<br>external_ref: Dict[str, Any] | <a title="slack_sdk.models.metadata.ExternalRef" href="#slack_sdk.models.metadata.ExternalRef">ExternalRef</a>,<br>title: str,<br>display_type: str | None = None,<br>icon: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityIconField" href="#slack_sdk.models.metadata.EntityIconField">EntityIconField</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityRefField(JsonObject):
+    &#34;&#34;&#34;Entity reference field&#34;&#34;&#34;
+
+    attributes = {
+        &#34;entity_url&#34;,
+        &#34;external_ref&#34;,
+        &#34;title&#34;,
+        &#34;display_type&#34;,
+        &#34;icon&#34;,
+    }
+
+    def __init__(
+        self,
+        entity_url: str,
+        external_ref: Union[Dict[str, Any], ExternalRef],
+        title: str,
+        display_type: Optional[str] = None,
+        icon: Optional[Union[Dict[str, Any], EntityIconField]] = None,
+        **kwargs,
+    ):
+        self.entity_url = entity_url
+        self.external_ref = external_ref
+        self.title = title
+        self.display_type = display_type
+        self.icon = icon
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Entity reference field</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityRefField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityStringField"><code class="flex name class">
+<span>class <span class="ident">EntityStringField</span></span>
+<span>(</span><span>value: str,<br>label: str | None = None,<br>format: str | None = None,<br>link: str | None = None,<br>icon: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityIconField" href="#slack_sdk.models.metadata.EntityIconField">EntityIconField</a> | None = None,<br>long: bool | None = None,<br>type: str | None = None,<br>tag_color: str | None = None,<br>edit: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityEditSupport" href="#slack_sdk.models.metadata.EntityEditSupport">EntityEditSupport</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityStringField(JsonObject):
+    &#34;&#34;&#34;String field for entity&#34;&#34;&#34;
+
+    attributes = {
+        &#34;value&#34;,
+        &#34;label&#34;,
+        &#34;format&#34;,
+        &#34;link&#34;,
+        &#34;icon&#34;,
+        &#34;long&#34;,
+        &#34;type&#34;,
+        &#34;tag_color&#34;,
+        &#34;edit&#34;,
+    }
+
+    def __init__(
+        self,
+        value: str,
+        label: Optional[str] = None,
+        format: Optional[str] = None,
+        link: Optional[str] = None,
+        icon: Optional[Union[Dict[str, Any], EntityIconField]] = None,
+        long: Optional[bool] = None,
+        type: Optional[str] = None,
+        tag_color: Optional[str] = None,
+        edit: Optional[Union[Dict[str, Any], EntityEditSupport]] = None,
+        **kwargs,
+    ):
+        self.value = value
+        self.label = label
+        self.format = format
+        self.link = link
+        self.icon = icon
+        self.long = long
+        self.type = type
+        self.tag_color = tag_color
+        self.edit = edit
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>String field for entity</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityStringField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityTimestampField"><code class="flex name class">
+<span>class <span class="ident">EntityTimestampField</span></span>
+<span>(</span><span>value: int,<br>label: str | None = None,<br>type: str | None = None,<br>edit: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityEditSupport" href="#slack_sdk.models.metadata.EntityEditSupport">EntityEditSupport</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityTimestampField(JsonObject):
+    &#34;&#34;&#34;Timestamp field for entity&#34;&#34;&#34;
+
+    attributes = {
+        &#34;value&#34;,
+        &#34;label&#34;,
+        &#34;type&#34;,
+        &#34;edit&#34;,
+    }
+
+    def __init__(
+        self,
+        value: int,
+        label: Optional[str] = None,
+        type: Optional[str] = None,
+        edit: Optional[Union[Dict[str, Any], EntityEditSupport]] = None,
+        **kwargs,
+    ):
+        self.value = value
+        self.label = label
+        self.type = type
+        self.edit = edit
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Timestamp field for entity</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityTimestampField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityTitle"><code class="flex name class">
+<span>class <span class="ident">EntityTitle</span></span>
+<span>(</span><span>text: str,<br>edit: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityEditSupport" href="#slack_sdk.models.metadata.EntityEditSupport">EntityEditSupport</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityTitle(JsonObject):
+    &#34;&#34;&#34;Title for entity attributes&#34;&#34;&#34;
+
+    attributes = {
+        &#34;text&#34;,
+        &#34;edit&#34;,
+    }
+
+    def __init__(
+        self,
+        text: str,
+        edit: Optional[Union[Dict[str, Any], EntityEditSupport]] = None,
+        **kwargs,
+    ):
+        self.text = text
+        self.edit = edit
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Title for entity attributes</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityTitle.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityTypedField"><code class="flex name class">
+<span>class <span class="ident">EntityTypedField</span></span>
+<span>(</span><span>type: str,<br>label: str | None = None,<br>value: str | int | None = None,<br>link: str | None = None,<br>icon: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityIconField" href="#slack_sdk.models.metadata.EntityIconField">EntityIconField</a> | None = None,<br>long: bool | None = None,<br>format: str | None = None,<br>image_url: str | None = None,<br>slack_file: Dict[str, Any] | None = None,<br>alt_text: str | None = None,<br>edit: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityEditSupport" href="#slack_sdk.models.metadata.EntityEditSupport">EntityEditSupport</a> | None = None,<br>tag_color: str | None = None,<br>user: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityUserIDField" href="#slack_sdk.models.metadata.EntityUserIDField">EntityUserIDField</a> | <a title="slack_sdk.models.metadata.EntityUserField" href="#slack_sdk.models.metadata.EntityUserField">EntityUserField</a> | None = None,<br>entity_ref: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityRefField" href="#slack_sdk.models.metadata.EntityRefField">EntityRefField</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityTypedField(JsonObject):
+    &#34;&#34;&#34;Typed field for entity with various display options&#34;&#34;&#34;
+
+    attributes = {
+        &#34;type&#34;,
+        &#34;label&#34;,
+        &#34;value&#34;,
+        &#34;link&#34;,
+        &#34;icon&#34;,
+        &#34;long&#34;,
+        &#34;format&#34;,
+        &#34;image_url&#34;,
+        &#34;slack_file&#34;,
+        &#34;alt_text&#34;,
+        &#34;edit&#34;,
+        &#34;tag_color&#34;,
+        &#34;user&#34;,
+        &#34;entity_ref&#34;,
+    }
+
+    def __init__(
+        self,
+        type: str,
+        label: Optional[str] = None,
+        value: Optional[Union[str, int]] = None,
+        link: Optional[str] = None,
+        icon: Optional[Union[Dict[str, Any], EntityIconField]] = None,
+        long: Optional[bool] = None,
+        format: Optional[str] = None,
+        image_url: Optional[str] = None,
+        slack_file: Optional[Dict[str, Any]] = None,
+        alt_text: Optional[str] = None,
+        edit: Optional[Union[Dict[str, Any], EntityEditSupport]] = None,
+        tag_color: Optional[str] = None,
+        user: Optional[Union[Dict[str, Any], EntityUserIDField, EntityUserField]] = None,
+        entity_ref: Optional[Union[Dict[str, Any], EntityRefField]] = None,
+        **kwargs,
+    ):
+        self.type = type
+        self.label = label
+        self.value = value
+        self.link = link
+        self.icon = icon
+        self.long = long
+        self.format = format
+        self.image_url = image_url
+        self.slack_file = slack_file
+        self.alt_text = alt_text
+        self.edit = edit
+        self.tag_color = tag_color
+        self.user = user
+        self.entity_ref = entity_ref
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Typed field for entity with various display options</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityTypedField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityUserField"><code class="flex name class">
+<span>class <span class="ident">EntityUserField</span></span>
+<span>(</span><span>text: str,<br>url: str | None = None,<br>email: str | None = None,<br>icon: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityIconField" href="#slack_sdk.models.metadata.EntityIconField">EntityIconField</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityUserField(JsonObject):
+    &#34;&#34;&#34;User field for entity&#34;&#34;&#34;
+
+    attributes = {
+        &#34;text&#34;,
+        &#34;url&#34;,
+        &#34;email&#34;,
+        &#34;icon&#34;,
+    }
+
+    def __init__(
+        self,
+        text: str,
+        url: Optional[str] = None,
+        email: Optional[str] = None,
+        icon: Optional[Union[Dict[str, Any], EntityIconField]] = None,
+        **kwargs,
+    ):
+        self.text = text
+        self.url = url
+        self.email = email
+        self.icon = icon
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>User field for entity</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityUserField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EntityUserIDField"><code class="flex name class">
+<span>class <span class="ident">EntityUserIDField</span></span>
+<span>(</span><span>user_id: str, **kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EntityUserIDField(JsonObject):
+    &#34;&#34;&#34;User ID field for entity&#34;&#34;&#34;
+
+    attributes = {
+        &#34;user_id&#34;,
+    }
+
+    def __init__(
+        self,
+        user_id: str,
+        **kwargs,
+    ):
+        self.user_id = user_id
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>User ID field for entity</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EntityUserIDField.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.EventAndEntityMetadata"><code class="flex name class">
+<span>class <span class="ident">EventAndEntityMetadata</span></span>
+<span>(</span><span>event_type: str | None = None,<br>event_payload: Dict[str, Any] | None = None,<br>entities: List[Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityMetadata" href="#slack_sdk.models.metadata.EntityMetadata">EntityMetadata</a>] | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class EventAndEntityMetadata(JsonObject):
+    &#34;&#34;&#34;Message metadata with entities
+
+    https://docs.slack.dev/messaging/message-metadata/
+    https://docs.slack.dev/messaging/work-objects/
+    &#34;&#34;&#34;
+
+    attributes = {&#34;event_type&#34;, &#34;event_payload&#34;, &#34;entities&#34;}
+
+    def __init__(
+        self,
+        event_type: Optional[str] = None,
+        event_payload: Optional[Dict[str, Any]] = None,
+        entities: Optional[List[Union[Dict[str, Any], EntityMetadata]]] = None,
+        **kwargs,
+    ):
+        self.event_type = event_type
+        self.event_payload = event_payload
+        self.entities = entities
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Message metadata with entities</p>
+<p><a href="https://docs.slack.dev/messaging/message-metadata/">https://docs.slack.dev/messaging/message-metadata/</a>
+<a href="https://docs.slack.dev/messaging/work-objects/">https://docs.slack.dev/messaging/work-objects/</a></p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.EventAndEntityMetadata.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.ExternalRef"><code class="flex name class">
+<span>class <span class="ident">ExternalRef</span></span>
+<span>(</span><span>id: str, type: str | None = None, **kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ExternalRef(JsonObject):
+    &#34;&#34;&#34;Reference (and optional type) used to identify an entity within the developer&#39;s system&#34;&#34;&#34;
+
+    attributes = {
+        &#34;id&#34;,
+        &#34;type&#34;,
+    }
+
+    def __init__(
+        self,
+        id: str,
+        type: Optional[str] = None,
+        **kwargs,
+    ):
+        self.id = id
+        self.type = type
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Reference (and optional type) used to identify an entity within the developer's system</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.ExternalRef.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.FileEntityFields"><code class="flex name class">
+<span>class <span class="ident">FileEntityFields</span></span>
+<span>(</span><span>preview: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityImageField" href="#slack_sdk.models.metadata.EntityImageField">EntityImageField</a> | None = None,<br>created_by: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTypedField" href="#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a> | None = None,<br>date_created: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTimestampField" href="#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a> | None = None,<br>date_updated: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTimestampField" href="#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a> | None = None,<br>last_modified_by: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTypedField" href="#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a> | None = None,<br>file_size: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>mime_type: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>full_size_preview: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityFullSizePreview" href="#slack_sdk.models.metadata.EntityFullSizePreview">EntityFullSizePreview</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class FileEntityFields(JsonObject):
+    &#34;&#34;&#34;Fields specific to file entities&#34;&#34;&#34;
+
+    attributes = {
+        &#34;preview&#34;,
+        &#34;created_by&#34;,
+        &#34;date_created&#34;,
+        &#34;date_updated&#34;,
+        &#34;last_modified_by&#34;,
+        &#34;file_size&#34;,
+        &#34;mime_type&#34;,
+        &#34;full_size_preview&#34;,
+    }
+
+    def __init__(
+        self,
+        preview: Optional[Union[Dict[str, Any], EntityImageField]] = None,
+        created_by: Optional[Union[Dict[str, Any], EntityTypedField]] = None,
+        date_created: Optional[Union[Dict[str, Any], EntityTimestampField]] = None,
+        date_updated: Optional[Union[Dict[str, Any], EntityTimestampField]] = None,
+        last_modified_by: Optional[Union[Dict[str, Any], EntityTypedField]] = None,
+        file_size: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        mime_type: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        full_size_preview: Optional[Union[Dict[str, Any], EntityFullSizePreview]] = None,
+        **kwargs,
+    ):
+        self.preview = preview
+        self.created_by = created_by
+        self.date_created = date_created
+        self.date_updated = date_updated
+        self.last_modified_by = last_modified_by
+        self.file_size = file_size
+        self.mime_type = mime_type
+        self.full_size_preview = full_size_preview
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Fields specific to file entities</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.FileEntityFields.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.FileEntitySlackFile"><code class="flex name class">
+<span>class <span class="ident">FileEntitySlackFile</span></span>
+<span>(</span><span>id: str, type: str | None = None, **kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class FileEntitySlackFile(JsonObject):
+    &#34;&#34;&#34;Slack file reference for file entities&#34;&#34;&#34;
+
+    attributes = {
+        &#34;id&#34;,
+        &#34;type&#34;,
+    }
+
+    def __init__(
+        self,
+        id: str,
+        type: Optional[str] = None,
+        **kwargs,
+    ):
+        self.id = id
+        self.type = type
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Slack file reference for file entities</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.FileEntitySlackFile.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="slack_sdk.models.metadata.IncidentEntityFields"><code class="flex name class">
+<span>class <span class="ident">IncidentEntityFields</span></span>
+<span>(</span><span>status: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>priority: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>urgency: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>created_by: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTypedField" href="#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a> | None = None,<br>assigned_to: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTypedField" href="#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a> | None = None,<br>date_created: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTimestampField" href="#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a> | None = None,<br>date_updated: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTimestampField" href="#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a> | None = None,<br>description: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>service: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class IncidentEntityFields(JsonObject):
+    &#34;&#34;&#34;Fields specific to incident entities&#34;&#34;&#34;
+
+    attributes = {
+        &#34;status&#34;,
+        &#34;priority&#34;,
+        &#34;urgency&#34;,
+        &#34;created_by&#34;,
+        &#34;assigned_to&#34;,
+        &#34;date_created&#34;,
+        &#34;date_updated&#34;,
+        &#34;description&#34;,
+        &#34;service&#34;,
+    }
+
+    def __init__(
+        self,
+        status: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        priority: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        urgency: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        created_by: Optional[Union[Dict[str, Any], EntityTypedField]] = None,
+        assigned_to: Optional[Union[Dict[str, Any], EntityTypedField]] = None,
+        date_created: Optional[Union[Dict[str, Any], EntityTimestampField]] = None,
+        date_updated: Optional[Union[Dict[str, Any], EntityTimestampField]] = None,
+        description: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        service: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        **kwargs,
+    ):
+        self.status = status
+        self.priority = priority
+        self.urgency = urgency
+        self.created_by = created_by
+        self.assigned_to = assigned_to
+        self.date_created = date_created
+        self.date_updated = date_updated
+        self.description = description
+        self.service = service
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Fields specific to incident entities</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.IncidentEntityFields.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
 <dt id="slack_sdk.models.metadata.Metadata"><code class="flex name class">
 <span>class <span class="ident">Metadata</span></span>
 <span>(</span><span>event_type: str, event_payload: Dict[str, Any], **kwargs)</span>
@@ -107,6 +2365,81 @@ el.replaceWith(d);
 </li>
 </ul>
 </dd>
+<dt id="slack_sdk.models.metadata.TaskEntityFields"><code class="flex name class">
+<span>class <span class="ident">TaskEntityFields</span></span>
+<span>(</span><span>description: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>created_by: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTypedField" href="#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a> | None = None,<br>date_created: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTimestampField" href="#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a> | None = None,<br>date_updated: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTimestampField" href="#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a> | None = None,<br>assignee: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTypedField" href="#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a> | None = None,<br>status: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>due_date: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityTypedField" href="#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a> | None = None,<br>priority: Dict[str, Any] | <a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a> | None = None,<br>**kwargs)</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class TaskEntityFields(JsonObject):
+    &#34;&#34;&#34;Fields specific to task entities&#34;&#34;&#34;
+
+    attributes = {
+        &#34;description&#34;,
+        &#34;created_by&#34;,
+        &#34;date_created&#34;,
+        &#34;date_updated&#34;,
+        &#34;assignee&#34;,
+        &#34;status&#34;,
+        &#34;due_date&#34;,
+        &#34;priority&#34;,
+    }
+
+    def __init__(
+        self,
+        description: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        created_by: Optional[Union[Dict[str, Any], EntityTypedField]] = None,
+        date_created: Optional[Union[Dict[str, Any], EntityTimestampField]] = None,
+        date_updated: Optional[Union[Dict[str, Any], EntityTimestampField]] = None,
+        assignee: Optional[Union[Dict[str, Any], EntityTypedField]] = None,
+        status: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        due_date: Optional[Union[Dict[str, Any], EntityTypedField]] = None,
+        priority: Optional[Union[Dict[str, Any], EntityStringField]] = None,
+        **kwargs,
+    ):
+        self.description = description
+        self.created_by = created_by
+        self.date_created = date_created
+        self.date_updated = date_updated
+        self.assignee = assignee
+        self.status = status
+        self.due_date = due_date
+        self.priority = priority
+        self.additional_attributes = kwargs
+
+    def __str__(self):
+        return str(self.get_non_null_attributes())
+
+    def __repr__(self):
+        return self.__str__()</code></pre>
+</details>
+<div class="desc"><p>Fields specific to task entities</p></div>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></li>
+<li><a title="slack_sdk.models.basic_objects.BaseObject" href="../basic_objects.html#slack_sdk.models.basic_objects.BaseObject">BaseObject</a></li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="slack_sdk.models.metadata.TaskEntityFields.attributes"><code class="name">var <span class="ident">attributes</span></code></dt>
+<dd>
+<div class="desc"><p>The type of the None singleton.</p></div>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="slack_sdk.models.basic_objects.JsonObject" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject">JsonObject</a></b></code>:
+<ul class="hlist">
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.get_non_null_attributes">get_non_null_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.to_dict" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.to_dict">to_dict</a></code></li>
+<li><code><a title="slack_sdk.models.basic_objects.JsonObject.validate_json" href="../basic_objects.html#slack_sdk.models.basic_objects.JsonObject.validate_json">validate_json</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
 </dl>
 </section>
 </article>
@@ -120,12 +2453,219 @@ el.replaceWith(d);
 <li><code><a title="slack_sdk.models" href="../index.html">slack_sdk.models</a></code></li>
 </ul>
 </li>
+<li><h3><a href="#header-variables">Global variables</a></h3>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityType" href="#slack_sdk.models.metadata.EntityType">EntityType</a></code></li>
+</ul>
+</li>
 <li><h3><a href="#header-classes">Classes</a></h3>
 <ul>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.ContentItemEntityFields" href="#slack_sdk.models.metadata.ContentItemEntityFields">ContentItemEntityFields</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.ContentItemEntityFields.attributes" href="#slack_sdk.models.metadata.ContentItemEntityFields.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityActionButton" href="#slack_sdk.models.metadata.EntityActionButton">EntityActionButton</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityActionButton.attributes" href="#slack_sdk.models.metadata.EntityActionButton.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityActionProcessingState" href="#slack_sdk.models.metadata.EntityActionProcessingState">EntityActionProcessingState</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityActionProcessingState.attributes" href="#slack_sdk.models.metadata.EntityActionProcessingState.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityActions" href="#slack_sdk.models.metadata.EntityActions">EntityActions</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityActions.attributes" href="#slack_sdk.models.metadata.EntityActions.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityArrayItemField" href="#slack_sdk.models.metadata.EntityArrayItemField">EntityArrayItemField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityArrayItemField.attributes" href="#slack_sdk.models.metadata.EntityArrayItemField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityAttributes" href="#slack_sdk.models.metadata.EntityAttributes">EntityAttributes</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityAttributes.attributes" href="#slack_sdk.models.metadata.EntityAttributes.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityBooleanCheckboxField" href="#slack_sdk.models.metadata.EntityBooleanCheckboxField">EntityBooleanCheckboxField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityBooleanCheckboxField.attributes" href="#slack_sdk.models.metadata.EntityBooleanCheckboxField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityBooleanTextField" href="#slack_sdk.models.metadata.EntityBooleanTextField">EntityBooleanTextField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityBooleanTextField.attributes" href="#slack_sdk.models.metadata.EntityBooleanTextField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityCustomField" href="#slack_sdk.models.metadata.EntityCustomField">EntityCustomField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityCustomField.attributes" href="#slack_sdk.models.metadata.EntityCustomField.attributes">attributes</a></code></li>
+<li><code><a title="slack_sdk.models.metadata.EntityCustomField.type_valid" href="#slack_sdk.models.metadata.EntityCustomField.type_valid">type_valid</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityEditNumberConfig" href="#slack_sdk.models.metadata.EntityEditNumberConfig">EntityEditNumberConfig</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityEditNumberConfig.attributes" href="#slack_sdk.models.metadata.EntityEditNumberConfig.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityEditSelectConfig" href="#slack_sdk.models.metadata.EntityEditSelectConfig">EntityEditSelectConfig</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityEditSelectConfig.attributes" href="#slack_sdk.models.metadata.EntityEditSelectConfig.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityEditSupport" href="#slack_sdk.models.metadata.EntityEditSupport">EntityEditSupport</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityEditSupport.attributes" href="#slack_sdk.models.metadata.EntityEditSupport.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityEditTextConfig" href="#slack_sdk.models.metadata.EntityEditTextConfig">EntityEditTextConfig</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityEditTextConfig.attributes" href="#slack_sdk.models.metadata.EntityEditTextConfig.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityFullSizePreview" href="#slack_sdk.models.metadata.EntityFullSizePreview">EntityFullSizePreview</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityFullSizePreview.attributes" href="#slack_sdk.models.metadata.EntityFullSizePreview.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityFullSizePreviewError" href="#slack_sdk.models.metadata.EntityFullSizePreviewError">EntityFullSizePreviewError</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityFullSizePreviewError.attributes" href="#slack_sdk.models.metadata.EntityFullSizePreviewError.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityIconField" href="#slack_sdk.models.metadata.EntityIconField">EntityIconField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityIconField.attributes" href="#slack_sdk.models.metadata.EntityIconField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityIconSlackFile" href="#slack_sdk.models.metadata.EntityIconSlackFile">EntityIconSlackFile</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityIconSlackFile.attributes" href="#slack_sdk.models.metadata.EntityIconSlackFile.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityImageField" href="#slack_sdk.models.metadata.EntityImageField">EntityImageField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityImageField.attributes" href="#slack_sdk.models.metadata.EntityImageField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityMetadata" href="#slack_sdk.models.metadata.EntityMetadata">EntityMetadata</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityMetadata.attributes" href="#slack_sdk.models.metadata.EntityMetadata.attributes">attributes</a></code></li>
+<li><code><a title="slack_sdk.models.metadata.EntityMetadata.entity_type_valid" href="#slack_sdk.models.metadata.EntityMetadata.entity_type_valid">entity_type_valid</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityPayload" href="#slack_sdk.models.metadata.EntityPayload">EntityPayload</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityPayload.attributes" href="#slack_sdk.models.metadata.EntityPayload.attributes">attributes</a></code></li>
+<li><code><a title="slack_sdk.models.metadata.EntityPayload.entity_attributes" href="#slack_sdk.models.metadata.EntityPayload.entity_attributes">entity_attributes</a></code></li>
+<li><code><a title="slack_sdk.models.metadata.EntityPayload.get_object_attribute" href="#slack_sdk.models.metadata.EntityPayload.get_object_attribute">get_object_attribute</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityRefField" href="#slack_sdk.models.metadata.EntityRefField">EntityRefField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityRefField.attributes" href="#slack_sdk.models.metadata.EntityRefField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityStringField" href="#slack_sdk.models.metadata.EntityStringField">EntityStringField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityStringField.attributes" href="#slack_sdk.models.metadata.EntityStringField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityTimestampField" href="#slack_sdk.models.metadata.EntityTimestampField">EntityTimestampField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityTimestampField.attributes" href="#slack_sdk.models.metadata.EntityTimestampField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityTitle" href="#slack_sdk.models.metadata.EntityTitle">EntityTitle</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityTitle.attributes" href="#slack_sdk.models.metadata.EntityTitle.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityTypedField" href="#slack_sdk.models.metadata.EntityTypedField">EntityTypedField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityTypedField.attributes" href="#slack_sdk.models.metadata.EntityTypedField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityUserField" href="#slack_sdk.models.metadata.EntityUserField">EntityUserField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityUserField.attributes" href="#slack_sdk.models.metadata.EntityUserField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EntityUserIDField" href="#slack_sdk.models.metadata.EntityUserIDField">EntityUserIDField</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EntityUserIDField.attributes" href="#slack_sdk.models.metadata.EntityUserIDField.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.EventAndEntityMetadata.attributes" href="#slack_sdk.models.metadata.EventAndEntityMetadata.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.ExternalRef" href="#slack_sdk.models.metadata.ExternalRef">ExternalRef</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.ExternalRef.attributes" href="#slack_sdk.models.metadata.ExternalRef.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.FileEntityFields" href="#slack_sdk.models.metadata.FileEntityFields">FileEntityFields</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.FileEntityFields.attributes" href="#slack_sdk.models.metadata.FileEntityFields.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.FileEntitySlackFile" href="#slack_sdk.models.metadata.FileEntitySlackFile">FileEntitySlackFile</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.FileEntitySlackFile.attributes" href="#slack_sdk.models.metadata.FileEntitySlackFile.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.IncidentEntityFields" href="#slack_sdk.models.metadata.IncidentEntityFields">IncidentEntityFields</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.IncidentEntityFields.attributes" href="#slack_sdk.models.metadata.IncidentEntityFields.attributes">attributes</a></code></li>
+</ul>
+</li>
 <li>
 <h4><code><a title="slack_sdk.models.metadata.Metadata" href="#slack_sdk.models.metadata.Metadata">Metadata</a></code></h4>
 <ul class="">
 <li><code><a title="slack_sdk.models.metadata.Metadata.attributes" href="#slack_sdk.models.metadata.Metadata.attributes">attributes</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="slack_sdk.models.metadata.TaskEntityFields" href="#slack_sdk.models.metadata.TaskEntityFields">TaskEntityFields</a></code></h4>
+<ul class="">
+<li><code><a title="slack_sdk.models.metadata.TaskEntityFields.attributes" href="#slack_sdk.models.metadata.TaskEntityFields.attributes">attributes</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/reference/web/async_client.html
+++ b/docs/reference/web/async_client.html
@@ -2790,7 +2790,7 @@ el.replaceWith(d);
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
-        metadata: Optional[Union[Dict, Metadata]] = None,
+        metadata: Optional[Union[Dict, Metadata, EventAndEntityMetadata]] = None,
         markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; AsyncSlackResponse:
@@ -3019,6 +3019,7 @@ el.replaceWith(d);
         source: Optional[str] = None,
         unfurl_id: Optional[str] = None,
         unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
+        metadata: Optional[Union[Dict, EventAndEntityMetadata]] = None,
         user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
         user_auth_message: Optional[str] = None,
         user_auth_required: Optional[bool] = None,
@@ -3035,6 +3036,7 @@ el.replaceWith(d);
                 &#34;source&#34;: source,
                 &#34;unfurl_id&#34;: unfurl_id,
                 &#34;unfurls&#34;: unfurls,
+                &#34;metadata&#34;: metadata,
                 &#34;user_auth_blocks&#34;: user_auth_blocks,
                 &#34;user_auth_message&#34;: user_auth_message,
                 &#34;user_auth_required&#34;: user_auth_required,
@@ -3665,6 +3667,30 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         kwargs.update({&#34;include_categories&#34;: include_categories})
         return await self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
+    async def entity_presentDetails(
+        self,
+        trigger_id: str,
+        metadata: Optional[Union[Dict, EntityMetadata]] = None,
+        user_auth_required: Optional[bool] = None,
+        user_auth_url: Optional[str] = None,
+        error: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Provides entity details for the flexpane.
+        https://docs.slack.dev/reference/methods/entity.presentDetails/
+        &#34;&#34;&#34;
+        kwargs.update({&#34;trigger_id&#34;: trigger_id})
+        if metadata is not None:
+            kwargs.update({&#34;metadata&#34;: metadata})
+        if user_auth_required is not None:
+            kwargs.update({&#34;user_auth_required&#34;: user_auth_required})
+        if user_auth_url is not None:
+            kwargs.update({&#34;user_auth_url&#34;: user_auth_url})
+        if error is not None:
+            kwargs.update({&#34;error&#34;: error})
+        _parse_web_class_objects(kwargs)
+        return await self.api_call(&#34;entity.presentDetails&#34;, json=kwargs)
 
     async def files_comments_delete(
         self,
@@ -4919,6 +4945,249 @@ el.replaceWith(d);
             }
         )
         return await self.api_call(&#34;search.messages&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
+    async def slackLists_access_delete(
+        self,
+        *,
+        list_id: str,
+        channel_ids: Optional[List[str]] = None,
+        user_ids: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Revoke access to a List for specified entities.
+        https://docs.slack.dev/reference/methods/slackLists.access.delete
+        &#34;&#34;&#34;
+        kwargs.update({&#34;list_id&#34;: list_id, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.access.delete&#34;, json=kwargs)
+
+    async def slackLists_access_set(
+        self,
+        *,
+        list_id: str,
+        access_level: str,
+        channel_ids: Optional[List[str]] = None,
+        user_ids: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Set the access level to a List for specified entities.
+        https://docs.slack.dev/reference/methods/slackLists.access.set
+        &#34;&#34;&#34;
+        kwargs.update({&#34;list_id&#34;: list_id, &#34;access_level&#34;: access_level, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.access.set&#34;, json=kwargs)
+
+    async def slackLists_create(
+        self,
+        *,
+        name: str,
+        description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+        schema: Optional[List[Dict[str, Any]]] = None,
+        copy_from_list_id: Optional[str] = None,
+        include_copied_list_records: Optional[bool] = None,
+        todo_mode: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Creates a List.
+        https://docs.slack.dev/reference/methods/slackLists.create
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;name&#34;: name,
+                &#34;description_blocks&#34;: description_blocks,
+                &#34;schema&#34;: schema,
+                &#34;copy_from_list_id&#34;: copy_from_list_id,
+                &#34;include_copied_list_records&#34;: include_copied_list_records,
+                &#34;todo_mode&#34;: todo_mode,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.create&#34;, json=kwargs)
+
+    async def slackLists_download_get(
+        self,
+        *,
+        list_id: str,
+        job_id: str,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Retrieve List download URL from an export job to download List contents.
+        https://docs.slack.dev/reference/methods/slackLists.download.get
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;job_id&#34;: job_id,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.download.get&#34;, json=kwargs)
+
+    async def slackLists_download_start(
+        self,
+        *,
+        list_id: str,
+        include_archived: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Initiate a job to export List contents.
+        https://docs.slack.dev/reference/methods/slackLists.download.start
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;include_archived&#34;: include_archived,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.download.start&#34;, json=kwargs)
+
+    async def slackLists_items_create(
+        self,
+        *,
+        list_id: str,
+        duplicated_item_id: Optional[str] = None,
+        parent_item_id: Optional[str] = None,
+        initial_fields: Optional[List[Dict[str, Any]]] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Add a new item to an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.create
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;duplicated_item_id&#34;: duplicated_item_id,
+                &#34;parent_item_id&#34;: parent_item_id,
+                &#34;initial_fields&#34;: initial_fields,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.items.create&#34;, json=kwargs)
+
+    async def slackLists_items_delete(
+        self,
+        *,
+        list_id: str,
+        id: str,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Deletes an item from an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.delete
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;id&#34;: id,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.items.delete&#34;, json=kwargs)
+
+    async def slackLists_items_deleteMultiple(
+        self,
+        *,
+        list_id: str,
+        ids: List[str],
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Deletes multiple items from an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;ids&#34;: ids,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.items.deleteMultiple&#34;, json=kwargs)
+
+    async def slackLists_items_info(
+        self,
+        *,
+        list_id: str,
+        id: str,
+        include_is_subscribed: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Get a row from a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.info
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;id&#34;: id,
+                &#34;include_is_subscribed&#34;: include_is_subscribed,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.items.info&#34;, json=kwargs)
+
+    async def slackLists_items_list(
+        self,
+        *,
+        list_id: str,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        archived: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Get records from a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;limit&#34;: limit,
+                &#34;cursor&#34;: cursor,
+                &#34;archived&#34;: archived,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.items.list&#34;, json=kwargs)
+
+    async def slackLists_items_update(
+        self,
+        *,
+        list_id: str,
+        cells: List[Dict[str, Any]],
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Updates cells in a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.update
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;cells&#34;: cells,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.items.update&#34;, json=kwargs)
+
+    async def slackLists_update(
+        self,
+        *,
+        id: str,
+        name: Optional[str] = None,
+        description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+        todo_mode: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; AsyncSlackResponse:
+        &#34;&#34;&#34;Update a List.
+        https://docs.slack.dev/reference/methods/slackLists.update
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;id&#34;: id,
+                &#34;name&#34;: name,
+                &#34;description_blocks&#34;: description_blocks,
+                &#34;todo_mode&#34;: todo_mode,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return await self.api_call(&#34;slackLists.update&#34;, json=kwargs)
 
     async def stars_add(
         self,
@@ -10066,7 +10335,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/chat.postEphemeral">https://docs.slack.dev/reference/methods/chat.postEphemeral</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_postMessage"><code class="name flex">
-<span>async def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | <a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10092,7 +10361,7 @@ Each authorization represents an app installation that the event is visible to.
     link_names: Optional[bool] = None,
     username: Optional[str] = None,
     parse: Optional[str] = None,  # none, full
-    metadata: Optional[Union[Dict, Metadata]] = None,
+    metadata: Optional[Union[Dict, Metadata, EventAndEntityMetadata]] = None,
     markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; AsyncSlackResponse:
@@ -10414,7 +10683,7 @@ await streamer.stop()
 </code></pre></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.chat_unfurl"><code class="name flex">
-<span>async def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a> | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10429,6 +10698,7 @@ await streamer.stop()
     source: Optional[str] = None,
     unfurl_id: Optional[str] = None,
     unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
+    metadata: Optional[Union[Dict, EventAndEntityMetadata]] = None,
     user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
     user_auth_message: Optional[str] = None,
     user_auth_required: Optional[bool] = None,
@@ -10445,6 +10715,7 @@ await streamer.stop()
             &#34;source&#34;: source,
             &#34;unfurl_id&#34;: unfurl_id,
             &#34;unfurls&#34;: unfurls,
+            &#34;metadata&#34;: metadata,
             &#34;user_auth_blocks&#34;: user_auth_blocks,
             &#34;user_auth_message&#34;: user_auth_message,
             &#34;user_auth_required&#34;: user_auth_required,
@@ -11475,6 +11746,41 @@ or received but have not yet been approved by all parties.
 </details>
 <div class="desc"><p>Lists custom emoji for a team.
 <a href="https://docs.slack.dev/reference/methods/emoji.list">https://docs.slack.dev/reference/methods/emoji.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.entity_presentDetails"><code class="name flex">
+<span>async def <span class="ident">entity_presentDetails</span></span>(<span>self,<br>trigger_id: str,<br>metadata: Dict | <a title="slack_sdk.models.metadata.EntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EntityMetadata">EntityMetadata</a> | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>error: Dict[str, Any] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def entity_presentDetails(
+    self,
+    trigger_id: str,
+    metadata: Optional[Union[Dict, EntityMetadata]] = None,
+    user_auth_required: Optional[bool] = None,
+    user_auth_url: Optional[str] = None,
+    error: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Provides entity details for the flexpane.
+    https://docs.slack.dev/reference/methods/entity.presentDetails/
+    &#34;&#34;&#34;
+    kwargs.update({&#34;trigger_id&#34;: trigger_id})
+    if metadata is not None:
+        kwargs.update({&#34;metadata&#34;: metadata})
+    if user_auth_required is not None:
+        kwargs.update({&#34;user_auth_required&#34;: user_auth_required})
+    if user_auth_url is not None:
+        kwargs.update({&#34;user_auth_url&#34;: user_auth_url})
+    if error is not None:
+        kwargs.update({&#34;error&#34;: error})
+    _parse_web_class_objects(kwargs)
+    return await self.api_call(&#34;entity.presentDetails&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Provides entity details for the flexpane.
+<a href="https://docs.slack.dev/reference/methods/entity.presentDetails/">https://docs.slack.dev/reference/methods/entity.presentDetails/</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.files_comments_delete"><code class="name flex">
 <span>async def <span class="ident">files_comments_delete</span></span>(<span>self, *, file: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
@@ -13451,6 +13757,381 @@ multiparty direct message.</p></div>
 <div class="desc"><p>Searches for messages matching a query.
 <a href="https://docs.slack.dev/reference/methods/search.messages">https://docs.slack.dev/reference/methods/search.messages</a></p></div>
 </dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_access_delete"><code class="name flex">
+<span>async def <span class="ident">slackLists_access_delete</span></span>(<span>self,<br>*,<br>list_id: str,<br>channel_ids: List[str] | None = None,<br>user_ids: List[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_access_delete(
+    self,
+    *,
+    list_id: str,
+    channel_ids: Optional[List[str]] = None,
+    user_ids: Optional[List[str]] = None,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Revoke access to a List for specified entities.
+    https://docs.slack.dev/reference/methods/slackLists.access.delete
+    &#34;&#34;&#34;
+    kwargs.update({&#34;list_id&#34;: list_id, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.access.delete&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Revoke access to a List for specified entities.
+<a href="https://docs.slack.dev/reference/methods/slackLists.access.delete">https://docs.slack.dev/reference/methods/slackLists.access.delete</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_access_set"><code class="name flex">
+<span>async def <span class="ident">slackLists_access_set</span></span>(<span>self,<br>*,<br>list_id: str,<br>access_level: str,<br>channel_ids: List[str] | None = None,<br>user_ids: List[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_access_set(
+    self,
+    *,
+    list_id: str,
+    access_level: str,
+    channel_ids: Optional[List[str]] = None,
+    user_ids: Optional[List[str]] = None,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Set the access level to a List for specified entities.
+    https://docs.slack.dev/reference/methods/slackLists.access.set
+    &#34;&#34;&#34;
+    kwargs.update({&#34;list_id&#34;: list_id, &#34;access_level&#34;: access_level, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.access.set&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Set the access level to a List for specified entities.
+<a href="https://docs.slack.dev/reference/methods/slackLists.access.set">https://docs.slack.dev/reference/methods/slackLists.access.set</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_create"><code class="name flex">
+<span>async def <span class="ident">slackLists_create</span></span>(<span>self,<br>*,<br>name: str,<br>description_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a>] | None = None,<br>schema: List[Dict[str, Any]] | None = None,<br>copy_from_list_id: str | None = None,<br>include_copied_list_records: bool | None = None,<br>todo_mode: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_create(
+    self,
+    *,
+    name: str,
+    description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+    schema: Optional[List[Dict[str, Any]]] = None,
+    copy_from_list_id: Optional[str] = None,
+    include_copied_list_records: Optional[bool] = None,
+    todo_mode: Optional[bool] = None,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Creates a List.
+    https://docs.slack.dev/reference/methods/slackLists.create
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;name&#34;: name,
+            &#34;description_blocks&#34;: description_blocks,
+            &#34;schema&#34;: schema,
+            &#34;copy_from_list_id&#34;: copy_from_list_id,
+            &#34;include_copied_list_records&#34;: include_copied_list_records,
+            &#34;todo_mode&#34;: todo_mode,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.create&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Creates a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.create">https://docs.slack.dev/reference/methods/slackLists.create</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_download_get"><code class="name flex">
+<span>async def <span class="ident">slackLists_download_get</span></span>(<span>self, *, list_id: str, job_id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_download_get(
+    self,
+    *,
+    list_id: str,
+    job_id: str,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Retrieve List download URL from an export job to download List contents.
+    https://docs.slack.dev/reference/methods/slackLists.download.get
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;job_id&#34;: job_id,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.download.get&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Retrieve List download URL from an export job to download List contents.
+<a href="https://docs.slack.dev/reference/methods/slackLists.download.get">https://docs.slack.dev/reference/methods/slackLists.download.get</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_download_start"><code class="name flex">
+<span>async def <span class="ident">slackLists_download_start</span></span>(<span>self, *, list_id: str, include_archived: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_download_start(
+    self,
+    *,
+    list_id: str,
+    include_archived: Optional[bool] = None,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Initiate a job to export List contents.
+    https://docs.slack.dev/reference/methods/slackLists.download.start
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;include_archived&#34;: include_archived,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.download.start&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Initiate a job to export List contents.
+<a href="https://docs.slack.dev/reference/methods/slackLists.download.start">https://docs.slack.dev/reference/methods/slackLists.download.start</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_create"><code class="name flex">
+<span>async def <span class="ident">slackLists_items_create</span></span>(<span>self,<br>*,<br>list_id: str,<br>duplicated_item_id: str | None = None,<br>parent_item_id: str | None = None,<br>initial_fields: List[Dict[str, Any]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_items_create(
+    self,
+    *,
+    list_id: str,
+    duplicated_item_id: Optional[str] = None,
+    parent_item_id: Optional[str] = None,
+    initial_fields: Optional[List[Dict[str, Any]]] = None,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Add a new item to an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.create
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;duplicated_item_id&#34;: duplicated_item_id,
+            &#34;parent_item_id&#34;: parent_item_id,
+            &#34;initial_fields&#34;: initial_fields,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.items.create&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Add a new item to an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.create">https://docs.slack.dev/reference/methods/slackLists.items.create</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_delete"><code class="name flex">
+<span>async def <span class="ident">slackLists_items_delete</span></span>(<span>self, *, list_id: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_items_delete(
+    self,
+    *,
+    list_id: str,
+    id: str,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Deletes an item from an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.delete
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;id&#34;: id,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.items.delete&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Deletes an item from an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.delete">https://docs.slack.dev/reference/methods/slackLists.items.delete</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_deleteMultiple"><code class="name flex">
+<span>async def <span class="ident">slackLists_items_deleteMultiple</span></span>(<span>self, *, list_id: str, ids: List[str], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_items_deleteMultiple(
+    self,
+    *,
+    list_id: str,
+    ids: List[str],
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Deletes multiple items from an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;ids&#34;: ids,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.items.deleteMultiple&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Deletes multiple items from an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple">https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_info"><code class="name flex">
+<span>async def <span class="ident">slackLists_items_info</span></span>(<span>self, *, list_id: str, id: str, include_is_subscribed: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_items_info(
+    self,
+    *,
+    list_id: str,
+    id: str,
+    include_is_subscribed: Optional[bool] = None,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Get a row from a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.info
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;id&#34;: id,
+            &#34;include_is_subscribed&#34;: include_is_subscribed,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.items.info&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Get a row from a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.info">https://docs.slack.dev/reference/methods/slackLists.items.info</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_list"><code class="name flex">
+<span>async def <span class="ident">slackLists_items_list</span></span>(<span>self,<br>*,<br>list_id: str,<br>limit: int | None = None,<br>cursor: str | None = None,<br>archived: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_items_list(
+    self,
+    *,
+    list_id: str,
+    limit: Optional[int] = None,
+    cursor: Optional[str] = None,
+    archived: Optional[bool] = None,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Get records from a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.list
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;limit&#34;: limit,
+            &#34;cursor&#34;: cursor,
+            &#34;archived&#34;: archived,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.items.list&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Get records from a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.list">https://docs.slack.dev/reference/methods/slackLists.items.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_update"><code class="name flex">
+<span>async def <span class="ident">slackLists_items_update</span></span>(<span>self, *, list_id: str, cells: List[Dict[str, Any]], **kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_items_update(
+    self,
+    *,
+    list_id: str,
+    cells: List[Dict[str, Any]],
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Updates cells in a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.update
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;cells&#34;: cells,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.items.update&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Updates cells in a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.update">https://docs.slack.dev/reference/methods/slackLists.items.update</a></p></div>
+</dd>
+<dt id="slack_sdk.web.async_client.AsyncWebClient.slackLists_update"><code class="name flex">
+<span>async def <span class="ident">slackLists_update</span></span>(<span>self,<br>*,<br>id: str,<br>name: str | None = None,<br>description_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a>] | None = None,<br>todo_mode: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def slackLists_update(
+    self,
+    *,
+    id: str,
+    name: Optional[str] = None,
+    description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+    todo_mode: Optional[bool] = None,
+    **kwargs,
+) -&gt; AsyncSlackResponse:
+    &#34;&#34;&#34;Update a List.
+    https://docs.slack.dev/reference/methods/slackLists.update
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;id&#34;: id,
+            &#34;name&#34;: name,
+            &#34;description_blocks&#34;: description_blocks,
+            &#34;todo_mode&#34;: todo_mode,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return await self.api_call(&#34;slackLists.update&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Update a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.update">https://docs.slack.dev/reference/methods/slackLists.update</a></p></div>
+</dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.stars_add"><code class="name flex">
 <span>async def <span class="ident">stars_add</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
@@ -14968,6 +15649,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.dnd_setSnooze" href="#slack_sdk.web.async_client.AsyncWebClient.dnd_setSnooze">dnd_setSnooze</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.dnd_teamInfo" href="#slack_sdk.web.async_client.AsyncWebClient.dnd_teamInfo">dnd_teamInfo</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.emoji_list" href="#slack_sdk.web.async_client.AsyncWebClient.emoji_list">emoji_list</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.entity_presentDetails" href="#slack_sdk.web.async_client.AsyncWebClient.entity_presentDetails">entity_presentDetails</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.files_comments_delete" href="#slack_sdk.web.async_client.AsyncWebClient.files_comments_delete">files_comments_delete</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.files_completeUploadExternal" href="#slack_sdk.web.async_client.AsyncWebClient.files_completeUploadExternal">files_completeUploadExternal</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.files_delete" href="#slack_sdk.web.async_client.AsyncWebClient.files_delete">files_delete</a></code></li>
@@ -15037,6 +15719,18 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.search_all" href="#slack_sdk.web.async_client.AsyncWebClient.search_all">search_all</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.search_files" href="#slack_sdk.web.async_client.AsyncWebClient.search_files">search_files</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.search_messages" href="#slack_sdk.web.async_client.AsyncWebClient.search_messages">search_messages</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_access_delete" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_access_delete">slackLists_access_delete</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_access_set" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_access_set">slackLists_access_set</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_create" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_create">slackLists_create</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_download_get" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_download_get">slackLists_download_get</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_download_start" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_download_start">slackLists_download_start</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_create" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_items_create">slackLists_items_create</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_delete" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_items_delete">slackLists_items_delete</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_deleteMultiple" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_items_deleteMultiple">slackLists_items_deleteMultiple</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_info" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_items_info">slackLists_items_info</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_list" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_items_list">slackLists_items_list</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_items_update" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_items_update">slackLists_items_update</a></code></li>
+<li><code><a title="slack_sdk.web.async_client.AsyncWebClient.slackLists_update" href="#slack_sdk.web.async_client.AsyncWebClient.slackLists_update">slackLists_update</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.stars_add" href="#slack_sdk.web.async_client.AsyncWebClient.stars_add">stars_add</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.stars_list" href="#slack_sdk.web.async_client.AsyncWebClient.stars_list">stars_list</a></code></li>
 <li><code><a title="slack_sdk.web.async_client.AsyncWebClient.stars_remove" href="#slack_sdk.web.async_client.AsyncWebClient.stars_remove">stars_remove</a></code></li>

--- a/docs/reference/web/client.html
+++ b/docs/reference/web/client.html
@@ -2790,7 +2790,7 @@ el.replaceWith(d);
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
-        metadata: Optional[Union[Dict, Metadata]] = None,
+        metadata: Optional[Union[Dict, Metadata, EventAndEntityMetadata]] = None,
         markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
@@ -3019,6 +3019,7 @@ el.replaceWith(d);
         source: Optional[str] = None,
         unfurl_id: Optional[str] = None,
         unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
+        metadata: Optional[Union[Dict, EventAndEntityMetadata]] = None,
         user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
         user_auth_message: Optional[str] = None,
         user_auth_required: Optional[bool] = None,
@@ -3035,6 +3036,7 @@ el.replaceWith(d);
                 &#34;source&#34;: source,
                 &#34;unfurl_id&#34;: unfurl_id,
                 &#34;unfurls&#34;: unfurls,
+                &#34;metadata&#34;: metadata,
                 &#34;user_auth_blocks&#34;: user_auth_blocks,
                 &#34;user_auth_message&#34;: user_auth_message,
                 &#34;user_auth_required&#34;: user_auth_required,
@@ -3665,6 +3667,30 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         kwargs.update({&#34;include_categories&#34;: include_categories})
         return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
+    def entity_presentDetails(
+        self,
+        trigger_id: str,
+        metadata: Optional[Union[Dict, EntityMetadata]] = None,
+        user_auth_required: Optional[bool] = None,
+        user_auth_url: Optional[str] = None,
+        error: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Provides entity details for the flexpane.
+        https://docs.slack.dev/reference/methods/entity.presentDetails/
+        &#34;&#34;&#34;
+        kwargs.update({&#34;trigger_id&#34;: trigger_id})
+        if metadata is not None:
+            kwargs.update({&#34;metadata&#34;: metadata})
+        if user_auth_required is not None:
+            kwargs.update({&#34;user_auth_required&#34;: user_auth_required})
+        if user_auth_url is not None:
+            kwargs.update({&#34;user_auth_url&#34;: user_auth_url})
+        if error is not None:
+            kwargs.update({&#34;error&#34;: error})
+        _parse_web_class_objects(kwargs)
+        return self.api_call(&#34;entity.presentDetails&#34;, json=kwargs)
 
     def files_comments_delete(
         self,
@@ -4919,6 +4945,249 @@ el.replaceWith(d);
             }
         )
         return self.api_call(&#34;search.messages&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
+    def slackLists_access_delete(
+        self,
+        *,
+        list_id: str,
+        channel_ids: Optional[List[str]] = None,
+        user_ids: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Revoke access to a List for specified entities.
+        https://docs.slack.dev/reference/methods/slackLists.access.delete
+        &#34;&#34;&#34;
+        kwargs.update({&#34;list_id&#34;: list_id, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.access.delete&#34;, json=kwargs)
+
+    def slackLists_access_set(
+        self,
+        *,
+        list_id: str,
+        access_level: str,
+        channel_ids: Optional[List[str]] = None,
+        user_ids: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Set the access level to a List for specified entities.
+        https://docs.slack.dev/reference/methods/slackLists.access.set
+        &#34;&#34;&#34;
+        kwargs.update({&#34;list_id&#34;: list_id, &#34;access_level&#34;: access_level, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.access.set&#34;, json=kwargs)
+
+    def slackLists_create(
+        self,
+        *,
+        name: str,
+        description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+        schema: Optional[List[Dict[str, Any]]] = None,
+        copy_from_list_id: Optional[str] = None,
+        include_copied_list_records: Optional[bool] = None,
+        todo_mode: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Creates a List.
+        https://docs.slack.dev/reference/methods/slackLists.create
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;name&#34;: name,
+                &#34;description_blocks&#34;: description_blocks,
+                &#34;schema&#34;: schema,
+                &#34;copy_from_list_id&#34;: copy_from_list_id,
+                &#34;include_copied_list_records&#34;: include_copied_list_records,
+                &#34;todo_mode&#34;: todo_mode,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.create&#34;, json=kwargs)
+
+    def slackLists_download_get(
+        self,
+        *,
+        list_id: str,
+        job_id: str,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Retrieve List download URL from an export job to download List contents.
+        https://docs.slack.dev/reference/methods/slackLists.download.get
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;job_id&#34;: job_id,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.download.get&#34;, json=kwargs)
+
+    def slackLists_download_start(
+        self,
+        *,
+        list_id: str,
+        include_archived: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Initiate a job to export List contents.
+        https://docs.slack.dev/reference/methods/slackLists.download.start
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;include_archived&#34;: include_archived,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.download.start&#34;, json=kwargs)
+
+    def slackLists_items_create(
+        self,
+        *,
+        list_id: str,
+        duplicated_item_id: Optional[str] = None,
+        parent_item_id: Optional[str] = None,
+        initial_fields: Optional[List[Dict[str, Any]]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Add a new item to an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.create
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;duplicated_item_id&#34;: duplicated_item_id,
+                &#34;parent_item_id&#34;: parent_item_id,
+                &#34;initial_fields&#34;: initial_fields,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.create&#34;, json=kwargs)
+
+    def slackLists_items_delete(
+        self,
+        *,
+        list_id: str,
+        id: str,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Deletes an item from an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.delete
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;id&#34;: id,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.delete&#34;, json=kwargs)
+
+    def slackLists_items_deleteMultiple(
+        self,
+        *,
+        list_id: str,
+        ids: List[str],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Deletes multiple items from an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;ids&#34;: ids,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.deleteMultiple&#34;, json=kwargs)
+
+    def slackLists_items_info(
+        self,
+        *,
+        list_id: str,
+        id: str,
+        include_is_subscribed: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Get a row from a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.info
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;id&#34;: id,
+                &#34;include_is_subscribed&#34;: include_is_subscribed,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.info&#34;, json=kwargs)
+
+    def slackLists_items_list(
+        self,
+        *,
+        list_id: str,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        archived: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Get records from a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;limit&#34;: limit,
+                &#34;cursor&#34;: cursor,
+                &#34;archived&#34;: archived,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.list&#34;, json=kwargs)
+
+    def slackLists_items_update(
+        self,
+        *,
+        list_id: str,
+        cells: List[Dict[str, Any]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Updates cells in a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.update
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;cells&#34;: cells,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.update&#34;, json=kwargs)
+
+    def slackLists_update(
+        self,
+        *,
+        id: str,
+        name: Optional[str] = None,
+        description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+        todo_mode: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Update a List.
+        https://docs.slack.dev/reference/methods/slackLists.update
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;id&#34;: id,
+                &#34;name&#34;: name,
+                &#34;description_blocks&#34;: description_blocks,
+                &#34;todo_mode&#34;: todo_mode,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.update&#34;, json=kwargs)
 
     def stars_add(
         self,
@@ -10066,7 +10335,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/chat.postEphemeral">https://docs.slack.dev/reference/methods/chat.postEphemeral</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_postMessage"><code class="name flex">
-<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | <a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10092,7 +10361,7 @@ Each authorization represents an app installation that the event is visible to.
     link_names: Optional[bool] = None,
     username: Optional[str] = None,
     parse: Optional[str] = None,  # none, full
-    metadata: Optional[Union[Dict, Metadata]] = None,
+    metadata: Optional[Union[Dict, Metadata, EventAndEntityMetadata]] = None,
     markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
@@ -10414,7 +10683,7 @@ streamer.stop()
 </code></pre></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.chat_unfurl"><code class="name flex">
-<span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a> | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10429,6 +10698,7 @@ streamer.stop()
     source: Optional[str] = None,
     unfurl_id: Optional[str] = None,
     unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
+    metadata: Optional[Union[Dict, EventAndEntityMetadata]] = None,
     user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
     user_auth_message: Optional[str] = None,
     user_auth_required: Optional[bool] = None,
@@ -10445,6 +10715,7 @@ streamer.stop()
             &#34;source&#34;: source,
             &#34;unfurl_id&#34;: unfurl_id,
             &#34;unfurls&#34;: unfurls,
+            &#34;metadata&#34;: metadata,
             &#34;user_auth_blocks&#34;: user_auth_blocks,
             &#34;user_auth_message&#34;: user_auth_message,
             &#34;user_auth_required&#34;: user_auth_required,
@@ -11475,6 +11746,41 @@ or received but have not yet been approved by all parties.
 </details>
 <div class="desc"><p>Lists custom emoji for a team.
 <a href="https://docs.slack.dev/reference/methods/emoji.list">https://docs.slack.dev/reference/methods/emoji.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.entity_presentDetails"><code class="name flex">
+<span>def <span class="ident">entity_presentDetails</span></span>(<span>self,<br>trigger_id: str,<br>metadata: Dict | <a title="slack_sdk.models.metadata.EntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EntityMetadata">EntityMetadata</a> | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>error: Dict[str, Any] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def entity_presentDetails(
+    self,
+    trigger_id: str,
+    metadata: Optional[Union[Dict, EntityMetadata]] = None,
+    user_auth_required: Optional[bool] = None,
+    user_auth_url: Optional[str] = None,
+    error: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Provides entity details for the flexpane.
+    https://docs.slack.dev/reference/methods/entity.presentDetails/
+    &#34;&#34;&#34;
+    kwargs.update({&#34;trigger_id&#34;: trigger_id})
+    if metadata is not None:
+        kwargs.update({&#34;metadata&#34;: metadata})
+    if user_auth_required is not None:
+        kwargs.update({&#34;user_auth_required&#34;: user_auth_required})
+    if user_auth_url is not None:
+        kwargs.update({&#34;user_auth_url&#34;: user_auth_url})
+    if error is not None:
+        kwargs.update({&#34;error&#34;: error})
+    _parse_web_class_objects(kwargs)
+    return self.api_call(&#34;entity.presentDetails&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Provides entity details for the flexpane.
+<a href="https://docs.slack.dev/reference/methods/entity.presentDetails/">https://docs.slack.dev/reference/methods/entity.presentDetails/</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.files_comments_delete"><code class="name flex">
 <span>def <span class="ident">files_comments_delete</span></span>(<span>self, *, file: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13451,6 +13757,381 @@ multiparty direct message.</p></div>
 <div class="desc"><p>Searches for messages matching a query.
 <a href="https://docs.slack.dev/reference/methods/search.messages">https://docs.slack.dev/reference/methods/search.messages</a></p></div>
 </dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_access_delete"><code class="name flex">
+<span>def <span class="ident">slackLists_access_delete</span></span>(<span>self,<br>*,<br>list_id: str,<br>channel_ids: List[str] | None = None,<br>user_ids: List[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_access_delete(
+    self,
+    *,
+    list_id: str,
+    channel_ids: Optional[List[str]] = None,
+    user_ids: Optional[List[str]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Revoke access to a List for specified entities.
+    https://docs.slack.dev/reference/methods/slackLists.access.delete
+    &#34;&#34;&#34;
+    kwargs.update({&#34;list_id&#34;: list_id, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.access.delete&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Revoke access to a List for specified entities.
+<a href="https://docs.slack.dev/reference/methods/slackLists.access.delete">https://docs.slack.dev/reference/methods/slackLists.access.delete</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_access_set"><code class="name flex">
+<span>def <span class="ident">slackLists_access_set</span></span>(<span>self,<br>*,<br>list_id: str,<br>access_level: str,<br>channel_ids: List[str] | None = None,<br>user_ids: List[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_access_set(
+    self,
+    *,
+    list_id: str,
+    access_level: str,
+    channel_ids: Optional[List[str]] = None,
+    user_ids: Optional[List[str]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Set the access level to a List for specified entities.
+    https://docs.slack.dev/reference/methods/slackLists.access.set
+    &#34;&#34;&#34;
+    kwargs.update({&#34;list_id&#34;: list_id, &#34;access_level&#34;: access_level, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.access.set&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Set the access level to a List for specified entities.
+<a href="https://docs.slack.dev/reference/methods/slackLists.access.set">https://docs.slack.dev/reference/methods/slackLists.access.set</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_create"><code class="name flex">
+<span>def <span class="ident">slackLists_create</span></span>(<span>self,<br>*,<br>name: str,<br>description_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a>] | None = None,<br>schema: List[Dict[str, Any]] | None = None,<br>copy_from_list_id: str | None = None,<br>include_copied_list_records: bool | None = None,<br>todo_mode: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_create(
+    self,
+    *,
+    name: str,
+    description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+    schema: Optional[List[Dict[str, Any]]] = None,
+    copy_from_list_id: Optional[str] = None,
+    include_copied_list_records: Optional[bool] = None,
+    todo_mode: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Creates a List.
+    https://docs.slack.dev/reference/methods/slackLists.create
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;name&#34;: name,
+            &#34;description_blocks&#34;: description_blocks,
+            &#34;schema&#34;: schema,
+            &#34;copy_from_list_id&#34;: copy_from_list_id,
+            &#34;include_copied_list_records&#34;: include_copied_list_records,
+            &#34;todo_mode&#34;: todo_mode,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.create&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Creates a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.create">https://docs.slack.dev/reference/methods/slackLists.create</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_download_get"><code class="name flex">
+<span>def <span class="ident">slackLists_download_get</span></span>(<span>self, *, list_id: str, job_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_download_get(
+    self,
+    *,
+    list_id: str,
+    job_id: str,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Retrieve List download URL from an export job to download List contents.
+    https://docs.slack.dev/reference/methods/slackLists.download.get
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;job_id&#34;: job_id,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.download.get&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Retrieve List download URL from an export job to download List contents.
+<a href="https://docs.slack.dev/reference/methods/slackLists.download.get">https://docs.slack.dev/reference/methods/slackLists.download.get</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_download_start"><code class="name flex">
+<span>def <span class="ident">slackLists_download_start</span></span>(<span>self, *, list_id: str, include_archived: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_download_start(
+    self,
+    *,
+    list_id: str,
+    include_archived: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Initiate a job to export List contents.
+    https://docs.slack.dev/reference/methods/slackLists.download.start
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;include_archived&#34;: include_archived,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.download.start&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Initiate a job to export List contents.
+<a href="https://docs.slack.dev/reference/methods/slackLists.download.start">https://docs.slack.dev/reference/methods/slackLists.download.start</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_items_create"><code class="name flex">
+<span>def <span class="ident">slackLists_items_create</span></span>(<span>self,<br>*,<br>list_id: str,<br>duplicated_item_id: str | None = None,<br>parent_item_id: str | None = None,<br>initial_fields: List[Dict[str, Any]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_create(
+    self,
+    *,
+    list_id: str,
+    duplicated_item_id: Optional[str] = None,
+    parent_item_id: Optional[str] = None,
+    initial_fields: Optional[List[Dict[str, Any]]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Add a new item to an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.create
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;duplicated_item_id&#34;: duplicated_item_id,
+            &#34;parent_item_id&#34;: parent_item_id,
+            &#34;initial_fields&#34;: initial_fields,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.create&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Add a new item to an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.create">https://docs.slack.dev/reference/methods/slackLists.items.create</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_items_delete"><code class="name flex">
+<span>def <span class="ident">slackLists_items_delete</span></span>(<span>self, *, list_id: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_delete(
+    self,
+    *,
+    list_id: str,
+    id: str,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Deletes an item from an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.delete
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;id&#34;: id,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.delete&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Deletes an item from an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.delete">https://docs.slack.dev/reference/methods/slackLists.items.delete</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_items_deleteMultiple"><code class="name flex">
+<span>def <span class="ident">slackLists_items_deleteMultiple</span></span>(<span>self, *, list_id: str, ids: List[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_deleteMultiple(
+    self,
+    *,
+    list_id: str,
+    ids: List[str],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Deletes multiple items from an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;ids&#34;: ids,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.deleteMultiple&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Deletes multiple items from an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple">https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_items_info"><code class="name flex">
+<span>def <span class="ident">slackLists_items_info</span></span>(<span>self, *, list_id: str, id: str, include_is_subscribed: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_info(
+    self,
+    *,
+    list_id: str,
+    id: str,
+    include_is_subscribed: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Get a row from a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.info
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;id&#34;: id,
+            &#34;include_is_subscribed&#34;: include_is_subscribed,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.info&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Get a row from a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.info">https://docs.slack.dev/reference/methods/slackLists.items.info</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_items_list"><code class="name flex">
+<span>def <span class="ident">slackLists_items_list</span></span>(<span>self,<br>*,<br>list_id: str,<br>limit: int | None = None,<br>cursor: str | None = None,<br>archived: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_list(
+    self,
+    *,
+    list_id: str,
+    limit: Optional[int] = None,
+    cursor: Optional[str] = None,
+    archived: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Get records from a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.list
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;limit&#34;: limit,
+            &#34;cursor&#34;: cursor,
+            &#34;archived&#34;: archived,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.list&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Get records from a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.list">https://docs.slack.dev/reference/methods/slackLists.items.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_items_update"><code class="name flex">
+<span>def <span class="ident">slackLists_items_update</span></span>(<span>self, *, list_id: str, cells: List[Dict[str, Any]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_update(
+    self,
+    *,
+    list_id: str,
+    cells: List[Dict[str, Any]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Updates cells in a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.update
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;cells&#34;: cells,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.update&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Updates cells in a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.update">https://docs.slack.dev/reference/methods/slackLists.items.update</a></p></div>
+</dd>
+<dt id="slack_sdk.web.client.WebClient.slackLists_update"><code class="name flex">
+<span>def <span class="ident">slackLists_update</span></span>(<span>self,<br>*,<br>id: str,<br>name: str | None = None,<br>description_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a>] | None = None,<br>todo_mode: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_update(
+    self,
+    *,
+    id: str,
+    name: Optional[str] = None,
+    description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+    todo_mode: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Update a List.
+    https://docs.slack.dev/reference/methods/slackLists.update
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;id&#34;: id,
+            &#34;name&#34;: name,
+            &#34;description_blocks&#34;: description_blocks,
+            &#34;todo_mode&#34;: todo_mode,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.update&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Update a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.update">https://docs.slack.dev/reference/methods/slackLists.update</a></p></div>
+</dd>
 <dt id="slack_sdk.web.client.WebClient.stars_add"><code class="name flex">
 <span>def <span class="ident">stars_add</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
@@ -14967,6 +15648,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.client.WebClient.dnd_setSnooze" href="#slack_sdk.web.client.WebClient.dnd_setSnooze">dnd_setSnooze</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.dnd_teamInfo" href="#slack_sdk.web.client.WebClient.dnd_teamInfo">dnd_teamInfo</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.emoji_list" href="#slack_sdk.web.client.WebClient.emoji_list">emoji_list</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.entity_presentDetails" href="#slack_sdk.web.client.WebClient.entity_presentDetails">entity_presentDetails</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.files_comments_delete" href="#slack_sdk.web.client.WebClient.files_comments_delete">files_comments_delete</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.files_completeUploadExternal" href="#slack_sdk.web.client.WebClient.files_completeUploadExternal">files_completeUploadExternal</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.files_delete" href="#slack_sdk.web.client.WebClient.files_delete">files_delete</a></code></li>
@@ -15036,6 +15718,18 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.client.WebClient.search_all" href="#slack_sdk.web.client.WebClient.search_all">search_all</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.search_files" href="#slack_sdk.web.client.WebClient.search_files">search_files</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.search_messages" href="#slack_sdk.web.client.WebClient.search_messages">search_messages</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_access_delete" href="#slack_sdk.web.client.WebClient.slackLists_access_delete">slackLists_access_delete</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_access_set" href="#slack_sdk.web.client.WebClient.slackLists_access_set">slackLists_access_set</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_create" href="#slack_sdk.web.client.WebClient.slackLists_create">slackLists_create</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_download_get" href="#slack_sdk.web.client.WebClient.slackLists_download_get">slackLists_download_get</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_download_start" href="#slack_sdk.web.client.WebClient.slackLists_download_start">slackLists_download_start</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_items_create" href="#slack_sdk.web.client.WebClient.slackLists_items_create">slackLists_items_create</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_items_delete" href="#slack_sdk.web.client.WebClient.slackLists_items_delete">slackLists_items_delete</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_items_deleteMultiple" href="#slack_sdk.web.client.WebClient.slackLists_items_deleteMultiple">slackLists_items_deleteMultiple</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_items_info" href="#slack_sdk.web.client.WebClient.slackLists_items_info">slackLists_items_info</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_items_list" href="#slack_sdk.web.client.WebClient.slackLists_items_list">slackLists_items_list</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_items_update" href="#slack_sdk.web.client.WebClient.slackLists_items_update">slackLists_items_update</a></code></li>
+<li><code><a title="slack_sdk.web.client.WebClient.slackLists_update" href="#slack_sdk.web.client.WebClient.slackLists_update">slackLists_update</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.stars_add" href="#slack_sdk.web.client.WebClient.stars_add">stars_add</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.stars_list" href="#slack_sdk.web.client.WebClient.stars_list">stars_list</a></code></li>
 <li><code><a title="slack_sdk.web.client.WebClient.stars_remove" href="#slack_sdk.web.client.WebClient.stars_remove">stars_remove</a></code></li>

--- a/docs/reference/web/index.html
+++ b/docs/reference/web/index.html
@@ -3159,7 +3159,7 @@ This method returns it's own object. e.g. 'self'</p>
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
-        metadata: Optional[Union[Dict, Metadata]] = None,
+        metadata: Optional[Union[Dict, Metadata, EventAndEntityMetadata]] = None,
         markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; SlackResponse:
@@ -3388,6 +3388,7 @@ This method returns it's own object. e.g. 'self'</p>
         source: Optional[str] = None,
         unfurl_id: Optional[str] = None,
         unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
+        metadata: Optional[Union[Dict, EventAndEntityMetadata]] = None,
         user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
         user_auth_message: Optional[str] = None,
         user_auth_required: Optional[bool] = None,
@@ -3404,6 +3405,7 @@ This method returns it's own object. e.g. 'self'</p>
                 &#34;source&#34;: source,
                 &#34;unfurl_id&#34;: unfurl_id,
                 &#34;unfurls&#34;: unfurls,
+                &#34;metadata&#34;: metadata,
                 &#34;user_auth_blocks&#34;: user_auth_blocks,
                 &#34;user_auth_message&#34;: user_auth_message,
                 &#34;user_auth_required&#34;: user_auth_required,
@@ -4034,6 +4036,30 @@ This method returns it's own object. e.g. 'self'</p>
         &#34;&#34;&#34;
         kwargs.update({&#34;include_categories&#34;: include_categories})
         return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
+    def entity_presentDetails(
+        self,
+        trigger_id: str,
+        metadata: Optional[Union[Dict, EntityMetadata]] = None,
+        user_auth_required: Optional[bool] = None,
+        user_auth_url: Optional[str] = None,
+        error: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Provides entity details for the flexpane.
+        https://docs.slack.dev/reference/methods/entity.presentDetails/
+        &#34;&#34;&#34;
+        kwargs.update({&#34;trigger_id&#34;: trigger_id})
+        if metadata is not None:
+            kwargs.update({&#34;metadata&#34;: metadata})
+        if user_auth_required is not None:
+            kwargs.update({&#34;user_auth_required&#34;: user_auth_required})
+        if user_auth_url is not None:
+            kwargs.update({&#34;user_auth_url&#34;: user_auth_url})
+        if error is not None:
+            kwargs.update({&#34;error&#34;: error})
+        _parse_web_class_objects(kwargs)
+        return self.api_call(&#34;entity.presentDetails&#34;, json=kwargs)
 
     def files_comments_delete(
         self,
@@ -5288,6 +5314,249 @@ This method returns it's own object. e.g. 'self'</p>
             }
         )
         return self.api_call(&#34;search.messages&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
+    def slackLists_access_delete(
+        self,
+        *,
+        list_id: str,
+        channel_ids: Optional[List[str]] = None,
+        user_ids: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Revoke access to a List for specified entities.
+        https://docs.slack.dev/reference/methods/slackLists.access.delete
+        &#34;&#34;&#34;
+        kwargs.update({&#34;list_id&#34;: list_id, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.access.delete&#34;, json=kwargs)
+
+    def slackLists_access_set(
+        self,
+        *,
+        list_id: str,
+        access_level: str,
+        channel_ids: Optional[List[str]] = None,
+        user_ids: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Set the access level to a List for specified entities.
+        https://docs.slack.dev/reference/methods/slackLists.access.set
+        &#34;&#34;&#34;
+        kwargs.update({&#34;list_id&#34;: list_id, &#34;access_level&#34;: access_level, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.access.set&#34;, json=kwargs)
+
+    def slackLists_create(
+        self,
+        *,
+        name: str,
+        description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+        schema: Optional[List[Dict[str, Any]]] = None,
+        copy_from_list_id: Optional[str] = None,
+        include_copied_list_records: Optional[bool] = None,
+        todo_mode: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Creates a List.
+        https://docs.slack.dev/reference/methods/slackLists.create
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;name&#34;: name,
+                &#34;description_blocks&#34;: description_blocks,
+                &#34;schema&#34;: schema,
+                &#34;copy_from_list_id&#34;: copy_from_list_id,
+                &#34;include_copied_list_records&#34;: include_copied_list_records,
+                &#34;todo_mode&#34;: todo_mode,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.create&#34;, json=kwargs)
+
+    def slackLists_download_get(
+        self,
+        *,
+        list_id: str,
+        job_id: str,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Retrieve List download URL from an export job to download List contents.
+        https://docs.slack.dev/reference/methods/slackLists.download.get
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;job_id&#34;: job_id,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.download.get&#34;, json=kwargs)
+
+    def slackLists_download_start(
+        self,
+        *,
+        list_id: str,
+        include_archived: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Initiate a job to export List contents.
+        https://docs.slack.dev/reference/methods/slackLists.download.start
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;include_archived&#34;: include_archived,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.download.start&#34;, json=kwargs)
+
+    def slackLists_items_create(
+        self,
+        *,
+        list_id: str,
+        duplicated_item_id: Optional[str] = None,
+        parent_item_id: Optional[str] = None,
+        initial_fields: Optional[List[Dict[str, Any]]] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Add a new item to an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.create
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;duplicated_item_id&#34;: duplicated_item_id,
+                &#34;parent_item_id&#34;: parent_item_id,
+                &#34;initial_fields&#34;: initial_fields,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.create&#34;, json=kwargs)
+
+    def slackLists_items_delete(
+        self,
+        *,
+        list_id: str,
+        id: str,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Deletes an item from an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.delete
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;id&#34;: id,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.delete&#34;, json=kwargs)
+
+    def slackLists_items_deleteMultiple(
+        self,
+        *,
+        list_id: str,
+        ids: List[str],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Deletes multiple items from an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;ids&#34;: ids,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.deleteMultiple&#34;, json=kwargs)
+
+    def slackLists_items_info(
+        self,
+        *,
+        list_id: str,
+        id: str,
+        include_is_subscribed: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Get a row from a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.info
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;id&#34;: id,
+                &#34;include_is_subscribed&#34;: include_is_subscribed,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.info&#34;, json=kwargs)
+
+    def slackLists_items_list(
+        self,
+        *,
+        list_id: str,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        archived: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Get records from a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;limit&#34;: limit,
+                &#34;cursor&#34;: cursor,
+                &#34;archived&#34;: archived,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.list&#34;, json=kwargs)
+
+    def slackLists_items_update(
+        self,
+        *,
+        list_id: str,
+        cells: List[Dict[str, Any]],
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Updates cells in a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.update
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;cells&#34;: cells,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.update&#34;, json=kwargs)
+
+    def slackLists_update(
+        self,
+        *,
+        id: str,
+        name: Optional[str] = None,
+        description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+        todo_mode: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; SlackResponse:
+        &#34;&#34;&#34;Update a List.
+        https://docs.slack.dev/reference/methods/slackLists.update
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;id&#34;: id,
+                &#34;name&#34;: name,
+                &#34;description_blocks&#34;: description_blocks,
+                &#34;todo_mode&#34;: todo_mode,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.update&#34;, json=kwargs)
 
     def stars_add(
         self,
@@ -10435,7 +10704,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/chat.postEphemeral">https://docs.slack.dev/reference/methods/chat.postEphemeral</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_postMessage"><code class="name flex">
-<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | <a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10461,7 +10730,7 @@ Each authorization represents an app installation that the event is visible to.
     link_names: Optional[bool] = None,
     username: Optional[str] = None,
     parse: Optional[str] = None,  # none, full
-    metadata: Optional[Union[Dict, Metadata]] = None,
+    metadata: Optional[Union[Dict, Metadata, EventAndEntityMetadata]] = None,
     markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; SlackResponse:
@@ -10783,7 +11052,7 @@ streamer.stop()
 </code></pre></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.chat_unfurl"><code class="name flex">
-<span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a> | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10798,6 +11067,7 @@ streamer.stop()
     source: Optional[str] = None,
     unfurl_id: Optional[str] = None,
     unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
+    metadata: Optional[Union[Dict, EventAndEntityMetadata]] = None,
     user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
     user_auth_message: Optional[str] = None,
     user_auth_required: Optional[bool] = None,
@@ -10814,6 +11084,7 @@ streamer.stop()
             &#34;source&#34;: source,
             &#34;unfurl_id&#34;: unfurl_id,
             &#34;unfurls&#34;: unfurls,
+            &#34;metadata&#34;: metadata,
             &#34;user_auth_blocks&#34;: user_auth_blocks,
             &#34;user_auth_message&#34;: user_auth_message,
             &#34;user_auth_required&#34;: user_auth_required,
@@ -11844,6 +12115,41 @@ or received but have not yet been approved by all parties.
 </details>
 <div class="desc"><p>Lists custom emoji for a team.
 <a href="https://docs.slack.dev/reference/methods/emoji.list">https://docs.slack.dev/reference/methods/emoji.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.entity_presentDetails"><code class="name flex">
+<span>def <span class="ident">entity_presentDetails</span></span>(<span>self,<br>trigger_id: str,<br>metadata: Dict | <a title="slack_sdk.models.metadata.EntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EntityMetadata">EntityMetadata</a> | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>error: Dict[str, Any] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def entity_presentDetails(
+    self,
+    trigger_id: str,
+    metadata: Optional[Union[Dict, EntityMetadata]] = None,
+    user_auth_required: Optional[bool] = None,
+    user_auth_url: Optional[str] = None,
+    error: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Provides entity details for the flexpane.
+    https://docs.slack.dev/reference/methods/entity.presentDetails/
+    &#34;&#34;&#34;
+    kwargs.update({&#34;trigger_id&#34;: trigger_id})
+    if metadata is not None:
+        kwargs.update({&#34;metadata&#34;: metadata})
+    if user_auth_required is not None:
+        kwargs.update({&#34;user_auth_required&#34;: user_auth_required})
+    if user_auth_url is not None:
+        kwargs.update({&#34;user_auth_url&#34;: user_auth_url})
+    if error is not None:
+        kwargs.update({&#34;error&#34;: error})
+    _parse_web_class_objects(kwargs)
+    return self.api_call(&#34;entity.presentDetails&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Provides entity details for the flexpane.
+<a href="https://docs.slack.dev/reference/methods/entity.presentDetails/">https://docs.slack.dev/reference/methods/entity.presentDetails/</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.files_comments_delete"><code class="name flex">
 <span>def <span class="ident">files_comments_delete</span></span>(<span>self, *, file: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
@@ -13820,6 +14126,381 @@ multiparty direct message.</p></div>
 <div class="desc"><p>Searches for messages matching a query.
 <a href="https://docs.slack.dev/reference/methods/search.messages">https://docs.slack.dev/reference/methods/search.messages</a></p></div>
 </dd>
+<dt id="slack_sdk.web.WebClient.slackLists_access_delete"><code class="name flex">
+<span>def <span class="ident">slackLists_access_delete</span></span>(<span>self,<br>*,<br>list_id: str,<br>channel_ids: List[str] | None = None,<br>user_ids: List[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_access_delete(
+    self,
+    *,
+    list_id: str,
+    channel_ids: Optional[List[str]] = None,
+    user_ids: Optional[List[str]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Revoke access to a List for specified entities.
+    https://docs.slack.dev/reference/methods/slackLists.access.delete
+    &#34;&#34;&#34;
+    kwargs.update({&#34;list_id&#34;: list_id, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.access.delete&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Revoke access to a List for specified entities.
+<a href="https://docs.slack.dev/reference/methods/slackLists.access.delete">https://docs.slack.dev/reference/methods/slackLists.access.delete</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_access_set"><code class="name flex">
+<span>def <span class="ident">slackLists_access_set</span></span>(<span>self,<br>*,<br>list_id: str,<br>access_level: str,<br>channel_ids: List[str] | None = None,<br>user_ids: List[str] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_access_set(
+    self,
+    *,
+    list_id: str,
+    access_level: str,
+    channel_ids: Optional[List[str]] = None,
+    user_ids: Optional[List[str]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Set the access level to a List for specified entities.
+    https://docs.slack.dev/reference/methods/slackLists.access.set
+    &#34;&#34;&#34;
+    kwargs.update({&#34;list_id&#34;: list_id, &#34;access_level&#34;: access_level, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.access.set&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Set the access level to a List for specified entities.
+<a href="https://docs.slack.dev/reference/methods/slackLists.access.set">https://docs.slack.dev/reference/methods/slackLists.access.set</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_create"><code class="name flex">
+<span>def <span class="ident">slackLists_create</span></span>(<span>self,<br>*,<br>name: str,<br>description_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a>] | None = None,<br>schema: List[Dict[str, Any]] | None = None,<br>copy_from_list_id: str | None = None,<br>include_copied_list_records: bool | None = None,<br>todo_mode: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_create(
+    self,
+    *,
+    name: str,
+    description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+    schema: Optional[List[Dict[str, Any]]] = None,
+    copy_from_list_id: Optional[str] = None,
+    include_copied_list_records: Optional[bool] = None,
+    todo_mode: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Creates a List.
+    https://docs.slack.dev/reference/methods/slackLists.create
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;name&#34;: name,
+            &#34;description_blocks&#34;: description_blocks,
+            &#34;schema&#34;: schema,
+            &#34;copy_from_list_id&#34;: copy_from_list_id,
+            &#34;include_copied_list_records&#34;: include_copied_list_records,
+            &#34;todo_mode&#34;: todo_mode,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.create&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Creates a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.create">https://docs.slack.dev/reference/methods/slackLists.create</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_download_get"><code class="name flex">
+<span>def <span class="ident">slackLists_download_get</span></span>(<span>self, *, list_id: str, job_id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_download_get(
+    self,
+    *,
+    list_id: str,
+    job_id: str,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Retrieve List download URL from an export job to download List contents.
+    https://docs.slack.dev/reference/methods/slackLists.download.get
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;job_id&#34;: job_id,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.download.get&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Retrieve List download URL from an export job to download List contents.
+<a href="https://docs.slack.dev/reference/methods/slackLists.download.get">https://docs.slack.dev/reference/methods/slackLists.download.get</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_download_start"><code class="name flex">
+<span>def <span class="ident">slackLists_download_start</span></span>(<span>self, *, list_id: str, include_archived: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_download_start(
+    self,
+    *,
+    list_id: str,
+    include_archived: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Initiate a job to export List contents.
+    https://docs.slack.dev/reference/methods/slackLists.download.start
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;include_archived&#34;: include_archived,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.download.start&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Initiate a job to export List contents.
+<a href="https://docs.slack.dev/reference/methods/slackLists.download.start">https://docs.slack.dev/reference/methods/slackLists.download.start</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_items_create"><code class="name flex">
+<span>def <span class="ident">slackLists_items_create</span></span>(<span>self,<br>*,<br>list_id: str,<br>duplicated_item_id: str | None = None,<br>parent_item_id: str | None = None,<br>initial_fields: List[Dict[str, Any]] | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_create(
+    self,
+    *,
+    list_id: str,
+    duplicated_item_id: Optional[str] = None,
+    parent_item_id: Optional[str] = None,
+    initial_fields: Optional[List[Dict[str, Any]]] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Add a new item to an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.create
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;duplicated_item_id&#34;: duplicated_item_id,
+            &#34;parent_item_id&#34;: parent_item_id,
+            &#34;initial_fields&#34;: initial_fields,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.create&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Add a new item to an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.create">https://docs.slack.dev/reference/methods/slackLists.items.create</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_items_delete"><code class="name flex">
+<span>def <span class="ident">slackLists_items_delete</span></span>(<span>self, *, list_id: str, id: str, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_delete(
+    self,
+    *,
+    list_id: str,
+    id: str,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Deletes an item from an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.delete
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;id&#34;: id,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.delete&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Deletes an item from an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.delete">https://docs.slack.dev/reference/methods/slackLists.items.delete</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_items_deleteMultiple"><code class="name flex">
+<span>def <span class="ident">slackLists_items_deleteMultiple</span></span>(<span>self, *, list_id: str, ids: List[str], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_deleteMultiple(
+    self,
+    *,
+    list_id: str,
+    ids: List[str],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Deletes multiple items from an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;ids&#34;: ids,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.deleteMultiple&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Deletes multiple items from an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple">https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_items_info"><code class="name flex">
+<span>def <span class="ident">slackLists_items_info</span></span>(<span>self, *, list_id: str, id: str, include_is_subscribed: bool | None = None, **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_info(
+    self,
+    *,
+    list_id: str,
+    id: str,
+    include_is_subscribed: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Get a row from a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.info
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;id&#34;: id,
+            &#34;include_is_subscribed&#34;: include_is_subscribed,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.info&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Get a row from a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.info">https://docs.slack.dev/reference/methods/slackLists.items.info</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_items_list"><code class="name flex">
+<span>def <span class="ident">slackLists_items_list</span></span>(<span>self,<br>*,<br>list_id: str,<br>limit: int | None = None,<br>cursor: str | None = None,<br>archived: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_list(
+    self,
+    *,
+    list_id: str,
+    limit: Optional[int] = None,
+    cursor: Optional[str] = None,
+    archived: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Get records from a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.list
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;limit&#34;: limit,
+            &#34;cursor&#34;: cursor,
+            &#34;archived&#34;: archived,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.list&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Get records from a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.list">https://docs.slack.dev/reference/methods/slackLists.items.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_items_update"><code class="name flex">
+<span>def <span class="ident">slackLists_items_update</span></span>(<span>self, *, list_id: str, cells: List[Dict[str, Any]], **kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_update(
+    self,
+    *,
+    list_id: str,
+    cells: List[Dict[str, Any]],
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Updates cells in a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.update
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;cells&#34;: cells,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.update&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Updates cells in a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.update">https://docs.slack.dev/reference/methods/slackLists.items.update</a></p></div>
+</dd>
+<dt id="slack_sdk.web.WebClient.slackLists_update"><code class="name flex">
+<span>def <span class="ident">slackLists_update</span></span>(<span>self,<br>*,<br>id: str,<br>name: str | None = None,<br>description_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a>] | None = None,<br>todo_mode: bool | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_update(
+    self,
+    *,
+    id: str,
+    name: Optional[str] = None,
+    description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+    todo_mode: Optional[bool] = None,
+    **kwargs,
+) -&gt; SlackResponse:
+    &#34;&#34;&#34;Update a List.
+    https://docs.slack.dev/reference/methods/slackLists.update
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;id&#34;: id,
+            &#34;name&#34;: name,
+            &#34;description_blocks&#34;: description_blocks,
+            &#34;todo_mode&#34;: todo_mode,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.update&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Update a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.update">https://docs.slack.dev/reference/methods/slackLists.update</a></p></div>
+</dd>
 <dt id="slack_sdk.web.WebClient.stars_add"><code class="name flex">
 <span>def <span class="ident">stars_add</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
@@ -15362,6 +16043,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.WebClient.dnd_setSnooze" href="#slack_sdk.web.WebClient.dnd_setSnooze">dnd_setSnooze</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.dnd_teamInfo" href="#slack_sdk.web.WebClient.dnd_teamInfo">dnd_teamInfo</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.emoji_list" href="#slack_sdk.web.WebClient.emoji_list">emoji_list</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.entity_presentDetails" href="#slack_sdk.web.WebClient.entity_presentDetails">entity_presentDetails</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.files_comments_delete" href="#slack_sdk.web.WebClient.files_comments_delete">files_comments_delete</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.files_completeUploadExternal" href="#slack_sdk.web.WebClient.files_completeUploadExternal">files_completeUploadExternal</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.files_delete" href="#slack_sdk.web.WebClient.files_delete">files_delete</a></code></li>
@@ -15431,6 +16113,18 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.WebClient.search_all" href="#slack_sdk.web.WebClient.search_all">search_all</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.search_files" href="#slack_sdk.web.WebClient.search_files">search_files</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.search_messages" href="#slack_sdk.web.WebClient.search_messages">search_messages</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_access_delete" href="#slack_sdk.web.WebClient.slackLists_access_delete">slackLists_access_delete</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_access_set" href="#slack_sdk.web.WebClient.slackLists_access_set">slackLists_access_set</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_create" href="#slack_sdk.web.WebClient.slackLists_create">slackLists_create</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_download_get" href="#slack_sdk.web.WebClient.slackLists_download_get">slackLists_download_get</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_download_start" href="#slack_sdk.web.WebClient.slackLists_download_start">slackLists_download_start</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_items_create" href="#slack_sdk.web.WebClient.slackLists_items_create">slackLists_items_create</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_items_delete" href="#slack_sdk.web.WebClient.slackLists_items_delete">slackLists_items_delete</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_items_deleteMultiple" href="#slack_sdk.web.WebClient.slackLists_items_deleteMultiple">slackLists_items_deleteMultiple</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_items_info" href="#slack_sdk.web.WebClient.slackLists_items_info">slackLists_items_info</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_items_list" href="#slack_sdk.web.WebClient.slackLists_items_list">slackLists_items_list</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_items_update" href="#slack_sdk.web.WebClient.slackLists_items_update">slackLists_items_update</a></code></li>
+<li><code><a title="slack_sdk.web.WebClient.slackLists_update" href="#slack_sdk.web.WebClient.slackLists_update">slackLists_update</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.stars_add" href="#slack_sdk.web.WebClient.stars_add">stars_add</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.stars_list" href="#slack_sdk.web.WebClient.stars_list">stars_list</a></code></li>
 <li><code><a title="slack_sdk.web.WebClient.stars_remove" href="#slack_sdk.web.WebClient.stars_remove">stars_remove</a></code></li>

--- a/docs/reference/web/legacy_client.html
+++ b/docs/reference/web/legacy_client.html
@@ -2789,7 +2789,7 @@ el.replaceWith(d);
         link_names: Optional[bool] = None,
         username: Optional[str] = None,
         parse: Optional[str] = None,  # none, full
-        metadata: Optional[Union[Dict, Metadata]] = None,
+        metadata: Optional[Union[Dict, Metadata, EventAndEntityMetadata]] = None,
         markdown_text: Optional[str] = None,
         **kwargs,
     ) -&gt; Union[Future, SlackResponse]:
@@ -2955,6 +2955,7 @@ el.replaceWith(d);
         source: Optional[str] = None,
         unfurl_id: Optional[str] = None,
         unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
+        metadata: Optional[Union[Dict, EventAndEntityMetadata]] = None,
         user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
         user_auth_message: Optional[str] = None,
         user_auth_required: Optional[bool] = None,
@@ -2971,6 +2972,7 @@ el.replaceWith(d);
                 &#34;source&#34;: source,
                 &#34;unfurl_id&#34;: unfurl_id,
                 &#34;unfurls&#34;: unfurls,
+                &#34;metadata&#34;: metadata,
                 &#34;user_auth_blocks&#34;: user_auth_blocks,
                 &#34;user_auth_message&#34;: user_auth_message,
                 &#34;user_auth_required&#34;: user_auth_required,
@@ -3601,6 +3603,30 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         kwargs.update({&#34;include_categories&#34;: include_categories})
         return self.api_call(&#34;emoji.list&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
+    def entity_presentDetails(
+        self,
+        trigger_id: str,
+        metadata: Optional[Union[Dict, EntityMetadata]] = None,
+        user_auth_required: Optional[bool] = None,
+        user_auth_url: Optional[str] = None,
+        error: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Provides entity details for the flexpane.
+        https://docs.slack.dev/reference/methods/entity.presentDetails/
+        &#34;&#34;&#34;
+        kwargs.update({&#34;trigger_id&#34;: trigger_id})
+        if metadata is not None:
+            kwargs.update({&#34;metadata&#34;: metadata})
+        if user_auth_required is not None:
+            kwargs.update({&#34;user_auth_required&#34;: user_auth_required})
+        if user_auth_url is not None:
+            kwargs.update({&#34;user_auth_url&#34;: user_auth_url})
+        if error is not None:
+            kwargs.update({&#34;error&#34;: error})
+        _parse_web_class_objects(kwargs)
+        return self.api_call(&#34;entity.presentDetails&#34;, json=kwargs)
 
     def files_comments_delete(
         self,
@@ -4855,6 +4881,249 @@ el.replaceWith(d);
             }
         )
         return self.api_call(&#34;search.messages&#34;, http_verb=&#34;GET&#34;, params=kwargs)
+
+    def slackLists_access_delete(
+        self,
+        *,
+        list_id: str,
+        channel_ids: Optional[List[str]] = None,
+        user_ids: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Revoke access to a List for specified entities.
+        https://docs.slack.dev/reference/methods/slackLists.access.delete
+        &#34;&#34;&#34;
+        kwargs.update({&#34;list_id&#34;: list_id, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.access.delete&#34;, json=kwargs)
+
+    def slackLists_access_set(
+        self,
+        *,
+        list_id: str,
+        access_level: str,
+        channel_ids: Optional[List[str]] = None,
+        user_ids: Optional[List[str]] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Set the access level to a List for specified entities.
+        https://docs.slack.dev/reference/methods/slackLists.access.set
+        &#34;&#34;&#34;
+        kwargs.update({&#34;list_id&#34;: list_id, &#34;access_level&#34;: access_level, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.access.set&#34;, json=kwargs)
+
+    def slackLists_create(
+        self,
+        *,
+        name: str,
+        description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+        schema: Optional[List[Dict[str, Any]]] = None,
+        copy_from_list_id: Optional[str] = None,
+        include_copied_list_records: Optional[bool] = None,
+        todo_mode: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Creates a List.
+        https://docs.slack.dev/reference/methods/slackLists.create
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;name&#34;: name,
+                &#34;description_blocks&#34;: description_blocks,
+                &#34;schema&#34;: schema,
+                &#34;copy_from_list_id&#34;: copy_from_list_id,
+                &#34;include_copied_list_records&#34;: include_copied_list_records,
+                &#34;todo_mode&#34;: todo_mode,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.create&#34;, json=kwargs)
+
+    def slackLists_download_get(
+        self,
+        *,
+        list_id: str,
+        job_id: str,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Retrieve List download URL from an export job to download List contents.
+        https://docs.slack.dev/reference/methods/slackLists.download.get
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;job_id&#34;: job_id,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.download.get&#34;, json=kwargs)
+
+    def slackLists_download_start(
+        self,
+        *,
+        list_id: str,
+        include_archived: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Initiate a job to export List contents.
+        https://docs.slack.dev/reference/methods/slackLists.download.start
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;include_archived&#34;: include_archived,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.download.start&#34;, json=kwargs)
+
+    def slackLists_items_create(
+        self,
+        *,
+        list_id: str,
+        duplicated_item_id: Optional[str] = None,
+        parent_item_id: Optional[str] = None,
+        initial_fields: Optional[List[Dict[str, Any]]] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Add a new item to an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.create
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;duplicated_item_id&#34;: duplicated_item_id,
+                &#34;parent_item_id&#34;: parent_item_id,
+                &#34;initial_fields&#34;: initial_fields,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.create&#34;, json=kwargs)
+
+    def slackLists_items_delete(
+        self,
+        *,
+        list_id: str,
+        id: str,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Deletes an item from an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.delete
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;id&#34;: id,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.delete&#34;, json=kwargs)
+
+    def slackLists_items_deleteMultiple(
+        self,
+        *,
+        list_id: str,
+        ids: List[str],
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Deletes multiple items from an existing List.
+        https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;ids&#34;: ids,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.deleteMultiple&#34;, json=kwargs)
+
+    def slackLists_items_info(
+        self,
+        *,
+        list_id: str,
+        id: str,
+        include_is_subscribed: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Get a row from a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.info
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;id&#34;: id,
+                &#34;include_is_subscribed&#34;: include_is_subscribed,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.info&#34;, json=kwargs)
+
+    def slackLists_items_list(
+        self,
+        *,
+        list_id: str,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        archived: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Get records from a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.list
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;limit&#34;: limit,
+                &#34;cursor&#34;: cursor,
+                &#34;archived&#34;: archived,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.list&#34;, json=kwargs)
+
+    def slackLists_items_update(
+        self,
+        *,
+        list_id: str,
+        cells: List[Dict[str, Any]],
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Updates cells in a List.
+        https://docs.slack.dev/reference/methods/slackLists.items.update
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;list_id&#34;: list_id,
+                &#34;cells&#34;: cells,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.items.update&#34;, json=kwargs)
+
+    def slackLists_update(
+        self,
+        *,
+        id: str,
+        name: Optional[str] = None,
+        description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+        todo_mode: Optional[bool] = None,
+        **kwargs,
+    ) -&gt; Union[Future, SlackResponse]:
+        &#34;&#34;&#34;Update a List.
+        https://docs.slack.dev/reference/methods/slackLists.update
+        &#34;&#34;&#34;
+        kwargs.update(
+            {
+                &#34;id&#34;: id,
+                &#34;name&#34;: name,
+                &#34;description_blocks&#34;: description_blocks,
+                &#34;todo_mode&#34;: todo_mode,
+            }
+        )
+        kwargs = _remove_none_values(kwargs)
+        return self.api_call(&#34;slackLists.update&#34;, json=kwargs)
 
     def stars_add(
         self,
@@ -10002,7 +10271,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/chat.postEphemeral">https://docs.slack.dev/reference/methods/chat.postEphemeral</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_postMessage"><code class="name flex">
-<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+<span>def <span class="ident">chat_postMessage</span></span>(<span>self,<br>*,<br>channel: str,<br>text: str | None = None,<br>as_user: bool | None = None,<br>attachments: str | Sequence[Dict | <a title="slack_sdk.models.attachments.Attachment" href="../models/attachments/index.html#slack_sdk.models.attachments.Attachment">Attachment</a>] | None = None,<br>blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>thread_ts: str | None = None,<br>reply_broadcast: bool | None = None,<br>unfurl_links: bool | None = None,<br>unfurl_media: bool | None = None,<br>container_id: str | None = None,<br>icon_emoji: str | None = None,<br>icon_url: str | None = None,<br>mrkdwn: bool | None = None,<br>link_names: bool | None = None,<br>username: str | None = None,<br>parse: str | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.Metadata" href="../models/metadata/index.html#slack_sdk.models.metadata.Metadata">Metadata</a> | <a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a> | None = None,<br>markdown_text: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10028,7 +10297,7 @@ Each authorization represents an app installation that the event is visible to.
     link_names: Optional[bool] = None,
     username: Optional[str] = None,
     parse: Optional[str] = None,  # none, full
-    metadata: Optional[Union[Dict, Metadata]] = None,
+    metadata: Optional[Union[Dict, Metadata, EventAndEntityMetadata]] = None,
     markdown_text: Optional[str] = None,
     **kwargs,
 ) -&gt; Union[Future, SlackResponse]:
@@ -10234,7 +10503,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/chat.stopStream">https://docs.slack.dev/reference/methods/chat.stopStream</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.chat_unfurl"><code class="name flex">
-<span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+<span>def <span class="ident">chat_unfurl</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>ts: str | None = None,<br>source: str | None = None,<br>unfurl_id: str | None = None,<br>unfurls: Dict[str, Dict] | None = None,<br>metadata: Dict | <a title="slack_sdk.models.metadata.EventAndEntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EventAndEntityMetadata">EventAndEntityMetadata</a> | None = None,<br>user_auth_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.Block" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.Block">Block</a>] | None = None,<br>user_auth_message: str | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -10249,6 +10518,7 @@ Each authorization represents an app installation that the event is visible to.
     source: Optional[str] = None,
     unfurl_id: Optional[str] = None,
     unfurls: Optional[Dict[str, Dict]] = None,  # or user_auth_*
+    metadata: Optional[Union[Dict, EventAndEntityMetadata]] = None,
     user_auth_blocks: Optional[Union[str, Sequence[Union[Dict, Block]]]] = None,
     user_auth_message: Optional[str] = None,
     user_auth_required: Optional[bool] = None,
@@ -10265,6 +10535,7 @@ Each authorization represents an app installation that the event is visible to.
             &#34;source&#34;: source,
             &#34;unfurl_id&#34;: unfurl_id,
             &#34;unfurls&#34;: unfurls,
+            &#34;metadata&#34;: metadata,
             &#34;user_auth_blocks&#34;: user_auth_blocks,
             &#34;user_auth_message&#34;: user_auth_message,
             &#34;user_auth_required&#34;: user_auth_required,
@@ -11295,6 +11566,41 @@ or received but have not yet been approved by all parties.
 </details>
 <div class="desc"><p>Lists custom emoji for a team.
 <a href="https://docs.slack.dev/reference/methods/emoji.list">https://docs.slack.dev/reference/methods/emoji.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.entity_presentDetails"><code class="name flex">
+<span>def <span class="ident">entity_presentDetails</span></span>(<span>self,<br>trigger_id: str,<br>metadata: Dict | <a title="slack_sdk.models.metadata.EntityMetadata" href="../models/metadata/index.html#slack_sdk.models.metadata.EntityMetadata">EntityMetadata</a> | None = None,<br>user_auth_required: bool | None = None,<br>user_auth_url: str | None = None,<br>error: Dict[str, Any] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def entity_presentDetails(
+    self,
+    trigger_id: str,
+    metadata: Optional[Union[Dict, EntityMetadata]] = None,
+    user_auth_required: Optional[bool] = None,
+    user_auth_url: Optional[str] = None,
+    error: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Provides entity details for the flexpane.
+    https://docs.slack.dev/reference/methods/entity.presentDetails/
+    &#34;&#34;&#34;
+    kwargs.update({&#34;trigger_id&#34;: trigger_id})
+    if metadata is not None:
+        kwargs.update({&#34;metadata&#34;: metadata})
+    if user_auth_required is not None:
+        kwargs.update({&#34;user_auth_required&#34;: user_auth_required})
+    if user_auth_url is not None:
+        kwargs.update({&#34;user_auth_url&#34;: user_auth_url})
+    if error is not None:
+        kwargs.update({&#34;error&#34;: error})
+    _parse_web_class_objects(kwargs)
+    return self.api_call(&#34;entity.presentDetails&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Provides entity details for the flexpane.
+<a href="https://docs.slack.dev/reference/methods/entity.presentDetails/">https://docs.slack.dev/reference/methods/entity.presentDetails/</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.files_comments_delete"><code class="name flex">
 <span>def <span class="ident">files_comments_delete</span></span>(<span>self, *, file: str, id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
@@ -13271,6 +13577,381 @@ multiparty direct message.</p></div>
 <div class="desc"><p>Searches for messages matching a query.
 <a href="https://docs.slack.dev/reference/methods/search.messages">https://docs.slack.dev/reference/methods/search.messages</a></p></div>
 </dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_access_delete"><code class="name flex">
+<span>def <span class="ident">slackLists_access_delete</span></span>(<span>self,<br>*,<br>list_id: str,<br>channel_ids: List[str] | None = None,<br>user_ids: List[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_access_delete(
+    self,
+    *,
+    list_id: str,
+    channel_ids: Optional[List[str]] = None,
+    user_ids: Optional[List[str]] = None,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Revoke access to a List for specified entities.
+    https://docs.slack.dev/reference/methods/slackLists.access.delete
+    &#34;&#34;&#34;
+    kwargs.update({&#34;list_id&#34;: list_id, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.access.delete&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Revoke access to a List for specified entities.
+<a href="https://docs.slack.dev/reference/methods/slackLists.access.delete">https://docs.slack.dev/reference/methods/slackLists.access.delete</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_access_set"><code class="name flex">
+<span>def <span class="ident">slackLists_access_set</span></span>(<span>self,<br>*,<br>list_id: str,<br>access_level: str,<br>channel_ids: List[str] | None = None,<br>user_ids: List[str] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_access_set(
+    self,
+    *,
+    list_id: str,
+    access_level: str,
+    channel_ids: Optional[List[str]] = None,
+    user_ids: Optional[List[str]] = None,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Set the access level to a List for specified entities.
+    https://docs.slack.dev/reference/methods/slackLists.access.set
+    &#34;&#34;&#34;
+    kwargs.update({&#34;list_id&#34;: list_id, &#34;access_level&#34;: access_level, &#34;channel_ids&#34;: channel_ids, &#34;user_ids&#34;: user_ids})
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.access.set&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Set the access level to a List for specified entities.
+<a href="https://docs.slack.dev/reference/methods/slackLists.access.set">https://docs.slack.dev/reference/methods/slackLists.access.set</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_create"><code class="name flex">
+<span>def <span class="ident">slackLists_create</span></span>(<span>self,<br>*,<br>name: str,<br>description_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a>] | None = None,<br>schema: List[Dict[str, Any]] | None = None,<br>copy_from_list_id: str | None = None,<br>include_copied_list_records: bool | None = None,<br>todo_mode: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_create(
+    self,
+    *,
+    name: str,
+    description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+    schema: Optional[List[Dict[str, Any]]] = None,
+    copy_from_list_id: Optional[str] = None,
+    include_copied_list_records: Optional[bool] = None,
+    todo_mode: Optional[bool] = None,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Creates a List.
+    https://docs.slack.dev/reference/methods/slackLists.create
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;name&#34;: name,
+            &#34;description_blocks&#34;: description_blocks,
+            &#34;schema&#34;: schema,
+            &#34;copy_from_list_id&#34;: copy_from_list_id,
+            &#34;include_copied_list_records&#34;: include_copied_list_records,
+            &#34;todo_mode&#34;: todo_mode,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.create&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Creates a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.create">https://docs.slack.dev/reference/methods/slackLists.create</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_download_get"><code class="name flex">
+<span>def <span class="ident">slackLists_download_get</span></span>(<span>self, *, list_id: str, job_id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_download_get(
+    self,
+    *,
+    list_id: str,
+    job_id: str,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Retrieve List download URL from an export job to download List contents.
+    https://docs.slack.dev/reference/methods/slackLists.download.get
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;job_id&#34;: job_id,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.download.get&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Retrieve List download URL from an export job to download List contents.
+<a href="https://docs.slack.dev/reference/methods/slackLists.download.get">https://docs.slack.dev/reference/methods/slackLists.download.get</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_download_start"><code class="name flex">
+<span>def <span class="ident">slackLists_download_start</span></span>(<span>self, *, list_id: str, include_archived: bool | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_download_start(
+    self,
+    *,
+    list_id: str,
+    include_archived: Optional[bool] = None,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Initiate a job to export List contents.
+    https://docs.slack.dev/reference/methods/slackLists.download.start
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;include_archived&#34;: include_archived,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.download.start&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Initiate a job to export List contents.
+<a href="https://docs.slack.dev/reference/methods/slackLists.download.start">https://docs.slack.dev/reference/methods/slackLists.download.start</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_create"><code class="name flex">
+<span>def <span class="ident">slackLists_items_create</span></span>(<span>self,<br>*,<br>list_id: str,<br>duplicated_item_id: str | None = None,<br>parent_item_id: str | None = None,<br>initial_fields: List[Dict[str, Any]] | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_create(
+    self,
+    *,
+    list_id: str,
+    duplicated_item_id: Optional[str] = None,
+    parent_item_id: Optional[str] = None,
+    initial_fields: Optional[List[Dict[str, Any]]] = None,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Add a new item to an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.create
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;duplicated_item_id&#34;: duplicated_item_id,
+            &#34;parent_item_id&#34;: parent_item_id,
+            &#34;initial_fields&#34;: initial_fields,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.create&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Add a new item to an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.create">https://docs.slack.dev/reference/methods/slackLists.items.create</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_delete"><code class="name flex">
+<span>def <span class="ident">slackLists_items_delete</span></span>(<span>self, *, list_id: str, id: str, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_delete(
+    self,
+    *,
+    list_id: str,
+    id: str,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Deletes an item from an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.delete
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;id&#34;: id,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.delete&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Deletes an item from an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.delete">https://docs.slack.dev/reference/methods/slackLists.items.delete</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_deleteMultiple"><code class="name flex">
+<span>def <span class="ident">slackLists_items_deleteMultiple</span></span>(<span>self, *, list_id: str, ids: List[str], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_deleteMultiple(
+    self,
+    *,
+    list_id: str,
+    ids: List[str],
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Deletes multiple items from an existing List.
+    https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;ids&#34;: ids,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.deleteMultiple&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Deletes multiple items from an existing List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple">https://docs.slack.dev/reference/methods/slackLists.items.deleteMultiple</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_info"><code class="name flex">
+<span>def <span class="ident">slackLists_items_info</span></span>(<span>self, *, list_id: str, id: str, include_is_subscribed: bool | None = None, **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_info(
+    self,
+    *,
+    list_id: str,
+    id: str,
+    include_is_subscribed: Optional[bool] = None,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Get a row from a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.info
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;id&#34;: id,
+            &#34;include_is_subscribed&#34;: include_is_subscribed,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.info&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Get a row from a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.info">https://docs.slack.dev/reference/methods/slackLists.items.info</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_list"><code class="name flex">
+<span>def <span class="ident">slackLists_items_list</span></span>(<span>self,<br>*,<br>list_id: str,<br>limit: int | None = None,<br>cursor: str | None = None,<br>archived: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_list(
+    self,
+    *,
+    list_id: str,
+    limit: Optional[int] = None,
+    cursor: Optional[str] = None,
+    archived: Optional[bool] = None,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Get records from a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.list
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;limit&#34;: limit,
+            &#34;cursor&#34;: cursor,
+            &#34;archived&#34;: archived,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.list&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Get records from a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.list">https://docs.slack.dev/reference/methods/slackLists.items.list</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_update"><code class="name flex">
+<span>def <span class="ident">slackLists_items_update</span></span>(<span>self, *, list_id: str, cells: List[Dict[str, Any]], **kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_items_update(
+    self,
+    *,
+    list_id: str,
+    cells: List[Dict[str, Any]],
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Updates cells in a List.
+    https://docs.slack.dev/reference/methods/slackLists.items.update
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;list_id&#34;: list_id,
+            &#34;cells&#34;: cells,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.items.update&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Updates cells in a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.items.update">https://docs.slack.dev/reference/methods/slackLists.items.update</a></p></div>
+</dd>
+<dt id="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_update"><code class="name flex">
+<span>def <span class="ident">slackLists_update</span></span>(<span>self,<br>*,<br>id: str,<br>name: str | None = None,<br>description_blocks: str | Sequence[Dict | <a title="slack_sdk.models.blocks.blocks.RichTextBlock" href="../models/blocks/blocks.html#slack_sdk.models.blocks.blocks.RichTextBlock">RichTextBlock</a>] | None = None,<br>todo_mode: bool | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def slackLists_update(
+    self,
+    *,
+    id: str,
+    name: Optional[str] = None,
+    description_blocks: Optional[Union[str, Sequence[Union[Dict, RichTextBlock]]]] = None,
+    todo_mode: Optional[bool] = None,
+    **kwargs,
+) -&gt; Union[Future, SlackResponse]:
+    &#34;&#34;&#34;Update a List.
+    https://docs.slack.dev/reference/methods/slackLists.update
+    &#34;&#34;&#34;
+    kwargs.update(
+        {
+            &#34;id&#34;: id,
+            &#34;name&#34;: name,
+            &#34;description_blocks&#34;: description_blocks,
+            &#34;todo_mode&#34;: todo_mode,
+        }
+    )
+    kwargs = _remove_none_values(kwargs)
+    return self.api_call(&#34;slackLists.update&#34;, json=kwargs)</code></pre>
+</details>
+<div class="desc"><p>Update a List.
+<a href="https://docs.slack.dev/reference/methods/slackLists.update">https://docs.slack.dev/reference/methods/slackLists.update</a></p></div>
+</dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.stars_add"><code class="name flex">
 <span>def <span class="ident">stars_add</span></span>(<span>self,<br>*,<br>channel: str | None = None,<br>file: str | None = None,<br>file_comment: str | None = None,<br>timestamp: str | None = None,<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
@@ -14785,6 +15466,7 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.dnd_setSnooze" href="#slack_sdk.web.legacy_client.LegacyWebClient.dnd_setSnooze">dnd_setSnooze</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.dnd_teamInfo" href="#slack_sdk.web.legacy_client.LegacyWebClient.dnd_teamInfo">dnd_teamInfo</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.emoji_list" href="#slack_sdk.web.legacy_client.LegacyWebClient.emoji_list">emoji_list</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.entity_presentDetails" href="#slack_sdk.web.legacy_client.LegacyWebClient.entity_presentDetails">entity_presentDetails</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.files_comments_delete" href="#slack_sdk.web.legacy_client.LegacyWebClient.files_comments_delete">files_comments_delete</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.files_completeUploadExternal" href="#slack_sdk.web.legacy_client.LegacyWebClient.files_completeUploadExternal">files_completeUploadExternal</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.files_delete" href="#slack_sdk.web.legacy_client.LegacyWebClient.files_delete">files_delete</a></code></li>
@@ -14854,6 +15536,18 @@ to learn more about updating views and avoiding race conditions with the hash ar
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.search_all" href="#slack_sdk.web.legacy_client.LegacyWebClient.search_all">search_all</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.search_files" href="#slack_sdk.web.legacy_client.LegacyWebClient.search_files">search_files</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.search_messages" href="#slack_sdk.web.legacy_client.LegacyWebClient.search_messages">search_messages</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_access_delete" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_access_delete">slackLists_access_delete</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_access_set" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_access_set">slackLists_access_set</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_create" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_create">slackLists_create</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_download_get" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_download_get">slackLists_download_get</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_download_start" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_download_start">slackLists_download_start</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_create" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_create">slackLists_items_create</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_delete" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_delete">slackLists_items_delete</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_deleteMultiple" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_deleteMultiple">slackLists_items_deleteMultiple</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_info" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_info">slackLists_items_info</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_list" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_list">slackLists_items_list</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_update" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_items_update">slackLists_items_update</a></code></li>
+<li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.slackLists_update" href="#slack_sdk.web.legacy_client.LegacyWebClient.slackLists_update">slackLists_update</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.stars_add" href="#slack_sdk.web.legacy_client.LegacyWebClient.stars_add">stars_add</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.stars_list" href="#slack_sdk.web.legacy_client.LegacyWebClient.stars_list">stars_list</a></code></li>
 <li><code><a title="slack_sdk.web.legacy_client.LegacyWebClient.stars_remove" href="#slack_sdk.web.legacy_client.LegacyWebClient.stars_remove">stars_remove</a></code></li>

--- a/slack_sdk/version.py
+++ b/slack_sdk/version.py
@@ -1,3 +1,3 @@
 """Check the latest version at https://pypi.org/project/slack-sdk/"""
 
-__version__ = "3.38.0"
+__version__ = "3.39.0"


### PR DESCRIPTION
## Summary

Bump the version for release 3.39.0

Feature work included in the [Milestone](https://github.com/slackapi/python-slack-sdk/milestone/114?closed=1) : ([diff](https://github.com/slackapi/python-slack-sdk/compare/v3.38.0...main)) 
- Work Objects support
- slackLists methods
- Table block support

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
