### PR TITLE
fix: stop aiohttp Socket Mode connect() retrying forever after close

### DIFF
--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -349,7 +349,7 @@ class SocketModeClient(AsyncBaseSocketModeClient):
         # a new monitor and a new message receiver are also created.
         # If a new session is created but we failed to create the new
         # monitor or the new message, we should try it.
-        while True:
+        while not self.closed:
             try:
                 old_session: Optional[ClientWebSocketResponse] = (
                     None if self.current_session is None else self.current_session
@@ -405,6 +405,10 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                     self.logger.debug(f"A new receive_messages() executor has been recreated for {session_id}")
                 break
             except Exception as e:
+                if self.closed:
+                    if self.logger.level <= logging.DEBUG:
+                        self.logger.debug(f"Stopped connecting because the client is closed (error: {e})")
+                    return
                 self.logger.exception(f"Failed to connect (error: {e}); Retrying...")
                 await asyncio.sleep(self.ping_interval)
 

--- a/tests/slack_sdk_async/socket_mode/test_aiohttp.py
+++ b/tests/slack_sdk_async/socket_mode/test_aiohttp.py
@@ -1,5 +1,7 @@
 import asyncio
+import logging
 import unittest
+from unittest.mock import MagicMock
 
 from slack_sdk.socket_mode.aiohttp import SocketModeClient
 from slack_sdk.web.async_client import AsyncWebClient
@@ -44,6 +46,27 @@ class TestAiohttp(unittest.TestCase):
         await client.close()
         await asyncio.wait_for(client.connect(), timeout=1.0)
         self.assertTrue(client.closed)
+
+    @async_test
+    async def test_connect_returns_when_exception_raised_after_close(self):
+        client = SocketModeClient(
+            app_token="xapp-A111-222-xyz",
+            web_client=self.web_client,
+            auto_reconnect_enabled=False,
+            ping_interval=0.01,
+        )
+        client.logger = MagicMock()
+        client.logger.level = logging.DEBUG
+
+        async def close_then_raise(*args, **kwargs):
+            await client.close()
+            raise RuntimeError("Session is closed")
+
+        client.issue_new_wss_url = close_then_raise
+
+        await asyncio.wait_for(client.connect(), timeout=1.0)
+        self.assertTrue(client.closed)
+        client.logger.exception.assert_not_called()
 
     @async_test
     async def test_init_with_loop(self):

--- a/tests/slack_sdk_async/socket_mode/test_aiohttp.py
+++ b/tests/slack_sdk_async/socket_mode/test_aiohttp.py
@@ -32,6 +32,20 @@ class TestAiohttp(unittest.TestCase):
             await client.close()
 
     @async_test
+    async def test_connect_returns_when_closed(self):
+        # Regression test for #1913: connect() must not loop forever once the client is closed.
+        client = SocketModeClient(
+            app_token="xapp-A111-222-xyz",
+            web_client=self.web_client,
+            auto_reconnect_enabled=False,
+            ping_interval=0.01,
+        )
+        client.wss_uri = "ws://localhost:8888/link"
+        await client.close()
+        await asyncio.wait_for(client.connect(), timeout=1.0)
+        self.assertTrue(client.closed)
+
+    @async_test
     async def test_init_with_loop(self):
         client = SocketModeClient(
             app_token="xapp-A111-222-xyz",


### PR DESCRIPTION
## Summary

The aiohttp Socket Mode `SocketModeClient.connect()` looped with `while True:`, and its retry
handler never checked `self.closed`. If a connect/reconnect attempt was in flight when the client
was closed, every retry's `ws_connect()` raised `RuntimeError: Session is closed`, so the loop kept retrying at the `ping_interval` cadence forever.

The fix aligns `connect()` with the `while not self.closed:` idiom already used by its sibling loops (`monitor_current_session`, `receive_messages`, and the base `process_messages`), and returns from the retry handler once `self.closed` is set. A background task orphaned by shutdown now exits within one iteration instead of spinning forever; normal startup/reconnect is unchanged.

Closes #1913.

### Testing

```sh
./scripts/run_tests.sh tests/slack_sdk_async/socket_mode/test_aiohttp.py
```

To watch it fail against the pre-fix code, restore the old `connect()` (keeping the new test), then
put the fix back:

```sh
git fetch origin
git checkout origin/main -- slack_sdk/socket_mode/aiohttp/__init__.py   # buggy `while True:` connect()
./scripts/run_tests.sh tests/slack_sdk_async/socket_mode/test_aiohttp.py
#  -> test_connect_returns_when_closed spins on the closed session;
#     asyncio.wait_for(..., timeout=1.0) raises TimeoutError -> FAIL

git checkout HEAD -- slack_sdk/socket_mode/aiohttp/__init__.py          # restore the fix
./scripts/run_tests.sh tests/slack_sdk_async/socket_mode/test_aiohttp.py   # PASS
```

(Equivalent manual repro: change `while not self.closed:` back to `while True:` and delete the
`if self.closed: return` guard in `connect()`'s `except` block.)

### Category

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [x] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.
