### PR TITLE
Fix typo in SectionBlock field validation

### DIFF
--- a/docs/reference/models/blocks/blocks.html
+++ b/docs/reference/models/blocks/blocks.html
@@ -1601,7 +1601,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
                 else:
                     field_objects.append(PlainTextObject(**d))  # type: ignore[arg-type]
             else:
-                self.logger.warning(f&#34;Unsupported filed detected and skipped {f}&#34;)
+                self.logger.warning(f&#34;Unsupported field detected and skipped {f}&#34;)
         self.fields = field_objects
         self.accessory = BlockElement.parse(accessory)  # type: ignore[arg-type]
         self.expand = expand

--- a/docs/reference/models/blocks/index.html
+++ b/docs/reference/models/blocks/index.html
@@ -6592,7 +6592,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
                 else:
                     field_objects.append(PlainTextObject(**d))  # type: ignore[arg-type]
             else:
-                self.logger.warning(f&#34;Unsupported filed detected and skipped {f}&#34;)
+                self.logger.warning(f&#34;Unsupported field detected and skipped {f}&#34;)
         self.fields = field_objects
         self.accessory = BlockElement.parse(accessory)  # type: ignore[arg-type]
         self.expand = expand

--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -179,7 +179,7 @@ class SectionBlock(Block):
                 else:
                     field_objects.append(PlainTextObject(**d))  # type: ignore[arg-type]
             else:
-                self.logger.warning(f"Unsupported filed detected and skipped {f}")
+                self.logger.warning(f"Unsupported field detected and skipped: {f}")
         self.fields = field_objects
         self.accessory = BlockElement.parse(accessory)  # type: ignore[arg-type]
         self.expand = expand


### PR DESCRIPTION
## Summary

Fix typo in SectionBlock field validation

### Testing

Run `codespell`

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
