### PR TITLE
Fix Socket Mode builtin WebSocket masked payload unmasking (RFC 6455)

### DIFF
--- a/slack_sdk/socket_mode/builtin/internals.py
+++ b/slack_sdk/socket_mode/builtin/internals.py
@@ -161,6 +161,7 @@ def _generate_sec_websocket_key() -> str:
 
 def _validate_sec_websocket_accept(sec_websocket_key: str, headers: dict) -> bool:
     v = (sec_websocket_key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode("utf-8")
+    # RFC 6455 section 1.3: Sec-WebSocket-Accept must use SHA-1 over the challenge key.
     expected = encodebytes(hashlib.sha1(v).digest()).decode("utf-8").strip()
     actual = headers.get("sec-websocket-accept", "").strip()
     return compare_digest(expected, actual)
@@ -306,10 +307,12 @@ def _fetch_messages(
 
         current_data = bytes()
         if current_header.masked > 0:
-            for i in range(data_to_append):  # type: ignore[call-overload]
+            # bytes is immutable; RFC 6455 masking XORs octets (use bytearray).
+            mutable_payload = bytearray(data_to_append)
+            for i in range(len(mutable_payload)):
                 mask = current_mask_key[i % 4]  # type: ignore[index]
-                data_to_append[i] ^= mask  # type: ignore[index]
-            current_data += data_to_append
+                mutable_payload[i] ^= mask
+            current_data += bytes(mutable_payload)
         else:
             current_data += data_to_append
         if len(current_data) == current_data_length:


### PR DESCRIPTION
## Summary

This change fixes the **masked WebSocket frame** handling path in the builtin Socket Mode client (`slack_sdk/socket_mode/builtin/internals.py`).

The previous code used `range(data_to_append)` where `data_to_append` is `bytes` (invalid in Python 3) and attempted in-place XOR on an **immutable** `bytes` object. Per RFC 6455, masking XORs octets; unmasking is now implemented with a `bytearray` and `range(len(...))`.

A short comment was also added in `_validate_sec_websocket_accept`: **SHA-1** for `Sec-WebSocket-Accept` is **required by RFC 6455 section 1.3**, not a discretionary hash upgrade to SHA-256.

## Verification

```bash
pytest tests/slack_sdk/socket_mode/test_builtin_message_parser.py -q
```

(2 passed locally.)

## Context

Servers normally send **unmasked** frames to clients; the masked branch is uncommon but should be correct for compliance and tests that exercise masked server frames.
