### PR TITLE
fix(signature): validate signing_secret is a non-empty string

### DIFF
--- a/slack_sdk/signature/__init__.py
+++ b/slack_sdk/signature/__init__.py
@@ -29,6 +29,18 @@ class SignatureVerifier:
         self.signing_secret = signing_secret
         self.clock = clock
 
+    @property
+    def signing_secret(self) -> str:
+        return self._signing_secret
+
+    @signing_secret.setter
+    def signing_secret(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise ValueError("signing_secret must be a string")
+        if not value.strip():
+            raise ValueError("signing_secret must not be empty.")
+        self._signing_secret = value
+
     def is_valid_request(
         self,
         body: Union[str, bytes],

--- a/tests/signature/test_signature_verifier.py
+++ b/tests/signature/test_signature_verifier.py
@@ -97,3 +97,23 @@ class TestSignatureVerifier(unittest.TestCase):
         self.assertFalse(verifier.is_valid(None, self.timestamp, None))
         self.assertFalse(verifier.is_valid(self.body, None, None))
         self.assertFalse(verifier.is_valid(None, None, None))
+
+    def test_invalid_signing_secret(self):
+        with self.assertRaises(ValueError):
+            SignatureVerifier("")
+        with self.assertRaises(ValueError):
+            SignatureVerifier("   ")
+        with self.assertRaises(ValueError):
+            SignatureVerifier(None)
+        with self.assertRaises(ValueError):
+            SignatureVerifier(123)
+        with self.assertRaises(ValueError):
+            SignatureVerifier(b"secret")
+
+    def test_invalid_signing_secret_reassignment(self):
+        verifier = SignatureVerifier(self.signing_secret)
+        with self.assertRaises(ValueError):
+            verifier.signing_secret = ""
+        with self.assertRaises(ValueError):
+            verifier.signing_secret = None
+        self.assertEqual(verifier.signing_secret, self.signing_secret)

--- a/tests/slack_sdk/signature/test_signature_verifier.py
+++ b/tests/slack_sdk/signature/test_signature_verifier.py
@@ -97,3 +97,23 @@ class TestSignatureVerifier(unittest.TestCase):
         self.assertFalse(verifier.is_valid(None, self.timestamp, None))
         self.assertFalse(verifier.is_valid(self.body, None, None))
         self.assertFalse(verifier.is_valid(None, None, None))
+
+    def test_invalid_signing_secret(self):
+        with self.assertRaises(ValueError):
+            SignatureVerifier("")
+        with self.assertRaises(ValueError):
+            SignatureVerifier("   ")
+        with self.assertRaises(ValueError):
+            SignatureVerifier(None)
+        with self.assertRaises(ValueError):
+            SignatureVerifier(123)
+        with self.assertRaises(ValueError):
+            SignatureVerifier(b"secret")
+
+    def test_invalid_signing_secret_reassignment(self):
+        verifier = SignatureVerifier(self.signing_secret)
+        with self.assertRaises(ValueError):
+            verifier.signing_secret = ""
+        with self.assertRaises(ValueError):
+            verifier.signing_secret = None
+        self.assertEqual(verifier.signing_secret, self.signing_secret)


### PR DESCRIPTION
## Summary

Adds input validation to `SignatureVerifier.signing_secret` to fail fast with a clear error when an empty or non-string value is provided. Previously, passing `""`, `None`, or a non-string type would silently produce incorrect HMAC signatures, making debugging difficult for users who misconfigured their app.

- Introduces a property getter/setter on `signing_secret` that raises
  `ValueError` for non-string or blank values
- Validation applies both at construction time and on reassignment

Note: this is a similar fix as https://github.com/slackapi/bolt-js/pull/2946

### Testing

CI tests should be sufficient 

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [x] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
