### PR TITLE
feat(models): add AttachmentMention rich text element

### DIFF
--- a/slack_sdk/models/blocks/block_elements.py
+++ b/slack_sdk/models/blocks/block_elements.py
@@ -2096,6 +2096,60 @@ class RichTextElementParts:
             }
             return {k: v for k, v in result.items() if v is not None}
 
+    class AttachmentMention(RichTextElement):
+        type = "attachment_mention"
+
+        @property
+        def attributes(self) -> Set[str]:  # type: ignore[override]
+            return super().attributes.union(
+                {
+                    "url",
+                    "text",
+                    "app_id",
+                    "entity_id",
+                    "icon_url",
+                    "channel_id",
+                    "ts",
+                    "full_size_preview_enabled",
+                    "icon_name",
+                    "reference_object_type",
+                    "product_name",
+                    "style",
+                }
+            )
+
+        def __init__(
+            self,
+            *,
+            url: str,
+            text: Optional[str] = None,
+            app_id: Optional[str] = None,
+            entity_id: Optional[str] = None,
+            icon_url: Optional[str] = None,
+            channel_id: Optional[str] = None,
+            ts: Optional[str] = None,
+            full_size_preview_enabled: Optional[bool] = None,
+            icon_name: Optional[str] = None,
+            reference_object_type: Optional[str] = None,
+            product_name: Optional[str] = None,
+            style: Optional[Union[dict, "RichTextElementParts.TextStyle"]] = None,
+            **others: dict,
+        ):
+            super().__init__(type=self.type)
+            show_unknown_key_warning(self, others)
+            self.url = url
+            self.text = text
+            self.app_id = app_id
+            self.entity_id = entity_id
+            self.icon_url = icon_url
+            self.channel_id = channel_id
+            self.ts = ts
+            self.full_size_preview_enabled = full_size_preview_enabled
+            self.icon_name = icon_name
+            self.reference_object_type = reference_object_type
+            self.product_name = product_name
+            self.style = style
+
     class Text(RichTextElement):
         type = "text"
 

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -91,6 +91,40 @@ class InteractiveElementTests(unittest.TestCase):
         self.assertDictEqual(input, InputInteractiveElement(**input).to_dict())
 
 
+# -------------------------------------------------
+# Rich text element parts
+# -------------------------------------------------
+
+
+class AttachmentMentionElementTests(unittest.TestCase):
+    def test_all_fields(self):
+        input = {
+            "type": "attachment_mention",
+            "url": "https://example.com/attachment",
+            "text": "Fallback text",
+            "app_id": "A0123456789",
+            "entity_id": "E0123456789",
+            "icon_url": "https://example.com/icon.png",
+            "channel_id": "C0123456789",
+            "ts": "1234567890.123456",
+            "full_size_preview_enabled": True,
+            "icon_name": "sf-account",
+            "reference_object_type": "record",
+            "product_name": "Salesforce",
+            "style": {"bold": True},
+        }
+        self.assertDictEqual(input, RichTextElementParts.AttachmentMention(**input).to_dict())
+
+    def test_document(self):
+        # Matches the docs reference example field-for-field:
+        # https://docs.slack.dev/reference/block-kit/block-elements/attachment-mention-element
+        input = {
+            "type": "attachment_mention",
+            "url": "https://example.com/attachment",
+        }
+        self.assertDictEqual(input, RichTextElementParts.AttachmentMention(**input).to_dict())
+
+
 class ButtonElementTests(unittest.TestCase):
     def test_document_1(self):
         input = {
@@ -1110,40 +1144,6 @@ class OverflowMenuElementTests(unittest.TestCase):
             "action_id": "overflow",
         }
         self.assertDictEqual(input, OverflowMenuElement(**input).to_dict())
