### PR TITLE
chore(release): version 3.43.0

### DIFF
--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -2255,7 +2255,7 @@ and message responses using response_url in payloads.</p></div>
         self,
         *,
         channel_id: str,
-        thread_ts: str,
+        thread_ts: Optional[str] = None,
         title: Optional[str] = None,
         prompts: List[Dict[str, str]],
         **kwargs,
@@ -2263,7 +2263,9 @@ and message responses using response_url in payloads.</p></div>
         &#34;&#34;&#34;Set suggested prompts for the given assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         &#34;&#34;&#34;
-        kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
+        kwargs.update({&#34;channel_id&#34;: channel_id, &#34;prompts&#34;: prompts})
+        if thread_ts is not None:
+            kwargs.update({&#34;thread_ts&#34;: thread_ts})
         if title is not None:
             kwargs.update({&#34;title&#34;: title})
         return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)
@@ -9417,7 +9419,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/assistant.threads.setStatus">https://docs.slack.dev/reference/methods/assistant.threads.setStatus</a></p></div>
 </dd>
 <dt id="slack_sdk.WebClient.assistant_threads_setSuggestedPrompts"><code class="name flex">
-<span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str | None = None,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="web/slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9428,7 +9430,7 @@ Each authorization represents an app installation that the event is visible to.
     self,
     *,
     channel_id: str,
-    thread_ts: str,
+    thread_ts: Optional[str] = None,
     title: Optional[str] = None,
     prompts: List[Dict[str, str]],
     **kwargs,
@@ -9436,7 +9438,9 @@ Each authorization represents an app installation that the event is visible to.
     &#34;&#34;&#34;Set suggested prompts for the given assistant thread.
     https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
     &#34;&#34;&#34;
-    kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
+    kwargs.update({&#34;channel_id&#34;: channel_id, &#34;prompts&#34;: prompts})
+    if thread_ts is not None:
+        kwargs.update({&#34;thread_ts&#34;: thread_ts})
     if title is not None:
         kwargs.update({&#34;title&#34;: title})
     return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)</code></pre>

--- a/docs/reference/signature/index.html
+++ b/docs/reference/signature/index.html
@@ -98,6 +98,18 @@ el.replaceWith(d);
         self.signing_secret = signing_secret
         self.clock = clock
 
+    @property
+    def signing_secret(self) -&gt; str:
+        return self._signing_secret
+
+    @signing_secret.setter
+    def signing_secret(self, value: str) -&gt; None:
+        if not isinstance(value, str):
+            raise ValueError(&#34;signing_secret must be a string&#34;)
+        if not value.strip():
+            raise ValueError(&#34;signing_secret must not be empty.&#34;)
+        self._signing_secret = value
+
     def is_valid_request(
         self,
         body: Union[str, bytes],
@@ -151,6 +163,21 @@ el.replaceWith(d);
 With the help of signing secrets, your app can more confidently verify
 whether requests from us are authentic.
 <a href="https://docs.slack.dev/authentication/verifying-requests-from-slack/">https://docs.slack.dev/authentication/verifying-requests-from-slack/</a></p></div>
+<h3>Instance variables</h3>
+<dl>
+<dt id="slack_sdk.signature.SignatureVerifier.signing_secret"><code class="name">prop <span class="ident">signing_secret</span> : str</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def signing_secret(self) -&gt; str:
+    return self._signing_secret</code></pre>
+</details>
+<div class="desc"></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="slack_sdk.signature.SignatureVerifier.generate_signature"><code class="name flex">
@@ -260,6 +287,7 @@ whether requests from us are authentic.
 <li><code><a title="slack_sdk.signature.SignatureVerifier.generate_signature" href="#slack_sdk.signature.SignatureVerifier.generate_signature">generate_signature</a></code></li>
 <li><code><a title="slack_sdk.signature.SignatureVerifier.is_valid" href="#slack_sdk.signature.SignatureVerifier.is_valid">is_valid</a></code></li>
 <li><code><a title="slack_sdk.signature.SignatureVerifier.is_valid_request" href="#slack_sdk.signature.SignatureVerifier.is_valid_request">is_valid_request</a></code></li>
+<li><code><a title="slack_sdk.signature.SignatureVerifier.signing_secret" href="#slack_sdk.signature.SignatureVerifier.signing_secret">signing_secret</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/reference/web/async_chat_stream.html
+++ b/docs/reference/web/async_chat_stream.html
@@ -119,6 +119,15 @@ el.replaceWith(d);
         self._stream_ts: Optional[str] = None
         self._buffer_size = buffer_size
 
+    @property
+    def ts(self) -&gt; Optional[str]:
+        &#34;&#34;&#34;The message timestamp of the stream.
+
+        Returns None until the first flush (when chat.startStream is called).
+        Can be used with chat.update as a fallback if the stream expires server-side.
+        &#34;&#34;&#34;
+        return self._stream_ts
+
     async def append(
         self,
         *,
@@ -309,6 +318,28 @@ decreases the number of method calls made for the same amount of text, which is 
 <dt><strong><code>**kwargs</code></strong></dt>
 <dd>Additional arguments passed to the underlying API calls.</dd>
 </dl></div>
+<h3>Instance variables</h3>
+<dl>
+<dt id="slack_sdk.web.async_chat_stream.AsyncChatStream.ts"><code class="name">prop <span class="ident">ts</span> : str | None</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def ts(self) -&gt; Optional[str]:
+    &#34;&#34;&#34;The message timestamp of the stream.
+
+    Returns None until the first flush (when chat.startStream is called).
+    Can be used with chat.update as a fallback if the stream expires server-side.
+    &#34;&#34;&#34;
+    return self._stream_ts</code></pre>
+</details>
+<div class="desc"><p>The message timestamp of the stream.</p>
+<p>Returns None until the first flush (when chat.startStream is called).
+Can be used with chat.update as a fallback if the stream expires server-side.</p></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="slack_sdk.web.async_chat_stream.AsyncChatStream.append"><code class="name flex">
@@ -543,6 +574,7 @@ streamer.stop()
 <ul class="">
 <li><code><a title="slack_sdk.web.async_chat_stream.AsyncChatStream.append" href="#slack_sdk.web.async_chat_stream.AsyncChatStream.append">append</a></code></li>
 <li><code><a title="slack_sdk.web.async_chat_stream.AsyncChatStream.stop" href="#slack_sdk.web.async_chat_stream.AsyncChatStream.stop">stop</a></code></li>
+<li><code><a title="slack_sdk.web.async_chat_stream.AsyncChatStream.ts" href="#slack_sdk.web.async_chat_stream.AsyncChatStream.ts">ts</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/reference/web/async_client.html
+++ b/docs/reference/web/async_client.html
@@ -2151,7 +2151,7 @@ el.replaceWith(d);
         self,
         *,
         channel_id: str,
-        thread_ts: str,
+        thread_ts: Optional[str] = None,
         title: Optional[str] = None,
         prompts: List[Dict[str, str]],
         **kwargs,
@@ -2159,7 +2159,9 @@ el.replaceWith(d);
         &#34;&#34;&#34;Set suggested prompts for the given assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         &#34;&#34;&#34;
-        kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
+        kwargs.update({&#34;channel_id&#34;: channel_id, &#34;prompts&#34;: prompts})
+        if thread_ts is not None:
+            kwargs.update({&#34;thread_ts&#34;: thread_ts})
         if title is not None:
             kwargs.update({&#34;title&#34;: title})
         return await self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)
@@ -9313,7 +9315,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/assistant.threads.setStatus">https://docs.slack.dev/reference/methods/assistant.threads.setStatus</a></p></div>
 </dd>
 <dt id="slack_sdk.web.async_client.AsyncWebClient.assistant_threads_setSuggestedPrompts"><code class="name flex">
-<span>async def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
+<span>async def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str | None = None,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.async_slack_response.AsyncSlackResponse" href="async_slack_response.html#slack_sdk.web.async_slack_response.AsyncSlackResponse">AsyncSlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9324,7 +9326,7 @@ Each authorization represents an app installation that the event is visible to.
     self,
     *,
     channel_id: str,
-    thread_ts: str,
+    thread_ts: Optional[str] = None,
     title: Optional[str] = None,
     prompts: List[Dict[str, str]],
     **kwargs,
@@ -9332,7 +9334,9 @@ Each authorization represents an app installation that the event is visible to.
     &#34;&#34;&#34;Set suggested prompts for the given assistant thread.
     https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
     &#34;&#34;&#34;
-    kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
+    kwargs.update({&#34;channel_id&#34;: channel_id, &#34;prompts&#34;: prompts})
+    if thread_ts is not None:
+        kwargs.update({&#34;thread_ts&#34;: thread_ts})
     if title is not None:
         kwargs.update({&#34;title&#34;: title})
     return await self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)</code></pre>

--- a/docs/reference/web/chat_stream.html
+++ b/docs/reference/web/chat_stream.html
@@ -119,6 +119,15 @@ el.replaceWith(d);
         self._stream_ts: Optional[str] = None
         self._buffer_size = buffer_size
 
+    @property
+    def ts(self) -&gt; Optional[str]:
+        &#34;&#34;&#34;The message timestamp of the stream.
+
+        Returns None until the first flush (when chat.startStream is called).
+        Can be used with chat.update as a fallback if the stream expires server-side.
+        &#34;&#34;&#34;
+        return self._stream_ts
+
     def append(
         self,
         *,
@@ -309,6 +318,28 @@ decreases the number of method calls made for the same amount of text, which is 
 <dt><strong><code>**kwargs</code></strong></dt>
 <dd>Additional arguments passed to the underlying API calls.</dd>
 </dl></div>
+<h3>Instance variables</h3>
+<dl>
+<dt id="slack_sdk.web.chat_stream.ChatStream.ts"><code class="name">prop <span class="ident">ts</span> : str | None</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def ts(self) -&gt; Optional[str]:
+    &#34;&#34;&#34;The message timestamp of the stream.
+
+    Returns None until the first flush (when chat.startStream is called).
+    Can be used with chat.update as a fallback if the stream expires server-side.
+    &#34;&#34;&#34;
+    return self._stream_ts</code></pre>
+</details>
+<div class="desc"><p>The message timestamp of the stream.</p>
+<p>Returns None until the first flush (when chat.startStream is called).
+Can be used with chat.update as a fallback if the stream expires server-side.</p></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="slack_sdk.web.chat_stream.ChatStream.append"><code class="name flex">
@@ -543,6 +574,7 @@ streamer.stop()
 <ul class="">
 <li><code><a title="slack_sdk.web.chat_stream.ChatStream.append" href="#slack_sdk.web.chat_stream.ChatStream.append">append</a></code></li>
 <li><code><a title="slack_sdk.web.chat_stream.ChatStream.stop" href="#slack_sdk.web.chat_stream.ChatStream.stop">stop</a></code></li>
+<li><code><a title="slack_sdk.web.chat_stream.ChatStream.ts" href="#slack_sdk.web.chat_stream.ChatStream.ts">ts</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/reference/web/client.html
+++ b/docs/reference/web/client.html
@@ -2151,7 +2151,7 @@ el.replaceWith(d);
         self,
         *,
         channel_id: str,
-        thread_ts: str,
+        thread_ts: Optional[str] = None,
         title: Optional[str] = None,
         prompts: List[Dict[str, str]],
         **kwargs,
@@ -2159,7 +2159,9 @@ el.replaceWith(d);
         &#34;&#34;&#34;Set suggested prompts for the given assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         &#34;&#34;&#34;
-        kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
+        kwargs.update({&#34;channel_id&#34;: channel_id, &#34;prompts&#34;: prompts})
+        if thread_ts is not None:
+            kwargs.update({&#34;thread_ts&#34;: thread_ts})
         if title is not None:
             kwargs.update({&#34;title&#34;: title})
         return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)
@@ -9313,7 +9315,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/assistant.threads.setStatus">https://docs.slack.dev/reference/methods/assistant.threads.setStatus</a></p></div>
 </dd>
 <dt id="slack_sdk.web.client.WebClient.assistant_threads_setSuggestedPrompts"><code class="name flex">
-<span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str | None = None,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9324,7 +9326,7 @@ Each authorization represents an app installation that the event is visible to.
     self,
     *,
     channel_id: str,
-    thread_ts: str,
+    thread_ts: Optional[str] = None,
     title: Optional[str] = None,
     prompts: List[Dict[str, str]],
     **kwargs,
@@ -9332,7 +9334,9 @@ Each authorization represents an app installation that the event is visible to.
     &#34;&#34;&#34;Set suggested prompts for the given assistant thread.
     https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
     &#34;&#34;&#34;
-    kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
+    kwargs.update({&#34;channel_id&#34;: channel_id, &#34;prompts&#34;: prompts})
+    if thread_ts is not None:
+        kwargs.update({&#34;thread_ts&#34;: thread_ts})
     if title is not None:
         kwargs.update({&#34;title&#34;: title})
     return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)</code></pre>

--- a/docs/reference/web/index.html
+++ b/docs/reference/web/index.html
@@ -2518,7 +2518,7 @@ This method returns it's own object. e.g. 'self'</p>
         self,
         *,
         channel_id: str,
-        thread_ts: str,
+        thread_ts: Optional[str] = None,
         title: Optional[str] = None,
         prompts: List[Dict[str, str]],
         **kwargs,
@@ -2526,7 +2526,9 @@ This method returns it's own object. e.g. 'self'</p>
         &#34;&#34;&#34;Set suggested prompts for the given assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         &#34;&#34;&#34;
-        kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
+        kwargs.update({&#34;channel_id&#34;: channel_id, &#34;prompts&#34;: prompts})
+        if thread_ts is not None:
+            kwargs.update({&#34;thread_ts&#34;: thread_ts})
         if title is not None:
             kwargs.update({&#34;title&#34;: title})
         return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)
@@ -9680,7 +9682,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/assistant.threads.setStatus">https://docs.slack.dev/reference/methods/assistant.threads.setStatus</a></p></div>
 </dd>
 <dt id="slack_sdk.web.WebClient.assistant_threads_setSuggestedPrompts"><code class="name flex">
-<span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
+<span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str | None = None,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> <a title="slack_sdk.web.slack_response.SlackResponse" href="slack_response.html#slack_sdk.web.slack_response.SlackResponse">SlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9691,7 +9693,7 @@ Each authorization represents an app installation that the event is visible to.
     self,
     *,
     channel_id: str,
-    thread_ts: str,
+    thread_ts: Optional[str] = None,
     title: Optional[str] = None,
     prompts: List[Dict[str, str]],
     **kwargs,
@@ -9699,7 +9701,9 @@ Each authorization represents an app installation that the event is visible to.
     &#34;&#34;&#34;Set suggested prompts for the given assistant thread.
     https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
     &#34;&#34;&#34;
-    kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
+    kwargs.update({&#34;channel_id&#34;: channel_id, &#34;prompts&#34;: prompts})
+    if thread_ts is not None:
+        kwargs.update({&#34;thread_ts&#34;: thread_ts})
     if title is not None:
         kwargs.update({&#34;title&#34;: title})
     return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)</code></pre>

--- a/docs/reference/web/legacy_client.html
+++ b/docs/reference/web/legacy_client.html
@@ -2150,7 +2150,7 @@ el.replaceWith(d);
         self,
         *,
         channel_id: str,
-        thread_ts: str,
+        thread_ts: Optional[str] = None,
         title: Optional[str] = None,
         prompts: List[Dict[str, str]],
         **kwargs,
@@ -2158,7 +2158,9 @@ el.replaceWith(d);
         &#34;&#34;&#34;Set suggested prompts for the given assistant thread.
         https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
         &#34;&#34;&#34;
-        kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
+        kwargs.update({&#34;channel_id&#34;: channel_id, &#34;prompts&#34;: prompts})
+        if thread_ts is not None:
+            kwargs.update({&#34;thread_ts&#34;: thread_ts})
         if title is not None:
             kwargs.update({&#34;title&#34;: title})
         return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)
@@ -9236,7 +9238,7 @@ Each authorization represents an app installation that the event is visible to.
 <a href="https://docs.slack.dev/reference/methods/assistant.threads.setStatus">https://docs.slack.dev/reference/methods/assistant.threads.setStatus</a></p></div>
 </dd>
 <dt id="slack_sdk.web.legacy_client.LegacyWebClient.assistant_threads_setSuggestedPrompts"><code class="name flex">
-<span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
+<span>def <span class="ident">assistant_threads_setSuggestedPrompts</span></span>(<span>self,<br>*,<br>channel_id: str,<br>thread_ts: str | None = None,<br>title: str | None = None,<br>prompts: List[Dict[str, str]],<br>**kwargs) ‑> _asyncio.Future | <a title="slack_sdk.web.legacy_slack_response.LegacySlackResponse" href="legacy_slack_response.html#slack_sdk.web.legacy_slack_response.LegacySlackResponse">LegacySlackResponse</a></span>
 </code></dt>
 <dd>
 <details class="source">
@@ -9247,7 +9249,7 @@ Each authorization represents an app installation that the event is visible to.
     self,
     *,
     channel_id: str,
-    thread_ts: str,
+    thread_ts: Optional[str] = None,
     title: Optional[str] = None,
     prompts: List[Dict[str, str]],
     **kwargs,
@@ -9255,7 +9257,9 @@ Each authorization represents an app installation that the event is visible to.
     &#34;&#34;&#34;Set suggested prompts for the given assistant thread.
     https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts
     &#34;&#34;&#34;
-    kwargs.update({&#34;channel_id&#34;: channel_id, &#34;thread_ts&#34;: thread_ts, &#34;prompts&#34;: prompts})
+    kwargs.update({&#34;channel_id&#34;: channel_id, &#34;prompts&#34;: prompts})
+    if thread_ts is not None:
+        kwargs.update({&#34;thread_ts&#34;: thread_ts})
     if title is not None:
         kwargs.update({&#34;title&#34;: title})
     return self.api_call(&#34;assistant.threads.setSuggestedPrompts&#34;, json=kwargs)</code></pre>

--- a/slack_sdk/version.py
+++ b/slack_sdk/version.py
@@ -1,3 +1,3 @@
 """Check the latest version at https://pypi.org/project/slack-sdk/"""
 
-__version__ = "3.42.0"
+__version__ = "3.43.0"


### PR DESCRIPTION
## Summary

This PR releases the latest changes of `main` as 3.43.0 🚀 🔮 ✨ 

### Testing

CI

### Category <!-- place an `x` in each of the `[ ]`  -->

- [x] Release

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
