### PR TITLE
fix(socket-mode): only release connect_operation_lock in send_message when acquired

### DIFF
--- a/slack_sdk/socket_mode/aiohttp/__init__.py
+++ b/slack_sdk/socket_mode/aiohttp/__init__.py
@@ -434,15 +434,16 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                 )
             # Although acquiring self.connect_operation_lock also for the first method call is the safest way,
             # we avoid synchronizing a lot for better performance. That's why we are doing a retry here.
+            acquired = False
             try:
-                await self.connect_operation_lock.acquire()
+                acquired = await self.connect_operation_lock.acquire()
                 if await self.is_connected():
                     await self.current_session.send_str(message)  # type: ignore[union-attr]
                 else:
                     self.logger.warning(f"The current session ({session_id}) is no longer active. Failed to send a message")
                     raise e
             finally:
-                if self.connect_operation_lock.locked() is True:
+                if acquired:
                     self.connect_operation_lock.release()
 
     async def close(self):

--- a/slack_sdk/socket_mode/websockets/__init__.py
+++ b/slack_sdk/socket_mode/websockets/__init__.py
@@ -245,14 +245,16 @@ class SocketModeClient(AsyncBaseSocketModeClient):
                 )
             # Although acquiring self.connect_operation_lock also for the first method call is the safest way,
             # we avoid synchronizing a lot for better performance. That's why we are doing a retry here.
+            acquired = False
             try:
+                acquired = await self.connect_operation_lock.acquire()
                 if await self.is_connected():
                     await self.current_session.send(message)  # type: ignore[union-attr]
                 else:
                     self.logger.warning(f"The current session ({session_id}) is no longer active. Failed to send a message")
                     raise e
             finally:
-                if self.connect_operation_lock.locked() is True:
+                if acquired:
                     self.connect_operation_lock.release()
 
     async def close(self):

--- a/tests/slack_sdk_async/socket_mode/test_aiohttp.py
+++ b/tests/slack_sdk_async/socket_mode/test_aiohttp.py
@@ -134,3 +134,52 @@ class TestAiohttp(unittest.TestCase):
 
 async def listener(self, message, raw_message):
     pass
+
+
+class _LockProbeClient(SocketModeClient):
+    """Just enough state for send_message(), with no real connection."""
+
+    def __init__(self):
+        self.connect_operation_lock = asyncio.Lock()
+        self.logger = logging.getLogger(__name__)
+        self.closed = False
+        self.current_session = MagicMock()
+
+    async def is_connected(self) -> bool:
+        return True
+
+    @classmethod
+    def build_session_id(cls, session) -> str:
+        return "test-session"
+
+    async def session_id(self) -> str:
+        return "test-session"
+
+
+class TestAiohttpSendMessageLock(unittest.TestCase):
+    @async_test
+    async def test_send_message_leaves_another_tasks_lock_alone(self):
+        client = _LockProbeClient()
+
+        async def send_str(message):
+            raise ConnectionError("the underlying connection was replaced")
+
+        client.current_session.send_str = send_str
+
+        # Stand in for a reconnect holding the lock for the whole call.
+        await client.connect_operation_lock.acquire()
+
+        task = asyncio.ensure_future(client.send_message("hello"))
+        await asyncio.sleep(0.1)
+
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, ConnectionError):
+            pass
+
+        self.assertTrue(
+            client.connect_operation_lock.locked(),
+            "send_message() released the connect lock held by another task",
+        )
+        client.connect_operation_lock.release()

--- a/tests/slack_sdk_async/socket_mode/test_websockets.py
+++ b/tests/slack_sdk_async/socket_mode/test_websockets.py
@@ -1,4 +1,9 @@
+import asyncio
+import logging
 import unittest
+from unittest.mock import MagicMock
+
+from websockets.exceptions import WebSocketException
 
 from slack_sdk.socket_mode.websockets import SocketModeClient
 from slack_sdk.web.async_client import AsyncWebClient
