### PR TITLE
fix: resolve OAuth installation store bugs and typos

### DIFF
--- a/slack_sdk/oauth/installation_store/amazon_s3/__init__.py
+++ b/slack_sdk/oauth/installation_store/amazon_s3/__init__.py
@@ -106,7 +106,7 @@ class AmazonS3InstallationStore(InstallationStore, AsyncInstallationStore):
 
     def save_bot(self, bot: Bot):
         if bot.bot_token is None:
-            self.logger.debug("Skipped saving a new row because of the absense of bot token in it")
+            self.logger.debug("Skipped saving a new row because of the absence of bot token in it")
             return
 
         none = "none"
@@ -273,7 +273,7 @@ class AmazonS3InstallationStore(InstallationStore, AsyncInstallationStore):
                         Key=content.get("Key"),
                     )
                 except Exception as e:
-                    message = f"Failed to find bot installation data for enterprise: {e_id}, team: {t_id}: {e}"
+                    message = f"Failed to delete bot installation data for enterprise: {e_id}, team: {t_id}: {e}"
                     raise SlackClientConfigurationError(message)
 
     async def async_delete_installation(
@@ -316,7 +316,7 @@ class AmazonS3InstallationStore(InstallationStore, AsyncInstallationStore):
                     )
                     deleted_keys.append(key)
                 except Exception as e:
-                    message = f"Failed to find bot installation data for enterprise: {e_id}, team: {t_id}: {e}"
+                    message = f"Failed to delete installation data for enterprise: {e_id}, team: {t_id}: {e}"
                     raise SlackClientConfigurationError(message)
 
                 try:
@@ -328,7 +328,7 @@ class AmazonS3InstallationStore(InstallationStore, AsyncInstallationStore):
                         )
                         deleted_keys.append(no_user_id_key)
                 except Exception as e:
-                    message = f"Failed to find bot installation data for enterprise: {e_id}, team: {t_id}: {e}"
+                    message = f"Failed to delete installation data for enterprise: {e_id}, team: {t_id}: {e}"
                     raise SlackClientConfigurationError(message)
 
         # Check the remaining installation data
@@ -347,5 +347,5 @@ class AmazonS3InstallationStore(InstallationStore, AsyncInstallationStore):
                     Key=content.get("Key"),
                 )
             except Exception as e:
-                message = f"Failed to find bot installation data for enterprise: {e_id}, team: {t_id}: {e}"
+                message = f"Failed to delete installation data for enterprise: {e_id}, team: {t_id}: {e}"
                 raise SlackClientConfigurationError(message)

--- a/slack_sdk/oauth/installation_store/async_cacheable_installation_store.py
+++ b/slack_sdk/oauth/installation_store/async_cacheable_installation_store.py
@@ -98,7 +98,8 @@ class AsyncCacheableInstallationStore(AsyncInstallationStore):
             team_id=team_id,
         )
         key = f"{enterprise_id or ''}-{team_id or ''}"
