### PR TITLE
fix: pass default ssl=True to aiohttp to avoid deprecation warning

### DIFF
--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -379,7 +379,7 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                     autoping=False,
                     heartbeat=self.ping_interval,
                     proxy=self.proxy,
-                    ssl=self.web_client.ssl,
+                    ssl=self.web_client.ssl if self.web_client.ssl is not None else True,
                 )
                 session_id: str = await self.session_id()
                 self.auto_reconnect_enabled = self.default_auto_reconnect_enabled


### PR DESCRIPTION
## Summary

This PR aims to fix a warning that shows up if `ssl` is None, we should pass `True` instead

### Testing

Unit tests should be sufficient

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
