### PR TITLE
feat: make thread_ts optional for assistant.threads.setSuggestedPrompts

### DIFF
--- a/slack_sdk/web/async_client.py
+++ b/slack_sdk/web/async_client.py
@@ -2131,7 +2131,7 @@ class AsyncWebClient(AsyncBaseClient):
         self,
         *,
         channel_id: str,
-        thread_ts: str,
+        thread_ts: Optional[str] = None,
         title: Optional[str] = None,
         prompts: List[Dict[str, str]],
         **kwargs,
@@ -2139,7 +2139,9 @@ class AsyncWebClient(AsyncBaseClient):
         """Set suggested prompts for the given assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         """
-        kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "prompts": prompts})
+        kwargs.update({"channel_id": channel_id, "prompts": prompts})
+        if thread_ts is not None:
+            kwargs.update({"thread_ts": thread_ts})
         if title is not None:
             kwargs.update({"title": title})
         return await self.api_call("assistant.threads.setSuggestedPrompts", json=kwargs)

--- a/slack_sdk/web/client.py
+++ b/slack_sdk/web/client.py
@@ -2121,7 +2121,7 @@ class WebClient(BaseClient):
         self,
         *,
         channel_id: str,
-        thread_ts: str,
+        thread_ts: Optional[str] = None,
         title: Optional[str] = None,
         prompts: List[Dict[str, str]],
         **kwargs,
@@ -2129,7 +2129,9 @@ class WebClient(BaseClient):
         """Set suggested prompts for the given assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         """
-        kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "prompts": prompts})
+        kwargs.update({"channel_id": channel_id, "prompts": prompts})
+        if thread_ts is not None:
+            kwargs.update({"thread_ts": thread_ts})
         if title is not None:
             kwargs.update({"title": title})
         return self.api_call("assistant.threads.setSuggestedPrompts", json=kwargs)

--- a/slack_sdk/web/legacy_client.py
+++ b/slack_sdk/web/legacy_client.py
@@ -2132,7 +2132,7 @@ class LegacyWebClient(LegacyBaseClient):
         self,
         *,
         channel_id: str,
-        thread_ts: str,
+        thread_ts: Optional[str] = None,
         title: Optional[str] = None,
         prompts: List[Dict[str, str]],
         **kwargs,
@@ -2140,7 +2140,9 @@ class LegacyWebClient(LegacyBaseClient):
         """Set suggested prompts for the given assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         """
-        kwargs.update({"channel_id": channel_id, "thread_ts": thread_ts, "prompts": prompts})
+        kwargs.update({"channel_id": channel_id, "prompts": prompts})
+        if thread_ts is not None:
+            kwargs.update({"thread_ts": thread_ts})
         if title is not None:
             kwargs.update({"title": title})
         return self.api_call("assistant.threads.setSuggestedPrompts", json=kwargs)


### PR DESCRIPTION
## Summary

This pull request makes the `thread_ts` argument of `assistant.threads.setSuggestedPrompts` optional.

### Testing

Confirm this no longer raises for a missing `thread_ts`:

```python
app.client.assistant_threads_setSuggestedPrompts(
    channel_id="C0123456789",
    prompts=[],
)
```

### Category

- [x] **slack_sdk.web.WebClient (sync/async)** (Web API client)

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.