### PR TITLE
docs - adds chat_stream helper to python sdk docs (removing from bolt-py)

### DIFF
--- a/docs/english/web.md
+++ b/docs/english/web.md
@@ -61,11 +61,8 @@ You can have your app's messages stream in to replicate conventional AI chatbot 
 * [`chat_appendStream`](/reference/methods/chat.appendStream)
 * [`chat_stopStream`](/reference/methods/chat.stopStream)
 
-:::tip[The Python Slack SDK provides a [`chat_stream()`](https://docs.slack.dev/tools/python-slack-sdk/reference/web/client.html#slack_sdk.web.client.WebClient.chat_stream) helper utility to streamline calling these methods.]
 
-See the [_Streaming messages_](/tools/bolt-python/concepts/message-sending#streaming-messages) section of the Bolt for Python docs for implementation instructions. 
-
-:::
+You can streamline calling these methods by using the [`chat_stream()`](#chat_stream) helper.
 
 #### Starting the message stream {#starting-stream}
 
@@ -160,6 +157,30 @@ def handle_message(message, client):
 ```
 
 See [Formatting messages with Block Kit](#block-kit) below for more details on using Block Kit with messages.
+
+#### Using the `chat_stream()` helper {#chat_stream}
+
+The Python Slack SDK provides a [`chat_stream()`](https://docs.slack.dev/tools/python-slack-sdk/reference/web/client.html#slack_sdk.web.client.WebClient.chat_stream) helper utility to streamline calling these methods. Here's an excerpt from our [Assistant template app](https://github.com/slack-samples/bolt-python-assistant-template):
+
+```python
+streamer = client.chat_stream(
+    channel=channel_id,
+    recipient_team_id=team_id,
+    recipient_user_id=user_id,
+    thread_ts=thread_ts,
+)
+
+# Loop over OpenAI response stream
+# https://platform.openai.com/docs/api-reference/responses/create
+for event in returned_message:
+    if event.type == "response.output_text.delta":
+        streamer.append(markdown_text=f"{event.delta}")
+    else:
+        continue
+
+feedback_block = create_feedback_block()
+streamer.stop()
+```
 
 ## Formatting messages with Block Kit {#block-kit}
 

--- a/docs/english/web.md
+++ b/docs/english/web.md
@@ -179,7 +179,7 @@ for event in returned_message:
         continue
 
 feedback_block = create_feedback_block()
-streamer.stop()
+streamer.stop(blocks=feedback_block)
 ```
 
 ## Formatting messages with Block Kit {#block-kit}


### PR DESCRIPTION
## Summary

This is a result of say_stream being added to Bolt; shifts this helper down. This can go out whenever we want as long as we don't mind duplicating content about the python sdk helper. Otherwise, wait until [this Bolt PR goes out ](https://github.com/slackapi/bolt-python/pull/1463)

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [X] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [X] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
