### PR TITLE
test: fix intermittent CI hang in the unit test matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ filterwarnings = [
 	"ignore:slack.* package is deprecated. Please use slack_sdk.* package instead.*:UserWarning",
 ]
 asyncio_mode = "auto"
+timeout = 180
+timeout_method = "thread"
 
 
 [tool.mypy]

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -15,6 +15,10 @@ pytest>=9.1.1,<10; python_version >= "3.10"
 # Note: for async.
 pytest-asyncio<2
 
+# pytest-timeout
+# Note: per-test timeout so a hung test fails fast with a thread dump instead of stalling CI.
+pytest-timeout>=2.2,<3
+
 # pytest-cov
 # Note: pytest-cov 7.1+ requires Python >=3.9; cap older interpreters below it.
 pytest-cov>=4,<7.1.0; python_version < "3.9"

--- a/tests/mock_web_api_server/__init__.py
+++ b/tests/mock_web_api_server/__init__.py
@@ -16,7 +16,9 @@ def setup_mock_web_api_server(test: TestCase, handler: Type[SimpleHTTPRequestHan
     test.thread = MockServerThread(queue=test.received_requests.queue, test=test, handler=handler, port=port)
     test.thread.start()
     if not test.server_started.wait(timeout=5):
-        raise RuntimeError(f"Mock web API server failed to start on port {port} within 5s (port already in use?)")
+        raise RuntimeError(
+            f"Mock web API server failed to start on port {test.thread.port} within 5s (port already in use?)"
+        )
 
 
 def cleanup_mock_web_api_server(test: TestCase):
@@ -58,11 +60,13 @@ def setup_mock_web_api_server_async(test: TestCase, handler: Type[SimpleHTTPRequ
     test.thread = MockServerThread(queue=test.received_requests.queue, test=test, handler=handler, port=port)
     test.thread.start()
     if not test.server_started.wait(timeout=5):
-        raise RuntimeError(f"Mock web API server failed to start on port {port} within 5s (port already in use?)")
+        raise RuntimeError(
+            f"Mock web API server failed to start on port {test.thread.port} within 5s (port already in use?)"
+        )
 
 
 def cleanup_mock_web_api_server_async(test: TestCase):
-    test.thread.stop_unsafe()
+    test.thread.stop()
     test.thread = None
 
 

--- a/tests/mock_web_api_server/__init__.py
+++ b/tests/mock_web_api_server/__init__.py
@@ -15,7 +15,8 @@ def setup_mock_web_api_server(test: TestCase, handler: Type[SimpleHTTPRequestHan
     test.received_requests = ReceivedRequests(Queue())
     test.thread = MockServerThread(queue=test.received_requests.queue, test=test, handler=handler, port=port)
     test.thread.start()
-    test.server_started.wait()
+    if not test.server_started.wait(timeout=5):
+        raise RuntimeError(f"Mock web API server failed to start on port {port} within 5s (port already in use?)")
 
 
 def cleanup_mock_web_api_server(test: TestCase):
@@ -56,7 +57,8 @@ def setup_mock_web_api_server_async(test: TestCase, handler: Type[SimpleHTTPRequ
     test.received_requests = ReceivedRequests(asyncio.Queue())
     test.thread = MockServerThread(queue=test.received_requests.queue, test=test, handler=handler, port=port)
     test.thread.start()
-    test.server_started.wait()
+    if not test.server_started.wait(timeout=5):
+        raise RuntimeError(f"Mock web API server failed to start on port {port} within 5s (port already in use?)")
 
 
 def cleanup_mock_web_api_server_async(test: TestCase):

--- a/tests/mock_web_api_server/mock_server_thread.py
+++ b/tests/mock_web_api_server/mock_server_thread.py
@@ -1,6 +1,6 @@
 from asyncio import Queue
 import asyncio
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 import threading
 from typing import Type, Union
 from unittest import TestCase
@@ -10,14 +10,14 @@ class MockServerThread(threading.Thread):
     def __init__(
         self, queue: Union[Queue, asyncio.Queue], test: TestCase, handler: Type[SimpleHTTPRequestHandler], port: int = 8888
     ):
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, daemon=True)
         self.handler = handler
         self.test = test
         self.queue = queue
         self.port = port
 
     def run(self):
-        self.server = HTTPServer(("localhost", self.port), self.handler)
+        self.server = ThreadingHTTPServer(("localhost", self.port), self.handler)
         self.server.queue = self.queue
         self.test.server_url = f"http://localhost:{str(self.port)}"
         self.test.host, self.test.port = self.server.socket.getsockname()
@@ -33,9 +33,9 @@ class MockServerThread(threading.Thread):
         with self.server.queue.mutex:
             del self.server.queue
         self.server.shutdown()
-        self.join()
+        self.join(timeout=5)
 
     def stop_unsafe(self):
         del self.server.queue
         self.server.shutdown()
-        self.join()
+        self.join(timeout=5)

--- a/tests/mock_web_api_server/mock_server_thread.py
+++ b/tests/mock_web_api_server/mock_server_thread.py
@@ -1,14 +1,21 @@
-from asyncio import Queue
 import asyncio
-from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+import logging
 import threading
-from typing import Type, Union
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from queue import Queue
+from typing import Optional, Type, Union
 from unittest import TestCase
+
+logger = logging.getLogger(__name__)
 
 
 class MockServerThread(threading.Thread):
     def __init__(
-        self, queue: Union[Queue, asyncio.Queue], test: TestCase, handler: Type[SimpleHTTPRequestHandler], port: int = 8888
+        self,
+        test: TestCase,
+        handler: Type[SimpleHTTPRequestHandler],
+        queue: Optional[Union[Queue, asyncio.Queue]] = None,
+        port: int = 8888,
     ):
         threading.Thread.__init__(self, daemon=True)
         self.handler = handler
@@ -18,8 +25,9 @@ class MockServerThread(threading.Thread):
 
     def run(self):
         self.server = ThreadingHTTPServer(("localhost", self.port), self.handler)
-        self.server.queue = self.queue
-        self.test.server_url = f"http://localhost:{str(self.port)}"
+        if self.queue is not None:
+            self.server.queue = self.queue
+        self.test.server_url = f"http://localhost:{self.port}"
         self.test.host, self.test.port = self.server.socket.getsockname()
         self.test.server_started.set()  # threading.Event()
 
@@ -30,12 +38,9 @@ class MockServerThread(threading.Thread):
             self.server.server_close()
 
     def stop(self):
-        with self.server.queue.mutex:
+        self.server.shutdown()
+        self.join(timeout=5)
+        if self.is_alive():
+            logger.warning(f"Mock web API server thread on port {self.port} did not stop within 5s")
+        if getattr(self.server, "queue", None) is not None:
             del self.server.queue
-        self.server.shutdown()
-        self.join(timeout=5)
-
-    def stop_unsafe(self):
-        del self.server.queue
-        self.server.shutdown()
-        self.join(timeout=5)

--- a/tests/rtm/mock_web_api_server.py
+++ b/tests/rtm/mock_web_api_server.py
@@ -2,7 +2,7 @@ import json
 import logging
 import threading
 from http import HTTPStatus
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from typing import Type
 from unittest import TestCase
 
@@ -63,14 +63,16 @@ class MockHandler(SimpleHTTPRequestHandler):
 
 
 class MockServerThread(threading.Thread):
+    port = 8888
+
     def __init__(self, test: TestCase, handler: Type[SimpleHTTPRequestHandler] = MockHandler):
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, daemon=True)
         self.handler = handler
         self.test = test
 
     def run(self):
-        self.server = HTTPServer(("localhost", 8888), self.handler)
-        self.test.server_url = "http://localhost:8888"
+        self.server = ThreadingHTTPServer(("localhost", self.port), self.handler)
+        self.test.server_url = f"http://localhost:{self.port}"
         self.test.host, self.test.port = self.server.socket.getsockname()
         self.test.server_started.set()  # threading.Event()
 
@@ -82,14 +84,17 @@ class MockServerThread(threading.Thread):
 
     def stop(self):
         self.server.shutdown()
-        self.join()
+        self.join(timeout=5)
 
 
 def setup_mock_web_api_server(test: TestCase):
     test.server_started = threading.Event()
     test.thread = MockServerThread(test)
     test.thread.start()
-    test.server_started.wait()
+    if not test.server_started.wait(timeout=5):
+        raise RuntimeError(
+            f"Mock web API server failed to start on port {test.thread.port} within 5s (port already in use?)"
+        )
 
 
 def cleanup_mock_web_api_server(test: TestCase):

--- a/tests/rtm/mock_web_api_server.py
+++ b/tests/rtm/mock_web_api_server.py
@@ -2,9 +2,10 @@ import json
 import logging
 import threading
 from http import HTTPStatus
-from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
-from typing import Type
+from http.server import SimpleHTTPRequestHandler
 from unittest import TestCase
+
+from tests.mock_web_api_server.mock_server_thread import MockServerThread
 
 
 class MockHandler(SimpleHTTPRequestHandler):
@@ -62,34 +63,9 @@ class MockHandler(SimpleHTTPRequestHandler):
         self._handle()
 
 
-class MockServerThread(threading.Thread):
-    port = 8888
-
-    def __init__(self, test: TestCase, handler: Type[SimpleHTTPRequestHandler] = MockHandler):
-        threading.Thread.__init__(self, daemon=True)
-        self.handler = handler
-        self.test = test
-
-    def run(self):
-        self.server = ThreadingHTTPServer(("localhost", self.port), self.handler)
-        self.test.server_url = f"http://localhost:{self.port}"
-        self.test.host, self.test.port = self.server.socket.getsockname()
-        self.test.server_started.set()  # threading.Event()
-
-        self.test = None
-        try:
-            self.server.serve_forever(0.05)
-        finally:
-            self.server.server_close()
-
-    def stop(self):
-        self.server.shutdown()
-        self.join(timeout=5)
-
-
 def setup_mock_web_api_server(test: TestCase):
     test.server_started = threading.Event()
-    test.thread = MockServerThread(test)
+    test.thread = MockServerThread(test=test, handler=MockHandler)
     test.thread.start()
     if not test.server_started.wait(timeout=5):
         raise RuntimeError(

--- a/tests/slack_sdk/socket_mode/test_interactions_builtin.py
+++ b/tests/slack_sdk/socket_mode/test_interactions_builtin.py
@@ -112,14 +112,12 @@ class TestInteractionsBuiltin(unittest.TestCase):
 
                     self.assertEqual(len(socket_mode_envelopes), len(received_socket_mode_requests))
                 finally:
-                    pass
-                    # client.close()
+                    client.close()
                 self.logger.info(f"Passed with buffer size: {buffer_size}")
 
         finally:
             # Restore the default value
             sys.setrecursionlimit(default_recursion_limit)
-            client.close()
 
         self.logger.info(f"Passed with buffer size: {buffer_size_list}")
 

--- a/tests/slack_sdk/web/mock_web_api_handler.py
+++ b/tests/slack_sdk/web/mock_web_api_handler.py
@@ -1,14 +1,9 @@
-import asyncio
 import json
 import logging
-from queue import Queue
 import re
-import threading
 import time
 from http import HTTPStatus
-from http.server import HTTPServer, SimpleHTTPRequestHandler
-from typing import Type, Union
-from unittest import TestCase
+from http.server import SimpleHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 
 
@@ -258,37 +253,3 @@ class MockHandler(SimpleHTTPRequestHandler):
 
     def do_POST(self):
         self._handle()
-
-
-class MockServerThread(threading.Thread):
-    def __init__(
-        self, queue: Union[Queue, asyncio.Queue], test: TestCase, handler: Type[SimpleHTTPRequestHandler] = MockHandler
-    ):
-        threading.Thread.__init__(self)
-        self.handler = handler
-        self.test = test
-        self.queue = queue
-
-    def run(self):
-        self.server = HTTPServer(("localhost", 8888), self.handler)
-        self.server.queue = self.queue
-        self.test.server_url = "http://localhost:8888"
-        self.test.host, self.test.port = self.server.socket.getsockname()
-        self.test.server_started.set()  # threading.Event()
-
-        self.test = None
-        try:
-            self.server.serve_forever(0.05)
-        finally:
-            self.server.server_close()
-
-    def stop(self):
-        with self.server.queue.mutex:
-            del self.server.queue
-        self.server.shutdown()
-        self.join()
-
-    def stop_unsafe(self):
-        del self.server.queue
-        self.server.shutdown()
-        self.join()

--- a/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
@@ -36,8 +36,10 @@ class TestInteractionsWebsockets(unittest.TestCase):
         start_socket_mode_server(self, 3001)
 
     def tearDown(self):
-        cleanup_mock_web_api_server_async(self)
-        stop_socket_mode_server(self)
+        try:
+            cleanup_mock_web_api_server_async(self)
+        finally:
+            stop_socket_mode_server(self)
 
     @async_test
     async def test_interactions(self):

--- a/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
@@ -17,6 +17,7 @@ from tests.slack_sdk.socket_mode.mock_socket_mode_server import (
     start_socket_mode_server,
     socket_mode_envelopes,
     socket_mode_hello_message,
+    stop_socket_mode_server,
 )
 from tests.slack_sdk.socket_mode.mock_web_api_handler import MockHandler
 from tests.mock_web_api_server import setup_mock_web_api_server_async, cleanup_mock_web_api_server_async
@@ -36,6 +37,7 @@ class TestInteractionsWebsockets(unittest.TestCase):
 
     def tearDown(self):
         cleanup_mock_web_api_server_async(self)
+        stop_socket_mode_server(self)
 
     @async_test
     async def test_interactions(self):


### PR DESCRIPTION
## Summary

Fixes an intermittent hang in the **Unit tests** CI matrix that occasionally stalled the job until the workflow-level timeout.

**Root cause:** the tests' mock web API server ran on a single-threaded `HTTPServer` with a non-daemon thread, and teardown did `del self.server.queue` *before* `server.shutdown()`. An in-flight request handler (whose first action is `queue.put_nowait(...)`) could race the teardown, and a non-daemon thread that never joined could wedge the whole run.

**Changes (test infra only):**

- Switch the mock server to `ThreadingHTTPServer` and run it on a `daemon=True` thread so a stuck worker can never block interpreter exit.
- Reorder teardown to `shutdown()` → `join(timeout=5)` → `del queue`, closing the delete-before-shutdown race (`server_close()` in the run loop's `finally` joins workers, so no handler touches the queue after the join).
- Unify `stop()`/`stop_unsafe()` into a single `stop()` that works for both the sync `queue.Queue` and async `asyncio.Queue` paths (the mutex is no longer needed), and make the queue optional so RTM can reuse the class.
- Add startup guards: `server_started.wait(timeout=5)` now raises a clear `RuntimeError` (e.g. "port already in use") instead of blocking forever.
- Log a warning when a server thread outlives the 5s join, so a re-emerging leak is visible instead of silent.
- De-duplicate: delete the near-identical `MockServerThread` copies in `tests/rtm/` and `tests/slack_sdk/web/`; both now import the canonical implementation.
- Wrap the async socket-mode websockets `tearDown` in `try/finally` so the socket-mode server is always stopped even if mock-server cleanup raises.
- Restore `client.close()` in `test_interactions_builtin.py` (was commented out).
- Add `pytest-timeout` (`timeout=180`, `timeout_method="thread"`) so a future hang fails fast with a thread dump instead of stalling CI. The `thread` method is required here because `signal` cannot interrupt hangs on non-main threads (asyncio/socket-mode).

### Testing

Reviewers can verify with:

```sh
./scripts/run_tests.sh tests/slack_sdk/web/
./scripts/run_tests.sh tests/slack_sdk_async/web/
./scripts/run_tests.sh tests/rtm/
./scripts/run_tests.sh tests/slack_sdk/rtm_v2/
./scripts/run_tests.sh tests/slack_sdk_async/socket_mode/test_interactions_websockets.py
```

Verified locally: full suite **988 passed, 5 skipped** (4m17s) with the per-test timeout armed (no hang), `black --check` clean, and the async socket-mode test stable across 5 consecutive runs.

### Category <!-- place an `x` in each of the `[ ]`  -->

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [ ] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements <!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
