### PR TITLE
feat: add authorship arguments to assistant threads and chat stream

### DIFF
--- a/slack_sdk/web/async_chat_stream.py
+++ b/slack_sdk/web/async_chat_stream.py
@@ -40,6 +40,9 @@ class AsyncChatStream:
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
         task_display_mode: Optional[str] = None,
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
         **kwargs,
     ):
         """Initialize a new ChatStream instance.
@@ -57,6 +60,9 @@ class AsyncChatStream:
             recipient_user_id: The encoded ID of the user to receive the streaming text. Required when streaming to channels.
             task_display_mode: Specifies how tasks are displayed in the message. A "timeline" displays individual tasks
               with text and "plan" displays all tasks together.
+            icon_emoji: Emoji to use as the icon for this message. Overrides icon_url.
+            icon_url: Image URL to use as the icon for this message.
+            username: The bot's username to display.
             buffer_size: The length of markdown_text to buffer in-memory before calling a method. Increasing this value
               decreases the number of method calls made for the same amount of text, which is useful to avoid rate limits.
             **kwargs: Additional arguments passed to the underlying API calls.
@@ -70,6 +76,9 @@ class AsyncChatStream:
             "recipient_team_id": recipient_team_id,
             "recipient_user_id": recipient_user_id,
             "task_display_mode": task_display_mode,
+            "icon_emoji": icon_emoji,
+            "icon_url": icon_url,
+            "username": username,
             **kwargs,
         }
         self._buffer = ""

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2977,6 +2977,9 @@ class AsyncWebClient(AsyncBaseClient):
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
         task_display_mode: Optional[str] = None,
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
         **kwargs,
     ) -> AsyncChatStream:
         """Stream markdown text into a conversation.
@@ -3005,6 +3008,9 @@ class AsyncWebClient(AsyncBaseClient):
             recipient_user_id: The encoded ID of the user to receive the streaming text. Required when streaming to channels.
             task_display_mode: Specifies how tasks are displayed in the message. A "timeline" displays individual tasks
               with text and "plan" displays all tasks together.
+            icon_emoji: Emoji to use as the icon for this message. Overrides icon_url.
+            icon_url: Image URL to use as the icon for this message.
+            username: The bot's username to display.
             **kwargs: Additional arguments passed to the underlying API calls.
 
         Returns:
@@ -3031,6 +3037,9 @@ class AsyncWebClient(AsyncBaseClient):
             recipient_team_id=recipient_team_id,
             recipient_user_id=recipient_user_id,
             task_display_mode=task_display_mode,
+            icon_emoji=icon_emoji,
+            icon_url=icon_url,
+            username=username,
             buffer_size=buffer_size,
             **kwargs,
         )

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2091,13 +2091,24 @@ class AsyncWebClient(AsyncBaseClient):
         thread_ts: str,
         status: str,
         loading_messages: Optional[List[str]] = None,
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Set the status for an AI assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         """
         kwargs.update(
-            {"channel_id": channel_id, "thread_ts": thread_ts, "status": status, "loading_messages": loading_messages}
+            {
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "status": status,
+                "loading_messages": loading_messages,
+                "icon_emoji": icon_emoji,
+                "icon_url": icon_url,
+                "username": username,
+            }
         )
         kwargs = _remove_none_values(kwargs)
         return await self.api_call("assistant.threads.setStatus", json=kwargs)
@@ -2903,6 +2914,9 @@ class AsyncWebClient(AsyncBaseClient):
         recipient_user_id: Optional[str] = None,
         chunks: Optional[Sequence[Union[Dict, Chunk]]] = None,
         task_display_mode: Optional[str] = None,  # timeline, plan
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
         **kwargs,
     ) -> AsyncSlackResponse:
         """Starts a new streaming conversation.
@@ -2917,6 +2931,9 @@ class AsyncWebClient(AsyncBaseClient):
                 "recipient_user_id": recipient_user_id,
                 "chunks": chunks,
                 "task_display_mode": task_display_mode,
+                "icon_emoji": icon_emoji,
+                "icon_url": icon_url,
+                "username": username,
             }
         )
         _parse_web_class_objects(kwargs)

