### PR TITLE
feat(web): expose public ts property on ChatStream

### DIFF
--- a/slack_sdk/web/async_chat_stream.py
+++ b/slack_sdk/web/async_chat_stream.py
@@ -86,6 +86,15 @@ class AsyncChatStream:
         self._stream_ts: Optional[str] = None
         self._buffer_size = buffer_size
 
+    @property
+    def ts(self) -> Optional[str]:
+        """The message timestamp of the stream.
+
+        Returns None until the first flush (when chat.startStream is called).
+        Can be used with chat.update as a fallback if the stream expires server-side.
+        """
+        return self._stream_ts
+
     async def append(
         self,
         *,

--- a/slack_sdk/web/chat_stream.py
+++ b/slack_sdk/web/chat_stream.py
@@ -76,6 +76,15 @@ class ChatStream:
         self._stream_ts: Optional[str] = None
         self._buffer_size = buffer_size
 
+    @property
+    def ts(self) -> Optional[str]:
+        """The message timestamp of the stream.
+
+        Returns None until the first flush (when chat.startStream is called).
+        Can be used with chat.update as a fallback if the stream expires server-side.
+        """
+        return self._stream_ts
+
     def append(
         self,
         *,

--- a/tests/slack_sdk/web/test_chat_stream.py
+++ b/tests/slack_sdk/web/test_chat_stream.py
@@ -262,6 +262,22 @@ class TestChatStream(unittest.TestCase):
             self.assertEqual(start_request.get("icon_emoji"), "abacus")
             self.assertNotIn("icon_url", start_request)
 
+    def test_ts_property_is_none_before_flush_and_set_after(self):
+        streamer = self.client.chat_stream(
+            buffer_size=5,
+            channel="C0123456789",
+            thread_ts="123.000",
+            recipient_team_id="T0123456789",
+            recipient_user_id="U0123456789",
+        )
+        self.assertIsNone(streamer.ts)
+
+        streamer.append(markdown_text="hello!")
+        self.assertEqual(streamer.ts, "123.123")
+
+        streamer.stop()
+        self.assertEqual(streamer.ts, "123.123")
+
     def test_streams_errors_when_appending_to_an_unstarted_stream(self):
         streamer = self.client.chat_stream(
             channel="C0123456789",

--- a/tests/slack_sdk_async/web/test_async_chat_stream.py
+++ b/tests/slack_sdk_async/web/test_async_chat_stream.py
@@ -245,6 +245,23 @@ class TestAsyncChatStream(unittest.TestCase):
             )
 
     @async_test
+    async def test_ts_property_is_none_before_flush_and_set_after(self):
+        streamer = await self.client.chat_stream(
+            buffer_size=5,
+            channel="C0123456789",
+            thread_ts="123.000",
+            recipient_team_id="T0123456789",
+            recipient_user_id="U0123456789",
+        )
+        self.assertIsNone(streamer.ts)
+
+        await streamer.append(markdown_text="hello!")
+        self.assertEqual(streamer.ts, "123.123")
+
+        await streamer.stop()
+        self.assertEqual(streamer.ts, "123.123")
+
+    @async_test
     async def test_streams_errors_when_appending_to_an_unstarted_stream(self):
         streamer = await self.client.chat_stream(
             channel="C0123456789",


### PR DESCRIPTION
## Summary

- Adds a public read-only `ts` property to `ChatStream` and `AsyncChatStream`, enabling users to call `chat.update` as a fallback when the server closes a stream due to undocumented timeouts.

Resolves #1859

## Background

When Slack's server-side timeout kills a stream, both `chat.appendStream` and `chat.stopStream` return `message_not_in_streaming_state`. The message still exists but is stuck as a broken pill in the UI. The only recovery path is `chat.update(ts=...)`, but `ts` was previously a private attribute (`_stream_ts`).

## Changes

- `slack_sdk/web/chat_stream.py`: Added `ts` property (read-only, returns `Optional[str]`)
- `slack_sdk/web/async_chat_stream.py`: Same (auto-generated via codegen)
- `tests/slack_sdk/web/test_chat_stream.py`: Added test verifying `ts` is `None` before flush and set after

<details> <summary> code snippet </summary>

```python
from slack_sdk import WebClient
  from slack_sdk.errors import SlackApiError

  client = WebClient(token=...)


  def send_streaming(channel, thread_ts, team_id, user_id, content_iter):
      stream = client.chat_stream(
          channel=channel,
          thread_ts=thread_ts,
          recipient_team_id=team_id,
          recipient_user_id=user_id,
      )

      full_text = ""
      stream_alive = True

      for chunk in content_iter:
          full_text += chunk

          if stream_alive:
              try:
                  stream.append(markdown_text=chunk)
              except SlackApiError as e:
                  if e.response["error"] == "message_not_in_streaming_state":
                      stream_alive = False
                  else:
                      raise

          if not stream_alive:
              client.chat_update(channel=channel, ts=stream.ts, text=full_text)

      if stream_alive:
          stream.stop()
      else:
          client.chat_update(channel=channel, ts=stream.ts, text=full_text)

```

</details>



## Test plan

- [x] Existing ChatStream tests pass
- [x] New test verifies `ts` is `None` before first flush and set after
- [ ] CI passes