### PR TITLE
fix: resolve flaky sqlite3 installation store bot token lookup (#1441)

### DIFF
--- a/slack_sdk/oauth/installation_store/sqlite3/__init__.py
+++ b/slack_sdk/oauth/installation_store/sqlite3/__init__.py
@@ -486,7 +486,10 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                         installed_at=row[23],
                     )
 
-                    if user_id is not None:
+                    has_user_installation = user_id is not None and installation is not None
+                    no_bot_token_installation = installation is not None and installation.bot_token is None
+                    should_find_bot_installation = has_user_installation or no_bot_token_installation
+                    if should_find_bot_installation:
                         # Retrieve the latest bot token, just in case
                         # See also: https://github.com/slackapi/bolt-python/issues/664
                         cur = conn.execute(
@@ -514,12 +517,13 @@ class SQLite3InstallationStore(InstallationStore, AsyncInstallationStore):
                             [self.client_id, enterprise_id or "", team_id],
                         )
                         row = cur.fetchone()
-                        installation.bot_token = row[0]
-                        installation.bot_id = row[1]
-                        installation.bot_user_id = row[2]
-                        installation.bot_scopes = row[3]
-                        installation.bot_refresh_token = row[4]
-                        installation.bot_token_expires_at = row[5]
+                        if row is not None:
+                            installation.bot_token = row[0]
+                            installation.bot_id = row[1]
+                            installation.bot_user_id = row[2]
+                            installation.bot_scopes = row[3]
+                            installation.bot_refresh_token = row[4]
+                            installation.bot_token_expires_at = row[5]
 
                     return installation
                 return None


### PR DESCRIPTION
## Summary

Fixes intermittent CI failures in `tests/slack_sdk/oauth/installation_store/test_sqlite3.py::TestSQLite3::test_issue_1441_mixing_user_and_bot_installations`.

The failure surfaces at the final assertion (`find_installation` called with `user_id=None`):

```python
installation = store.find_installation(enterprise_id="E111", team_id="T111")
self.assertIsNotNone(installation.bot_token)   # AssertionError: unexpectedly None
```

## Root cause

This is a real store inconsistency, not just a test-timing issue.

The test:
1. saves a bot installation (`bot_token="xoxb-111"`) 
2. a user-only installation (`bot_token=None`) for the same team.
3. Both rows land in `slack_installations` within the same second, and the schema uses `installed_at datetime not null default current_timestamp`
    - SQLite's `current_timestamp` has **1-second resolution**, so the two rows usually share an identical `installed_at`.
4. The `user_id=None` branch of `find_installation` runs `... order by installed_at desc limit 1` with no bot-token fallback.
5. On the `installed_at` tie, SQLite may return the user-only row, whose `bot_token` is `None`, and the assertion fails.

The SQLite3 store was the **only** OAuth backend missing this fallback.
- The `file`, `amazon_s3` and `sqlalchemy` stores all got a `should_find_bot_installation` condition in #1442 (fixing #1441), which re-fetches the latest bot token even when `user_id` is absent.
- The async SQLAlchemy store got the same logic in #1633.
- The SQLite3 `user_id=None` path was never brought in line, so its otherwise byte-for-byte-identical `issue_1441` test is the only one that flakes.

## Related

- Issue #1441 / PR #1442 : added the `no_bot_token_installation` fallback to the `file`, `amazon_s3`, and `sqlalchemy` stores (but not `sqlite3`).
- PR #1633 : added the same fallback to the async SQLAlchemy store.