### PR TITLE
ci: do not fail CI when Codecov test-results upload errors

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -98,7 +98,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           directory: ./reports/
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: ${{ matrix.python-version }}
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

The `unittest` job's **Upload test results to Codecov** step currently sets `fail_ci_if_error: true`, so a transient Codecov outage or upload hiccup fails the whole CI pipeline even when every test passed.

Uploading test results to Codecov is a best-effort reporting side-channel, not a gate on code correctness. This PR flips that step to `fail_ci_if_error: false` — a "send and forget" upload — so a third-party upload failure no longer reddens an otherwise green build.

Scope is intentionally limited to the test-results upload. The separate coverage upload step (`report_type: coverage`) is left unchanged.

This mirrors slackapi/bolt-python#1552.

### Testing

- `fail_ci_if_error: false` is a documented `codecov/codecov-action` input; the workflow YAML still parses.
- CI behavior is exercised by the workflow running on this PR.

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] Others (CI workflow — `.github/workflows/ci-build.yml`)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes. (CI-only change; no source code affected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)