### PR TITLE
fix: pin cryptography<46 for PyPy 3.10 CI builds

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -5,6 +5,8 @@ pytest-asyncio<2  # for async
 pytest-cov>=2,<8
 click==8.0.4  # black is affected by https://github.com/pallets/click/issues/2225
 psutil>=6.0.0,<8
+# cryptography 46+ dropped PyPy 3.10 wheels; pin to <46 for PyPy 3.10 only
+cryptography<46; implementation_name == "pypy" and python_version == "3.10"
 #  used only under slack_sdk/*_store
 boto3<=2
 # For AWS tests


### PR DESCRIPTION
## Summary

These changes aim to fix the CI by pinning `cryptography<46` for PyPy 3.10 via environment markers
  - `cryptography` 46+ uses PyO3 0.27+, which [dropped PyPy 3.10 support](https://github.com/PyO3/pyo3/releases/tag/v0.27.0), causing the source build to fail with: `error: the configured PyPy interpreter version (3.10) is lower than PyO3's minimum supported version (3.11)`
  - `cryptography` 45.0.x is the last version with pre-built PyPy 3.10 wheels     

### Testing

CI tests should be sufficient

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
