### PR TITLE
feat(blocks): add Card, Carousel, and Alert block types

### DIFF
--- a/slack_sdk/models/blocks/__init__.py
+++ b/slack_sdk/models/blocks/__init__.py
@@ -61,8 +61,11 @@ from .block_elements import (
 )
 from .blocks import (
     ActionsBlock,
+    AlertBlock,
     Block,
     CallBlock,
+    CardBlock,
+    CarouselBlock,
     ContextActionsBlock,
     ContextBlock,
     DividerBlock,
@@ -129,8 +132,11 @@ __all__ = [
     "RichTextQuoteElement",
     "RichTextSectionElement",
     "ActionsBlock",
+    "AlertBlock",
     "Block",
     "CallBlock",
+    "CardBlock",
+    "CarouselBlock",
     "ContextActionsBlock",
     "ContextBlock",
     "DividerBlock",

--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -938,7 +938,7 @@ class CardBlock(Block):
         self.title = TextObject.parse(title, default_type=MarkdownTextObject.type)  # type: ignore[arg-type]
         self.subtitle = TextObject.parse(subtitle, default_type=MarkdownTextObject.type)  # type: ignore[arg-type]
         self.body = TextObject.parse(body, default_type=MarkdownTextObject.type)  # type: ignore[arg-type]
-        self.actions = BlockElement.parse_all(actions) if actions else None  # type: ignore[arg-type]
+        self.actions = BlockElement.parse_all(actions) if actions else None
 
     @JsonValidator("At least one of hero_image, title, actions, or body is required")
     def _validate_content(self):
@@ -986,7 +986,7 @@ class AlertBlock(Block):
         super().__init__(type=self.type, block_id=block_id)
         show_unknown_key_warning(self, others)
 
-        self.text = TextObject.parse(text)  # type: ignore[arg-type]
+        self.text = TextObject.parse(text)
         self.level = level
 
     @JsonValidator("text attribute must be specified")

--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -917,7 +917,7 @@ class CardBlock(Block):
         actions: Optional[Sequence[Union[dict, BlockElement]]] = None,
         **others: dict,
     ):
-        """A rich display block for presenting structured content such as recommendations, results, or work items.
+        """Displays content in a card."""
         https://docs.slack.dev/reference/block-kit/blocks/card-block
 
         Args:

--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -886,6 +886,46 @@ class PlanBlock(Block):
         self.tasks = tasks
 
 
+class AlertBlock(Block):
+    type = "alert"
+    valid_levels = {"default", "info", "warning", "error", "success"}
+
+    @property
+    def attributes(self) -> Set[str]:  # type: ignore[override]
+        return super().attributes.union({"text", "level"})
+
+    def __init__(
+        self,
+        *,
+        text: Union[str, dict, TextObject],
+        level: Optional[str] = None,
+        block_id: Optional[str] = None,
+        **others: dict,
+    ):
+        """Displays alerts, warnings, and informational messages.
+        https://docs.slack.dev/reference/block-kit/blocks/alert-block
+
+        Args:
+            text (required): The alert message, using plain_text or mrkdwn formatting.
+            level: One of "default", "info", "warning", "error", or "success".
+                Will be "default" if omitted.
+            block_id: A unique identifier for a block. If not specified, a block_id will be generated.
+        """
+        super().__init__(type=self.type, block_id=block_id)
+        show_unknown_key_warning(self, others)
+
+        self.text = TextObject.parse(text)
+        self.level = level
+
+    @JsonValidator("text attribute must be specified")
+    def _validate_text(self):
+        return self.text is not None
+
+    @JsonValidator("level must be a valid value (default, info, warning, error, success)")
+    def _validate_level(self):
+        return self.level is None or self.level in self.valid_levels
+
+
 class CardBlock(Block):
     type = "card"
     title_max_length = 150
@@ -909,32 +949,31 @@ class CardBlock(Block):
         self,
         *,
         block_id: Optional[str] = None,
-        hero_image: Optional[Union[dict, ImageElement]] = None,
-        icon: Optional[Union[dict, ImageElement]] = None,
+        hero_image: Optional[str] = None,
+        icon: Optional[str] = None,
         title: Optional[Union[str, dict, TextObject]] = None,
         subtitle: Optional[Union[str, dict, TextObject]] = None,
         body: Optional[Union[str, dict, TextObject]] = None,
         actions: Optional[Sequence[Union[dict, BlockElement]]] = None,
         **others: dict,
     ):
-        """Displays content in a card."""
+        """Displays content in a card.
         https://docs.slack.dev/reference/block-kit/blocks/card-block
 
         Args:
-            block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
-                Maximum length for this field is 255 characters.
-            hero_image: A top banner image for the card. An image element with type, image_url, and alt_text.
-            icon: A small icon next to the title/subtitle. An image element with type, image_url, and alt_text.
-            title: The title of the card. Supports mrkdwn text. Maximum length is 150 characters.
-            subtitle: The subtitle of the card. Supports mrkdwn text. Maximum length is 150 characters.
-            body: The body text of the card. Supports mrkdwn text. Maximum length is 200 characters.
-            actions: An array of button elements displayed at the bottom of the card.
+            block_id: A unique identifier for a block. If not specified, a block_id will be generated.
+            hero_image: Link to the top image used on the card.
+            icon: Link to the small image used next to the card's title and subtitle.
+            title: Title of the card. 150 characters max.
+            subtitle: Subtitle of the card. 150 characters max.
+            body: Content of the card. 200 characters max.
+            actions: Action buttons shown at the bottom of the card.
         """
         super().__init__(type=self.type, block_id=block_id)
         show_unknown_key_warning(self, others)
 
-        self.hero_image = BlockElement.parse(hero_image)  # type: ignore[arg-type]
-        self.icon = BlockElement.parse(icon)  # type: ignore[arg-type]
+        self.hero_image = hero_image
+        self.icon = icon
         self.title = TextObject.parse(title, default_type=MarkdownTextObject.type)  # type: ignore[arg-type]
         self.subtitle = TextObject.parse(subtitle, default_type=MarkdownTextObject.type)  # type: ignore[arg-type]
         self.body = TextObject.parse(body, default_type=MarkdownTextObject.type)  # type: ignore[arg-type]
@@ -957,47 +996,6 @@ class CardBlock(Block):
         return self.body is None or self.body.text is None or len(self.body.text) <= self.body_max_length
 
 
-class AlertBlock(Block):
-    type = "alert"
-    valid_levels = {"default", "info", "warning", "error", "success"}
-
-    @property
-    def attributes(self) -> Set[str]:  # type: ignore[override]
-        return super().attributes.union({"text", "level"})
-
-    def __init__(
-        self,
-        *,
-        text: Union[str, dict, TextObject],
-        level: Optional[str] = None,
-        block_id: Optional[str] = None,
-        **others: dict,
-    ):
-        """A prominent notice block for displaying warnings, status updates, or other important information.
-        https://docs.slack.dev/reference/block-kit/blocks/alert-block
-
-        Args:
-            text (required): The alert message content. Supports plain_text or mrkdwn.
-            level: The severity level of the alert. One of "default", "info", "warning", "error", "success".
-                Defaults to "default".
-            block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
-                Maximum length for this field is 255 characters.
-        """
-        super().__init__(type=self.type, block_id=block_id)
-        show_unknown_key_warning(self, others)
-
-        self.text = TextObject.parse(text)
-        self.level = level
-
-    @JsonValidator("text attribute must be specified")
-    def _validate_text(self):
-        return self.text is not None
-
-    @JsonValidator("level must be a valid value (default, info, warning, error, success)")
-    def _validate_level(self):
-        return self.level is None or self.level in self.valid_levels
-
-
 class CarouselBlock(Block):
     type = "carousel"
     elements_max_length = 10
@@ -1009,17 +1007,16 @@ class CarouselBlock(Block):
     def __init__(
         self,
         *,
-        elements: Sequence[Union[dict, "CardBlock"]],
+        elements: Sequence[Union[dict, CardBlock]],
         block_id: Optional[str] = None,
         **others: dict,
     ):
-        """A horizontally scrollable collection of card blocks.
+        """Displays related card blocks in a horizontally-scrolling container.
         https://docs.slack.dev/reference/block-kit/blocks/carousel-block
 
         Args:
-            elements (required): An array of card block objects. Minimum 1, maximum 10 cards.
-            block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
-                Maximum length for this field is 255 characters.
+            elements (required): A list of cards. Minimum 1, maximum 10 cards.
+            block_id: A unique identifier for a block. If not specified, a block_id will be generated.
         """
         super().__init__(type=self.type, block_id=block_id)
         show_unknown_key_warning(self, others)

--- a/slack_sdk/models/blocks/blocks.py
+++ b/slack_sdk/models/blocks/blocks.py
@@ -102,6 +102,12 @@ class Block(JsonObject):
                     return TaskCardBlock(**block)
                 elif type == PlanBlock.type:
                     return PlanBlock(**block)
+                elif type == CardBlock.type:
+                    return CardBlock(**block)
+                elif type == AlertBlock.type:
+                    return AlertBlock(**block)
+                elif type == CarouselBlock.type:
+                    return CarouselBlock(**block)
                 else:
                     cls.logger.warning(f"Unknown block detected and skipped ({block})")
                     return None
@@ -878,3 +884,152 @@ class PlanBlock(Block):
 
         self.title = title
         self.tasks = tasks
+
+
+class CardBlock(Block):
+    type = "card"
+    title_max_length = 150
+    subtitle_max_length = 150
+    body_max_length = 200
+
+    @property
+    def attributes(self) -> Set[str]:  # type: ignore[override]
+        return super().attributes.union(
+            {
+                "hero_image",
+                "icon",
+                "title",
+                "subtitle",
+                "body",
+                "actions",
+            }
+        )
+
+    def __init__(
+        self,
+        *,
+        block_id: Optional[str] = None,
+        hero_image: Optional[Union[dict, ImageElement]] = None,
+        icon: Optional[Union[dict, ImageElement]] = None,
+        title: Optional[Union[str, dict, TextObject]] = None,
+        subtitle: Optional[Union[str, dict, TextObject]] = None,
+        body: Optional[Union[str, dict, TextObject]] = None,
+        actions: Optional[Sequence[Union[dict, BlockElement]]] = None,
+        **others: dict,
+    ):
+        """A rich display block for presenting structured content such as recommendations, results, or work items.
+        https://docs.slack.dev/reference/block-kit/blocks/card-block
+
+        Args:
+            block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
+                Maximum length for this field is 255 characters.
+            hero_image: A top banner image for the card. An image element with type, image_url, and alt_text.
+            icon: A small icon next to the title/subtitle. An image element with type, image_url, and alt_text.
+            title: The title of the card. Supports mrkdwn text. Maximum length is 150 characters.
+            subtitle: The subtitle of the card. Supports mrkdwn text. Maximum length is 150 characters.
+            body: The body text of the card. Supports mrkdwn text. Maximum length is 200 characters.
+            actions: An array of button elements displayed at the bottom of the card.
+        """
+        super().__init__(type=self.type, block_id=block_id)
+        show_unknown_key_warning(self, others)
+
+        self.hero_image = BlockElement.parse(hero_image)  # type: ignore[arg-type]
+        self.icon = BlockElement.parse(icon)  # type: ignore[arg-type]
+        self.title = TextObject.parse(title, default_type=MarkdownTextObject.type)  # type: ignore[arg-type]
+        self.subtitle = TextObject.parse(subtitle, default_type=MarkdownTextObject.type)  # type: ignore[arg-type]
+        self.body = TextObject.parse(body, default_type=MarkdownTextObject.type)  # type: ignore[arg-type]
+        self.actions = BlockElement.parse_all(actions) if actions else None  # type: ignore[arg-type]
+
+    @JsonValidator("At least one of hero_image, title, actions, or body is required")
+    def _validate_content(self):
+        return self.hero_image is not None or self.title is not None or self.actions is not None or self.body is not None
+
+    @JsonValidator(f"title attribute cannot exceed {title_max_length} characters")
+    def _validate_title_length(self):
+        return self.title is None or self.title.text is None or len(self.title.text) <= self.title_max_length
+
+    @JsonValidator(f"subtitle attribute cannot exceed {subtitle_max_length} characters")
+    def _validate_subtitle_length(self):
+        return self.subtitle is None or self.subtitle.text is None or len(self.subtitle.text) <= self.subtitle_max_length
+
+    @JsonValidator(f"body attribute cannot exceed {body_max_length} characters")
+    def _validate_body_length(self):
+        return self.body is None or self.body.text is None or len(self.body.text) <= self.body_max_length
+
+
+class AlertBlock(Block):
+    type = "alert"
+    valid_levels = {"default", "info", "warning", "error", "success"}
+
+    @property
+    def attributes(self) -> Set[str]:  # type: ignore[override]
+        return super().attributes.union({"text", "level"})
+
+    def __init__(
+        self,
+        *,
+        text: Union[str, dict, TextObject],
+        level: Optional[str] = None,
+        block_id: Optional[str] = None,
+        **others: dict,
+    ):
+        """A prominent notice block for displaying warnings, status updates, or other important information.
+        https://docs.slack.dev/reference/block-kit/blocks/alert-block
+
+        Args:
+            text (required): The alert message content. Supports plain_text or mrkdwn.
+            level: The severity level of the alert. One of "default", "info", "warning", "error", "success".
+                Defaults to "default".
+            block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
+                Maximum length for this field is 255 characters.
+        """
+        super().__init__(type=self.type, block_id=block_id)
+        show_unknown_key_warning(self, others)
+
+        self.text = TextObject.parse(text)  # type: ignore[arg-type]
+        self.level = level
+
+    @JsonValidator("text attribute must be specified")
+    def _validate_text(self):
+        return self.text is not None
+
+    @JsonValidator("level must be a valid value (default, info, warning, error, success)")
+    def _validate_level(self):
+        return self.level is None or self.level in self.valid_levels
+
+
+class CarouselBlock(Block):
+    type = "carousel"
+    elements_max_length = 10
+
+    @property
+    def attributes(self) -> Set[str]:  # type: ignore[override]
+        return super().attributes.union({"elements"})
+
+    def __init__(
+        self,
+        *,
+        elements: Sequence[Union[dict, "CardBlock"]],
+        block_id: Optional[str] = None,
+        **others: dict,
+    ):
+        """A horizontally scrollable collection of card blocks.
+        https://docs.slack.dev/reference/block-kit/blocks/carousel-block
+
+        Args:
+            elements (required): An array of card block objects. Minimum 1, maximum 10 cards.
+            block_id: A string acting as a unique identifier for a block. If not specified, one will be generated.
+                Maximum length for this field is 255 characters.
+        """
+        super().__init__(type=self.type, block_id=block_id)
+        show_unknown_key_warning(self, others)
+
+        self.elements = Block.parse_all(elements)
+
+    @JsonValidator("elements attribute must contain at least 1 card")
+    def _validate_elements_present(self):
+        return self.elements is not None and len(self.elements) >= 1
+
+    @JsonValidator(f"elements attribute cannot exceed {elements_max_length} cards")
+    def _validate_elements_length(self):
+        return self.elements is None or len(self.elements) <= self.elements_max_length

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -1560,10 +1560,10 @@ class CardBlockTests(unittest.TestCase):
     def test_document(self):
         input = {
             "type": "card",
-            "icon": {"type": "image", "image_url": "https://picsum.photos/36/36", "alt_text": "Icon"},
+            "icon": "https://picsum.photos/36/36",
             "title": {"type": "mrkdwn", "text": "Lumon Industries", "verbatim": False},
             "subtitle": {"type": "mrkdwn", "text": "Committed to work-life balance", "verbatim": False},
-            "hero_image": {"type": "image", "image_url": "https://picsum.photos/400/300", "alt_text": "Sample hero image"},
+            "hero_image": "https://picsum.photos/400/300",
             "body": {"type": "mrkdwn", "text": "Please enjoy each card equally.", "verbatim": False},
             "actions": [
                 {

--- a/tests/slack_sdk/models/test_blocks.py
+++ b/tests/slack_sdk/models/test_blocks.py
@@ -4,9 +4,12 @@ from typing import List
 from slack_sdk.errors import SlackObjectFormationError
 from slack_sdk.models.blocks import (
     ActionsBlock,
+    AlertBlock,
     Block,
     ButtonElement,
     CallBlock,
+    CardBlock,
+    CarouselBlock,
     ContextActionsBlock,
     ContextBlock,
     DividerBlock,
@@ -1551,3 +1554,153 @@ class TableBlockTests(unittest.TestCase):
             ],
         }
         self.assertDictEqual(expected, block.to_dict())
+
+
+class CardBlockTests(unittest.TestCase):
+    def test_document(self):
+        input = {
+            "type": "card",
+            "icon": {"type": "image", "image_url": "https://picsum.photos/36/36", "alt_text": "Icon"},
+            "title": {"type": "mrkdwn", "text": "Lumon Industries", "verbatim": False},
+            "subtitle": {"type": "mrkdwn", "text": "Committed to work-life balance", "verbatim": False},
+            "hero_image": {"type": "image", "image_url": "https://picsum.photos/400/300", "alt_text": "Sample hero image"},
+            "body": {"type": "mrkdwn", "text": "Please enjoy each card equally.", "verbatim": False},
+            "actions": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Action Button", "emoji": False},
+                    "action_id": "button_action",
+                }
+            ],
+        }
+        self.assertDictEqual(input, CardBlock(**input).to_dict())
+
+    def test_parse(self):
+        input = {
+            "type": "card",
+            "title": {"type": "mrkdwn", "text": "Title"},
+            "body": {"type": "mrkdwn", "text": "Body text"},
+        }
+        parsed = Block.parse(input)
+        self.assertIsNotNone(parsed)
+        self.assertDictEqual(input, parsed.to_dict())
+
+    def test_minimal_with_title(self):
+        input = {
+            "type": "card",
+            "title": {"type": "mrkdwn", "text": "Just a title"},
+        }
+        self.assertDictEqual(input, CardBlock(**input).to_dict())
+
+    def test_minimal_with_body(self):
+        input = {
+            "type": "card",
+            "body": {"type": "mrkdwn", "text": "Just body text"},
+        }
+        self.assertDictEqual(input, CardBlock(**input).to_dict())
+
+    def test_validation_at_least_one_field(self):
+        with self.assertRaises(SlackObjectFormationError):
+            CardBlock().validate_json()
+
+    def test_title_length_validation(self):
+        with self.assertRaises(SlackObjectFormationError):
+            CardBlock(title={"type": "mrkdwn", "text": "a" * 151}).validate_json()
+
+    def test_subtitle_length_validation(self):
+        with self.assertRaises(SlackObjectFormationError):
+            CardBlock(
+                title={"type": "mrkdwn", "text": "Title"},
+                subtitle={"type": "mrkdwn", "text": "a" * 151},
+            ).validate_json()
+
+    def test_body_length_validation(self):
+        with self.assertRaises(SlackObjectFormationError):
+            CardBlock(body={"type": "mrkdwn", "text": "a" * 201}).validate_json()
+
+
+class AlertBlockTests(unittest.TestCase):
+    def test_document(self):
+        input = {
+            "type": "alert",
+            "text": {"type": "mrkdwn", "text": "The work is mysterious and important.", "verbatim": False},
+            "level": "info",
+        }
+        self.assertDictEqual(input, AlertBlock(**input).to_dict())
+
+    def test_parse(self):
+        input = {
+            "type": "alert",
+            "text": {"type": "mrkdwn", "text": "Notice"},
+            "level": "warning",
+        }
+        parsed = Block.parse(input)
+        self.assertIsNotNone(parsed)
+        self.assertDictEqual(input, parsed.to_dict())
+
+    def test_minimal(self):
+        input = {
+            "type": "alert",
+            "text": {"type": "plain_text", "text": "Simple alert"},
+        }
+        self.assertDictEqual(input, AlertBlock(**input).to_dict())
+
+    def test_all_levels(self):
+        for level in ["default", "info", "warning", "error", "success"]:
+            input = {
+                "type": "alert",
+                "text": {"type": "plain_text", "text": "Test"},
+                "level": level,
+            }
+            AlertBlock(**input).validate_json()
+
+    def test_invalid_level(self):
+        with self.assertRaises(SlackObjectFormationError):
+            AlertBlock(text={"type": "plain_text", "text": "Test"}, level="critical").validate_json()
+
+    def test_missing_text(self):
+        with self.assertRaises(SlackObjectFormationError):
+            AlertBlock(text="").validate_json()
+
+
+class CarouselBlockTests(unittest.TestCase):
+    def test_document(self):
+        input = {
+            "type": "carousel",
+            "elements": [
+                {
+                    "type": "card",
+                    "title": {"type": "mrkdwn", "text": "Card 1"},
+                },
+                {
+                    "type": "card",
+                    "title": {"type": "mrkdwn", "text": "Card 2"},
+                    "body": {"type": "mrkdwn", "text": "Some body text"},
+                },
+            ],
+        }
+        self.assertDictEqual(input, CarouselBlock(**input).to_dict())
+
+    def test_parse(self):
+        input = {
+            "type": "carousel",
+            "elements": [
+                {"type": "card", "title": {"type": "mrkdwn", "text": "Card 1"}},
+            ],
+        }
+        parsed = Block.parse(input)
+        self.assertIsNotNone(parsed)
+        self.assertDictEqual(input, parsed.to_dict())
+
+    def test_single_card(self):
+        input = {
+            "type": "carousel",
+            "elements": [
+                {"type": "card", "title": {"type": "mrkdwn", "text": "Only card"}},
+            ],
+        }
+        self.assertDictEqual(input, CarouselBlock(**input).to_dict())
+
+    def test_empty_elements_validation(self):
+        with self.assertRaises(SlackObjectFormationError):
+            CarouselBlock(elements=[]).validate_json()


### PR DESCRIPTION
## Summary
- Adds `CardBlock` — a rich display block for presenting structured content (hero image, icon, title, subtitle, body, actions)
- Adds `CarouselBlock` — a horizontally scrollable collection of card blocks (1–10 cards)
- Adds `AlertBlock` — a prominent notice block for warnings, status updates, or important information with severity levels (default, info, warning, error, success)

All three blocks include deserialization support via `Block.parse()`, exports in `__init__.py`, and round-trip tests.

> **Note:** The `AlertBlock` is only supported in **modal views** (`views_open` / `views_update`). It is not supported in `chat_postMessage` or other message surfaces.

## Test plan
<details><summary>Test app.py (sends carousel + cards via chat_postMessage on startup)</summary>

```py
import os
import logging

from slack_bolt import App
from slack_bolt.adapter.socket_mode import SocketModeHandler
from slack_sdk.models.blocks import CarouselBlock, CardBlock, ButtonElement, ImageElement

from listeners import register_listeners

logging.basicConfig(level=logging.DEBUG)

# Initialization
app = App(token=os.environ.get("SLACK_BOT_TOKEN"))

# Register Listeners
register_listeners(app)

# Start Bolt app
if __name__ == "__main__":
    app.client.chat_postMessage(
        channel="#test-blockkit-new-types",
        blocks=[
            CarouselBlock(elements=[
                CardBlock(
                    hero_image=ImageElement(image_url="https://picsum.photos/seed/a/400/200", alt_text="Card 1 hero"),
                    title="Card Block",
                    subtitle="Rich structured content",
                    body="Recommendations, results, or work items.",
                    actions=[ButtonElement(text="Learn more", action_id="card_1_btn")],
                ),
                CardBlock(
                    hero_image=ImageElement(image_url="https://picsum.photos/seed/b/400/200", alt_text="Card 2 hero"),
                    title="Alert Block",
                    subtitle="Prominent notices",
                    body="Warnings, status updates, and more.",
                    actions=[ButtonElement(text="Learn more", action_id="card_2_btn")],
                ),
                CardBlock(
                    hero_image=ImageElement(image_url="https://picsum.photos/seed/c/400/200", alt_text="Card 3 hero"),
                    title="Carousel Block",
                    subtitle="Scrollable card collections",
                    body="Up to 10 cards, side by side.",
                    actions=[ButtonElement(text="Learn more", action_id="card_3_btn")],
                ),
            ]),
        ],
        text="New Block Kit types demo",
    )
    SocketModeHandler(app, os.environ.get("SLACK_APP_TOKEN")).start()
```
</details>

<details><summary>Test shortcut handler (opens modal with alert blocks via global shortcut)</summary>

```py
def sample_shortcut_callback(body: dict, ack: Ack, client: WebClient, logger: Logger):
    try:
        ack()
        blocks = [
            AlertBlock(text="This is a *default* alert block").to_dict(),
            AlertBlock(text="This is an *info* alert block", level="info").to_dict(),
            AlertBlock(text="This is a *warning* alert block", level="warning").to_dict(),
            AlertBlock(text="This is an *error* alert block", level="error").to_dict(),
            AlertBlock(text="This is a *success* alert block", level="success").to_dict(),
            {
                "type": "input",
                "block_id": "input_block_id",
                "label": {
                    "type": "plain_text",
                    "text": "What are your hopes and dreams?",
                },
                "element": {
                    "type": "plain_text_input",
                    "action_id": "sample_input_id",
                    "multiline": True,
                },
            },
            {
                "block_id": "select_channel_block_id",
                "type": "input",
                "label": {
                    "type": "plain_text",
                    "text": "Select a channel to message the result to",
                },
                "element": {
                    "type": "conversations_select",
                    "action_id": "sample_dropdown_id",
                    "response_url_enabled": True,
                },
            },
        ]
        client.views_open(
            trigger_id=body["trigger_id"],
            view={
                "type": "modal",
                "callback_id": "sample_view_id",
                "title": {"type": "plain_text", "text": "Alert Block Demo"},
                "blocks": blocks,
                "submit": {"type": "plain_text", "text": "Submit"},
            },
        )
    except Exception as e:
        logger.error(e)
```
</details>

- [x] Round-trip serialization tests for all three block types
- [x] `Block.parse()` deserialization tests
- [x] Validation tests (required fields, length constraints, enum values)
- [x] Integration test: send a message with `CardBlock` to Slack
- [x] Integration test: send a message with `CarouselBlock` to Slack
- [x] Integration test: open a modal with `AlertBlock` in Slack (alert blocks are only supported in modal views)

🤖 Generated with [Claude Code](https://claude.com/claude-code)