### PR TITLE
feat(blocks): add min_lines/max_lines to RichTextInputElement

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -1442,6 +1442,8 @@ class RichTextInputElement(InputInteractiveElement):
             {
                 "initial_value",
                 "dispatch_action_config",
+                "min_lines",
+                "max_lines",
             }
         )
 
@@ -1454,6 +1456,8 @@ class RichTextInputElement(InputInteractiveElement):
         initial_value: Optional[Union[Dict[str, Any], "RichTextBlock"]] = None,  # type: ignore[name-defined] # noqa: F821
         dispatch_action_config: Optional[Union[dict, DispatchActionConfig]] = None,
         focus_on_load: Optional[bool] = None,
+        min_lines: Optional[int] = None,
+        max_lines: Optional[int] = None,
         **others: dict,
     ):
         super().__init__(
@@ -1466,6 +1470,8 @@ class RichTextInputElement(InputInteractiveElement):
 
         self.initial_value = initial_value
         self.dispatch_action_config = dispatch_action_config
+        self.min_lines = min_lines
+        self.max_lines = max_lines
 
 
 # -------------------------------------------------

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -1173,6 +1173,31 @@ class RichTextInputElementTests(unittest.TestCase):
             },
         )
 
+    def test_min_lines(self):
+        input = {
+            "type": "rich_text_input",
+            "action_id": "rich_input",
+            "min_lines": 5,
+        }
+        self.assertDictEqual(input, RichTextInputElement(**input).to_dict())
+
+    def test_max_lines(self):
+        input = {
+            "type": "rich_text_input",
+            "action_id": "rich_input",
+            "max_lines": 16,
+        }
+        self.assertDictEqual(input, RichTextInputElement(**input).to_dict())
+
+    def test_min_and_max_lines(self):
+        input = {
+            "type": "rich_text_input",
+            "action_id": "rich_input",
+            "min_lines": 3,
+            "max_lines": 20,
+        }
+        self.assertDictEqual(input, RichTextInputElement(**input).to_dict())
+
 
 class PlainTextInputElementTests(unittest.TestCase):
     def test_document_1(self):


### PR DESCRIPTION
## Summary

Adds optional `min_lines` and `max_lines` integer properties to the `RichTextInputElement` Block Kit model, allowing developers to control the visible height of `rich_text_input` elements.

- `min_lines` — minimum number of visible lines (1–100)
- `max_lines` — maximum number of visible lines before scrolling (1–100, defaults to 8 on the platform when unset)

Both properties are optional, preserving full backward compatibility.

### Testing

```bash
./scripts/run_tests.sh tests/slack_sdk/models/test_elements.py
```
New test methods: `test_min_lines`, `test_max_lines`, `test_min_and_max_lines` — all verify round-trip serialization.


<details><summary>Test app.py </summary>


```python
import os
import logging

from slack_bolt import App
from slack_bolt.adapter.socket_mode import SocketModeHandler

logging.basicConfig(level=logging.DEBUG)

app = App(token=os.environ.get("SLACK_BOT_TOKEN"))


@app.command("/sample-command")
def open_rich_text_modal(ack, client, body):
    ack()
    client.views_open(
        trigger_id=body["trigger_id"],
        view={
            "type": "modal",
            "title": {"type": "plain_text", "text": "Rich Text Test"},
            "submit": {"type": "plain_text", "text": "Submit"},
            "blocks": [
                {
                    "type": "input",
                    "block_id": "rich_text_block",
                    "label": {"type": "plain_text", "text": "Default (no min/max — should be 8 max)"},
                    "element": {
                        "type": "rich_text_input",
                        "action_id": "default_input",
                    },
                },
                {
                    "type": "input",
                    "block_id": "rich_text_min_block",
                    "label": {"type": "plain_text", "text": "min_lines: 5"},
                    "element": {
                        "type": "rich_text_input",
                        "action_id": "min_input",
                        "min_lines": 5,
                    },
                },
                {
                    "type": "input",
                    "block_id": "rich_text_max_block",
                    "label": {"type": "plain_text", "text": "max_lines: 16"},
                    "element": {
                        "type": "rich_text_input",
                        "action_id": "max_input",
                        "max_lines": 16,
                    },
                },
                {
                    "type": "input",
                    "block_id": "rich_text_both_block",
                    "label": {"type": "plain_text", "text": "min_lines: 3, max_lines: 20"},
                    "element": {
                        "type": "rich_text_input",
                        "action_id": "both_input",
                        "min_lines": 3,
                        "max_lines": 20,
                    },
                },
            ],
        },
    )


if __name__ == "__main__":
    SocketModeHandler(app, os.environ.get("SLACK_APP_TOKEN")).start()
```


</details>


### Category

- [x] **slack_sdk.models** (UI component builders)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.