### PR TITLE
Add missing `style` attribute to RichTextElementParts.Date & friends

### DIFF
--- a/docs/reference/models/blocks/block_elements.html
+++ b/docs/reference/models/blocks/block_elements.html
@@ -3392,7 +3392,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 
         @property
         def attributes(self) -&gt; Set[str]:  # type: ignore[override]
-            return super().attributes.union({&#34;timestamp&#34;, &#34;format&#34;, &#34;url&#34;, &#34;fallback&#34;})
+            return super().attributes.union({&#34;timestamp&#34;, &#34;format&#34;, &#34;url&#34;, &#34;fallback&#34;, &#34;style&#34;})
 
         def __init__(
             self,
@@ -3401,6 +3401,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
             format: str,
             url: Optional[str] = None,
             fallback: Optional[str] = None,
+            style: Optional[Union[dict, &#34;RichTextElementParts.TextStyle&#34;]] = None,
             **others: dict,
         ):
             super().__init__(type=self.type)
@@ -3409,40 +3410,45 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
             self.format = format
             self.url = url
             self.fallback = fallback
+            self.style = style
 
     class Broadcast(RichTextElement):
         type = &#34;broadcast&#34;
 
         @property
         def attributes(self) -&gt; Set[str]:  # type: ignore[override]
-            return super().attributes.union({&#34;range&#34;})
+            return super().attributes.union({&#34;range&#34;, &#34;style&#34;})
 
         def __init__(
             self,
             *,
             range: str,  # channel, here, ..
+            style: Optional[Union[dict, &#34;RichTextElementParts.TextStyle&#34;]] = None,
             **others: dict,
         ):
             super().__init__(type=self.type)
             show_unknown_key_warning(self, others)
             self.range = range
+            self.style = style
 
     class Color(RichTextElement):
         type = &#34;color&#34;
 
         @property
         def attributes(self) -&gt; Set[str]:  # type: ignore[override]
-            return super().attributes.union({&#34;value&#34;})
+            return super().attributes.union({&#34;value&#34;, &#34;style&#34;})
 
         def __init__(
             self,
             *,
             value: str,
+            style: Optional[Union[dict, &#34;RichTextElementParts.TextStyle&#34;]] = None,
             **others: dict,
         ):
             super().__init__(type=self.type)
             show_unknown_key_warning(self, others)
-            self.value = value</code></pre>
+            self.value = value
+            self.style = style</code></pre>
 </details>
 <div class="desc"></div>
 <h3>Class variables</h3>

--- a/docs/reference/models/blocks/index.html
+++ b/docs/reference/models/blocks/index.html
@@ -6410,7 +6410,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
 
         @property
         def attributes(self) -&gt; Set[str]:  # type: ignore[override]
-            return super().attributes.union({&#34;timestamp&#34;, &#34;format&#34;, &#34;url&#34;, &#34;fallback&#34;})
+            return super().attributes.union({&#34;timestamp&#34;, &#34;format&#34;, &#34;url&#34;, &#34;fallback&#34;, &#34;style&#34;})
 
         def __init__(
             self,
@@ -6419,6 +6419,7 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
             format: str,
             url: Optional[str] = None,
             fallback: Optional[str] = None,
+            style: Optional[Union[dict, &#34;RichTextElementParts.TextStyle&#34;]] = None,
             **others: dict,
         ):
             super().__init__(type=self.type)
@@ -6427,40 +6428,45 @@ def attributes(self) -&gt; Set[str]:  # type: ignore[override]
             self.format = format
             self.url = url
             self.fallback = fallback
+            self.style = style
 
     class Broadcast(RichTextElement):
         type = &#34;broadcast&#34;
 
         @property
         def attributes(self) -&gt; Set[str]:  # type: ignore[override]
-            return super().attributes.union({&#34;range&#34;})
+            return super().attributes.union({&#34;range&#34;, &#34;style&#34;})
 
         def __init__(
             self,
             *,
             range: str,  # channel, here, ..
+            style: Optional[Union[dict, &#34;RichTextElementParts.TextStyle&#34;]] = None,
             **others: dict,
         ):
             super().__init__(type=self.type)
             show_unknown_key_warning(self, others)
             self.range = range
+            self.style = style
 
     class Color(RichTextElement):
         type = &#34;color&#34;
 
         @property
         def attributes(self) -&gt; Set[str]:  # type: ignore[override]
-            return super().attributes.union({&#34;value&#34;})
+            return super().attributes.union({&#34;value&#34;, &#34;style&#34;})
 
         def __init__(
             self,
             *,
             value: str,
+            style: Optional[Union[dict, &#34;RichTextElementParts.TextStyle&#34;]] = None,
             **others: dict,
         ):
             super().__init__(type=self.type)
             show_unknown_key_warning(self, others)
-            self.value = value</code></pre>
+            self.value = value
+            self.style = style</code></pre>
 </details>
 <div class="desc"></div>
 <h3>Class variables</h3>

--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -2234,7 +2234,7 @@ class RichTextElementParts:
 
         @property
         def attributes(self) -> Set[str]:  # type: ignore[override]
-            return super().attributes.union({"timestamp", "format", "url", "fallback"})
+            return super().attributes.union({"timestamp", "format", "url", "fallback", "style"})
 
         def __init__(
             self,
@@ -2243,6 +2243,7 @@ class RichTextElementParts:
             format: str,
             url: Optional[str] = None,
             fallback: Optional[str] = None,
+            style: Optional[Union[dict, "RichTextElementParts.TextStyle"]] = None,
             **others: dict,
         ):
             super().__init__(type=self.type)
@@ -2251,37 +2252,42 @@ class RichTextElementParts:
             self.format = format
             self.url = url
             self.fallback = fallback
+            self.style = style
 
     class Broadcast(RichTextElement):
         type = "broadcast"
 
         @property
         def attributes(self) -> Set[str]:  # type: ignore[override]
-            return super().attributes.union({"range"})
+            return super().attributes.union({"range", "style"})
 
         def __init__(
             self,
             *,
             range: str,  # channel, here, ..
+            style: Optional[Union[dict, "RichTextElementParts.TextStyle"]] = None,
             **others: dict,
         ):
             super().__init__(type=self.type)
             show_unknown_key_warning(self, others)
             self.range = range
+            self.style = style
 
     class Color(RichTextElement):
         type = "color"
 
         @property
         def attributes(self) -> Set[str]:  # type: ignore[override]
-            return super().attributes.union({"value"})
+            return super().attributes.union({"value", "style"})
 
         def __init__(
             self,
             *,
             value: str,
+            style: Optional[Union[dict, "RichTextElementParts.TextStyle"]] = None,
             **others: dict,
         ):
             super().__init__(type=self.type)
             show_unknown_key_warning(self, others)
             self.value = value
+            self.style = style


### PR DESCRIPTION
## Summary

I noticed that the `style` attribute was missing when I tried to make a date bold.
<!-- Describe the goal of this PR. Mention any related issue numbers -->


### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [x] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
