### PR TITLE
docs: removing external links for unified nav

### DIFF
--- a/docs/english/_sidebar.json
+++ b/docs/english/_sidebar.json
@@ -46,21 +46,5 @@
 		"type": "link",
 		"label": "Reference",
 		"href": "https://docs.slack.dev/tools/python-slack-sdk/reference/index.html"
-	},
-	{ "type": "html", "value": "<hr>" },
-	{
-		"type": "link",
-		"label": "Release notes",
-		"href": "https://github.com/slackapi/python-slack-sdk/releases"
-	},
-	{
-		"type": "link",
-		"label": "Code on GitHub",
-		"href": "https://github.com/SlackAPI/python-slack-sdk"
-	},
-	{
-		"type": "link",
-		"label": "Contributors Guide",
-		"href": "https://github.com/SlackAPI/python-slack-sdk/blob/main/.github/contributing.md"
 	}
 ]

--- a/docs/english/index.md
+++ b/docs/english/index.md
@@ -29,12 +29,12 @@ If you get stuck, we're here to help. The following are the best ways to get ass
 * [Issue Tracker](http://github.com/slackapi/python-slack-sdk/issues) for questions, bug reports, feature requests, and general discussion related to the Python Slack SDK. Try searching for an existing issue before creating a new one.
 * [Email](mailto:support@slack.com) our developer support team: `support@slack.com`.
 
+## Release notes
+
+Check out the [Python Slack SDK release notes](https://github.com/slackapi/python-slack-sdk/releases) for all the latest happenings.
+
 ## Contributing {/* #contributing */}
 
 These docs live within the [Python Slack SDK](https://github.com/slackapi/python-slack-sdk) repository and are open source.
 
 We welcome contributions from everyone! Please check out our [Contributor's Guide](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) for how to contribute in a helpful and collaborative way.
-
-## Release notes
-
-Check out the [Python Slack SDK release notes](https://github.com/slackapi/python-slack-sdk/releases) for all the latest happenings.

--- a/docs/english/index.md
+++ b/docs/english/index.md
@@ -34,3 +34,7 @@ If you get stuck, we're here to help. The following are the best ways to get ass
 These docs live within the [Python Slack SDK](https://github.com/slackapi/python-slack-sdk) repository and are open source.
 
 We welcome contributions from everyone! Please check out our [Contributor's Guide](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) for how to contribute in a helpful and collaborative way.
+
+## Release notes
+
+Check out the [Python Slack SDK release notes](https://github.com/slackapi/python-slack-sdk/releases) for all the latest happenings.


### PR DESCRIPTION
## Summary

I'm working on uniting the nav bar for all of the tools so that you don't lose the context of the rest of the nav when you click on one of the tools. In this PR, I'm removing the external links (release notes, github repo, contributor's guide) to cut down on bloat in the nav menu when they are all united. Since the github repo and contributor's guide are already mentioned in the landing page, I just added the release notes link to that.

Preview for one nav here: https://docs-slack-d-unified-na-idfrpr.herokuapp.com/tools
PR for unified nav here: https://github.com/slackapi/docs/pull/605

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