@@ -73,3 +78,49 @@ class TestAiohttp(unittest.TestCase):
 
 async def listener(message, raw_message):
     pass
+
+
+class _LockProbeClient(SocketModeClient):
+    """Just enough state for send_message(), with no real connection."""
+
+    def __init__(self):
+        self.connect_operation_lock = asyncio.Lock()
+        self.logger = logging.getLogger(__name__)
+        self.closed = False
+        self.current_session = MagicMock()
+
+    async def is_connected(self) -> bool:
+        return True
+
+    @classmethod
+    def build_session_id(cls, session) -> str:
+        return "test-session"
+
+
+class TestWebsocketsSendMessageLock(unittest.TestCase):
+    @async_test
+    async def test_send_message_leaves_another_tasks_lock_alone(self):
+        client = _LockProbeClient()
+
+        async def send(message):
+            raise WebSocketException("the underlying connection was replaced")
+
+        client.current_session.send = send
+
+        # Stand in for a reconnect holding the lock for the whole call.
+        await client.connect_operation_lock.acquire()
+
+        task = asyncio.ensure_future(client.send_message("hello"))
+        await asyncio.sleep(0.1)
+
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, WebSocketException):
+            pass
+
+        self.assertTrue(
+            client.connect_operation_lock.locked(),
+            "send_message() released the connect lock held by another task",
+        )
+        client.connect_operation_lock.release()


### PR DESCRIPTION
## Summary

#1926 fixed `if self.connect_operation_lock.locked() is True: release()` in `AsyncBaseSocketModeClient.connect_to_new_endpoint`. The same shape is still in `send_message()` in both async backends.

`websockets` is the worse of the two: its retry block **never acquires** the lock, it only releases it in `finally`. So while a reconnect holds the lock, any `send_message()` that falls into the retry path releases the reconnect's lock, and a second reconnect can start while the first is still running. The `aiohttp` sibling does acquire here, which is what makes the omission visible.

`aiohttp` acquires but releases based on `locked()`, so a task cancelled while awaiting `acquire()` releases whichever task does hold the lock. That is the case #1926 describes.

Both now track whether this task acquired. The three sync paths (`builtin`, `websocket_client`, `rtm_v2`) take the lock with `with` and cannot get this wrong, so they needed no change.

### Testing

A test per backend, in the style of the one added with #1926: another task holds the lock, `send_message()` hits its retry path and is cancelled, and the lock must still be held afterwards. Each fails on `main` and passes with the change.

- `pytest tests/slack_sdk_async/socket_mode/` — 22 passed (20 before these two)
- `./scripts/lint.sh` — `ruff format --check` 455 files clean, `ruff check slack/ slack_sdk/` clean
- `mypy --config-file pyproject.toml` on both changed modules — no issues

I ran those individually rather than through `./scripts/run_validation.sh`, so I have left that box unchecked.

### Category

- [ ] **slack_sdk.web.WebClient (sync/async)** (Web API client)
- [ ] **slack_sdk.webhook.WebhookClient (sync/async)** (Incoming Webhook, response_url sender)
- [x] **slack_sdk.socket_mode** (Socket Mode client)
- [ ] **slack_sdk.signature** (Request Signature Verifier)
- [ ] **slack_sdk.oauth** (OAuth Flow Utilities)
- [ ] **slack_sdk.models** (UI component builders)
- [ ] **slack_sdk.scim** (SCIM API client)
- [ ] **slack_sdk.audit_logs** (Audit Logs API client)
- [ ] **slack_sdk.rtm_v2** (RTM client)
- [ ] `/docs` (Documents)
- [ ] `/tutorial` (PythOnBoardingBot tutorial)
- [x] `tests`/`integration_tests` (Automated tests for this library)

## Requirements

- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slack-sdk/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
- [ ] I've run `python3 -m venv .venv && source .venv/bin/activate && ./scripts/run_validation.sh` after making the changes.