### PR TITLE
fix(socket_mode): shut down current_session_runner in built-in close()

### DIFF
--- a/slack_sdk/socket_mode/builtin/client.py
+++ b/slack_sdk/socket_mode/builtin/client.py
@@ -221,10 +221,13 @@ class SocketModeClient(BaseSocketModeClient):
                     )
                     raise e
 
-    def close(self):
+    def close(self) -> None:
         self.closed = True
         self.auto_reconnect_enabled = False
+        self.current_session_state.terminated = True
         self.disconnect()
+        if self.current_session_runner.is_alive():
+            self.current_session_runner.shutdown()
         if self.current_app_monitor.is_alive():
             self.current_app_monitor.shutdown()
         if self.message_processor.is_alive():

--- a/tests/slack_sdk/socket_mode/test_interactions_builtin.py
+++ b/tests/slack_sdk/socket_mode/test_interactions_builtin.py
@@ -145,3 +145,25 @@ class TestInteractionsBuiltin(unittest.TestCase):
             client.send_message("foo")
         finally:
             client.close()
+
+    def test_close_reaps_current_session_runner(self):
+        # Regression for #1873: close() must reap current_session_runner without hanging.
+        client = SocketModeClient(
+            app_token="xapp-A111-222-xyz",
+            web_client=self.web_client,
+            auto_reconnect_enabled=False,
+            trace_enabled=True,
+        )
+        try:
+            client.wss_uri = "ws://0.0.0.0:3011/link"
+            client.connect()
+            self.assertTrue(client.is_connected())
+            time.sleep(1)
+
+            client.close()
+
+            self.assertFalse(client.current_session_runner.is_alive())
+            self.assertFalse(client.current_app_monitor.is_alive())
+            self.assertFalse(client.message_processor.is_alive())
+        finally:
+            client.close()


### PR DESCRIPTION
## Summary

The built-in `SocketModeClient` starts three `IntervalRunner` daemon threads in `__init__`
- `current_session_runner`
- `current_app_monitor`
- `message_processor
But `close()` only shut down two of them. `current_session_runner` survived `close()`, so a long-lived process that opens and closes many client instances leaks one idle daemon thread per closed instance (issue #1873).

For comparison, the sync sibling `websocket_client`'s `close()` already shuts down `current_session_runner`, and the async backends cancel all their futures.

## Why

Adding `current_session_runner.shutdown()` call alone deadlocks `close()` on any client that actually connected. That runner runs `_run_current_session` -> `Connection.run_until_completion`, whose loop exits only when the connection state is `terminated`. `disconnect()` nulls the socket but does not set `terminated`, and `IntervalRunner.shutdown()` joins the thread with no timeout, so `join()` blocks forever.

So `close()` sets `current_session_state.terminated = True` before disconnecting, mirroring what `connect()` already does when it retires an old session. The loop returns, the join completes, and all three runners are reaped. This is the same CI hang the earlier #1874 ran into; setting `terminated` is what resolves it.

## Tests

Adds `test_close_reaps_current_session_runner` to `tests/slack_sdk/socket_mode/test_interactions_builtin.py`. It connects using the existing mock socket-mode server, calls `close()`, and asserts all three runner threads are no longer alive. Because it exercises the connected path, it hangs under `pytest-timeout` if `terminated` is not set. It guards both the leak and the deadlock. The existing `test_interactions` suite (connect/close over many buffer sizes) still passes.

## Notes

- Credit to @animaartificialis for reporting #1873 and diagnosing the leak in #1874.
- No changes to the async or `websocket_client` clients; they already shut this runner down.

Closes #1873

🤖 Generated with [Claude Code](https://claude.com/claude-code)