### PR TITLE
fix: Improve type annotations in `SignatureVerifier`

### DIFF
--- a/slack_sdk/signature/__init__.py
+++ b/slack_sdk/signature/__init__.py
@@ -2,9 +2,14 @@
 
 import hashlib
 import hmac
-from collections.abc import Mapping
 from time import time
-from typing import Optional, Union
+from typing import Dict, Optional, Union, TYPE_CHECKING
+
+# Fallback to Dict for Python 3.7/3.8 compatibility (safe to remove once these versions are no longer supported)
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+else:
+    Mapping = Dict
 
 
 class Clock:

--- a/slack_sdk/signature/__init__.py
+++ b/slack_sdk/signature/__init__.py
@@ -2,8 +2,9 @@
 
 import hashlib
 import hmac
+from collections.abc import Mapping
 from time import time
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 
 class Clock:
@@ -26,7 +27,7 @@ class SignatureVerifier:
     def is_valid_request(
         self,
         body: Union[str, bytes],
-        headers: Dict[str, str],
+        headers: Mapping[str, str],
     ) -> bool:
         """Verifies if the given signature is valid"""
         if headers is None:
@@ -34,15 +35,15 @@ class SignatureVerifier:
         normalized_headers = {k.lower(): v for k, v in headers.items()}
         return self.is_valid(
             body=body,
-            timestamp=normalized_headers.get("x-slack-request-timestamp", None),  # type: ignore[arg-type]
-            signature=normalized_headers.get("x-slack-signature", None),  # type: ignore[arg-type]
+            timestamp=normalized_headers.get("x-slack-request-timestamp", None),
+            signature=normalized_headers.get("x-slack-signature", None),
         )
 
     def is_valid(
         self,
         body: Union[str, bytes],
-        timestamp: str,
-        signature: str,
+        timestamp: Optional[str],
+        signature: Optional[str],
     ) -> bool:
         """Verifies if the given signature is valid"""
         if timestamp is None or signature is None:


### PR DESCRIPTION
## Summary

Receive headers as abstract/immutable `collections.abc.Mapping` instead of `Dict` to more accurately declare compatibility with dict-like objects (common for holding headers in HTTP frameworks), and mark timestamp/signature args as `Optional` in `is_valid` to reflect reality and fix the typechecker errors in `is_valid_request`.

### Testing

These changes only touch type annotations which have no runtime effects; The only expectation here is that type checks pass.

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [x] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