-
-
-# -------------------------------------------------
-# Rich text element parts
-# -------------------------------------------------
-
-
-class AttachmentMentionElementTests(unittest.TestCase):
-    def test_all_fields(self):
-        input = {
-            "type": "attachment_mention",
-            "url": "https://example.com/attachment",
-            "text": "Fallback text",
-            "app_id": "A0123456789",
-            "entity_id": "E0123456789",
-            "icon_url": "https://example.com/icon.png",
-            "channel_id": "C0123456789",
-            "ts": "1234567890.123456",
-            "full_size_preview_enabled": True,
-            "icon_name": "sf-account",
-            "reference_object_type": "record",
-            "product_name": "Salesforce",
-            "style": {"bold": True},
-        }
-        self.assertDictEqual(input, RichTextElementParts.AttachmentMention(**input).to_dict())
-
-    def test_document(self):
-        # Matches the docs reference example field-for-field:
-        # https://docs.slack.dev/reference/block-kit/block-elements/attachment-mention-element
-        input = {
-            "type": "attachment_mention",
-            "url": "https://example.com/attachment",
-        }
-        self.assertDictEqual(input, RichTextElementParts.AttachmentMention(**input).to_dict())
 
 
 # -------------------------------------------------

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -91,11 +91,6 @@ class InteractiveElementTests(unittest.TestCase):
         self.assertDictEqual(input, InputInteractiveElement(**input).to_dict())
 
 
-# -------------------------------------------------
-# Rich text element parts
-# -------------------------------------------------
-
-
 class AttachmentMentionElementTests(unittest.TestCase):
     def test_all_fields(self):
         input = {

--- a/tests/slack_sdk/models/test_elements.py
+++ b/tests/slack_sdk/models/test_elements.py
@@ -1113,6 +1113,40 @@ class OverflowMenuElementTests(unittest.TestCase):
 
 
 # -------------------------------------------------
+# Rich text element parts
+# -------------------------------------------------
+
+
+class AttachmentMentionElementTests(unittest.TestCase):
+    def test_all_fields(self):
+        input = {
+            "type": "attachment_mention",
+            "url": "https://example.com/attachment",
+            "text": "Fallback text",
+            "app_id": "A0123456789",
+            "entity_id": "E0123456789",
+            "icon_url": "https://example.com/icon.png",
+            "channel_id": "C0123456789",
+            "ts": "1234567890.123456",
+            "full_size_preview_enabled": True,
+            "icon_name": "sf-account",
+            "reference_object_type": "record",
+            "product_name": "Salesforce",
+            "style": {"bold": True},
+        }
+        self.assertDictEqual(input, RichTextElementParts.AttachmentMention(**input).to_dict())
+
+    def test_document(self):
+        # Matches the docs reference example field-for-field:
+        # https://docs.slack.dev/reference/block-kit/block-elements/attachment-mention-element
+        input = {
+            "type": "attachment_mention",
+            "url": "https://example.com/attachment",
+        }
+        self.assertDictEqual(input, RichTextElementParts.AttachmentMention(**input).to_dict())
+
+
+# -------------------------------------------------
 # Input
 # -------------------------------------------------
 


### PR DESCRIPTION
### Summary

Adds a typed `RichTextElementParts.AttachmentMention` builder for the [`attachment_mention`](https://docs.slack.dev/reference/block-kit/block-elements/attachment-mention-element/) rich text element — it renders as a rich app attachment or entity reference and is used within a `rich_text` block (inside a `rich_text_section`, `rich_text_list`, or `rich_text_quote`).

Fields mirror the reference docs field-for-field: required `url`, plus optional `text`, `app_id`, `entity_id`, `icon_url`, `channel_id`, `ts`, `full_size_preview_enabled`, `icon_name`, `reference_object_type`, `product_name`, and `style`.

### Testing

Adds two tests to `tests/slack_sdk/models/test_elements.py`:

- `test_document` — asserts the url-only payload shown in the docs example emits exactly `{"type": "attachment_mention", "url": "..."}`.
- `test_all_fields` — every optional field set, asserting `to_dict()`.

Both use `assertDictEqual` on `.to_dict()`.

### Related

- **Example** — slack-samples/bolt-python-examples#226 adds `block-kit/src/block_elements/attachment_mention.py` demonstrating this builder. Its test intentionally goes red against the released SDK until this builder ships — the example asserts the *expected released* shape.

_Draft until this and the example land together._

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>