### PR TITLE
chore: ignore docstring formatting commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,5 @@
 108955b601e768fd56696be903fc8b471c73ebf7
 # replace flake8 and black with ruff (#1954)
 1a38eb329dd5a1f2ee6b86f5873e7152e0d33d48
+# add docstring formatting + linting (#1959)
+8c4882d8781fa506c17211e2180caa467dfe601f


### PR DESCRIPTION
Adds the [#1959](https://github.com/slackapi/python-slack-sdk/pull/1959) squash-merge commit (`8c4882d8781fa506c17211e2180caa467dfe601f`) to `.git-blame-ignore-revs` so `git blame` skips the docstring formatting/linting sweep, per that PR's follow-up note.

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>