### PR TITLE
feat: add highlight_type to files.completeUploadExternal and files_upload_v2

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -4119,8 +4119,14 @@ class AsyncWebClient(AsyncBaseClient):
                 raise e.SlackRequestError(message)
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
+        complete_files = []
+        for f in files:
+            file_entry: Dict[str, str] = {"id": f["file_id"], "title": f["title"]}
+            if f.get("highlight_type") is not None:
+                file_entry["highlight_type"] = f["highlight_type"]
+            complete_files.append(file_entry)
         completion = await self.files_completeUploadExternal(
-            files=[{"id": f["file_id"], "title": f["title"], "highlight_type": f.get("highlight_type")} for f in files],
+            files=complete_files,
             channel_id=channel,
             channels=channels,
             initial_comment=initial_comment,

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -4037,6 +4037,7 @@ class AsyncWebClient(AsyncBaseClient):
         title: Optional[str] = None,
         alt_txt: Optional[str] = None,
         snippet_type: Optional[str] = None,
+        highlight_type: Optional[str] = None,
         # To upload multiple files at a time
         file_uploads: Optional[List[Dict[str, Any]]] = None,
         channel: Optional[str] = None,
@@ -4081,6 +4082,7 @@ class AsyncWebClient(AsyncBaseClient):
                     "title": title,
                     "alt_txt": alt_txt,
                     "snippet_type": snippet_type,
+                    "highlight_type": highlight_type,
                 }
             )
             files.append(f)
@@ -4118,7 +4120,7 @@ class AsyncWebClient(AsyncBaseClient):
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
         completion = await self.files_completeUploadExternal(
-            files=[{"id": f["file_id"], "title": f["title"]} for f in files],
+            files=[{"id": f["file_id"], "title": f["title"], "highlight_type": f.get("highlight_type")} for f in files],
             channel_id=channel,
             channels=channels,
             initial_comment=initial_comment,

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -4119,14 +4119,8 @@ class AsyncWebClient(AsyncBaseClient):
                 raise e.SlackRequestError(message)
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
-        complete_files = []
-        for f in files:
-            file_entry: Dict[str, str] = {"id": f["file_id"], "title": f["title"]}
-            if f.get("highlight_type") is not None:
-                file_entry["highlight_type"] = f["highlight_type"]
-            complete_files.append(file_entry)
         completion = await self.files_completeUploadExternal(
-            files=complete_files,
+            files=[{"id": f["file_id"], "title": f["title"], "highlight_type": f.get("highlight_type")} for f in files],
             channel_id=channel,
             channels=channels,
             initial_comment=initial_comment,
@@ -4162,7 +4156,7 @@ class AsyncWebClient(AsyncBaseClient):
     async def files_completeUploadExternal(
         self,
         *,
-        files: List[Dict[str, str]],
+        files: List[Dict[str, Optional[str]]],
         channel_id: Optional[str] = None,
         channels: Optional[List[str]] = None,
         initial_comment: Optional[str] = None,

--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -4036,8 +4036,8 @@ class AsyncWebClient(AsyncBaseClient):
         content: Optional[Union[str, bytes]] = None,
         title: Optional[str] = None,
         alt_txt: Optional[str] = None,
-        snippet_type: Optional[str] = None,
         highlight_type: Optional[str] = None,
+        snippet_type: Optional[str] = None,
         # To upload multiple files at a time
         file_uploads: Optional[List[Dict[str, Any]]] = None,
         channel: Optional[str] = None,
@@ -4081,8 +4081,8 @@ class AsyncWebClient(AsyncBaseClient):
                     "content": content,
                     "title": title,
                     "alt_txt": alt_txt,
-                    "snippet_type": snippet_type,
                     "highlight_type": highlight_type,
+                    "snippet_type": snippet_type,
                 }
             )
             files.append(f)

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -4026,8 +4026,8 @@ class WebClient(BaseClient):
         content: Optional[Union[str, bytes]] = None,
         title: Optional[str] = None,
         alt_txt: Optional[str] = None,
-        snippet_type: Optional[str] = None,
         highlight_type: Optional[str] = None,
+        snippet_type: Optional[str] = None,
         # To upload multiple files at a time
         file_uploads: Optional[List[Dict[str, Any]]] = None,
         channel: Optional[str] = None,
@@ -4071,8 +4071,8 @@ class WebClient(BaseClient):
                     "content": content,
                     "title": title,
                     "alt_txt": alt_txt,
-                    "snippet_type": snippet_type,
                     "highlight_type": highlight_type,
+                    "snippet_type": snippet_type,
                 }
             )
             files.append(f)

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -4027,6 +4027,7 @@ class WebClient(BaseClient):
         title: Optional[str] = None,
         alt_txt: Optional[str] = None,
         snippet_type: Optional[str] = None,