--- a/slack_sdk/web/chat_stream.py
+++ b/slack_sdk/web/chat_stream.py
@@ -30,6 +30,9 @@ class ChatStream:
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
         task_display_mode: Optional[str] = None,
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
         **kwargs,
     ):
         """Initialize a new ChatStream instance.
@@ -47,6 +50,9 @@ class ChatStream:
             recipient_user_id: The encoded ID of the user to receive the streaming text. Required when streaming to channels.
             task_display_mode: Specifies how tasks are displayed in the message. A "timeline" displays individual tasks
               with text and "plan" displays all tasks together.
+            icon_emoji: Emoji to use as the icon for this message. Overrides icon_url.
+            icon_url: Image URL to use as the icon for this message.
+            username: The bot's username to display.
             buffer_size: The length of markdown_text to buffer in-memory before calling a method. Increasing this value
               decreases the number of method calls made for the same amount of text, which is useful to avoid rate limits.
             **kwargs: Additional arguments passed to the underlying API calls.
@@ -60,6 +66,9 @@ class ChatStream:
             "recipient_team_id": recipient_team_id,
             "recipient_user_id": recipient_user_id,
             "task_display_mode": task_display_mode,
+            "icon_emoji": icon_emoji,
+            "icon_url": icon_url,
+            "username": username,
             **kwargs,
         }
         self._buffer = ""

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2081,13 +2081,24 @@ class WebClient(BaseClient):
         thread_ts: str,
         status: str,
         loading_messages: Optional[List[str]] = None,
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
         **kwargs,
     ) -> SlackResponse:
         """Set the status for an AI assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         """
         kwargs.update(
-            {"channel_id": channel_id, "thread_ts": thread_ts, "status": status, "loading_messages": loading_messages}
+            {
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "status": status,
+                "loading_messages": loading_messages,
+                "icon_emoji": icon_emoji,
+                "icon_url": icon_url,
+                "username": username,
+            }
         )
         kwargs = _remove_none_values(kwargs)
         return self.api_call("assistant.threads.setStatus", json=kwargs)
@@ -2893,6 +2904,9 @@ class WebClient(BaseClient):
         recipient_user_id: Optional[str] = None,
         chunks: Optional[Sequence[Union[Dict, Chunk]]] = None,
         task_display_mode: Optional[str] = None,  # timeline, plan
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
         **kwargs,
     ) -> SlackResponse:
         """Starts a new streaming conversation.
@@ -2907,6 +2921,9 @@ class WebClient(BaseClient):
                 "recipient_user_id": recipient_user_id,
                 "chunks": chunks,
                 "task_display_mode": task_display_mode,
+                "icon_emoji": icon_emoji,
+                "icon_url": icon_url,
+                "username": username,
             }
         )
         _parse_web_class_objects(kwargs)

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2967,6 +2967,9 @@ class WebClient(BaseClient):
         recipient_team_id: Optional[str] = None,
         recipient_user_id: Optional[str] = None,
         task_display_mode: Optional[str] = None,
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
         **kwargs,
     ) -> ChatStream:
         """Stream markdown text into a conversation.
@@ -2995,6 +2998,9 @@ class WebClient(BaseClient):
             recipient_user_id: The encoded ID of the user to receive the streaming text. Required when streaming to channels.
             task_display_mode: Specifies how tasks are displayed in the message. A "timeline" displays individual tasks
               with text and "plan" displays all tasks together.
+            icon_emoji: Emoji to use as the icon for this message. Overrides icon_url.
+            icon_url: Image URL to use as the icon for this message.
+            username: The bot's username to display.
             **kwargs: Additional arguments passed to the underlying API calls.
 
         Returns:
@@ -3021,6 +3027,9 @@ class WebClient(BaseClient):
             recipient_team_id=recipient_team_id,
             recipient_user_id=recipient_user_id,
             task_display_mode=task_display_mode,
+            icon_emoji=icon_emoji,
+            icon_url=icon_url,
+            username=username,
             buffer_size=buffer_size,
             **kwargs,
         )

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2092,13 +2092,24 @@ class LegacyWebClient(LegacyBaseClient):
         thread_ts: str,
         status: str,
         loading_messages: Optional[List[str]] = None,
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Set the status for an AI assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setStatus
         """
         kwargs.update(
-            {"channel_id": channel_id, "thread_ts": thread_ts, "status": status, "loading_messages": loading_messages}
+            {
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "status": status,
+                "loading_messages": loading_messages,
+                "icon_emoji": icon_emoji,
+                "icon_url": icon_url,
+                "username": username,
+            }
         )
         kwargs = _remove_none_values(kwargs)
         return self.api_call("assistant.threads.setStatus", json=kwargs)
@@ -2904,6 +2915,9 @@ class LegacyWebClient(LegacyBaseClient):
         recipient_user_id: Optional[str] = None,
         chunks: Optional[Sequence[Union[Dict, Chunk]]] = None,
         task_display_mode: Optional[str] = None,  # timeline, plan
