### PR TITLE
docs: fixing broken links to security concepts

### DIFF
--- a/docs/english/installation.md
+++ b/docs/english/installation.md
@@ -69,7 +69,7 @@ import os
 SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
 ```
 
-Refer to our [best practices for security](/security) page for more information.
+Refer to our [best practices for security](/concepts/security) page for more information.
 
 ## Installing on a single workspace {/* #single-workspace */}
 

--- a/docs/english/legacy/auth.md
+++ b/docs/english/legacy/auth.md
@@ -31,7 +31,7 @@ import os
 SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
 ```
 
-Refer to our [best practices for security](/security) page for more information.
+Refer to our [best practices for security](/concepts/security) page for more information.
 
 ## Installing on a single workspace {/* #single-workspace */}
 


### PR DESCRIPTION
## Summary

Fixing a link I broke a while ago. These do redirect, but it's cleaner (and eliminates warnings in our docs repo build) to fix them.

### Testing

<!-- Describe what steps a reviewer should follow to test your changes. -->

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [x] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [ ] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