-        self.cached_bots.pop(key)
+        if key in self.cached_bots:
+            self.cached_bots.pop(key)
 
     async def async_delete_installation(
         self,

--- a/slack_sdk/oauth/installation_store/file/__init__.py
+++ b/slack_sdk/oauth/installation_store/file/__init__.py
@@ -78,7 +78,7 @@ class FileInstallationStore(InstallationStore, AsyncInstallationStore):
 
     def save_bot(self, bot: Bot):
         if bot.bot_token is None:
-            self.logger.debug("Skipped saving a new row because of the absense of bot token in it")
+            self.logger.debug("Skipped saving a new row because of the absence of bot token in it")
             return
 
         none = "none"

--- a/slack_sdk/oauth/installation_store/sqlite3/__init__.py
+++ b/slack_sdk/oauth/installation_store/sqlite3/__init__.py
@@ -48,8 +48,7 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
 
     def create_tables(self):
         with sqlite3.connect(database=self.database) as conn:
-            conn.execute(
-                """
+            conn.execute("""
             create table slack_installations (
                 id integer primary key autoincrement,
                 client_id text not null,
@@ -78,10 +77,8 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 token_type text,
                 installed_at datetime not null default current_timestamp
             );
-            """
-            )
-            conn.execute(
-                """
+            """)
+            conn.execute("""
             create index slack_installations_idx on slack_installations (
                 client_id,
                 enterprise_id,
@@ -89,10 +86,8 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 user_id,
                 installed_at
             );
-            """
-            )
-            conn.execute(
-                """
+            """)
+            conn.execute("""
             create table slack_bots (
                 id integer primary key autoincrement,
                 client_id text not null,
@@ -110,18 +105,15 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 is_enterprise_install boolean not null default 0,
                 installed_at datetime not null default current_timestamp
             );
-            """
-            )
-            conn.execute(
-                """
+            """)
+            conn.execute("""
             create index slack_bots_idx on slack_bots (
                 client_id,
                 enterprise_id,
                 team_id,
                 installed_at
             );
-            """
-            )
+            """)
             self.logger.debug(f"Tables have been created (database: {self.database})")
             conn.commit()
 

--- a/slack_sdk/oauth/installation_store/sqlite3/__init__.py
+++ b/slack_sdk/oauth/installation_store/sqlite3/__init__.py
@@ -48,7 +48,8 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
 
     def create_tables(self):
         with sqlite3.connect(database=self.database) as conn:
-            conn.execute("""
+            conn.execute(
+                """
             create table slack_installations (
                 id integer primary key autoincrement,
                 client_id text not null,
@@ -77,8 +78,10 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 token_type text,
                 installed_at datetime not null default current_timestamp
             );
-            """)
-            conn.execute("""
+            """
+            )
+            conn.execute(
+                """
             create index slack_installations_idx on slack_installations (
                 client_id,
                 enterprise_id,
@@ -86,8 +89,10 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 user_id,
                 installed_at
             );
-            """)
-            conn.execute("""
+            """
+            )
+            conn.execute(
+                """
             create table slack_bots (
                 id integer primary key autoincrement,
                 client_id text not null,
@@ -105,15 +110,18 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                 is_enterprise_install boolean not null default 0,
                 installed_at datetime not null default current_timestamp
             );
-            """)
-            conn.execute("""
+            """
+            )
+            conn.execute(
+                """
             create index slack_bots_idx on slack_bots (
                 client_id,
                 enterprise_id,
                 team_id,
                 installed_at
             );
-            """)
+            """
+            )
             self.logger.debug(f"Tables have been created (database: {self.database})")
             conn.commit()
 
@@ -217,7 +225,7 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
 
     def save_bot(self, bot: Bot):
         if bot.bot_token is None:
-            self.logger.debug("Skipped saving a new row because of the absense of bot token in it")
+            self.logger.debug("Skipped saving a new row because of the absence of bot token in it")
             return
 
         with self.connect() as conn:

--- a/slack_sdk/oauth/state_store/sqlite3/__init__.py
+++ b/slack_sdk/oauth/state_store/sqlite3/__init__.py
@@ -45,13 +45,15 @@ class SQLite3OAuthStateStore(OAuthStateStore, AsyncOAuthStateStore):
 
     def create_tables(self):
         with sqlite3.connect(database=self.database) as conn:
-            conn.execute("""
+            conn.execute(
+                """
             create table oauth_states (
                 id integer primary key autoincrement,
                 state text not null,
                 expire_at datetime not null
             );
-            """)
+            """
+            )
             self.logger.debug(f"Tables have been created (database: {self.database})")
             conn.commit()
 

--- a/slack_sdk/oauth/state_store/sqlite3/__init__.py
+++ b/slack_sdk/oauth/state_store/sqlite3/__init__.py
@@ -45,15 +45,13 @@ class SQLite3OAuthStateStore(OAuthStateStore, AsyncOAuthStateStore):
 
     def create_tables(self):
         with sqlite3.connect(database=self.database) as conn:
-            conn.execute(
-                """
+            conn.execute("""
             create table oauth_states (
                 id integer primary key autoincrement,
                 state text not null,
                 expire_at datetime not null
             );
-            """
-            )
+            """)
             self.logger.debug(f"Tables have been created (database: {self.database})")
             conn.commit()
 


### PR DESCRIPTION
## Summary
- Fix `KeyError` in `AsyncCacheableInstallationStore.async_delete_bot` when deleting a bot that isn't cached (aligns with sync version's guard)
- Fix incorrect error messages in S3 delete_bot/delete_installation that said `"Failed to find bot installation data"` instead of `"Failed to delete"`
- Fix typo `"absense"` → `"absence"` in log messages across file, S3, and SQLite3 installation stores     

### Testing

CI coverage should be sufficient

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [x] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