+        icon_emoji: Optional[str] = None,
+        icon_url: Optional[str] = None,
+        username: Optional[str] = None,
         **kwargs,
     ) -> Union[Future, SlackResponse]:
         """Starts a new streaming conversation.
@@ -2918,6 +2932,9 @@ class LegacyWebClient(LegacyBaseClient):
                 "recipient_user_id": recipient_user_id,
                 "chunks": chunks,
                 "task_display_mode": task_display_mode,
+                "icon_emoji": icon_emoji,
+                "icon_url": icon_url,
+                "username": username,
             }
         )
         _parse_web_class_objects(kwargs)

--- a/tests/slack_sdk/web/test_chat_stream.py
+++ b/tests/slack_sdk/web/test_chat_stream.py
@@ -242,6 +242,26 @@ class TestChatStream(unittest.TestCase):
                 '[{"text": "\\n", "type": "markdown_text"}, {"text": ":space_invader:", "type": "markdown_text"}]',
             )
 
+    def test_streams_with_authorship_args(self):
+        streamer = self.client.chat_stream(
+            channel="C0123456789",
+            thread_ts="123.000",
+            username="Abacus",
+            icon_emoji="abacus",
+        )
+        self.assertEqual(streamer._stream_args["username"], "Abacus")
+        self.assertEqual(streamer._stream_args["icon_emoji"], "abacus")
+        self.assertIsNone(streamer._stream_args["icon_url"])
+
+        streamer.append(markdown_text="counting...")
+        streamer.stop()
+
+        if hasattr(self.thread.server, "chat_stream_requests"):
+            start_request = self.thread.server.chat_stream_requests.get("/chat.startStream", {})
+            self.assertEqual(start_request.get("username"), "Abacus")
+            self.assertEqual(start_request.get("icon_emoji"), "abacus")
+            self.assertNotIn("icon_url", start_request)
+
     def test_streams_errors_when_appending_to_an_unstarted_stream(self):
         streamer = self.client.chat_stream(
             channel="C0123456789",

--- a/tests/slack_sdk_async/web/test_web_client_coverage.py
+++ b/tests/slack_sdk_async/web/test_web_client_coverage.py
@@ -441,6 +441,19 @@ class TestWebClientCoverage(unittest.TestCase):
                     status="is typing...",
                     loading_states=["Thinking...", "Writing..."],
                 )
+                method(
+                    channel_id="D111",
+                    thread_ts="111.222",
+                    status="counting...",
+                    username="Abacus",
+                    icon_emoji="abacus",
+                )
+                await async_method(
+                    channel_id="D111",
+                    thread_ts="111.222",
+                    status="dreaming...",
+                    icon_url="https://example.com/clouds-square.png",
+                )
             elif method_name == "assistant_threads_setTitle":
                 self.api_methods_to_call.remove(method(channel_id="D111", thread_ts="111.222", title="New chat")["method"])
                 await async_method(channel_id="D111", thread_ts="111.222", title="New chat")
@@ -587,6 +600,21 @@ class TestWebClientCoverage(unittest.TestCase):
                 await async_method(channel="C123", thread_ts="123.123")
                 method(channel="C123", thread_ts="123.123", recipient_team_id="T123", recipient_user_id="U123")
                 await async_method(channel="C123", thread_ts="123.123", recipient_team_id="T123", recipient_user_id="U123")
+                method(
+                    channel="C123",
+                    thread_ts="123.123",
+                    recipient_team_id="T123",
+                    recipient_user_id="U123",
+                    username="Abacus",
+                    icon_emoji="abacus",
+                )
+                await async_method(
+                    channel="C123",
+                    thread_ts="123.123",
+                    recipient_team_id="T123",
+                    recipient_user_id="U123",
+                    icon_url="https://example.com/clouds-square.png",
+                )
             elif method_name == "chat_stopStream":
                 self.api_methods_to_call.remove(
                     method(channel="C123", ts="123.123", blocks=[{"type": "markdown", "text": "**twelve**"}])["method"]


### PR DESCRIPTION
## Summary

This pull request adds authorship arguments (`icon_emoji`, `icon_url`, `username`) to the `assistant.threads.setStatus` and `chat.startStream` Web API methods.

Mirrors slackapi/node-slack-sdk#2455 for the Python SDK.

### Testing

Try the following snippet against an assistant thread:

```python
import time

client.assistant_threads_setStatus(
    channel_id="C018QLSQ38A",
    thread_ts="1765934795.222209",
    status="dancing...",
    username="Charlie Brown",
    icon_emoji="maple_leaf",
)

time.sleep(4)

response = client.chat_startStream(
    channel="C018QLSQ38A",
    thread_ts="1765934795.222209",
    recipient_team_id="T07L2FPUY",
    recipient_user_id="U0187GKV2US",
    username="Charlie Brown",
    icon_emoji="maple_leaf",
)

time.sleep(2)

client.chat_appendStream(
    channel="C018QLSQ38A",
    ts=response["ts"],
    markdown_text="Dancing with snoopy dog.",
)

time.sleep(2)

client.chat_stopStream(
    channel="C018QLSQ38A",
    ts=response["ts"],
)
```

```py
streamer = app.client.chat_stream(
    channel="C07U19RTY90",
    thread_ts="1777925328.173729",
    recipient_user_id="U06MCF88LQY",
    recipient_team_id="T06M2FAFCF3",
    username="Charlie Brown",
    icon_emoji="maple_leaf",
    buffer_size=0,
)
streamer.append(markdown_text="Dancing with snoopy dog!")
time.sleep(2)
streamer.append(markdown_text=" Fun!")
streamer.stop()
```

### Category

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.