+        highlight_type: Optional[str] = None,
         # To upload multiple files at a time
         file_uploads: Optional[List[Dict[str, Any]]] = None,
         channel: Optional[str] = None,
@@ -4071,6 +4072,7 @@ class WebClient(BaseClient):
                     "title": title,
                     "alt_txt": alt_txt,
                     "snippet_type": snippet_type,
+                    "highlight_type": highlight_type,
                 }
             )
             files.append(f)
@@ -4108,7 +4110,7 @@ class WebClient(BaseClient):
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
         completion = self.files_completeUploadExternal(
-            files=[{"id": f["file_id"], "title": f["title"]} for f in files],
+            files=[{"id": f["file_id"], "title": f["title"], "highlight_type": f.get("highlight_type")} for f in files],
             channel_id=channel,
             channels=channels,
             initial_comment=initial_comment,

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -4109,14 +4109,8 @@ class WebClient(BaseClient):
                 raise e.SlackRequestError(message)
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
-        complete_files = []
-        for f in files:
-            file_entry: Dict[str, str] = {"id": f["file_id"], "title": f["title"]}
-            if f.get("highlight_type") is not None:
-                file_entry["highlight_type"] = f["highlight_type"]
-            complete_files.append(file_entry)
         completion = self.files_completeUploadExternal(
-            files=complete_files,
+            files=[{"id": f["file_id"], "title": f["title"], "highlight_type": f.get("highlight_type")} for f in files],
             channel_id=channel,
             channels=channels,
             initial_comment=initial_comment,
@@ -4152,7 +4146,7 @@ class WebClient(BaseClient):
     def files_completeUploadExternal(
         self,
         *,
-        files: List[Dict[str, str]],
+        files: List[Dict[str, Optional[str]]],
         channel_id: Optional[str] = None,
         channels: Optional[List[str]] = None,
         initial_comment: Optional[str] = None,

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -4109,8 +4109,14 @@ class WebClient(BaseClient):
                 raise e.SlackRequestError(message)
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
+        complete_files = []
+        for f in files:
+            file_entry: Dict[str, str] = {"id": f["file_id"], "title": f["title"]}
+            if f.get("highlight_type") is not None:
+                file_entry["highlight_type"] = f["highlight_type"]
+            complete_files.append(file_entry)
         completion = self.files_completeUploadExternal(
-            files=[{"id": f["file_id"], "title": f["title"], "highlight_type": f.get("highlight_type")} for f in files],
+            files=complete_files,
             channel_id=channel,
             channels=channels,
             initial_comment=initial_comment,

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -378,8 +378,8 @@ def _to_v2_file_upload_item(upload_file: Dict[str, Any]) -> Dict[str, Optional[A
         "length": len(data),
         "title": title,
         "alt_txt": upload_file.get("alt_txt"),
-        "snippet_type": upload_file.get("snippet_type"),
         "highlight_type": upload_file.get("highlight_type"),
+        "snippet_type": upload_file.get("snippet_type"),
     }
 
 

--- a/slack_sdk/web/internal_utils.py
+++ b/slack_sdk/web/internal_utils.py
@@ -379,6 +379,7 @@ def _to_v2_file_upload_item(upload_file: Dict[str, Any]) -> Dict[str, Optional[A
         "title": title,
         "alt_txt": upload_file.get("alt_txt"),
         "snippet_type": upload_file.get("snippet_type"),
+        "highlight_type": upload_file.get("highlight_type"),
     }
 
 

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -4044,8 +4044,14 @@ class LegacyWebClient(LegacyBaseClient):
                 raise e.SlackRequestError(message)
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
+        complete_files = []
+        for f in files:
+            file_entry: Dict[str, str] = {"id": f["file_id"], "title": f["title"]}
+            if f.get("highlight_type") is not None:
+                file_entry["highlight_type"] = f["highlight_type"]
+            complete_files.append(file_entry)
         completion = self.files_completeUploadExternal(
-            files=[{"id": f["file_id"], "title": f["title"], "highlight_type": f.get("highlight_type")} for f in files],
+            files=complete_files,
             channel_id=channel,
             channels=channels,
             initial_comment=initial_comment,

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -4044,14 +4044,8 @@ class LegacyWebClient(LegacyBaseClient):
                 raise e.SlackRequestError(message)
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
-        complete_files = []
-        for f in files:
-            file_entry: Dict[str, str] = {"id": f["file_id"], "title": f["title"]}
-            if f.get("highlight_type") is not None:
-                file_entry["highlight_type"] = f["highlight_type"]
-            complete_files.append(file_entry)
         completion = self.files_completeUploadExternal(
-            files=complete_files,
+            files=[{"id": f["file_id"], "title": f["title"], "highlight_type": f.get("highlight_type")} for f in files],
             channel_id=channel,
             channels=channels,
             initial_comment=initial_comment,
@@ -4087,7 +4081,7 @@ class LegacyWebClient(LegacyBaseClient):
     def files_completeUploadExternal(
         self,
         *,
-        files: List[Dict[str, str]],
+        files: List[Dict[str, Optional[str]]],
         channel_id: Optional[str] = None,
         channels: Optional[List[str]] = None,
         initial_comment: Optional[str] = None,

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3962,6 +3962,7 @@ class LegacyWebClient(LegacyBaseClient):
         title: Optional[str] = None,
         alt_txt: Optional[str] = None,
         snippet_type: Optional[str] = None,
+        highlight_type: Optional[str] = None,
         # To upload multiple files at a time
         file_uploads: Optional[List[Dict[str, Any]]] = None,
         channel: Optional[str] = None,
@@ -4006,6 +4007,7 @@ class LegacyWebClient(LegacyBaseClient):
                     "title": title,
                     "alt_txt": alt_txt,
                     "snippet_type": snippet_type,
+                    "highlight_type": highlight_type,
                 }
             )
             files.append(f)
@@ -4043,7 +4045,7 @@ class LegacyWebClient(LegacyBaseClient):
 
         # step3: files.completeUploadExternal with all the sets of (file_id + title)
         completion = self.files_completeUploadExternal(
-            files=[{"id": f["file_id"], "title": f["title"]} for f in files],
+            files=[{"id": f["file_id"], "title": f["title"], "highlight_type": f.get("highlight_type")} for f in files],
             channel_id=channel,
             channels=channels,
             initial_comment=initial_comment,

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -3961,8 +3961,8 @@ class LegacyWebClient(LegacyBaseClient):
         content: Optional[Union[str, bytes]] = None,
         title: Optional[str] = None,
         alt_txt: Optional[str] = None,
-        snippet_type: Optional[str] = None,
         highlight_type: Optional[str] = None,
+        snippet_type: Optional[str] = None,
         # To upload multiple files at a time
         file_uploads: Optional[List[Dict[str, Any]]] = None,
         channel: Optional[str] = None,
@@ -4006,8 +4006,8 @@ class LegacyWebClient(LegacyBaseClient):
                     "content": content,
                     "title": title,
                     "alt_txt": alt_txt,
-                    "snippet_type": snippet_type,
                     "highlight_type": highlight_type,
+                    "snippet_type": snippet_type,
                 }
             )
             files.append(f)

--- a/tests/slack_sdk/web/test_internal_utils.py
+++ b/tests/slack_sdk/web/test_internal_utils.py
@@ -133,6 +133,13 @@ class TestInternalUtils(unittest.TestCase):
         file_io_item = _to_v2_file_upload_item({"file": file_io, "filename": "foo.txt"})
         assert file_io_item.get("filename") == "foo.txt"
 
+    def test_to_v2_file_upload_item_passes_through_highlight_type(self):
+        item = _to_v2_file_upload_item({"content": "test", "filename": "image.png", "highlight_type": "png"})
+        assert item.get("highlight_type") == "png"
+
+        item_without = _to_v2_file_upload_item({"content": "test", "filename": "image.png"})
+        assert item_without.get("highlight_type") is None
+
     def test_to_v2_file_upload_item_can_accept_file_as_path(self):
         filepath = "tests/slack_sdk/web/test_internal_utils.py"
         upload_item_str = _to_v2_file_upload_item({"file": filepath})


### PR DESCRIPTION
## Summary

This pull request adds `highlight_type` support to `files.completeUploadExternal` and the `files_upload_v2` method.

The `highlight_type` parameter allows specifying the file type hint for uploads (e.g. `png`, `jpg`, `gif`), enabling optimistic rendering before the async upload processing job completes.

📚 https://docs.slack.dev/reference/methods/files.completeUploadExternal

#### Changes

- Added `highlight_type` to `_to_v2_file_upload_item` so it passes through per-file
- Added `highlight_type` to `files_upload_v2` so it can be specified when using the high-level upload method
- Updated the completion step to pass `highlight_type` through to each file object in `files.completeUploadExternal`

#### Usage

```python
from slack_sdk import WebClient

client = WebClient(token=os.environ["SLACK_BOT_TOKEN"])

client.files_upload_v2(
    channel="C0123456789",
    file="./image.png",
    filename="image.png",
    title="Image Upload",
    highlight_type="png",
    initial_comment="Uploaded with highlight_type for optimistic rendering",
)
```

### Testing

- Verified `_to_v2_file_upload_item` passes through `highlight_type` via new unit test
- Verified `highlight_type` is stripped from the files JSON when `None` (existing `files_completeUploadExternal` logic filters `None` values)

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.